### PR TITLE
feat: beta/stable web channel switching

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -8,73 +8,125 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      target:
+        description: Deploy target
+        required: true
+        default: beta
+        type: choice
+        options:
+          - beta
+          - production
 
 permissions:
   contents: read
   actions: write
 
 concurrency:
-  group: deploy-web-${{ github.ref }}
+  group: deploy-web-${{ github.ref }}-${{ github.event.inputs.target || 'beta' }}
   cancel-in-progress: true
 
+# ── Shared build steps (reusable) ─────────────────────────
+
 jobs:
-  detect-version-bump:
-    name: Detect web version bump
+  read-version:
+    name: Read version
     runs-on: ubuntu-latest
-    # Skip if triggered by workflow_run and CI failed
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
     outputs:
-      should_deploy: ${{ steps.detect.outputs.should_deploy }}
-      previous_version: ${{ steps.detect.outputs.previous_version }}
-      current_version: ${{ steps.detect.outputs.current_version }}
+      version: ${{ steps.v.outputs.version }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Read web version
+        id: v
+        run: echo "version=$(node -p "require('./packages/arm/web/package.json').version")" >> "$GITHUB_OUTPUT"
+
+  # ── Beta: eager deploy on every CI pass ──────────────────
+
+  deploy-beta:
+    name: Deploy beta v${{ needs.read-version.outputs.version }}
+    needs: read-version
+    if: >-
+      (github.event_name == 'workflow_run')
+      || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'beta')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: beta
+      url: ${{ vars.WEBAPP_PUBLIC_URL != '' && vars.WEBAPP_PUBLIC_URL || 'https://kraki.corelli.cloud' }}
+    env:
+      WEB_DEPLOY_HOST: ${{ vars.WEB_DEPLOY_HOST }}
+      WEB_DEPLOY_USER: ${{ vars.WEB_DEPLOY_USER }}
+      WEB_DEPLOY_PORT: ${{ vars.WEB_DEPLOY_PORT != '' && vars.WEB_DEPLOY_PORT || '22' }}
+      WEB_DEPLOY_PATH: ${{ vars.WEB_DEPLOY_PATH != '' && vars.WEB_DEPLOY_PATH || '/var/www/kraki-beta' }}
+      WEB_DEPLOY_KNOWN_HOSTS: ${{ vars.WEB_DEPLOY_KNOWN_HOSTS }}
+      WEBAPP_PUBLIC_URL: ${{ vars.WEBAPP_PUBLIC_URL != '' && vars.WEBAPP_PUBLIC_URL || 'https://kraki.corelli.cloud' }}
+      VITE_WS_URL: ${{ vars.WEBAPP_VITE_WS_URL != '' && vars.WEBAPP_VITE_WS_URL || 'wss://kraki.corelli.cloud' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
-          fetch-depth: 0
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
-      - name: Detect version bump
-        id: detect
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate repository
+        run: pnpm validate
+
+      - name: Build web app
+        run: pnpm --filter @kraki/arm-web build
+
+      - name: Configure SSH
         env:
-          EVENT_NAME: ${{ github.event_name }}
+          WEB_DEPLOY_SSH_KEY: ${{ secrets.WEB_DEPLOY_SSH_KEY }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import subprocess
-          from pathlib import Path
+          test -n "$WEB_DEPLOY_HOST" || { echo "Missing WEB_DEPLOY_HOST"; exit 1; }
+          test -n "$WEB_DEPLOY_USER" || { echo "Missing WEB_DEPLOY_USER"; exit 1; }
+          test -n "$WEB_DEPLOY_PATH" || { echo "Missing WEB_DEPLOY_PATH"; exit 1; }
+          test -n "$WEB_DEPLOY_SSH_KEY" || { echo "Missing WEB_DEPLOY_SSH_KEY"; exit 1; }
+          test -n "$WEB_DEPLOY_KNOWN_HOSTS" || { echo "Missing WEB_DEPLOY_KNOWN_HOSTS"; exit 1; }
 
-          current = json.loads(Path('packages/arm/web/package.json').read_text())['version']
-          previous = ''
-          should_deploy = os.environ['EVENT_NAME'] == 'workflow_dispatch'
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$WEB_DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$WEB_DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
 
-          if not should_deploy:
-              try:
-                  previous_source = subprocess.check_output(
-                      ['git', 'show', 'HEAD~1:packages/arm/web/package.json'],
-                      text=True,
-                  )
-                  previous = json.loads(previous_source)['version']
-                  should_deploy = previous != current
-              except subprocess.CalledProcessError:
-                  # File didn't exist in previous commit — first deploy
-                  should_deploy = True
+      - name: Deploy static bundle
+        run: |
+          SSH_RSYNC="ssh -p $WEB_DEPLOY_PORT -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes"
 
-          with Path(os.environ['GITHUB_OUTPUT']).open('a', encoding='utf-8') as fh:
-              fh.write(f'current_version={current}\n')
-              fh.write(f'previous_version={previous}\n')
-              fh.write(f"should_deploy={'true' if should_deploy else 'false'}\n")
+          ssh -p "$WEB_DEPLOY_PORT" -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes \
+            "$WEB_DEPLOY_USER@$WEB_DEPLOY_HOST" "mkdir -p '$WEB_DEPLOY_PATH'"
 
-          print(f'previous_version={previous or "(none)"}')
-          print(f'current_version={current}')
-          print(f'should_deploy={should_deploy}')
-          PY
+          rsync -az --delete -e "$SSH_RSYNC" \
+            packages/arm/web/dist/ \
+            "$WEB_DEPLOY_USER@$WEB_DEPLOY_HOST:$WEB_DEPLOY_PATH/"
 
-  deploy:
-    name: Deploy web v${{ needs.detect-version-bump.outputs.current_version }}
-    needs: detect-version-bump
-    if: needs.detect-version-bump.outputs.should_deploy == 'true'
+          ssh -p "$WEB_DEPLOY_PORT" -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes \
+            "$WEB_DEPLOY_USER@$WEB_DEPLOY_HOST" "test -f '$WEB_DEPLOY_PATH/index.html'"
+
+  # ── Production: manual dispatch only ─────────────────────
+
+  deploy-production:
+    name: Deploy production v${{ needs.read-version.outputs.version }}
+    needs: read-version
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'production'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
@@ -109,18 +161,18 @@ jobs:
       - name: Validate repository
         run: pnpm validate
 
-      - name: Build production web app
+      - name: Build web app
         run: pnpm --filter @kraki/arm-web build
 
       - name: Configure SSH
         env:
           WEB_DEPLOY_SSH_KEY: ${{ secrets.WEB_DEPLOY_SSH_KEY }}
         run: |
-          test -n "$WEB_DEPLOY_HOST" || { echo "Missing repository variable WEB_DEPLOY_HOST"; exit 1; }
-          test -n "$WEB_DEPLOY_USER" || { echo "Missing repository variable WEB_DEPLOY_USER"; exit 1; }
-          test -n "$WEB_DEPLOY_PATH" || { echo "Missing repository variable WEB_DEPLOY_PATH"; exit 1; }
-          test -n "$WEB_DEPLOY_SSH_KEY" || { echo "Missing repository secret WEB_DEPLOY_SSH_KEY"; exit 1; }
-          test -n "$WEB_DEPLOY_KNOWN_HOSTS" || { echo "Missing repository variable WEB_DEPLOY_KNOWN_HOSTS"; exit 1; }
+          test -n "$WEB_DEPLOY_HOST" || { echo "Missing WEB_DEPLOY_HOST"; exit 1; }
+          test -n "$WEB_DEPLOY_USER" || { echo "Missing WEB_DEPLOY_USER"; exit 1; }
+          test -n "$WEB_DEPLOY_PATH" || { echo "Missing WEB_DEPLOY_PATH"; exit 1; }
+          test -n "$WEB_DEPLOY_SSH_KEY" || { echo "Missing WEB_DEPLOY_SSH_KEY"; exit 1; }
+          test -n "$WEB_DEPLOY_KNOWN_HOSTS" || { echo "Missing WEB_DEPLOY_KNOWN_HOSTS"; exit 1; }
 
           install -m 700 -d ~/.ssh
           printf '%s\n' "$WEB_DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
@@ -144,21 +196,3 @@ jobs:
 
       - name: Verify live site
         run: curl --fail --silent --show-error "$WEBAPP_PUBLIC_URL" > /dev/null
-
-  status:
-    name: Deploy Web Status
-    needs: [detect-version-bump, deploy]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Report outcome
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ needs.deploy.result }}" = "success" ]; then
-            echo "✅ Deployed web v${{ needs.detect-version-bump.outputs.current_version }}"
-          else
-            echo "⏭️ No deploy needed — cancelling workflow"
-            gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
-            sleep 5
-          fi

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useMemo, useState, useCallback, type MutableRefObject } from 'react';
+import { memo, useEffect, useLayoutEffect, useRef, useMemo, useState, useCallback, type MutableRefObject } from 'react';
 import { useParams } from 'react-router';
 import { useStore } from '../../hooks/useStore';
 import { MessageBubble } from './MessageBubble';
@@ -34,7 +34,7 @@ function getSeq(m: ChatMessage): number {
   return 'seq' in m ? (m as { seq?: number }).seq ?? 0 : 0;
 }
 
-export function ChatView() {
+export const ChatView = memo(function ChatView() {
   const { sessionId } = useParams<{ sessionId: string }>();
   const messages = useStore((s) => sessionId ? s.messages.get(sessionId) : undefined) ?? EMPTY_MESSAGES;
   const streaming = useStore((s) => sessionId ? s.streamingContent.get(sessionId) : undefined);
@@ -313,4 +313,4 @@ export function ChatView() {
       )}
     </div>
   );
-}
+});

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -43,6 +43,8 @@ export const ChatView = memo(function ChatView() {
   const isDeviceOnline = session ? devices.get(session.deviceId)?.online ?? false : false;
   const permissionsMap = useStore((s) => s.pendingPermissions);
   const questionsMap = useStore((s) => s.pendingQuestions);
+  const storeUnread = useStore((s) => sessionId ? (s.unreadCount.get(sessionId) ?? 0) : 0);
+  const hadUnreadRef = useRef(false);
 
   const pendingPermIds = useMemo(
     () => new Set([...permissionsMap.values()].map((p) => p.id)),
@@ -112,6 +114,15 @@ export const ChatView = memo(function ChatView() {
     // No in-progress turn — append one so streaming has a home
     return [...rawGrouped, { type: 'turn' as const, turn: { thinkingMessages: [] as ChatMessage[], finalMessage: null } }];
   }, [rawGrouped, streaming]);
+
+  // Index of the last turn group that has a finalMessage (for data-last-agent marker)
+  const lastAgentIdx = useMemo(() => {
+    for (let i = grouped.length - 1; i >= 0; i--) {
+      const g = grouped[i];
+      if (g.type === 'turn' && g.turn.finalMessage) return i;
+    }
+    return -1;
+  }, [grouped]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const isAtBottomRef = useRef(true);
@@ -186,16 +197,35 @@ export const ChatView = memo(function ChatView() {
     prevLastSeqRef.current = curLastSeq;
   }, [grouped, streaming, scrollToBottom]);
 
+  // Snapshot unread state before SessionPage clears it
+  useEffect(() => {
+    hadUnreadRef.current = storeUnread > 0;
+  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps -- capture on session entry only
+
   // Reset when switching sessions
   useEffect(() => {
     setShowScrollBtn(false);
     setUnreadCount(0);
     isAtBottomRef.current = true;
-    // Scroll to bottom on session change
+    // Scroll after DOM settles
     setTimeout(() => {
-      if (scrollRef.current) {
-        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      const container = scrollRef.current;
+      if (!container) return;
+
+      // If session had unread messages, try to scroll to the top of the last
+      // agent message bubble so the user can start reading from the beginning.
+      if (hadUnreadRef.current) {
+        const lastAgent = container.querySelector<HTMLElement>('[data-last-agent]');
+        if (lastAgent && lastAgent.offsetHeight > container.clientHeight) {
+          lastAgent.scrollIntoView({ block: 'start' });
+          // Small top padding so it doesn't sit flush against the edge
+          container.scrollTop = Math.max(0, container.scrollTop - 12);
+          isAtBottomRef.current = false;
+          return;
+        }
       }
+
+      container.scrollTop = container.scrollHeight;
     }, 0);
   }, [sessionId]);
 
@@ -255,7 +285,7 @@ export const ChatView = memo(function ChatView() {
               const isActive = isLastTurn && !sessionIdle && (!turn.finalMessage || hasStreaming);
 
               return (
-                <div key={`turn-${idx}`}>
+                <div key={`turn-${idx}`} {...(idx === lastAgentIdx ? { 'data-last-agent': '' } : {})}>
                   {(turn.thinkingMessages.length > 0 || hasStreaming) && (
                     <ThinkingBox
                       messages={turn.thinkingMessages}

--- a/packages/arm/web/src/components/layout/SettingsPanel.tsx
+++ b/packages/arm/web/src/components/layout/SettingsPanel.tsx
@@ -165,7 +165,7 @@ export function SettingsPanel({ open, onClose, inline, className }: { open: bool
           About
         </h3>
         <div className="space-y-1 text-xs text-text-secondary">
-          <p>Client version: {version}</p>
+          <p>Client version: {version}{isBeta ? '-beta' : ''}</p>
           {relayVersion && <p>Relay version: {relayVersion}</p>}
           <p>Agent-agnostic relay for AI coding agents</p>
         </div>

--- a/packages/arm/web/src/components/layout/SettingsPanel.tsx
+++ b/packages/arm/web/src/components/layout/SettingsPanel.tsx
@@ -3,16 +3,19 @@ import { useTheme } from '../../hooks/useTheme';
 import { useStore } from '../../hooks/useStore';
 import { wsClient } from '../../lib/ws-client';
 import { isPushSupported, isPushSubscribed, subscribeToPush, unsubscribeFromPush, getPushPermission } from '../../lib/push';
+import { getCurrentChannel, setChannel } from '../../lib/auth';
 import { version } from '../../../package.json';
 
 export function SettingsPanel({ open, onClose, inline, className }: { open: boolean; onClose: () => void; inline?: boolean; className?: string }) {
   const { isDark, toggleDark } = useTheme();
   const relayVersion = useStore((s) => s.relayVersion);
   const vapidPublicKey = useStore((s) => s.vapidPublicKey);
+  const isInternal = useStore((s) => s.user?.preferences?.internal === true);
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushLoading, setPushLoading] = useState(false);
   const pushSupported = isPushSupported();
   const pushDenied = getPushPermission() === 'denied';
+  const isBeta = getCurrentChannel() === 'beta';
 
   // Check current push subscription state on mount
   useEffect(() => {
@@ -106,6 +109,38 @@ export function SettingsPanel({ open, onClose, inline, className }: { open: bool
               <span
                 className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
                   pushEnabled && !pushDenied ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+        </section>
+      )}
+
+      {isInternal && (
+        <section>
+          <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+            Dogfood
+          </h3>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-text-primary">Beta channel</p>
+              <p className="text-[11px] text-text-muted">
+                {isBeta ? 'Using latest unreleased build' : 'Switch to unreleased builds'}
+              </p>
+            </div>
+            <button
+              onClick={() => {
+                const next = isBeta ? 'stable' : 'beta';
+                wsClient.updatePreferences({ channel: next });
+                setChannel(next);
+              }}
+              className={`relative h-6 w-11 rounded-full transition-colors ${
+                isBeta ? 'bg-amber-500' : 'bg-slate-300'
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                  isBeta ? 'translate-x-5' : 'translate-x-0'
                 }`}
               />
             </button>

--- a/packages/arm/web/src/lib/auth.ts
+++ b/packages/arm/web/src/lib/auth.ts
@@ -160,4 +160,27 @@ export function applyPreferences(prefs: Record<string, unknown> | undefined): vo
   if (typeof prefs.theme === 'string' && ['light', 'dark', 'system'].includes(prefs.theme)) {
     setTheme(prefs.theme as 'light' | 'dark' | 'system');
   }
+  // Channel switching: set cookie so nginx serves the correct build
+  if (typeof prefs.channel === 'string' && /^[a-z]+$/.test(prefs.channel)) {
+    const current = getCurrentChannel();
+    if (prefs.channel !== current) {
+      setChannelCookie(prefs.channel);
+      window.location.reload();
+    }
+  }
+}
+
+/** Read the current release channel from the cookie. */
+export function getCurrentChannel(): string {
+  return document.cookie.match(/(?:^|; )kraki_channel=([a-z]+)/)?.[1] ?? 'stable';
+}
+
+/** Set the release channel cookie and reload to pick up the new build. */
+export function setChannel(channel: string): void {
+  setChannelCookie(channel);
+  window.location.reload();
+}
+
+function setChannelCookie(channel: string): void {
+  document.cookie = `kraki_channel=${channel};path=/;max-age=${365 * 86400};SameSite=Lax`;
 }

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -369,7 +369,17 @@ class MessageProvider {
       getStore().prependMessages(sessionId, messages);
       processReplayedActions(sessionId, messages);
       if (initial) {
+        const existingPreview = getStore().sessionPreviews.get(sessionId);
         rebuildPreview(sessionId);
+        // Preserve the existing preview timestamp if it's newer than the rebuilt one.
+        // This keeps forked sessions showing their fork time instead of the source
+        // session's last message time.
+        if (existingPreview) {
+          const rebuilt = getStore().sessionPreviews.get(sessionId);
+          if (rebuilt && existingPreview.timestamp > rebuilt.timestamp) {
+            getStore().setSessionPreview(sessionId, { ...rebuilt, timestamp: existingPreview.timestamp });
+          }
+        }
       }
     }
     logger.info('delivered', { sessionId, count: messages.length, initial });

--- a/packages/arm/web/src/main.tsx
+++ b/packages/arm/web/src/main.tsx
@@ -8,6 +8,19 @@ import { DevicesPage } from './pages/DevicesPage';
 import { useTheme } from './hooks/useTheme';
 import './index.css';
 
+// Self-service channel switch: ?channel=beta or ?channel=stable
+// Sets cookie and reloads before React mounts.
+(function handleChannelParam() {
+  const params = new URLSearchParams(window.location.search);
+  const channel = params.get('channel');
+  if (channel && /^[a-z]+$/.test(channel)) {
+    document.cookie = `kraki_channel=${channel};path=/;max-age=${365 * 86400};SameSite=Lax`;
+    params.delete('channel');
+    const clean = params.toString();
+    window.location.replace(window.location.pathname + (clean ? `?${clean}` : ''));
+  }
+})();
+
 function Root() {
   useTheme();
   return (


### PR DESCRIPTION
## Summary

Cookie-based channel routing to serve different web app builds from the same URL. Internal users can toggle between stable and beta builds via Settings, keeping a single PWA install.

## How it works

- **nginx** reads a `kraki_channel` cookie to pick the document root
- **Settings toggle** (visible when `preferences.internal === true`): flips the cookie + persists to relay preferences
- **URL param** (`?channel=beta`): self-service opt-in, sets cookie before React mounts
- **Relay-driven**: `applyPreferences()` syncs channel from `auth_ok` / `preferences_updated`
- **Version badge**: shows `x.x.x-beta` suffix when on beta channel

## Deploy pipeline changes

- **Beta**: deploys eagerly on every CI pass on main (no version bump gate)
- **Production**: manual `workflow_dispatch` only (select target: production)

## Server setup (already done)

- nginx `map` directive added for cookie routing
- `/var/www/kraki-beta` directory created
- GitHub `beta` environment created with deploy vars + SSH key