### PR TITLE
fix: switch release tags from tentacle/v* to v*, drop empty head releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'tentacle/v*'
-      - 'head/v*'
+      - 'v*'
   workflow_dispatch:
     inputs:
       mode:
@@ -136,14 +135,11 @@ jobs:
           set -euo pipefail
           TAG="${{ steps.meta.outputs.release_tag }}"
 
-          if [[ "$TAG" == tentacle/v* ]]; then
-            TAG_VERSION="${TAG#tentacle/v}"
+          if [[ "$TAG" == v* ]]; then
+            TAG_VERSION="${TAG#v}"
             PKG_VERSION=$(node -p "require('./packages/tentacle/package.json').version")
-          elif [[ "$TAG" == head/v* ]]; then
-            TAG_VERSION="${TAG#head/v}"
-            PKG_VERSION=$(node -p "require('./packages/head/package.json').version")
           else
-            echo "Unknown tag prefix: $TAG"
+            echo "Unknown tag prefix: $TAG (expected v*)"
             exit 1
           fi
 
@@ -158,7 +154,7 @@ jobs:
   build-binary:
     name: Build Binary (${{ matrix.label }})
     needs: prepare
-    if: startsWith(github.ref_name, 'tentacle/v') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref_name, 'v') || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -499,7 +495,7 @@ jobs:
     needs:
       - prepare
       - build-binary
-    if: startsWith(github.ref_name, 'tentacle/v') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref_name, 'v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -696,13 +692,3 @@ jobs:
             npm publish "$ARTIFACT_DIR/$tarball_name" --access public --provenance
             echo "::endgroup::"
           done
-
-      - name: Create GitHub Release (head)
-        if: startsWith(github.ref_name, 'head/v')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes


### PR DESCRIPTION
## Problem

Three related issues with the current release tag scheme (`tentacle/v*` and `head/v*`):

1. **Empty head releases** — `head/v*` tags create a GitHub Release with zero assets, which can become `/releases/latest` and break install scripts
2. **Slash in tags breaks download URLs** — `…/download/head/v0.10.4/…` 404s because GitHub can't resolve the extra path segment
3. **Self-updater silently broken** — `update.ts` already expects `v*` or `tentacle-v*` (dash) format, but current `tentacle/v*` (slash) tags never match, so the updater never finds new versions

## Fix

- **Tags**: `tentacle/v*` → `v*` (tentacle is the main binary, gets the unqualified tag)
- **Head releases**: Remove the `gh release create` step for head — npm publish is sufficient
- **install.sh**: Scan recent releases for one with binary assets instead of blindly using `/releases/latest`
- **update.ts**: No changes needed — already expects `v*` format

## Release workflow after this change

| Tag | Binary build | npm publish | GitHub Release |
|-----|-------------|-------------|----------------|
| `v*` | ✅ 4-platform matrix | ✅ all packages | ✅ with binary assets |
| *(head npm-only)* | — | via `v*` tag (skips already-published) | none |

## Next release

After merging, tag the next tentacle release as `v0.X.Y` instead of `tentacle/v0.X.Y`.