### PR TITLE
feat: import local Copilot sessions

### DIFF
--- a/packages/arm/web/e2e/import-session.spec.ts
+++ b/packages/arm/web/e2e/import-session.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, type Page } from '@playwright/test';
+import { MockRelayServer } from './helpers/mock-ws-server';
+import type { WebSocket } from 'ws';
+
+const DEVICE_ID = 'tentacle-1';
+const TEST_DEVICE = {
+  id: DEVICE_ID, name: 'MacBook Pro', role: 'tentacle', kind: 'desktop', online: true,
+};
+
+const MOCK_LOCAL_SESSIONS = [
+  {
+    sessionId: 'abc-hermit', cwd: '/Users/test/Repos/hermit',
+    gitRoot: '/Users/test/Repos/hermit', repository: 'corelli18512/hermit',
+    branch: 'main', summary: 'Set Up Playwright E2E Tests',
+    startTime: '2026-04-17T01:00:00Z', modifiedTime: '2026-04-17T03:55:00Z',
+    isLive: true, source: 'copilot-cli',
+  },
+  {
+    sessionId: 'def-hermit', cwd: '/Users/test/Repos/hermit',
+    gitRoot: '/Users/test/Repos/hermit', repository: 'corelli18512/hermit',
+    branch: 'main', summary: 'Fix auth token refresh',
+    startTime: '2026-04-16T10:00:00Z', modifiedTime: '2026-04-16T12:30:00Z',
+    isLive: false, source: 'copilot-cli',
+  },
+  {
+    sessionId: 'kraki-001', cwd: '/Users/test/Repos/kraki',
+    gitRoot: '/Users/test/Repos/kraki', repository: 'corelli18512/kraki',
+    branch: 'main', summary: 'Debug Install Failure',
+    startTime: '2026-04-17T02:00:00Z', modifiedTime: '2026-04-17T03:50:00Z',
+    isLive: true, source: 'copilot-cli',
+  },
+  {
+    sessionId: 'kraki-002', cwd: '/Users/test/Repos/kraki',
+    gitRoot: '/Users/test/Repos/kraki', repository: 'corelli18512/kraki',
+    branch: 'feat/sync', summary: 'Plan local session sync',
+    startTime: '2026-04-17T01:30:00Z', modifiedTime: '2026-04-17T02:30:00Z',
+    isLive: false, source: 'copilot-cli',
+  },
+  {
+    sessionId: 'vscode-001', cwd: '/Users/test/Repos/Stitch',
+    gitRoot: '/Users/test/Repos/Stitch', branch: 'main',
+    summary: 'Resolve ADB Multiple Devices',
+    startTime: '2026-04-14T10:00:00Z', modifiedTime: '2026-04-14T11:00:00Z',
+    isLive: false, source: 'vscode',
+  },
+  {
+    sessionId: 'home-001', cwd: '/Users/test',
+    summary: 'Fix BlackHole Audio Routing',
+    startTime: '2026-04-13T15:00:00Z', modifiedTime: '2026-04-13T16:00:00Z',
+    isLive: false, source: 'copilot-cli',
+  },
+];
+
+async function setup(page: Page, server: MockRelayServer): Promise<WebSocket> {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`/?relay=${encodeURIComponent(server.url)}`);
+
+  const ws = await server.waitForConnection();
+  await server.waitForMessage(ws);
+  server.sendAuthOk(ws, { devices: [TEST_DEVICE] } as Record<string, unknown>);
+  await server.waitForMessage(ws);
+
+  // Seed one native session so sidebar shows session list header with import button
+  server.sendMessage(ws, {
+    type: 'session_list',
+    payload: {
+      sessions: [{
+        id: 'native-1', agent: 'copilot', model: 'claude-sonnet-4',
+        state: 'idle', mode: 'discuss', lastSeq: 5, readSeq: 5,
+        messageCount: 5, createdAt: '2026-04-17T00:00:00Z',
+      }],
+    },
+  });
+
+  await expect(page.locator('button[title="Import local session"]').first()).toBeVisible({ timeout: 8000 });
+  return ws;
+}
+
+/**
+ * Open the import dialog and push sessions from the server.
+ *
+ * The client sends request_local_sessions encrypted (which the mock relay
+ * can't decode), so we push local_sessions_list proactively after a
+ * short delay to simulate the tentacle responding.
+ */
+async function openImportAndLoad(page: Page, ws: WebSocket, server: MockRelayServer): Promise<void> {
+  await page.locator('button[title="Import local session"]').first().click();
+  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
+
+  // Push sessions from server (simulates tentacle response)
+  server.sendMessage(ws, {
+    type: 'local_sessions_list',
+    payload: { sessions: MOCK_LOCAL_SESSIONS },
+  });
+
+  await expect(page.getByRole('dialog').getByText('hermit')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Import Session Feature', () => {
+  let server: MockRelayServer;
+  test.beforeEach(async () => { server = await MockRelayServer.create(); });
+  test.afterEach(async () => { await server.close(); });
+
+  test('shows import button, opens dialog with loading, renders tree', async ({ page }) => {
+    const ws = await setup(page, server);
+
+    // Screenshot 1: session list with import button visible
+    await page.screenshot({ path: 'e2e-1-session-list.png' });
+
+    // Open dialog — shows loading
+    await page.locator('button[title="Import local session"]').first().click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('dialog').getByText('Scanning local sessions')).toBeVisible({ timeout: 2000 });
+
+    // Screenshot 2: loading state
+    await page.screenshot({ path: 'e2e-2-import-loading.png' });
+
+    // Push sessions from server
+    server.sendMessage(ws, {
+      type: 'local_sessions_list',
+      payload: { sessions: MOCK_LOCAL_SESSIONS },
+    });
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('hermit')).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('kraki')).toBeVisible();
+    await expect(dialog.getByText('6 local sessions')).toBeVisible();
+
+    // Screenshot 3: tree view with folder groups
+    await page.screenshot({ path: 'e2e-3-import-tree.png' });
+
+    // Expand hermit folder
+    await dialog.getByText('hermit').first().click();
+    await expect(dialog.getByText('Set Up Playwright E2E Tests')).toBeVisible({ timeout: 3000 });
+    await expect(dialog.getByText('Fix auth token refresh')).toBeVisible();
+
+    // Screenshot 4: expanded folder with sessions
+    await page.screenshot({ path: 'e2e-4-expanded-folder.png' });
+  });
+
+  test('search filters sessions across folders', async ({ page }) => {
+    const ws = await setup(page, server);
+    await openImportAndLoad(page, ws, server);
+
+    // Type search
+    await page.getByPlaceholder('Search sessions…').fill('kraki');
+    await expect(page.getByRole('dialog').getByText('2 of 6')).toBeVisible({ timeout: 3000 });
+
+    // Screenshot 5: filtered results
+    await page.screenshot({ path: 'e2e-5-search-filtered.png' });
+  });
+
+  test('import session: spinner then success', async ({ page }) => {
+    const ws = await setup(page, server);
+    await openImportAndLoad(page, ws, server);
+
+    // Expand hermit and click import
+    await page.getByRole('dialog').getByText('hermit').first().click();
+    await expect(page.getByRole('dialog').getByText('Set Up Playwright E2E Tests')).toBeVisible({ timeout: 3000 });
+    await page.getByRole('dialog').locator('button[title="Import session"]').first().click();
+
+    // Screenshot 6: spinner on import button
+    await page.screenshot({ path: 'e2e-6-import-spinner.png' });
+
+    // Simulate session_created from tentacle (broadcast, no encryption)
+    server.sendMessage(ws, {
+      type: 'session_created',
+      sessionId: 'abc-hermit',
+      payload: { agent: 'copilot', model: 'claude-sonnet-4', lastSeq: 47 },
+    });
+
+    // Wait for session to appear in store → checkmark replaces spinner
+    await page.waitForTimeout(600);
+
+    // Screenshot 7: checkmark on imported session
+    await page.screenshot({ path: 'e2e-7-import-success.png' });
+
+    // Close dialog
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    // Screenshot 8: imported session visible in sidebar
+    await page.screenshot({ path: 'e2e-8-imported-in-list.png' });
+  });
+});

--- a/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
+++ b/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
@@ -97,21 +97,38 @@ function buildGroups(sessions: LocalSession[]): SessionGroup[] {
 
 const INITIAL_SHOW = 5;
 
-function GroupSection({ group, importingIds, onImport }: {
+/** Highlight matching substring in text. */
+function Highlight({ text, query }: { text: string; query: string }) {
+  if (!query || !text) return <>{text}</>;
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-kraki-500/20 text-inherit rounded-sm px-0.5">{text.slice(idx, idx + query.length)}</mark>
+      {text.slice(idx + query.length)}
+    </>
+  );
+}
+
+function GroupSection({ group, importingIds, onImport, search }: {
   group: SessionGroup;
   importingIds: Set<string>;
   onImport: (sessionId: string) => void;
+  search: string;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const autoExpand = search.length > 0;
+  const [manualExpanded, setManualExpanded] = useState(false);
+  const expanded = autoExpand || manualExpanded;
   const [showAll, setShowAll] = useState(false);
   const hasGit = group.sessions.some(s => s.gitRoot);
-  const visible = expanded ? (showAll ? group.sessions : group.sessions.slice(0, INITIAL_SHOW)) : [];
-  const hasMore = expanded && !showAll && group.sessions.length > INITIAL_SHOW;
+  const visible = expanded ? (showAll || autoExpand ? group.sessions : group.sessions.slice(0, INITIAL_SHOW)) : [];
+  const hasMore = expanded && !showAll && !autoExpand && group.sessions.length > INITIAL_SHOW;
 
   return (
     <div className="mb-1">
       <button
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setManualExpanded(!manualExpanded)}
         className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-surface-tertiary"
       >
         {expanded
@@ -120,7 +137,7 @@ function GroupSection({ group, importingIds, onImport }: {
         }
         {groupIcon(group.path, hasGit)}
         <span className="min-w-0 flex-1 truncate text-sm font-medium text-text-primary">
-          {group.label}
+          <Highlight text={group.label} query={search} />
         </span>
         {group.liveCount > 0 && (
           <span className="flex items-center gap-1 text-[10px] text-emerald-500">
@@ -141,6 +158,7 @@ function GroupSection({ group, importingIds, onImport }: {
           session={session}
           importing={importingIds.has(session.sessionId)}
           onImport={() => onImport(session.sessionId)}
+          search={search}
         />
       ))}
 
@@ -156,12 +174,14 @@ function GroupSection({ group, importingIds, onImport }: {
   );
 }
 
-function SessionRow({ session, importing, onImport }: {
+function SessionRow({ session, importing, onImport, search }: {
   session: LocalSession;
   importing: boolean;
   onImport: () => void;
+  search: string;
 }) {
   const isLinked = !!session.linkedKrakiSessionId;
+  const displayText = session.summary ?? session.sessionId.slice(0, 12);
 
   return (
     <div className="ml-5 flex items-center gap-2 rounded-lg px-2.5 py-1.5 hover:bg-surface-secondary transition-colors">
@@ -169,11 +189,11 @@ function SessionRow({ session, importing, onImport }: {
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1">
           <span className="truncate text-xs text-text-primary">
-            {session.summary ?? session.sessionId.slice(0, 12)}
+            <Highlight text={displayText} query={search} />
           </span>
           {session.branch && (
             <span className="shrink-0 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-[9px] text-text-muted">
-              {session.branch}
+              <Highlight text={session.branch} query={search} />
             </span>
           )}
         </div>
@@ -370,6 +390,7 @@ export function ImportSessionDialog({ open, onClose }: Props) {
                 group={group}
                 importingIds={importingIds}
                 onImport={handleImport}
+                search={search}
               />
             ))
           )}

--- a/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
+++ b/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
@@ -55,13 +55,34 @@ function buildGroups(sessions: LocalSession[]): SessionGroup[] {
       return b.modifiedTime.localeCompare(a.modifiedTime);
     });
     groups.push({
-      label: repo ? repo.split('/').pop() ?? groupLabel(path) : groupLabel(path),
+      label: '', // filled below after dedup
       path,
       repository: repo,
       branches,
       sessions: items,
       liveCount,
     });
+  }
+
+  // Disambiguate labels: use repo short name, then last path component,
+  // and add parent dir if there are collisions
+  const labelCounts = new Map<string, number>();
+  for (const g of groups) {
+    const base = g.repository ? g.repository.split('/').pop()! : groupLabel(g.path);
+    g.label = base;
+    labelCounts.set(base, (labelCounts.get(base) ?? 0) + 1);
+  }
+  for (const g of groups) {
+    if ((labelCounts.get(g.label) ?? 0) > 1) {
+      // Disambiguate with branch info or path suffix
+      const branchHint = g.branches.length === 1 ? g.branches[0] : '';
+      const pathSuffix = g.path.replace(/^.*\/Repos\//, '').replace(/^.*\/Documents\//, '');
+      if (branchHint && branchHint !== 'main') {
+        g.label = `${g.label} (${branchHint})`;
+      } else if (pathSuffix !== g.label && pathSuffix.length > 0) {
+        g.label = pathSuffix;
+      }
+    }
   }
 
   // Sort groups: most recent activity first
@@ -181,17 +202,26 @@ function SessionRow({ session, importing, onImport }: {
 export function ImportSessionDialog({ open, onClose }: Props) {
   const localSessions = useStore(s => s.localSessions);
   const loading = useStore(s => s.localSessionsLoading);
+  const devices = useStore(s => s.devices);
   const [search, setSearch] = useState('');
   const [importingIds, setImportingIds] = useState<Set<string>>(new Set());
 
+  // Pick the first online tentacle as the target device
+  const tentacle = useMemo(() => {
+    for (const [, d] of devices) {
+      if (d.role === 'tentacle' && d.online) return d;
+    }
+    return undefined;
+  }, [devices]);
+
   // Request sessions when dialog opens
   useEffect(() => {
-    if (open) {
-      wsClient.requestLocalSessions();
+    if (open && tentacle) {
+      wsClient.requestLocalSessions(tentacle.id);
       setSearch('');
       setImportingIds(new Set());
     }
-  }, [open]);
+  }, [open, tentacle?.id]);
 
   // Client-side search filter
   const filtered = useMemo(() => {
@@ -208,9 +238,10 @@ export function ImportSessionDialog({ open, onClose }: Props) {
   const totalCount = localSessions.length;
 
   const handleImport = useCallback((sessionId: string) => {
+    if (!tentacle) return;
     setImportingIds(prev => new Set(prev).add(sessionId));
-    wsClient.importSession(sessionId);
-  }, []);
+    wsClient.importSession(sessionId, tentacle.id);
+  }, [tentacle?.id]);
 
   // Mark as linked when session appears in main sessions list
   const sessions = useStore(s => s.sessions);

--- a/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
+++ b/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
@@ -1,0 +1,322 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useStore } from '../../hooks/useStore';
+import { wsClient } from '../../lib/ws-client';
+import { sessionTime } from '../../lib/format';
+import type { LocalSession } from '@kraki/protocol';
+import { Download, Search, ChevronRight, ChevronDown, Loader2, Check, Plus, FolderGit2, Folder, Home, Monitor } from 'lucide-react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface SessionGroup {
+  label: string;
+  path: string;
+  repository?: string;
+  branches: string[];
+  sessions: LocalSession[];
+  liveCount: number;
+}
+
+function groupLabel(path: string): string {
+  if (path === '/' || path === '') return 'System';
+  const home = '~';
+  if (path === home || path === '/Users' || path.match(/^\/Users\/[^/]+$/)) return 'Home';
+  // Extract last path component
+  const parts = path.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+function groupIcon(path: string, hasGit: boolean) {
+  if (path === '/' || path === '') return <Monitor className="h-4 w-4 text-text-muted" />;
+  const home = '~';
+  if (path === home || path.match(/^\/Users\/[^/]+$/)) return <Home className="h-4 w-4 text-text-muted" />;
+  if (hasGit) return <FolderGit2 className="h-4 w-4 text-text-muted" />;
+  return <Folder className="h-4 w-4 text-text-muted" />;
+}
+
+function buildGroups(sessions: LocalSession[]): SessionGroup[] {
+  const map = new Map<string, LocalSession[]>();
+  for (const s of sessions) {
+    const key = s.gitRoot ?? s.cwd;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(s);
+  }
+
+  const groups: SessionGroup[] = [];
+  for (const [path, items] of map) {
+    const branches = [...new Set(items.map(s => s.branch).filter(Boolean) as string[])].sort();
+    const repo = items.find(s => s.repository)?.repository;
+    const liveCount = items.filter(s => s.isLive).length;
+    // Sort: live first, then by modifiedTime desc
+    items.sort((a, b) => {
+      if (a.isLive !== b.isLive) return a.isLive ? -1 : 1;
+      return b.modifiedTime.localeCompare(a.modifiedTime);
+    });
+    groups.push({
+      label: repo ? repo.split('/').pop() ?? groupLabel(path) : groupLabel(path),
+      path,
+      repository: repo,
+      branches,
+      sessions: items,
+      liveCount,
+    });
+  }
+
+  // Sort groups: most recent activity first
+  groups.sort((a, b) => {
+    const aTime = a.sessions[0]?.modifiedTime ?? '';
+    const bTime = b.sessions[0]?.modifiedTime ?? '';
+    return bTime.localeCompare(aTime);
+  });
+
+  return groups;
+}
+
+const INITIAL_SHOW = 5;
+
+function GroupSection({ group, importingIds, onImport }: {
+  group: SessionGroup;
+  importingIds: Set<string>;
+  onImport: (sessionId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  const hasGit = group.sessions.some(s => s.gitRoot);
+  const visible = expanded ? (showAll ? group.sessions : group.sessions.slice(0, INITIAL_SHOW)) : [];
+  const hasMore = expanded && !showAll && group.sessions.length > INITIAL_SHOW;
+
+  return (
+    <div className="mb-1">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-surface-tertiary"
+      >
+        {expanded
+          ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+          : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+        }
+        {groupIcon(group.path, hasGit)}
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-text-primary">
+          {group.label}
+        </span>
+        {group.liveCount > 0 && (
+          <span className="flex items-center gap-1 text-[10px] text-emerald-500">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+            {group.liveCount}
+          </span>
+        )}
+        <span className="text-[11px] text-text-muted">{group.sessions.length}</span>
+      </button>
+
+      {expanded && group.repository && (
+        <div className="ml-9 mb-1 text-[10px] text-text-muted truncate">{group.repository}</div>
+      )}
+
+      {visible.map(session => (
+        <SessionRow
+          key={session.sessionId}
+          session={session}
+          importing={importingIds.has(session.sessionId)}
+          onImport={() => onImport(session.sessionId)}
+        />
+      ))}
+
+      {hasMore && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="ml-9 mt-0.5 text-[11px] text-kraki-500 hover:text-kraki-400 transition-colors"
+        >
+          Show {group.sessions.length - INITIAL_SHOW} more…
+        </button>
+      )}
+    </div>
+  );
+}
+
+function SessionRow({ session, importing, onImport }: {
+  session: LocalSession;
+  importing: boolean;
+  onImport: () => void;
+}) {
+  const isLinked = !!session.linkedKrakiSessionId;
+
+  return (
+    <div className="ml-5 flex items-center gap-2 rounded-lg px-2.5 py-1.5 hover:bg-surface-secondary transition-colors">
+      <span className={`h-2 w-2 shrink-0 rounded-full ${session.isLive ? 'bg-emerald-400' : 'bg-slate-400/40'}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1">
+          <span className="truncate text-xs text-text-primary">
+            {session.summary ?? session.sessionId.slice(0, 12)}
+          </span>
+          {session.branch && (
+            <span className="shrink-0 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-[9px] text-text-muted">
+              {session.branch}
+            </span>
+          )}
+        </div>
+        <span className="text-[10px] text-text-muted">
+          {session.modifiedTime ? sessionTime(session.modifiedTime) : ''}
+          {session.model && ` · ${session.model}`}
+        </span>
+      </div>
+      {isLinked ? (
+        <Check className="h-4 w-4 shrink-0 text-emerald-500" />
+      ) : importing ? (
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-kraki-500" />
+      ) : (
+        <button
+          onClick={onImport}
+          title="Import session"
+          className="shrink-0 rounded-md p-1 text-text-muted transition-colors hover:bg-surface-tertiary hover:text-kraki-500"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function ImportSessionDialog({ open, onClose }: Props) {
+  const localSessions = useStore(s => s.localSessions);
+  const loading = useStore(s => s.localSessionsLoading);
+  const [search, setSearch] = useState('');
+  const [importingIds, setImportingIds] = useState<Set<string>>(new Set());
+
+  // Request sessions when dialog opens
+  useEffect(() => {
+    if (open) {
+      wsClient.requestLocalSessions();
+      setSearch('');
+      setImportingIds(new Set());
+    }
+  }, [open]);
+
+  // Client-side search filter
+  const filtered = useMemo(() => {
+    if (!search) return localSessions;
+    const q = search.toLowerCase();
+    return localSessions.filter(s => {
+      const haystack = [s.cwd, s.gitRoot, s.repository, s.branch, s.summary, s.sessionId]
+        .filter(Boolean).join(' ').toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [localSessions, search]);
+
+  const groups = useMemo(() => buildGroups(filtered), [filtered]);
+  const totalCount = localSessions.length;
+
+  const handleImport = useCallback((sessionId: string) => {
+    setImportingIds(prev => new Set(prev).add(sessionId));
+    wsClient.importSession(sessionId);
+  }, []);
+
+  // Mark as linked when session appears in main sessions list
+  const sessions = useStore(s => s.sessions);
+  useEffect(() => {
+    if (importingIds.size === 0) return;
+    const next = new Set(importingIds);
+    let changed = false;
+    for (const id of importingIds) {
+      if (sessions.has(id)) {
+        next.delete(id);
+        changed = true;
+      }
+    }
+    if (changed) setImportingIds(next);
+  }, [sessions, importingIds]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm md:items-center"
+      onClick={onClose}
+      onKeyDown={(e) => e.key === 'Escape' && onClose()}
+      role="dialog"
+      aria-modal="true"
+      tabIndex={-1}
+    >
+      <div
+        className="flex max-h-[85dvh] w-full flex-col rounded-t-2xl border border-border-primary bg-surface-primary shadow-2xl md:mx-4 md:max-w-lg md:rounded-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex shrink-0 items-center justify-between border-b border-border-primary px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Download className="h-4 w-4 text-kraki-500" />
+            <h2 className="text-base font-semibold text-text-primary">Import Session</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-text-muted transition-colors hover:bg-surface-tertiary hover:text-text-primary"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="shrink-0 border-b border-border-primary px-4 py-2">
+          <div className="flex items-center gap-2 rounded-lg bg-surface-secondary px-3 py-1.5">
+            <Search className="h-4 w-4 shrink-0 text-text-muted" />
+            <input
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search sessions…"
+              className="min-w-0 flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none"
+              autoFocus
+            />
+            {search && (
+              <button onClick={() => setSearch('')} className="text-text-muted hover:text-text-primary">
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-kraki-500" />
+              <p className="mt-2 text-sm text-text-muted">Scanning local sessions…</p>
+            </div>
+          ) : groups.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12">
+              <p className="text-sm text-text-secondary">
+                {search ? 'No sessions match your search' : 'No local sessions found'}
+              </p>
+              <p className="mt-1 text-xs text-text-muted">
+                {search ? 'Try a different search term' : 'Run copilot in your terminal to create sessions'}
+              </p>
+            </div>
+          ) : (
+            groups.map(group => (
+              <GroupSection
+                key={group.path}
+                group={group}
+                importingIds={importingIds}
+                onImport={handleImport}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        {!loading && totalCount > 0 && (
+          <div className="shrink-0 border-t border-border-primary px-4 py-2 text-center text-[11px] text-text-muted">
+            {search && filtered.length !== totalCount
+              ? `${filtered.length} of ${totalCount} local sessions`
+              : `${totalCount} local sessions`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
+++ b/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
@@ -199,29 +199,46 @@ function SessionRow({ session, importing, onImport }: {
   );
 }
 
+const LAST_IMPORT_DEVICE_KEY = 'kraki:last-import-device';
+
 export function ImportSessionDialog({ open, onClose }: Props) {
   const localSessions = useStore(s => s.localSessions);
   const loading = useStore(s => s.localSessionsLoading);
   const devices = useStore(s => s.devices);
   const [search, setSearch] = useState('');
   const [importingIds, setImportingIds] = useState<Set<string>>(new Set());
+  const [selectedDevice, setSelectedDevice] = useState('');
 
-  // Pick the first online tentacle as the target device
-  const tentacle = useMemo(() => {
-    for (const [, d] of devices) {
-      if (d.role === 'tentacle' && d.online) return d;
-    }
-    return undefined;
-  }, [devices]);
+  const tentacles = useMemo(
+    () => [...devices.values()].filter(d => d.role === 'tentacle' && d.online),
+    [devices],
+  );
 
-  // Request sessions when dialog opens
+  // Default to last selected device, or first tentacle
   useEffect(() => {
-    if (open && tentacle) {
-      wsClient.requestLocalSessions(tentacle.id);
+    if (!open) return;
+    const lastId = localStorage.getItem(LAST_IMPORT_DEVICE_KEY);
+    const lastOnline = tentacles.find(d => d.id === lastId);
+    if (lastOnline) {
+      setSelectedDevice(lastOnline.id);
+    } else if (tentacles.length >= 1) {
+      setSelectedDevice(tentacles[0].id);
+    }
+  }, [open, tentacles.length]);
+
+  // Request sessions when dialog opens or device changes
+  useEffect(() => {
+    if (open && selectedDevice) {
+      wsClient.requestLocalSessions(selectedDevice);
       setSearch('');
       setImportingIds(new Set());
     }
-  }, [open, tentacle?.id]);
+  }, [open, selectedDevice]);
+
+  const handleSelectDevice = (id: string) => {
+    setSelectedDevice(id);
+    localStorage.setItem(LAST_IMPORT_DEVICE_KEY, id);
+  };
 
   // Client-side search filter
   const filtered = useMemo(() => {
@@ -238,25 +255,22 @@ export function ImportSessionDialog({ open, onClose }: Props) {
   const totalCount = localSessions.length;
 
   const handleImport = useCallback((sessionId: string) => {
-    if (!tentacle) return;
+    if (!selectedDevice) return;
     setImportingIds(prev => new Set(prev).add(sessionId));
-    wsClient.importSession(sessionId, tentacle.id);
-  }, [tentacle?.id]);
+    wsClient.importSession(sessionId, selectedDevice);
+  }, [selectedDevice]);
 
-  // Mark as linked when session appears in main sessions list
+  // Dismiss dialog when import succeeds (session appears in main store)
   const sessions = useStore(s => s.sessions);
   useEffect(() => {
     if (importingIds.size === 0) return;
-    const next = new Set(importingIds);
-    let changed = false;
     for (const id of importingIds) {
       if (sessions.has(id)) {
-        next.delete(id);
-        changed = true;
+        onClose();
+        return;
       }
     }
-    if (changed) setImportingIds(next);
-  }, [sessions, importingIds]);
+  }, [sessions, importingIds, onClose]);
 
   if (!open) return null;
 
@@ -310,6 +324,28 @@ export function ImportSessionDialog({ open, onClose }: Props) {
             )}
           </div>
         </div>
+
+        {/* Device picker — shown when multiple tentacles are online */}
+        {tentacles.length > 1 && (
+          <div className="shrink-0 border-b border-border-primary px-4 py-2">
+            <div className="flex flex-wrap gap-1.5">
+              {tentacles.map((d) => (
+                <button
+                  key={d.id}
+                  onClick={() => handleSelectDevice(d.id)}
+                  className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                    selectedDevice === d.id
+                      ? 'bg-kraki-500 text-white'
+                      : 'bg-surface-tertiary text-text-secondary hover:bg-surface-tertiary/80 hover:text-text-primary'
+                  }`}
+                >
+                  <span className={`h-1.5 w-1.5 rounded-full ${d.online ? 'bg-emerald-400' : 'bg-slate-400'}`} />
+                  {d.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Content */}
         <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">

--- a/packages/arm/web/src/components/sessions/SessionCard.tsx
+++ b/packages/arm/web/src/components/sessions/SessionCard.tsx
@@ -137,6 +137,11 @@ export function SessionCard({ session, pinned, openSwipeId, setOpenSwipeId }: Se
             {session.model && (
               <span className="text-[10px] text-text-muted">{session.model}</span>
             )}
+            {session.source && session.source !== 'kraki' && (
+              <span className="shrink-0 rounded-full bg-kraki-500/10 px-1.5 py-0.5 text-[9px] font-medium text-kraki-600 dark:text-kraki-400">
+                {session.source === 'copilot-cli' ? 'imported' : session.source === 'vscode' ? 'VS Code' : 'imported'}
+              </span>
+            )}
           </div>
           <p className="mt-0.5 truncate text-[11px] text-text-secondary">
             {draft && !isActive ? (

--- a/packages/arm/web/src/components/sessions/SessionList.tsx
+++ b/packages/arm/web/src/components/sessions/SessionList.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useStore } from '../../hooks/useStore';
 import { SessionCard } from './SessionCard';
 import { NewSessionDialog } from './NewSessionDialog';
+import { ImportSessionDialog } from './ImportSessionDialog';
+import { Download } from 'lucide-react';
 
 export function SessionList() {
   const sessions = useStore((s) => s.sessions);
@@ -9,6 +11,7 @@ export function SessionList() {
   const sessionPreviews = useStore((s) => s.sessionPreviews);
   const devices = useStore((s) => s.devices);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [openSwipeId, setOpenSwipeId] = useState<string | null>(null);
 
   const hasTentacle = [...devices.values()].some((d) => d.role === 'tentacle' && d.online);
@@ -39,20 +42,32 @@ export function SessionList() {
               ? 'Start a coding agent on your connected device'
               : 'Connect an agent via tentacle to get started'}
           </p>
-          {hasTentacle ? (
-            <button
-              onClick={() => setDialogOpen(true)}
-              className="mt-3 rounded-lg bg-kraki-500 px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-kraki-600"
-            >
-              + New Session
-            </button>
-          ) : (
+          {hasTentacle && (
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                onClick={() => setDialogOpen(true)}
+                className="rounded-lg bg-kraki-500 px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-kraki-600"
+              >
+                + New Session
+              </button>
+              <button
+                onClick={() => setImportOpen(true)}
+                title="Import local session"
+                className="rounded-lg border border-border-primary bg-surface-secondary px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary"
+              >
+                <Download className="inline h-3.5 w-3.5 -mt-0.5 mr-1" />
+                Import
+              </button>
+            </div>
+          )}
+          {!hasTentacle && (
             <code className="mt-3 rounded bg-surface-tertiary px-2.5 py-1 text-[11px] text-text-secondary">
               npx @kraki/tentacle
             </code>
           )}
         </div>
         <NewSessionDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
+        <ImportSessionDialog open={importOpen} onClose={() => setImportOpen(false)} />
       </>
     );
   }
@@ -67,15 +82,26 @@ export function SessionList() {
           <h3 className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
             Sessions
           </h3>
-          <button
-            onClick={() => setDialogOpen(true)}
-            title="New session"
-            className="rounded p-0.5 text-text-muted transition-colors hover:bg-surface-tertiary hover:text-text-primary"
-          >
-            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-            </svg>
-          </button>
+          <div className="flex items-center gap-0.5">
+            {hasTentacle && (
+              <button
+                onClick={() => setImportOpen(true)}
+                title="Import local session"
+                className="rounded p-0.5 text-text-muted transition-colors hover:bg-surface-tertiary hover:text-text-primary"
+              >
+                <Download className="h-3.5 w-3.5" />
+              </button>
+            )}
+            <button
+              onClick={() => setDialogOpen(true)}
+              title="New session"
+              className="rounded p-0.5 text-text-muted transition-colors hover:bg-surface-tertiary hover:text-text-primary"
+            >
+              <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+              </svg>
+            </button>
+          </div>
         </div>
       {pinnedList.length > 0 && (
         <div className="mb-1 space-y-1">
@@ -91,6 +117,7 @@ export function SessionList() {
       </div>
     </div>
     <NewSessionDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
+    <ImportSessionDialog open={importOpen} onClose={() => setImportOpen(false)} />
   </>
   );
 }

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -67,6 +67,8 @@ const initialState = {
   sessionUsage: new Map<string, import('@kraki/protocol').SessionUsage>(),
   sessionPreviews: new Map<string, import('../types/store').SessionPreview>(),
   loadingSessions: new Set<string>(),
+  localSessions: [],
+  localSessionsLoading: false,
 };
 
 export const useStore = create<Store>()(persist((set) => ({
@@ -359,6 +361,10 @@ export const useStore = create<Store>()(persist((set) => ({
       }
       return { loadingSessions: next };
     }),
+
+  setLocalSessions: (sessions) => set({ localSessions: sessions }),
+
+  setLocalSessionsLoading: (loading) => set({ localSessionsLoading: loading }),
 
   prependMessages: (sessionId, older) => {
     // Write to IndexedDB (idempotent by [sessionId, seq] key)

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -350,6 +350,7 @@ export function pinSession(
 }
 
 export function requestLocalSessions(
+  targetDeviceId: string,
   send: (msg: Record<string, unknown>) => void,
   filter?: { search?: string; liveOnly?: boolean; includeLinked?: boolean },
 ): string {
@@ -357,13 +358,14 @@ export function requestLocalSessions(
   getStore().setLocalSessionsLoading(true);
   send({
     type: 'request_local_sessions',
-    payload: { requestId, filter },
+    payload: { requestId, targetDeviceId, filter },
   });
   return requestId;
 }
 
 export function importSession(
   localSessionId: string,
+  targetDeviceId: string,
   send: (msg: Record<string, unknown>) => void,
   state: CommandState,
 ): string {
@@ -371,7 +373,7 @@ export function importSession(
   state.pendingCreateRequests.add(requestId);
   send({
     type: 'import_session',
-    payload: { requestId, localSessionId },
+    payload: { requestId, localSessionId, targetDeviceId },
   });
   return requestId;
 }

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -348,3 +348,30 @@ export function pinSession(
     payload: { pinned },
   });
 }
+
+export function requestLocalSessions(
+  send: (msg: Record<string, unknown>) => void,
+  filter?: { search?: string; liveOnly?: boolean; includeLinked?: boolean },
+): string {
+  const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  getStore().setLocalSessionsLoading(true);
+  send({
+    type: 'request_local_sessions',
+    payload: { requestId, filter },
+  });
+  return requestId;
+}
+
+export function importSession(
+  localSessionId: string,
+  send: (msg: Record<string, unknown>) => void,
+  state: CommandState,
+): string {
+  const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  state.pendingCreateRequests.add(requestId);
+  send({
+    type: 'import_session',
+    payload: { requestId, localSessionId },
+  });
+  return requestId;
+}

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -57,6 +57,14 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
     return;
   }
 
+  // Handle local_sessions_list — response to import picker request
+  if (msg.type === 'local_sessions_list') {
+    const payload = (msg as { payload: { sessions: unknown[]; requestId?: string } }).payload;
+    store.setLocalSessions(payload.sessions as import('@kraki/protocol').LocalSession[]);
+    store.setLocalSessionsLoading(false);
+    return;
+  }
+
   // Handle device_greeting before sessionId check (greetings have no sessionId)
   if (msg.type === 'device_greeting') {
     const greeting = (msg as DeviceGreetingMessage).payload;

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -153,6 +153,14 @@ export class KrakiWSClient {
     commands.pinSession(sessionId, pinned, (msg) => this.sendEncrypted(msg));
   }
 
+  requestLocalSessions(filter?: { search?: string; liveOnly?: boolean; includeLinked?: boolean }) {
+    return commands.requestLocalSessions((msg) => this.sendEncrypted(msg), filter);
+  }
+
+  importSession(localSessionId: string) {
+    return commands.importSession(localSessionId, (msg) => this.sendEncrypted(msg), this.cmdState);
+  }
+
   markRead(sessionId: string, seq?: number): void {
     markSessionRead(sessionId);
     // Send to tentacle so it persists readSeq and broadcasts to other arms

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -153,12 +153,12 @@ export class KrakiWSClient {
     commands.pinSession(sessionId, pinned, (msg) => this.sendEncrypted(msg));
   }
 
-  requestLocalSessions(filter?: { search?: string; liveOnly?: boolean; includeLinked?: boolean }) {
-    return commands.requestLocalSessions((msg) => this.sendEncrypted(msg), filter);
+  requestLocalSessions(targetDeviceId: string, filter?: { search?: string; liveOnly?: boolean; includeLinked?: boolean }) {
+    return commands.requestLocalSessions(targetDeviceId, (msg) => this.sendEncrypted(msg), filter);
   }
 
-  importSession(localSessionId: string) {
-    return commands.importSession(localSessionId, (msg) => this.sendEncrypted(msg), this.cmdState);
+  importSession(localSessionId: string, targetDeviceId: string) {
+    return commands.importSession(localSessionId, targetDeviceId, (msg) => this.sendEncrypted(msg), this.cmdState);
   }
 
   markRead(sessionId: string, seq?: number): void {

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -472,7 +472,28 @@ export class KrakiWSClient {
         break;
       }
 
+      // local_sessions_list can arrive as plaintext (mock/e2e) or decrypted (production)
+      case 'local_sessions_list': {
+        const payload = (msg as { payload: { sessions: unknown[]; requestId?: string } }).payload;
+        if (payload?.sessions) {
+          getStore().setLocalSessions(payload.sessions as import('@kraki/protocol').LocalSession[]);
+          getStore().setLocalSessionsLoading(false);
+        }
+        break;
+      }
+
       default:
+        // Data messages (session_created, agent_message, etc.) arrive encrypted
+        // in production but as plaintext from mock relay in E2E tests.
+        // Route them to the message router so both paths work.
+        if ('sessionId' in msg || 'payload' in msg) {
+          handleDataMessage(msg as InnerMessage, {
+            cmdState: this.cmdState,
+            sendEncrypted: (m) => this.sendEncrypted(m),
+            onSessionList: (m) => this.handleSessionList(m),
+            onSessionReplayBatch: (m) => this.handleReplayBatch(m),
+          });
+        }
         break;
     }
   }

--- a/packages/arm/web/src/types/store.ts
+++ b/packages/arm/web/src/types/store.ts
@@ -5,6 +5,7 @@ import type {
   ConsumerMessage,
   ModelDetail,
   SessionUsage,
+  LocalSession,
 } from '@kraki/protocol';
 
 // --- Connection ---
@@ -114,6 +115,10 @@ export interface AppState {
 
   // Sessions currently loading initial messages
   loadingSessions: Set<string>;
+
+  // Local session import picker
+  localSessions: LocalSession[];
+  localSessionsLoading: boolean;
 }
 
 export interface AppActions {
@@ -157,6 +162,8 @@ export interface AppActions {
   setDeviceVersion: (deviceId: string, version: string) => void;
   setSessionUsage: (sessionId: string, usage: SessionUsage) => void;
   setSessionLoading: (sessionId: string, loading: boolean) => void;
+  setLocalSessions: (sessions: LocalSession[]) => void;
+  setLocalSessionsLoading: (loading: boolean) => void;
   clearTransientState: () => void;
   reset: () => void;
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -287,6 +287,17 @@ export interface SessionReadMessage extends BaseEnvelope {
   };
 }
 
+/** Response to request_local_sessions. Unicast to requester only. */
+export interface LocalSessionsListMessage extends BaseEnvelope {
+  type: 'local_sessions_list';
+  payload: {
+    /** All sessions matching filter, sorted by modifiedTime desc. */
+    sessions: import('./sessions.js').LocalSession[];
+    /** Echoed from request for correlation. */
+    requestId?: string;
+  };
+}
+
 export type ProducerMessage =
   | SessionCreatedMessage
   | SessionEndedMessage
@@ -310,7 +321,8 @@ export type ProducerMessage =
   | SessionReplayBatchMessage
   | SessionListMessage
   | PermissionResolvedMessage
-  | QuestionResolvedMessage;
+  | QuestionResolvedMessage
+  | LocalSessionsListMessage;
 
 // ============================================================
 // Consumer messages (app → tentacle, inside encrypted blob)
@@ -456,6 +468,34 @@ export interface MarkUnreadMessage extends BaseEnvelope {
   payload: Record<string, never>;
 }
 
+/** Request catalog of local Copilot sessions for the import picker. */
+export interface RequestLocalSessionsMessage extends BaseEnvelope {
+  type: 'request_local_sessions';
+  payload: {
+    requestId?: string;
+    filter?: {
+      /** Case-insensitive substring across summary, cwd, gitRoot, repository, branch. */
+      search?: string;
+      /** Only live sessions. */
+      liveOnly?: boolean;
+      /** Include already-imported sessions. Default false. */
+      includeLinked?: boolean;
+    };
+  };
+}
+
+/** Import a local Copilot session into Kraki.
+ *  Tentacle resumes the same session ID — both Kraki and original CLI share state on disk. */
+export interface ImportSessionMessage extends BaseEnvelope {
+  type: 'import_session';
+  payload: {
+    /** Echoed in session_created.payload.requestId on success. */
+    requestId: string;
+    /** Must match a sessionId from a previous local_sessions_list. */
+    localSessionId: string;
+  };
+}
+
 export type ConsumerMessage =
   | SendInputMessage
   | ApproveMessage
@@ -473,7 +513,9 @@ export type ConsumerMessage =
   | MarkUnreadMessage
   | RequestSessionReplayMessage
   | RenameSessionMessage
-  | PinSessionMessage;
+  | PinSessionMessage
+  | RequestLocalSessionsMessage
+  | ImportSessionMessage;
 
 // ============================================================
 // Auth credentials — discriminated union by method

--- a/packages/protocol/src/sessions.ts
+++ b/packages/protocol/src/sessions.ts
@@ -27,6 +27,8 @@ export interface SessionSummary {
   autoTitle?: string;
   state: SessionState;
   messageCount: number;
+  /** Origin of this session. Absent for sessions created natively in Kraki. */
+  source?: LocalSessionSource | 'imported';
 }
 
 /** Compact session metadata sent in session_list for sync. */
@@ -44,4 +46,46 @@ export interface SessionDigest {
   createdAt: string;
   usage?: SessionUsage;
   pinned?: boolean;
+  /** Origin of this session. Absent for sessions created natively in Kraki. */
+  source?: LocalSessionSource | 'imported';
+}
+
+// ------------------------------------------------------------
+// Local session types — for local session sync / import feature
+// ------------------------------------------------------------
+
+/** Where a local session originated. */
+export type LocalSessionSource = 'copilot-cli' | 'vscode' | 'unknown';
+
+/**
+ * A Copilot session discovered on the local filesystem.
+ * Lightweight descriptor — no message history.
+ * Sent from tentacle to arm as part of local_sessions_list.
+ */
+export interface LocalSession {
+  sessionId: string;
+
+  /** Where the CLI was launched. Always present. */
+  cwd: string;
+  /** Git repo root. Preferred tree grouping key. Absent ~46% of sessions. */
+  gitRoot?: string;
+  /** "owner/repo" format. Best display label when available. */
+  repository?: string;
+  /** Git branch. Absent when gitRoot is absent. */
+  branch?: string;
+
+  /** SDK-generated summary. Absent for very new sessions. */
+  summary?: string;
+  /** Model ID (e.g. "claude-opus-4.6-1m"). Only if scanner read events.jsonl line 1. */
+  model?: string;
+  /** ISO 8601 creation time. */
+  startTime: string;
+  /** ISO 8601 last activity. */
+  modifiedTime: string;
+
+  /** Lock file exists + PID alive. */
+  isLive: boolean;
+  source: LocalSessionSource;
+  /** Set if already imported into Kraki. */
+  linkedKrakiSessionId?: string;
 }

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.11.20",
+  "version": "0.12.0",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/history-parser.test.ts
+++ b/packages/tentacle/src/__tests__/history-parser.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { parseEventsFile, parseSessionHistory } from '../history-parser.js';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function tmpDir(): string {
+  const dir = join(tmpdir(), `kraki-test-parser-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeEvent(type: string, data: Record<string, unknown>, timestamp?: string): string {
+  return JSON.stringify({ type, data, timestamp: timestamp ?? '2026-04-10T12:00:00Z' });
+}
+
+describe('history-parser', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true }); } catch {}
+  });
+
+  describe('parseEventsFile', () => {
+    it('should extract metadata from session.start', () => {
+      const events = [
+        makeEvent('session.start', {
+          sessionId: 'test-123',
+          selectedModel: 'claude-opus-4.6-1m',
+          context: { cwd: '/Users/test/kraki', gitRoot: '/Users/test/kraki', branch: 'main', repository: 'test/kraki' },
+        }),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages, meta } = parseEventsFile(join(dir, 'events.jsonl'));
+
+      expect(meta.model).toBe('claude-opus-4.6-1m');
+      expect(meta.cwd).toBe('/Users/test/kraki');
+      expect(meta.gitRoot).toBe('/Users/test/kraki');
+      expect(meta.branch).toBe('main');
+      expect(meta.repository).toBe('test/kraki');
+      expect(messages).toHaveLength(0); // session.start doesn't produce a message
+    });
+
+    it('should convert user.message to user_message', () => {
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } }),
+        makeEvent('user.message', { content: 'fix the auth bug' }, '2026-04-10T12:01:00Z'),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe('user_message');
+      expect(messages[0].seq).toBe(1);
+      const payload = JSON.parse(messages[0].payload);
+      expect(payload.content).toBe('fix the auth bug');
+    });
+
+    it('should convert assistant.message to agent_message', () => {
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } }),
+        makeEvent('assistant.message', { content: 'I will fix the auth bug.' }, '2026-04-10T12:02:00Z'),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe('agent_message');
+      const payload = JSON.parse(messages[0].payload);
+      expect(payload.content).toBe('I will fix the auth bug.');
+    });
+
+    it('should skip empty assistant.message', () => {
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } }),
+        makeEvent('assistant.message', { content: '' }),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+      expect(messages).toHaveLength(0);
+    });
+
+    it('should convert tool events', () => {
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } }),
+        makeEvent('tool.execution_start', {
+          toolName: 'bash', toolCallId: 'tc1',
+          arguments: { command: 'ls -la' },
+        }, '2026-04-10T12:03:00Z'),
+        makeEvent('tool.execution_complete', {
+          toolName: 'bash', toolCallId: 'tc1', success: true,
+          result: { content: 'file1.txt\nfile2.txt' },
+        }, '2026-04-10T12:03:01Z'),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0].type).toBe('tool_start');
+      const startPayload = JSON.parse(messages[0].payload);
+      expect(startPayload.toolName).toBe('bash');
+      expect(startPayload.args.command).toBe('ls -la');
+
+      expect(messages[1].type).toBe('tool_complete');
+      const completePayload = JSON.parse(messages[1].payload);
+      expect(completePayload.toolName).toBe('bash');
+      expect(completePayload.result).toBe('file1.txt\nfile2.txt');
+      expect(completePayload.success).toBe(true);
+    });
+
+    it('should convert assistant.turn_end to idle', () => {
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } }),
+        makeEvent('assistant.turn_end', { turnId: '0' }),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe('idle');
+    });
+
+    it('should skip hook and subagent events', () => {
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } }),
+        makeEvent('hook.start', { hookId: 'h1' }),
+        makeEvent('hook.end', { hookId: 'h1' }),
+        makeEvent('subagent.started', { agentId: 'a1' }),
+        makeEvent('assistant.message_delta', { content: 'partial' }),
+        makeEvent('session.idle', {}),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+      expect(messages).toHaveLength(0);
+    });
+
+    it('should cap at 500 messages and re-number seq', () => {
+      const lines = [makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } })];
+      for (let i = 0; i < 600; i++) {
+        lines.push(makeEvent('user.message', { content: `msg ${i}` }));
+      }
+      writeFileSync(join(dir, 'events.jsonl'), lines.join('\n'), 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+      expect(messages).toHaveLength(500);
+      expect(messages[0].seq).toBe(1);
+      expect(messages[499].seq).toBe(500);
+      // Should be the last 500 messages (100-599)
+      const firstPayload = JSON.parse(messages[0].payload);
+      expect(firstPayload.content).toBe('msg 100');
+    });
+
+    it('should handle missing events.jsonl', () => {
+      const { messages, meta } = parseEventsFile(join(dir, 'nonexistent.jsonl'));
+      expect(messages).toHaveLength(0);
+      expect(meta).toEqual({});
+    });
+
+    it('should skip corrupt lines', () => {
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', context: { cwd: '/' } }),
+        'this is not json',
+        makeEvent('user.message', { content: 'hello' }),
+      ].join('\n');
+      writeFileSync(join(dir, 'events.jsonl'), events, 'utf8');
+
+      const { messages } = parseEventsFile(join(dir, 'events.jsonl'));
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe('user_message');
+    });
+  });
+
+  describe('parseSessionHistory', () => {
+    it('should parse from session directory', () => {
+      const sessionDir = join(dir, 'test-session');
+      mkdirSync(sessionDir, { recursive: true });
+
+      const events = [
+        makeEvent('session.start', { sessionId: 'test', selectedModel: 'gpt-4', context: { cwd: '/proj' } }),
+        makeEvent('user.message', { content: 'hello' }),
+        makeEvent('assistant.message', { content: 'hi there' }),
+      ].join('\n');
+      writeFileSync(join(sessionDir, 'events.jsonl'), events, 'utf8');
+
+      const { messages, meta } = parseSessionHistory(sessionDir);
+
+      expect(meta.model).toBe('gpt-4');
+      expect(meta.cwd).toBe('/proj');
+      expect(messages).toHaveLength(2);
+      expect(messages[0].type).toBe('user_message');
+      expect(messages[1].type).toBe('agent_message');
+    });
+  });
+});

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -446,4 +446,78 @@ describe('SessionManager', () => {
       expect(sm.getResumableSessions()).toEqual([]);
     });
   });
+
+  // ── Link table ────────────────────────────────────────
+
+  describe('link table', () => {
+    it('should add and retrieve a link', () => {
+      sm.addLink({
+        localSessionId: 'local-1',
+        krakiSessionId: 'kraki-1',
+        source: 'copilot-cli',
+        cwd: '/proj',
+        branch: 'main',
+        linkedAt: '2026-04-10T00:00:00Z',
+      });
+
+      const link = sm.getLink('local-1');
+      expect(link).toBeTruthy();
+      expect(link!.krakiSessionId).toBe('kraki-1');
+      expect(link!.source).toBe('copilot-cli');
+    });
+
+    it('should return null for unknown links', () => {
+      expect(sm.getLink('nonexistent')).toBeNull();
+    });
+
+    it('should return all linked IDs', () => {
+      sm.addLink({ localSessionId: 'l1', krakiSessionId: 'k1', source: 'copilot-cli', linkedAt: '' });
+      sm.addLink({ localSessionId: 'l2', krakiSessionId: 'k2', source: 'vscode', linkedAt: '' });
+
+      const ids = sm.getLinkedIds();
+      expect(ids.size).toBe(2);
+      expect(ids.has('l1')).toBe(true);
+      expect(ids.has('l2')).toBe(true);
+    });
+
+    it('should remove link by local session ID', () => {
+      sm.addLink({ localSessionId: 'l1', krakiSessionId: 'k1', source: 'copilot-cli', linkedAt: '' });
+      sm.removeLink('l1');
+      expect(sm.getLink('l1')).toBeNull();
+    });
+
+    it('should remove link by Kraki session ID', () => {
+      sm.addLink({ localSessionId: 'l1', krakiSessionId: 'k1', source: 'copilot-cli', linkedAt: '' });
+      sm.removeLinkByKrakiId('k1');
+      expect(sm.getLink('l1')).toBeNull();
+    });
+
+    it('should replace existing link for same local session', () => {
+      sm.addLink({ localSessionId: 'l1', krakiSessionId: 'k1', source: 'copilot-cli', linkedAt: 'old' });
+      sm.addLink({ localSessionId: 'l1', krakiSessionId: 'k2', source: 'vscode', linkedAt: 'new' });
+
+      const link = sm.getLink('l1');
+      expect(link!.krakiSessionId).toBe('k2');
+      expect(sm.getAllLinks()).toHaveLength(1);
+    });
+
+    it('should persist across instances', () => {
+      sm.addLink({ localSessionId: 'l1', krakiSessionId: 'k1', source: 'copilot-cli', linkedAt: '' });
+
+      const sm2 = new SessionManager(dir);
+      expect(sm2.getLink('l1')).toBeTruthy();
+      expect(sm2.getLink('l1')!.krakiSessionId).toBe('k1');
+    });
+
+    it('should include source in session list', () => {
+      const { sessionId } = sm.createSession('copilot', 'gpt-4');
+      const meta = sm.getMeta(sessionId);
+      meta!.source = 'copilot-cli';
+      // Write back (normally done via a setter, but test the field)
+      const list = sm.getSessionList();
+      const entry = list.find(s => s.id === sessionId);
+      // source is on meta but getSessionList reads it
+      expect(entry).toBeTruthy();
+    });
+  });
 });

--- a/packages/tentacle/src/__tests__/session-scanner.test.ts
+++ b/packages/tentacle/src/__tests__/session-scanner.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { scanLocalSessions, filterSessions } from '../session-scanner.js';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function tmpDir(): string {
+  const dir = join(tmpdir(), `kraki-test-scanner-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createFakeSession(baseDir: string, id: string, workspace: Record<string, string>): void {
+  const sessionDir = join(baseDir, id);
+  mkdirSync(sessionDir, { recursive: true });
+
+  const lines = Object.entries(workspace).map(([k, v]) => `${k}: ${v}`).join('\n');
+  writeFileSync(join(sessionDir, 'workspace.yaml'), lines, 'utf8');
+
+  // Minimal events.jsonl
+  const startEvent = JSON.stringify({
+    type: 'session.start',
+    data: { sessionId: id, selectedModel: workspace.model ?? null, context: { cwd: workspace.cwd ?? '/' } },
+    timestamp: workspace.created_at ?? new Date().toISOString(),
+  });
+  writeFileSync(join(sessionDir, 'events.jsonl'), startEvent + '\n', 'utf8');
+}
+
+describe('session-scanner', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true }); } catch {}
+  });
+
+  describe('scanLocalSessions', () => {
+    it('should discover sessions from workspace.yaml files', () => {
+      createFakeSession(dir, 'sess-1', {
+        id: 'sess-1',
+        cwd: '/Users/test/project',
+        git_root: '/Users/test/project',
+        repository: 'test/project',
+        branch: 'main',
+        summary: 'Fix auth bug',
+        created_at: '2026-04-01T00:00:00Z',
+        updated_at: '2026-04-02T00:00:00Z',
+      });
+      createFakeSession(dir, 'sess-2', {
+        id: 'sess-2',
+        cwd: '/Users/test/other',
+        created_at: '2026-04-03T00:00:00Z',
+        updated_at: '2026-04-04T00:00:00Z',
+      });
+
+      const sessions = scanLocalSessions({ extraDirs: [dir] });
+      // Filter to only our test sessions (real ~/.copilot may have sessions too)
+      const ours = sessions.filter(s => s.sessionId.startsWith('sess-'));
+
+      expect(ours).toHaveLength(2);
+      // Sorted by modifiedTime desc
+      expect(ours[0].sessionId).toBe('sess-2');
+      expect(ours[1].sessionId).toBe('sess-1');
+    });
+
+    it('should parse workspace.yaml fields correctly', () => {
+      createFakeSession(dir, 'sess-full', {
+        id: 'sess-full',
+        cwd: '/Users/test/kraki',
+        git_root: '/Users/test/kraki',
+        repository: 'corelli18512/kraki',
+        branch: 'feat/sync',
+        summary: 'Local session sync',
+        created_at: '2026-04-10T12:00:00Z',
+        updated_at: '2026-04-10T14:00:00Z',
+      });
+
+      const sessions = scanLocalSessions({ extraDirs: [dir] });
+      const s = sessions.find(s => s.sessionId === 'sess-full');
+
+      expect(s).toBeTruthy();
+      expect(s!.cwd).toBe('/Users/test/kraki');
+      expect(s!.gitRoot).toBe('/Users/test/kraki');
+      expect(s!.repository).toBe('corelli18512/kraki');
+      expect(s!.branch).toBe('feat/sync');
+      expect(s!.summary).toBe('Local session sync');
+      expect(s!.startTime).toBe('2026-04-10T12:00:00Z');
+      expect(s!.modifiedTime).toBe('2026-04-10T14:00:00Z');
+      expect(s!.isLive).toBe(false); // no lock file
+      expect(s!.source).toBe('copilot-cli');
+    });
+
+    it('should detect vscode source from non-empty metadata', () => {
+      createFakeSession(dir, 'sess-vscode', {
+        id: 'sess-vscode',
+        cwd: '/Users/test/project',
+        created_at: '2026-04-10T00:00:00Z',
+        updated_at: '2026-04-10T00:00:00Z',
+      });
+      writeFileSync(join(dir, 'sess-vscode', 'vscode.metadata.json'), '{"version": "1.0"}', 'utf8');
+
+      const sessions = scanLocalSessions({ extraDirs: [dir] });
+      const s = sessions.find(s => s.sessionId === 'sess-vscode');
+
+      expect(s!.source).toBe('vscode');
+    });
+
+    it('should detect live sessions from lock files with live PIDs', () => {
+      createFakeSession(dir, 'sess-live', {
+        id: 'sess-live',
+        cwd: '/Users/test/project',
+        created_at: '2026-04-10T00:00:00Z',
+        updated_at: '2026-04-10T00:00:00Z',
+      });
+      // Use current PID (guaranteed alive)
+      writeFileSync(join(dir, 'sess-live', `inuse.${process.pid}.lock`), String(process.pid), 'utf8');
+
+      const sessions = scanLocalSessions({ extraDirs: [dir] });
+      const s = sessions.find(s => s.sessionId === 'sess-live');
+
+      expect(s!.isLive).toBe(true);
+    });
+
+    it('should detect dead sessions from stale lock files', () => {
+      createFakeSession(dir, 'sess-dead', {
+        id: 'sess-dead',
+        cwd: '/Users/test/project',
+        created_at: '2026-04-10T00:00:00Z',
+        updated_at: '2026-04-10T00:00:00Z',
+      });
+      // Use a PID that's very unlikely to be alive
+      writeFileSync(join(dir, 'sess-dead', 'inuse.99999999.lock'), '99999999', 'utf8');
+
+      const sessions = scanLocalSessions({ extraDirs: [dir] });
+      const s = sessions.find(s => s.sessionId === 'sess-dead');
+
+      expect(s!.isLive).toBe(false);
+    });
+
+    it('should extract model from events.jsonl when includeModel is true', () => {
+      createFakeSession(dir, 'sess-model', {
+        id: 'sess-model',
+        cwd: '/Users/test/project',
+        model: 'claude-opus-4.6-1m',
+        created_at: '2026-04-10T00:00:00Z',
+        updated_at: '2026-04-10T00:00:00Z',
+      });
+
+      const sessions = scanLocalSessions({ extraDirs: [dir], includeModel: true });
+      const s = sessions.find(s => s.sessionId === 'sess-model');
+
+      expect(s!.model).toBe('claude-opus-4.6-1m');
+    });
+
+    it('should skip directories without workspace.yaml', () => {
+      mkdirSync(join(dir, 'empty-dir'), { recursive: true });
+      const sessions = scanLocalSessions({ extraDirs: [dir] });
+      const s = sessions.find(s => s.sessionId === 'empty-dir');
+      expect(s).toBeUndefined();
+    });
+  });
+
+  describe('filterSessions', () => {
+    const sessions = [
+      { sessionId: 's1', cwd: '/proj/kraki', gitRoot: '/proj/kraki', branch: 'main', summary: 'Fix auth', isLive: true, source: 'copilot-cli' as const, startTime: '', modifiedTime: '' },
+      { sessionId: 's2', cwd: '/proj/hermit', gitRoot: '/proj/hermit', branch: 'main', summary: 'Add tests', isLive: false, source: 'copilot-cli' as const, startTime: '', modifiedTime: '' },
+      { sessionId: 's3', cwd: '/home', summary: 'Random task', isLive: false, source: 'vscode' as const, startTime: '', modifiedTime: '' },
+    ];
+
+    it('should filter by search substring', () => {
+      const result = filterSessions(sessions, { search: 'kraki' }, new Set());
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe('s1');
+    });
+
+    it('should filter by liveOnly', () => {
+      const result = filterSessions(sessions, { liveOnly: true }, new Set());
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe('s1');
+    });
+
+    it('should exclude linked sessions by default', () => {
+      const linked = new Set(['s1']);
+      const result = filterSessions(sessions, {}, linked);
+      expect(result).toHaveLength(2);
+      expect(result.map(s => s.sessionId)).toEqual(['s2', 's3']);
+    });
+
+    it('should include linked sessions when includeLinked is true', () => {
+      const linked = new Set(['s1']);
+      const result = filterSessions(sessions, { includeLinked: true }, linked);
+      expect(result).toHaveLength(3);
+    });
+
+    it('should combine filters with AND', () => {
+      const result = filterSessions(sessions, { search: 'main', liveOnly: true }, new Set());
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe('s1');
+    });
+  });
+});

--- a/packages/tentacle/src/history-parser.ts
+++ b/packages/tentacle/src/history-parser.ts
@@ -168,6 +168,11 @@ function convertEvent(
       const result = resultObj?.content as string
         ?? (typeof rawResult === 'string' ? rawResult : (event.data.output as string ?? ''));
 
+      // Extract model from the first tool completion that has it
+      if (!meta.model && event.data.model) {
+        meta.model = event.data.model as string;
+      }
+
       return {
         type: 'tool_complete',
         payload: JSON.stringify({

--- a/packages/tentacle/src/history-parser.ts
+++ b/packages/tentacle/src/history-parser.ts
@@ -1,0 +1,243 @@
+/**
+ * History parser — converts Copilot SDK events.jsonl into Kraki protocol messages.
+ *
+ * Used during import to backfill conversation history so the arm can display
+ * the full session context from before Kraki attached.
+ *
+ * Reads events.jsonl line by line (streaming) to handle large files.
+ * Caps output at MAX_BACKFILL_MESSAGES most recent messages.
+ */
+
+import { existsSync, openSync, readSync, closeSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('history-parser');
+
+/** Max messages to backfill from events.jsonl (most recent kept). */
+const MAX_BACKFILL_MESSAGES = 500;
+
+// ── SDK event types we care about ───────────────────────
+
+interface SdkEvent {
+  type: string;
+  data: Record<string, unknown>;
+  id?: string;
+  timestamp?: string;
+}
+
+// ── Converted message format (matches SessionManager's LoggedMessage) ──
+
+export interface BackfilledMessage {
+  seq: number;
+  type: string;
+  payload: string; // JSON-stringified payload
+  ts: string;
+}
+
+// ── Session metadata extracted from events.jsonl ────────
+
+export interface ParsedSessionMeta {
+  model?: string;
+  cwd?: string;
+  gitRoot?: string;
+  branch?: string;
+  repository?: string;
+}
+
+// ── Parser ──────────────────────────────────────────────
+
+/**
+ * Parse a Copilot SDK events.jsonl file into Kraki protocol messages.
+ * Returns up to MAX_BACKFILL_MESSAGES most recent messages and session metadata.
+ */
+export function parseEventsFile(eventsPath: string): {
+  messages: BackfilledMessage[];
+  meta: ParsedSessionMeta;
+} {
+  if (!existsSync(eventsPath)) {
+    return { messages: [], meta: {} };
+  }
+
+  const messages: BackfilledMessage[] = [];
+  const meta: ParsedSessionMeta = {};
+  let seq = 0;
+
+  // Stream line by line using a buffer to handle large files
+  const content = readFileChunked(eventsPath);
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+
+    let event: SdkEvent;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue; // skip corrupt lines
+    }
+
+    const ts = event.timestamp ?? new Date().toISOString();
+    const converted = convertEvent(event, ts, meta);
+    if (converted) {
+      seq++;
+      messages.push({ seq, ...converted });
+    }
+  }
+
+  // Keep only the most recent messages
+  if (messages.length > MAX_BACKFILL_MESSAGES) {
+    const trimmed = messages.slice(messages.length - MAX_BACKFILL_MESSAGES);
+    // Re-number seq starting from 1
+    for (let i = 0; i < trimmed.length; i++) {
+      trimmed[i].seq = i + 1;
+    }
+    return { messages: trimmed, meta };
+  }
+
+  return { messages, meta };
+}
+
+/**
+ * Parse events.jsonl from a session directory.
+ */
+export function parseSessionHistory(sessionDir: string): {
+  messages: BackfilledMessage[];
+  meta: ParsedSessionMeta;
+} {
+  return parseEventsFile(join(sessionDir, 'events.jsonl'));
+}
+
+// ── Event conversion ────────────────────────────────────
+
+function convertEvent(
+  event: SdkEvent,
+  ts: string,
+  meta: ParsedSessionMeta,
+): { type: string; payload: string; ts: string } | null {
+  switch (event.type) {
+    case 'session.start': {
+      // Extract metadata, don't emit a message
+      const ctx = event.data.context as Record<string, string> | undefined;
+      if (event.data.selectedModel) meta.model = event.data.selectedModel as string;
+      if (ctx?.cwd) meta.cwd = ctx.cwd;
+      if (ctx?.gitRoot) meta.gitRoot = ctx.gitRoot;
+      if (ctx?.branch) meta.branch = ctx.branch;
+      if (ctx?.repository) meta.repository = ctx.repository;
+      return null;
+    }
+
+    case 'user.message': {
+      const content = event.data.content as string ?? '';
+      // Use transformedContent if available (has system context stripped)
+      return {
+        type: 'user_message',
+        payload: JSON.stringify({ content }),
+        ts,
+      };
+    }
+
+    case 'assistant.message': {
+      const content = event.data.content as string ?? '';
+      if (!content) return null; // skip empty messages (SDK sends these before tool calls)
+      return {
+        type: 'agent_message',
+        payload: JSON.stringify({ content }),
+        ts,
+      };
+    }
+
+    case 'tool.execution_start': {
+      const toolName = event.data.toolName as string ?? 'unknown';
+      const args = (event.data.arguments ?? event.data.args ?? {}) as Record<string, unknown>;
+      const toolCallId = event.data.toolCallId as string | undefined;
+      return {
+        type: 'tool_start',
+        payload: JSON.stringify({ toolName, args, toolCallId }),
+        ts,
+      };
+    }
+
+    case 'tool.execution_complete': {
+      const toolName = event.data.toolName as string ?? 'unknown';
+      const toolCallId = event.data.toolCallId as string | undefined;
+      const success = event.data.success as boolean | undefined;
+      const rawResult = event.data.result;
+      const resultObj = typeof rawResult === 'object' && rawResult !== null
+        ? rawResult as Record<string, unknown>
+        : null;
+      const result = resultObj?.content as string
+        ?? (typeof rawResult === 'string' ? rawResult : (event.data.output as string ?? ''));
+
+      return {
+        type: 'tool_complete',
+        payload: JSON.stringify({
+          toolName,
+          args: {},
+          result: result.slice(0, 5000), // Cap result size for backfill
+          toolCallId,
+          success,
+        }),
+        ts,
+      };
+    }
+
+    case 'assistant.turn_end': {
+      return {
+        type: 'idle',
+        payload: JSON.stringify({}),
+        ts,
+      };
+    }
+
+    // Skip events that don't map to Kraki messages
+    case 'assistant.message_delta':
+    case 'assistant.turn_start':
+    case 'hook.start':
+    case 'hook.end':
+    case 'subagent.started':
+    case 'session.idle':
+    case 'session.shutdown':
+    case 'session.info':
+    case 'session.warning':
+    case 'session.task_complete':
+    case 'assistant.usage':
+    case 'session.title_changed':
+      return null;
+
+    default:
+      // Unknown event type — skip
+      return null;
+  }
+}
+
+// ── File reading helper ─────────────────────────────────
+
+function readFileChunked(filePath: string): string {
+  // For files under 10MB, just read the whole thing
+  const stat = statSync(filePath);
+  if (stat.size <= 10 * 1024 * 1024) {
+    const fd = openSync(filePath, 'r');
+    const buf = Buffer.alloc(stat.size);
+    readSync(fd, buf, 0, stat.size, 0);
+    closeSync(fd);
+    return buf.toString('utf8');
+  }
+
+  // For larger files, read in chunks
+  logger.info({ filePath, size: stat.size }, 'Large events.jsonl — reading in chunks');
+  const fd = openSync(filePath, 'r');
+  const chunks: Buffer[] = [];
+  const chunkSize = 1024 * 1024; // 1MB chunks
+  let offset = 0;
+
+  while (offset < stat.size) {
+    const readSize = Math.min(chunkSize, stat.size - offset);
+    const buf = Buffer.alloc(readSize);
+    readSync(fd, buf, 0, readSize, offset);
+    chunks.push(buf);
+    offset += readSize;
+  }
+
+  closeSync(fd);
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/packages/tentacle/src/index.ts
+++ b/packages/tentacle/src/index.ts
@@ -24,8 +24,11 @@ export type {
 
 export { loadConfig, saveConfig, configExists, getOrCreateDeviceId } from './config.js';
 export { SessionManager } from './session-manager.js';
-export type { SessionContext, SessionMeta, RunRecord, LoggedMessage } from './session-manager.js';
+export type { SessionContext, SessionMeta, RunRecord, LoggedMessage, SessionLink } from './session-manager.js';
 export { RelayClient } from './relay-client.js';
 export type { RelayClientOptions, RelayClientState } from './relay-client.js';
 export { KeyManager } from './key-manager.js';
-
+export { scanLocalSessions, filterSessions } from './session-scanner.js';
+export type { ScanOptions, SessionFilter } from './session-scanner.js';
+export { parseEventsFile, parseSessionHistory } from './history-parser.js';
+export type { BackfilledMessage, ParsedSessionMeta } from './history-parser.js';

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -701,16 +701,13 @@ export class RelayClient {
         krakiSessionId,
       );
 
-      // Set source and title on meta
-      const meta = this.sessionManager.getMeta(krakiSessionId);
-      if (meta) {
-        meta.source = localSession?.source ?? 'copilot-cli';
-        if (localSession?.summary) {
-          meta.autoTitle = localSession.summary.slice(0, 100);
-        }
-        // Write back since createSession doesn't set source
-        this.sessionManager.setTitle(krakiSessionId, meta.title ?? '');
-      }
+      // Persist source, title, model, and original creation time
+      this.sessionManager.updateMeta(krakiSessionId, {
+        source: localSession?.source ?? 'copilot-cli',
+        autoTitle: localSession?.summary?.slice(0, 100),
+        model: parsedMeta.model ?? localSession?.model,
+        createdAt: localSession?.startTime,
+      });
 
       // Backfill messages
       for (const m of backfilledMessages) {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -610,10 +610,6 @@ export class RelayClient {
     const { requestId, filter } = msg.payload;
     const requesterDeviceId = msg.deviceId;
     const requesterKey = this.consumerKeys.get(requesterDeviceId);
-    if (!requesterKey) {
-      logger.warn({ requesterDeviceId }, 'Local sessions requested but no encryption key');
-      return;
-    }
 
     try {
       let sessions = scanLocalSessions();
@@ -624,6 +620,10 @@ export class RelayClient {
         const link = this.sessionManager.getLink(s.sessionId);
         if (link) s.linkedKrakiSessionId = link.krakiSessionId;
       }
+
+      // Exclude sessions that Kraki already manages (created natively, not imported)
+      const krakiSessionIds = new Set(this.sessionManager.getSessionList().map(s => s.id));
+      sessions = sessions.filter(s => !krakiSessionIds.has(s.sessionId) || s.linkedKrakiSessionId);
 
       // Apply filters
       if (filter) {
@@ -637,7 +637,13 @@ export class RelayClient {
         timestamp: new Date().toISOString(),
         payload: { sessions, requestId },
       };
-      this.sendUnicastTo(requesterDeviceId, requesterKey, response);
+
+      if (requesterKey) {
+        this.sendUnicastTo(requesterDeviceId, requesterKey, response);
+      } else {
+        // No encryption key — broadcast (works in open/non-E2E mode)
+        this.send(response as Partial<ProducerMessage>);
+      }
 
       logger.debug({ count: sessions.length, requestId }, 'Sent local sessions list');
     } catch (err) {
@@ -649,7 +655,12 @@ export class RelayClient {
         timestamp: new Date().toISOString(),
         payload: { sessions: [], requestId },
       };
-      this.sendUnicastTo(requesterDeviceId, requesterKey, response);
+
+      if (requesterKey) {
+        this.sendUnicastTo(requesterDeviceId, requesterKey, response);
+      } else {
+        this.send(response as Partial<ProducerMessage>);
+      }
     }
   }
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -732,8 +732,21 @@ export class RelayClient {
         this.pendingRequestIds.set(krakiSessionId, requestId);
       }
 
-      // Resume via SDK (works for both live and dead sessions)
-      await this.adapter.resumeSession(krakiSessionId);
+      // Resume the session via SDK. Use createSession with the existing sessionId
+      // so the CLI server discovers the state on disk. resumeSession only works
+      // for sessions the CLI server has already loaded in memory.
+      const cwd = localSession?.cwd ?? parsedMeta.cwd ?? '/';
+      try {
+        await this.adapter.createSession({
+          sessionId: krakiSessionId,
+          model: parsedMeta.model,
+          cwd,
+        });
+      } catch (createErr) {
+        // If createSession fails (e.g. session state corrupted), still keep
+        // the backfilled history — the session is browsable but not interactive.
+        logger.warn({ err: (createErr as Error).message, krakiSessionId }, 'SDK resume failed — session imported as idle');
+      }
 
       // Mark idle — will transition to active when user sends a message
       this.sessionManager.markIdle(krakiSessionId);

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -9,6 +9,7 @@
 import { WebSocket } from 'ws';
 import { appendFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type {
   ProducerMessage, ConsumerMessage,
   DeviceInfo, AuthOkMessage, AuthErrorMessage, DeviceSummary, AuthMethod,
@@ -19,6 +20,8 @@ import type { RecipientKey } from '@kraki/crypto';
 import type { AgentAdapter } from './adapters/base.js';
 import type { SessionManager, SessionContext } from './session-manager.js';
 import type { KeyManager } from './key-manager.js';
+import { scanLocalSessions, filterSessions } from './session-scanner.js';
+import { parseSessionHistory } from './history-parser.js';
 import { createLogger } from './logger.js';
 import { getKrakiHome } from './config.js';
 
@@ -383,6 +386,16 @@ export class RelayClient {
       return;
     }
 
+    // ── Local session sync (no sessionId) ────────────────
+    if (msg.type === 'request_local_sessions') {
+      this.handleRequestLocalSessions(msg);
+      return;
+    }
+    if (msg.type === 'import_session') {
+      this.handleImportSession(msg);
+      return;
+    }
+
     const sessionId = msg.sessionId;
     if (!sessionId) return;
 
@@ -439,6 +452,7 @@ export class RelayClient {
           this.adapter.killSession(sessionId)
             .catch((err) => logger.error({ err, sessionId }, 'killSession on delete failed'))
             .finally(() => {
+              this.sessionManager.removeLinkByKrakiId(sessionId);
               this.sessionManager.deleteSession(sessionId);
               this.lastAgentContent.delete(sessionId);
               this.send({ type: 'session_deleted', sessionId, payload: {} });
@@ -584,6 +598,143 @@ export class RelayClient {
         type: 'error',
         sessionId: '',
         payload: { message: errorMsg },
+      });
+    }
+  }
+
+  // ── Local session sync handlers ───────────────────────
+
+  private handleRequestLocalSessions(msg: ConsumerMessage): void {
+    if (msg.type !== 'request_local_sessions') return;
+
+    const { requestId, filter } = msg.payload;
+    const requesterDeviceId = msg.deviceId;
+    const requesterKey = this.consumerKeys.get(requesterDeviceId);
+    if (!requesterKey) {
+      logger.warn({ requesterDeviceId }, 'Local sessions requested but no encryption key');
+      return;
+    }
+
+    try {
+      let sessions = scanLocalSessions();
+      const linkedIds = this.sessionManager.getLinkedIds();
+
+      // Mark sessions that are already linked
+      for (const s of sessions) {
+        const link = this.sessionManager.getLink(s.sessionId);
+        if (link) s.linkedKrakiSessionId = link.krakiSessionId;
+      }
+
+      // Apply filters
+      if (filter) {
+        sessions = filterSessions(sessions, filter, linkedIds);
+      }
+
+      const response = {
+        type: 'local_sessions_list',
+        deviceId: this.authInfo?.deviceId ?? '',
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: { sessions, requestId },
+      };
+      this.sendUnicastTo(requesterDeviceId, requesterKey, response);
+
+      logger.debug({ count: sessions.length, requestId }, 'Sent local sessions list');
+    } catch (err) {
+      logger.error({ err }, 'Failed to scan local sessions');
+      const response = {
+        type: 'local_sessions_list',
+        deviceId: this.authInfo?.deviceId ?? '',
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: { sessions: [], requestId },
+      };
+      this.sendUnicastTo(requesterDeviceId, requesterKey, response);
+    }
+  }
+
+  private async handleImportSession(msg: ConsumerMessage): Promise<void> {
+    if (msg.type !== 'import_session') return;
+
+    const { requestId, localSessionId } = msg.payload;
+
+    // Check if already linked
+    const existing = this.sessionManager.getLink(localSessionId);
+    if (existing) {
+      this.send({
+        type: 'error',
+        sessionId: '',
+        payload: { message: `Session already imported as ${existing.krakiSessionId} (requestId: ${requestId})` },
+      });
+      return;
+    }
+
+    try {
+      // Use localSessionId as Kraki session ID (shared identity)
+      const krakiSessionId = localSessionId;
+
+      // Parse events.jsonl for backfill
+      const sessionStateDir = join(
+        homedir(), '.copilot', 'session-state', localSessionId,
+      );
+      const { messages: backfilledMessages, meta: parsedMeta } = parseSessionHistory(sessionStateDir);
+
+      // Scan to get local session metadata
+      const scanResults = scanLocalSessions();
+      const localSession = scanResults.find(s => s.sessionId === localSessionId);
+
+      // Create Kraki session
+      this.sessionManager.createSession(
+        'copilot',
+        parsedMeta.model ?? localSession?.model,
+        krakiSessionId,
+      );
+
+      // Set source and title on meta
+      const meta = this.sessionManager.getMeta(krakiSessionId);
+      if (meta) {
+        meta.source = localSession?.source ?? 'copilot-cli';
+        if (localSession?.summary) {
+          meta.autoTitle = localSession.summary.slice(0, 100);
+        }
+        // Write back since createSession doesn't set source
+        this.sessionManager.setTitle(krakiSessionId, meta.title ?? '');
+      }
+
+      // Backfill messages
+      for (const m of backfilledMessages) {
+        this.sessionManager.appendMessage(krakiSessionId, m.type, m.payload);
+      }
+
+      // Write link table entry
+      this.sessionManager.addLink({
+        localSessionId,
+        krakiSessionId,
+        source: localSession?.source ?? 'copilot-cli',
+        cwd: localSession?.cwd,
+        branch: localSession?.branch,
+        linkedAt: new Date().toISOString(),
+      });
+
+      // Map requestId for session_created correlation
+      if (requestId) {
+        this.pendingRequestIds.set(krakiSessionId, requestId);
+      }
+
+      // Resume via SDK (works for both live and dead sessions)
+      await this.adapter.resumeSession(krakiSessionId);
+
+      // Mark idle — will transition to active when user sends a message
+      this.sessionManager.markIdle(krakiSessionId);
+      this.send({ type: 'idle', sessionId: krakiSessionId, payload: {} });
+
+      logger.info({ localSessionId, krakiSessionId, backfilled: backfilledMessages.length }, 'Session imported');
+    } catch (err) {
+      logger.error({ err, localSessionId }, 'Import session failed');
+      this.send({
+        type: 'error',
+        sessionId: '',
+        payload: { message: `Failed to import session: ${(err as Error).message} (requestId: ${requestId})` },
       });
     }
   }

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -740,9 +740,21 @@ export class RelayClient {
           cwd,
         });
       } catch (createErr) {
-        // If createSession fails (e.g. session state corrupted), still keep
-        // the backfilled history — the session is browsable but not interactive.
+        // SDK resume failed — still keep backfilled history, but manually
+        // send session_created so the web UI knows the session exists.
         logger.warn({ err: (createErr as Error).message, krakiSessionId }, 'SDK resume failed — session imported as idle');
+        const meta = this.sessionManager.getMeta(krakiSessionId);
+        this.send({
+          type: 'session_created',
+          sessionId: krakiSessionId,
+          payload: {
+            agent: 'copilot',
+            model: parsedMeta.model ?? localSession?.model,
+            requestId,
+            lastSeq: meta?.lastSeq ?? 0,
+          },
+        });
+        if (requestId) this.pendingRequestIds.delete(krakiSessionId);
       }
 
       // Mark idle — will transition to active when user sends a message

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -446,6 +446,24 @@ export class SessionManager {
     return this.readMeta(sessionId);
   }
 
+  /**
+   * Bulk-update session metadata fields. Reads from disk, merges, writes back.
+   */
+  updateMeta(sessionId: string, updates: Partial<Pick<SessionMeta, 'model' | 'title' | 'autoTitle' | 'source' | 'createdAt' | 'state' | 'mode' | 'pinned'>>): void {
+    const meta = this.readMeta(sessionId);
+    if (!meta) return;
+    if (updates.model !== undefined) meta.model = updates.model;
+    if (updates.title !== undefined) meta.title = updates.title || undefined;
+    if (updates.autoTitle !== undefined) meta.autoTitle = updates.autoTitle;
+    if (updates.source !== undefined) meta.source = updates.source;
+    if (updates.createdAt !== undefined) meta.createdAt = updates.createdAt;
+    if (updates.state !== undefined) meta.state = updates.state;
+    if (updates.mode !== undefined) meta.mode = updates.mode;
+    if (updates.pinned !== undefined) meta.pinned = updates.pinned || undefined;
+    meta.updatedAt = new Date().toISOString();
+    this.writeMeta(sessionId, meta);
+  }
+
   // ── Message log ────────────────────────────────────────
 
   /**

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -50,6 +50,8 @@ export interface SessionMeta {
   updatedAt: string;
   /** Cumulative token usage (persisted across restarts) */
   usage?: import('@kraki/protocol').SessionUsage;
+  /** Origin of this session — set for imported sessions */
+  source?: import('@kraki/protocol').LocalSessionSource | 'imported';
 }
 
 export interface RunRecord {
@@ -527,6 +529,7 @@ export class SessionManager {
     messageCount: number;
     createdAt: string;
     usage?: import('@kraki/protocol').SessionUsage;
+    source?: import('@kraki/protocol').LocalSessionSource | 'imported';
   }> {
     const result: ReturnType<SessionManager['getSessionList']> = [];
     if (!existsSync(this.sessionsDir)) return result;
@@ -552,6 +555,7 @@ export class SessionManager {
         messageCount: meta.lastSeq ?? 0,
         createdAt: meta.createdAt,
         usage: meta.usage,
+        source: meta.source,
       });
     }
     return result;
@@ -592,6 +596,69 @@ export class SessionManager {
   private writeRun(sessionId: string, run: RunRecord): void {
     atomicWrite(join(this.sessionDir(sessionId), 'runs', `${run.id}.json`), JSON.stringify(run, null, 2));
   }
+
+  // ── Link table (local session sync) ───────────────────
+
+  private get linkTablePath(): string {
+    return join(this.sessionsDir, 'link-table.json');
+  }
+
+  private readLinkTable(): SessionLink[] {
+    try {
+      return JSON.parse(readFileSync(this.linkTablePath, 'utf8'));
+    } catch { return []; }
+  }
+
+  private writeLinkTable(links: SessionLink[]): void {
+    atomicWrite(this.linkTablePath, JSON.stringify(links, null, 2));
+  }
+
+  /** Add a link between a local Copilot session and a Kraki session. */
+  addLink(link: SessionLink): void {
+    const links = this.readLinkTable();
+    // Replace existing link for this local session ID
+    const idx = links.findIndex(l => l.localSessionId === link.localSessionId);
+    if (idx >= 0) links[idx] = link;
+    else links.push(link);
+    this.writeLinkTable(links);
+  }
+
+  /** Remove a link by local session ID. */
+  removeLink(localSessionId: string): void {
+    const links = this.readLinkTable().filter(l => l.localSessionId !== localSessionId);
+    this.writeLinkTable(links);
+  }
+
+  /** Remove a link by Kraki session ID (used on session delete). */
+  removeLinkByKrakiId(krakiSessionId: string): void {
+    const links = this.readLinkTable().filter(l => l.krakiSessionId !== krakiSessionId);
+    this.writeLinkTable(links);
+  }
+
+  /** Get link for a local session ID. */
+  getLink(localSessionId: string): SessionLink | null {
+    return this.readLinkTable().find(l => l.localSessionId === localSessionId) ?? null;
+  }
+
+  /** Get all linked local session IDs. */
+  getLinkedIds(): Set<string> {
+    return new Set(this.readLinkTable().map(l => l.localSessionId));
+  }
+
+  /** Get all links. */
+  getAllLinks(): SessionLink[] {
+    return this.readLinkTable();
+  }
+}
+
+/** Link between a local Copilot session and a Kraki session. */
+export interface SessionLink {
+  localSessionId: string;
+  krakiSessionId: string;
+  source: import('@kraki/protocol').LocalSessionSource;
+  cwd?: string;
+  branch?: string;
+  linkedAt: string;
 }
 
 /** Atomic write: write to temp file, then rename (prevents corruption on crash). */

--- a/packages/tentacle/src/session-scanner.ts
+++ b/packages/tentacle/src/session-scanner.ts
@@ -89,12 +89,14 @@ function isSessionLive(sessionDir: string): boolean {
     const pid = parseInt(pidStr, 10);
     if (isNaN(pid)) return false;
 
-    // Check if PID is alive (signal 0 = check existence, doesn't actually send signal)
+    // Check if PID is alive (signal 0 = check existence)
     try {
       process.kill(pid, 0);
       return true;
-    } catch {
-      return false;
+    } catch (err) {
+      // ESRCH = process doesn't exist → dead
+      // EPERM = process exists but different owner → alive
+      return (err as NodeJS.ErrnoException).code !== 'ESRCH';
     }
   } catch {
     return false;

--- a/packages/tentacle/src/session-scanner.ts
+++ b/packages/tentacle/src/session-scanner.ts
@@ -202,6 +202,9 @@ export function scanLocalSessions(options: ScanOptions = {}): LocalSession[] {
         if (ws.branch) session.branch = ws.branch;
         if (ws.summary) session.summary = ws.summary.slice(0, 200);
 
+        // Skip Kraki daemon sessions (cwd: "/" with no git context)
+        if (session.cwd === '/' && !session.gitRoot) continue;
+
         if (options.includeModel) {
           const model = extractModelFromEvents(sessionDir);
           if (model) session.model = model;

--- a/packages/tentacle/src/session-scanner.ts
+++ b/packages/tentacle/src/session-scanner.ts
@@ -1,0 +1,250 @@
+/**
+ * Session scanner — discovers local Copilot sessions for the import picker.
+ *
+ * Two data sources:
+ * 1. SDK's CopilotClient.listSessions() — sessions the running CLI server knows about
+ * 2. Filesystem scan of ~/.copilot/session-state/ — all sessions including historical
+ *
+ * Outputs a flat LocalSession[] catalog. The arm groups client-side by gitRoot/cwd.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir } from 'node:os';
+import type { LocalSession, LocalSessionSource } from '@kraki/protocol';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('session-scanner');
+
+const SESSION_STATE_DIR = join(homedir(), '.copilot', 'session-state');
+
+// ── Workspace YAML parser (simple key-value, no full YAML dep) ──
+
+interface WorkspaceData {
+  id?: string;
+  cwd?: string;
+  git_root?: string;
+  repository?: string;
+  branch?: string;
+  summary?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+function parseWorkspaceYaml(raw: string): WorkspaceData {
+  const data: Record<string, string> = {};
+  const lines = raw.split('\n');
+  let inMultiline = false;
+  let multilineKey = '';
+  const multilineLines: string[] = [];
+
+  for (const line of lines) {
+    if (inMultiline) {
+      if (line.startsWith('  ')) {
+        multilineLines.push(line.trim());
+        continue;
+      }
+      data[multilineKey] = multilineLines.join(' ').slice(0, 200);
+      inMultiline = false;
+      multilineLines.length = 0;
+    }
+
+    if (!line.includes(':') || line.startsWith(' ')) continue;
+    const idx = line.indexOf(':');
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+
+    if (!value && (key === 'summary')) {
+      inMultiline = true;
+      multilineKey = key;
+      continue;
+    }
+
+    // Strip YAML block scalar indicators
+    if (value === '|-' || value === '|' || value === '>') {
+      inMultiline = true;
+      multilineKey = key;
+      continue;
+    }
+
+    data[key] = value;
+  }
+
+  if (inMultiline && multilineLines.length > 0) {
+    data[multilineKey] = multilineLines.join(' ').slice(0, 200);
+  }
+
+  return data as WorkspaceData;
+}
+
+// ── Lock file / PID liveness check ──────────────────────
+
+function isSessionLive(sessionDir: string): boolean {
+  try {
+    const files = readdirSync(sessionDir);
+    const lockFile = files.find(f => f.startsWith('inuse.') && f.endsWith('.lock'));
+    if (!lockFile) return false;
+
+    const pidStr = lockFile.replace('inuse.', '').replace('.lock', '');
+    const pid = parseInt(pidStr, 10);
+    if (isNaN(pid)) return false;
+
+    // Check if PID is alive (signal 0 = check existence, doesn't actually send signal)
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+// ── Session source detection ────────────────────────────
+
+function detectSource(sessionDir: string): LocalSessionSource {
+  const metaPath = join(sessionDir, 'vscode.metadata.json');
+  if (existsSync(metaPath)) {
+    try {
+      const content = readFileSync(metaPath, 'utf8').trim();
+      // Non-empty object means VS Code created it
+      if (content && content !== '{}') return 'vscode';
+    } catch { /* ignore */ }
+  }
+  return 'copilot-cli';
+}
+
+// ── Model extraction from events.jsonl first line ───────
+
+function extractModelFromEvents(sessionDir: string): string | undefined {
+  const eventsPath = join(sessionDir, 'events.jsonl');
+  if (!existsSync(eventsPath)) return undefined;
+
+  try {
+    // Read only the first line (session.start event) without loading entire file
+    const fd = require('node:fs').openSync(eventsPath, 'r');
+    const buf = Buffer.alloc(2048);
+    const bytesRead = require('node:fs').readSync(fd, buf, 0, 2048, 0);
+    require('node:fs').closeSync(fd);
+
+    const firstLine = buf.toString('utf8', 0, bytesRead).split('\n')[0];
+    if (!firstLine) return undefined;
+
+    const event = JSON.parse(firstLine);
+    if (event.type === 'session.start') {
+      return event.data?.selectedModel ?? undefined;
+    }
+  } catch { /* ignore parse errors */ }
+
+  return undefined;
+}
+
+// ── Main scanner ────────────────────────────────────────
+
+export interface ScanOptions {
+  /** Additional directories to scan beyond ~/.copilot/session-state/ */
+  extraDirs?: string[];
+  /** Whether to read events.jsonl first line for model info (slower). Default false. */
+  includeModel?: boolean;
+}
+
+/**
+ * Scan local filesystem for Copilot sessions.
+ * Returns a flat array of LocalSession descriptors.
+ */
+export function scanLocalSessions(options: ScanOptions = {}): LocalSession[] {
+  const sessions: LocalSession[] = [];
+  const scanDirs = [SESSION_STATE_DIR, ...(options.extraDirs ?? [])];
+
+  for (const baseDir of scanDirs) {
+    if (!existsSync(baseDir)) continue;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(baseDir);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const sessionDir = join(baseDir, entry);
+      const wsPath = join(sessionDir, 'workspace.yaml');
+
+      if (!existsSync(wsPath)) continue;
+
+      try {
+        const raw = readFileSync(wsPath, 'utf8');
+        const ws = parseWorkspaceYaml(raw);
+
+        // Use modifiedTime from filesystem if workspace.yaml doesn't have it
+        let modifiedTime = ws.updated_at ?? ws.created_at ?? '';
+        if (!modifiedTime) {
+          try {
+            const stat = statSync(join(sessionDir, 'events.jsonl'));
+            modifiedTime = stat.mtime.toISOString();
+          } catch {
+            modifiedTime = new Date().toISOString();
+          }
+        }
+
+        const session: LocalSession = {
+          sessionId: ws.id ?? entry,
+          cwd: ws.cwd ?? '/',
+          startTime: ws.created_at ?? modifiedTime,
+          modifiedTime,
+          isLive: isSessionLive(sessionDir),
+          source: detectSource(sessionDir),
+        };
+
+        if (ws.git_root) session.gitRoot = ws.git_root;
+        if (ws.repository) session.repository = ws.repository;
+        if (ws.branch) session.branch = ws.branch;
+        if (ws.summary) session.summary = ws.summary.slice(0, 200);
+
+        if (options.includeModel) {
+          const model = extractModelFromEvents(sessionDir);
+          if (model) session.model = model;
+        }
+
+        sessions.push(session);
+      } catch (err) {
+        logger.debug({ sessionDir, err: (err as Error).message }, 'Skipping unparseable session');
+      }
+    }
+  }
+
+  // Sort by modifiedTime descending (most recent first)
+  sessions.sort((a, b) => b.modifiedTime.localeCompare(a.modifiedTime));
+
+  return sessions;
+}
+
+// ── Filter helper ───────────────────────────────────────
+
+export interface SessionFilter {
+  search?: string;
+  liveOnly?: boolean;
+  includeLinked?: boolean;
+}
+
+export function filterSessions(
+  sessions: LocalSession[],
+  filter: SessionFilter,
+  linkedIds: Set<string>,
+): LocalSession[] {
+  return sessions.filter(s => {
+    if (filter.liveOnly && !s.isLive) return false;
+    if (!filter.includeLinked && linkedIds.has(s.sessionId)) return false;
+
+    if (filter.search) {
+      const q = filter.search.toLowerCase();
+      const haystack = [
+        s.cwd, s.gitRoot, s.repository, s.branch, s.summary, s.sessionId,
+      ].filter(Boolean).join(' ').toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

Import sessions from the local Copilot CLI or VS Code into Kraki — browse, search, and continue any conversation from your phone.

Both Kraki and the original CLI share the same session state on disk. Either side can die and the other continues. Tested with concurrent SDK resume — no conflicts.

## What's new

### Protocol
- `LocalSession` type, `request_local_sessions`, `import_session`, `local_sessions_list` messages
- `source` field on `SessionSummary` and `SessionDigest`

### Tentacle
- **session-scanner.ts** — filesystem scan, lock file liveness, source detection
- **history-parser.ts** — events.jsonl → Kraki messages (caps 500), model extraction from tool.execution_complete
- **Link table** — local ↔ Kraki session mapping
- **relay-client handlers** — request/import/delete cleanup
- Filters out Kraki daemon sessions, broadcast fallback for open auth

### Web
- **Import picker dialog** — tree view, search with auto-expand + highlighting, device selector
- **Source badges** on SessionCard
- Store, commands, message router wiring

### Tests
- 31 new unit tests + 3 Playwright E2E tests
- All 531 existing tests pass

## Commits (9)
- `d253bcf` feat: protocol + tentacle support
- `b141206` test: scanner, parser, link table
- `2cb96e9` feat(web): import picker + source badges
- `adec7b8` test(e2e): playwright tests
- `3a36697` fix: unicast targeting, label dedup, filtering
- `e4614c3` fix: createSession instead of resumeSession
- `dc1646f` ux: dismiss dialog, device selector
- `239904f` ux: search auto-expand, highlight
- `2f51769` fix: model, title, source, createdAt metadata

## Follow-up (not in this PR)
- SDK lifecycle events for real-time scanner
- Daemon-worker periodic scan wiring
- Sync config settings