### PR TITLE
fix: prune stale push tokens from abandoned PWA installs

### DIFF
--- a/packages/head/src/__tests__/push.test.ts
+++ b/packages/head/src/__tests__/push.test.ts
@@ -146,3 +146,139 @@ describe('PushManager', () => {
     expect(provider.sent[0].opts).toEqual({ environment: 'sandbox', bundleId: 'com.kraki.dev' });
   });
 });
+
+describe('Storage.deleteStaleUserPushTokens', () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = new Storage(':memory:');
+    storage.upsertUser('u1', 'alice');
+  });
+
+  afterEach(() => {
+    storage.close();
+  });
+
+  it('prunes push tokens from offline devices with stale last_seen', () => {
+    // Create a stale device (last_seen 48h ago) and a current device
+    storage.upsertDevice('dev-old', 'u1', 'Old Phone', 'app', 'web');
+    storage.upsertDevice('dev-new', 'u1', 'New Phone', 'app', 'web');
+
+    // Backdate the old device's last_seen
+    (storage as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db
+      .prepare("UPDATE devices SET last_seen = datetime('now', '-48 hours') WHERE id = ?")
+      .run('dev-old');
+
+    storage.upsertPushToken('dev-old', 'web_push', 'old_token');
+    storage.upsertPushToken('dev-new', 'web_push', 'new_token');
+
+    // dev-new is registering, no devices are online except dev-new
+    const pruned = storage.deleteStaleUserPushTokens('u1', 'dev-new', ['dev-new']);
+    expect(pruned).toBe(1);
+
+    // Only new token remains
+    const remaining = storage.getPushTokensForOfflineDevices('u1', []);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].deviceId).toBe('dev-new');
+  });
+
+  it('does not prune tokens from online devices even if last_seen is old', () => {
+    storage.upsertDevice('dev-online', 'u1', 'Online Phone', 'app', 'web');
+    storage.upsertDevice('dev-new', 'u1', 'New Phone', 'app', 'web');
+
+    // Backdate the online device
+    (storage as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db
+      .prepare("UPDATE devices SET last_seen = datetime('now', '-48 hours') WHERE id = ?")
+      .run('dev-online');
+
+    storage.upsertPushToken('dev-online', 'web_push', 'online_token');
+
+    // dev-online is in the online set — should be protected
+    const pruned = storage.deleteStaleUserPushTokens('u1', 'dev-new', ['dev-new', 'dev-online']);
+    expect(pruned).toBe(0);
+
+    const remaining = storage.getPushTokensForOfflineDevices('u1', []);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].deviceId).toBe('dev-online');
+  });
+
+  it('does not prune tokens from recently-seen offline devices', () => {
+    storage.upsertDevice('dev-recent', 'u1', 'Recent Phone', 'app', 'web');
+    storage.upsertDevice('dev-new', 'u1', 'New Phone', 'app', 'web');
+
+    // dev-recent was just created so last_seen is now — within 24h
+    storage.upsertPushToken('dev-recent', 'web_push', 'recent_token');
+
+    const pruned = storage.deleteStaleUserPushTokens('u1', 'dev-new', ['dev-new']);
+    expect(pruned).toBe(0);
+
+    const remaining = storage.getPushTokensForOfflineDevices('u1', []);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].deviceId).toBe('dev-recent');
+  });
+
+  it('does not prune the registering device own token', () => {
+    storage.upsertDevice('dev-self', 'u1', 'Self', 'app', 'web');
+
+    // Backdate own device (edge case)
+    (storage as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db
+      .prepare("UPDATE devices SET last_seen = datetime('now', '-48 hours') WHERE id = ?")
+      .run('dev-self');
+
+    storage.upsertPushToken('dev-self', 'web_push', 'self_token');
+
+    const pruned = storage.deleteStaleUserPushTokens('u1', 'dev-self', []);
+    expect(pruned).toBe(0);
+  });
+
+  it('does not touch tokens from other users', () => {
+    storage.upsertUser('u2', 'bob');
+    storage.upsertDevice('dev-a', 'u1', 'Alice Phone', 'app', 'web');
+    storage.upsertDevice('dev-b', 'u2', 'Bob Phone', 'app', 'web');
+
+    // Backdate both
+    (storage as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db
+      .prepare("UPDATE devices SET last_seen = datetime('now', '-48 hours') WHERE id IN ('dev-a', 'dev-b')")
+      .run();
+
+    storage.upsertPushToken('dev-a', 'web_push', 'alice_tok');
+    storage.upsertPushToken('dev-b', 'web_push', 'bob_tok');
+
+    storage.upsertDevice('dev-new', 'u1', 'Alice New', 'app', 'web');
+    const pruned = storage.deleteStaleUserPushTokens('u1', 'dev-new', ['dev-new']);
+    expect(pruned).toBe(1); // only alice's old token
+
+    // Bob's token untouched
+    const bobTokens = storage.getPushTokensForOfflineDevices('u2', []);
+    expect(bobTokens).toHaveLength(1);
+    expect(bobTokens[0].deviceId).toBe('dev-b');
+  });
+});
+
+describe('Storage.touchDeviceLastSeen', () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = new Storage(':memory:');
+    storage.upsertUser('u1', 'alice');
+  });
+
+  afterEach(() => {
+    storage.close();
+  });
+
+  it('updates last_seen to current time', () => {
+    storage.upsertDevice('dev-1', 'u1', 'Phone', 'app', 'web');
+
+    // Backdate
+    (storage as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db
+      .prepare("UPDATE devices SET last_seen = datetime('now', '-7 days') WHERE id = ?")
+      .run('dev-1');
+
+    const before = storage.getDevice('dev-1')!;
+    storage.touchDeviceLastSeen('dev-1');
+    const after = storage.getDevice('dev-1')!;
+
+    expect(new Date(after.lastSeen).getTime()).toBeGreaterThan(new Date(before.lastSeen).getTime());
+  });
+});

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -226,6 +226,7 @@ export class HeadServer {
         // Only clean up if this socket is still the active connection.
         // A reconnecting device may have already replaced us in the map.
         if (this.connections.get(disconnectedDeviceId) === ws) {
+          try { this.storage.touchDeviceLastSeen(disconnectedDeviceId); } catch { /* storage may be closed */ }
           this.connections.delete(disconnectedDeviceId);
           this.userByDevice.delete(disconnectedDeviceId);
           logger.info('Device disconnected', { deviceId: disconnectedDeviceId });
@@ -819,6 +820,14 @@ export class HeadServer {
       payload.environment as string | undefined,
       payload.bundleId as string | undefined,
     );
+
+    // Clean up push tokens from stale devices (offline >24h) to prevent
+    // duplicate notifications from abandoned PWA installs on the same phone.
+    const onlineDeviceIds = Array.from(this.connections.keys());
+    const pruned = this.storage.deleteStaleUserPushTokens(state.userId, state.deviceId, onlineDeviceIds);
+    if (pruned > 0) {
+      logger.info('Pruned stale push tokens', { userId: state.userId, count: pruned });
+    }
 
     logger.info('Push token registered', { deviceId: state.deviceId, provider: payload.provider });
     ws.send(JSON.stringify({ type: 'push_token_registered', payload: { provider: payload.provider } }));

--- a/packages/head/src/storage.ts
+++ b/packages/head/src/storage.ts
@@ -272,6 +272,13 @@ export class Storage {
     return result.changes;
   }
 
+  // --- Device activity ---
+
+  /** Update last_seen timestamp for a device (called on disconnect). */
+  touchDeviceLastSeen(deviceId: string): void {
+    this.db.prepare("UPDATE devices SET last_seen = datetime('now') WHERE id = ?").run(deviceId);
+  }
+
   // --- Push tokens ---
 
   upsertPushToken(deviceId: string, provider: string, token: string, environment?: string, bundleId?: string): void {
@@ -295,6 +302,29 @@ export class Storage {
 
   deletePushTokensForDevice(deviceId: string): void {
     this.db.prepare('DELETE FROM push_tokens WHERE device_id = ?').run(deviceId);
+  }
+
+  /**
+   * Delete push tokens from stale devices of the same user.
+   * A device is considered stale if it is not currently connected
+   * AND its last_seen is older than the given threshold (default 24h).
+   * Returns the number of tokens deleted.
+   */
+  deleteStaleUserPushTokens(userId: string, excludeDeviceId: string, onlineDeviceIds: string[], maxAgeHours = 24): number {
+    const hours = Math.floor(Math.abs(Number(maxAgeHours)));
+    if (!Number.isFinite(hours) || hours === 0) return 0;
+    const cutoff = new Date(Date.now() - hours * 3600_000).toISOString().replace('T', ' ').slice(0, 19);
+    const allExcluded = [excludeDeviceId, ...onlineDeviceIds];
+    const placeholders = allExcluded.map(() => '?').join(',');
+    const result = this.db.prepare(`
+      DELETE FROM push_tokens WHERE device_id IN (
+        SELECT d.id FROM devices d
+        WHERE d.user_id = ?
+          AND d.id NOT IN (${placeholders})
+          AND d.last_seen < ?
+      )
+    `).run(userId, ...allExcluded, cutoff);
+    return result.changes;
   }
 
   /** Get push tokens for offline devices of a user (devices NOT in the online set). */


### PR DESCRIPTION
## Problem

When a user re-installs the PWA (or the browser generates a new device ID), old device entries persist in the relay DB with active push token registrations. The relay treats those offline stale devices as needing push, but the Apple push endpoint still delivers to the same physical device — so the user gets **duplicate OS notifications** even while actively using the app.

Not fixable from the user side: the old PWA context (where `unsubscribeFromPush` would run) no longer exists.

## Fix

When a device registers a push token, delete push tokens from other devices of the same user that are:
- **Not currently connected** (not in the in-memory connections map)
- **Not seen in over 24 hours** (`last_seen < now - 24h`)

Also fixes `last_seen` to update on disconnect — previously it was only set on connect, making it inaccurate for long-lived WebSocket sessions.

## Changes

### `packages/head/src/storage.ts`
- `touchDeviceLastSeen(deviceId)` — updates `last_seen` to now
- `deleteStaleUserPushTokens(userId, excludeDeviceId, onlineDeviceIds, maxAgeHours)` — prunes tokens from stale offline devices

### `packages/head/src/server.ts`
- Call `touchDeviceLastSeen` on WebSocket close
- Call `deleteStaleUserPushTokens` after `upsertPushToken` in `handleRegisterPushToken`

### `packages/head/src/__tests__/push.test.ts`
- Stale offline device token gets pruned
- Online device token is never pruned (even with old last_seen)
- Recently-seen offline device token is kept
- Registering device's own token is never pruned
- Other users' tokens are untouched
- `touchDeviceLastSeen` updates the timestamp