### PR TITLE
fix: surface silent SDK errors and failed actions to user

### DIFF
--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -694,6 +694,23 @@ describe('CopilotAdapter', () => {
       );
     });
 
+    it('does not duplicate session.error reports within the same turn', async () => {
+      const spy = vi.fn();
+      adapter.onError = spy;
+      await adapter.start();
+      await adapter.createSession({});
+      mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '1' } });
+      mockSessions[0]._emit('session.error', {
+        data: { errorType: 'query', message: 'First error' },
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      mockSessions[0]._emit('session.error', {
+        data: { errorType: 'query', message: 'Duplicate error' },
+      });
+      // Second session.error should be suppressed
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
     it('does not fire empty-turn error when session.error already reported', async () => {
       const spy = vi.fn();
       adapter.onError = spy;

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -664,6 +664,23 @@ describe('CopilotAdapter', () => {
       // Should not double-report — session.error already surfaced
       expect(spy).not.toHaveBeenCalled();
     });
+
+    it('does not double-report when session.error fires before turn_start', async () => {
+      const spy = vi.fn();
+      adapter.onError = spy;
+      await adapter.start();
+      await adapter.createSession({});
+      // session.error arrives BEFORE turn_start (error recovery path)
+      mockSessions[0]._emit('session.error', {
+        data: { errorType: 'query', message: 'Model not available' },
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockClear();
+      // turn_start should NOT reset the error flag
+      mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '1' } });
+      mockSessions[0]._emit('assistant.turn_end', { data: {} });
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   // ── Permission flow ─────────────────────────────────

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -573,15 +573,34 @@ describe('CopilotAdapter', () => {
       expect(spy).toHaveBeenCalledWith(sessionId, { message: 'Unknown agent error' });
     });
 
-    it('does not fire onError for non-error turn_end', async () => {
+    it('does not fire onError for non-error turn_end with output', async () => {
       const spy = vi.fn();
       adapter.onError = spy;
       await adapter.start();
       await adapter.createSession({});
+      // Simulate a complete turn: start → message → end
+      mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '1' } });
+      mockSessions[0]._emit('assistant.message', { data: { content: 'hello' } });
       mockSessions[0]._emit('assistant.turn_end', {
         data: { reason: 'complete' },
       });
       expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('fires onError for empty turn (no output)', async () => {
+      const spy = vi.fn();
+      adapter.onError = spy;
+      await adapter.start();
+      await adapter.createSession({});
+      // Simulate an empty turn: start → end with no message or tool
+      mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '1' } });
+      mockSessions[0]._emit('assistant.turn_end', {
+        data: { reason: 'complete' },
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ message: expect.stringContaining('no output') }),
+      );
     });
 
     it('does not throw when callbacks are null', async () => {
@@ -591,6 +610,59 @@ describe('CopilotAdapter', () => {
       mockSessions[0]._emit('assistant.message', { data: { content: 'test' } });
       mockSessions[0]._emit('session.idle', {});
       mockSessions[0]._emit('assistant.turn_end', { data: { reason: 'error', error: 'test' } });
+    });
+
+    it('fires onError for session.error events', async () => {
+      const spy = vi.fn();
+      adapter.onError = spy;
+      await adapter.start();
+      const { sessionId } = await adapter.createSession({});
+      mockSessions[0]._emit('session.error', {
+        data: { errorType: 'query', message: 'Model "opus" is not available.', statusCode: 400 },
+      });
+      expect(spy).toHaveBeenCalledWith(sessionId, { message: 'Model "opus" is not available.' });
+    });
+
+    it('fires onError on involuntary model change', async () => {
+      const errorSpy = vi.fn();
+      adapter.onError = errorSpy;
+      await adapter.start();
+      await adapter.createSession({ model: 'claude-opus-4.6' });
+      mockSessions[0]._emit('session.model_change', {
+        data: { previousModel: 'claude-opus-4.6', newModel: 'goldeneye' },
+      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ message: expect.stringContaining('goldeneye') }),
+      );
+    });
+
+    it('does not fire onError on expected model change', async () => {
+      const errorSpy = vi.fn();
+      adapter.onError = errorSpy;
+      await adapter.start();
+      const { sessionId } = await adapter.createSession({ model: 'claude-opus-4.6' });
+      // User explicitly changes model
+      await adapter.setSessionModel(sessionId, 'gpt-4.1');
+      mockSessions[0]._emit('session.model_change', {
+        data: { previousModel: 'claude-opus-4.6', newModel: 'gpt-4.1' },
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not fire empty-turn error when session.error already reported', async () => {
+      const spy = vi.fn();
+      adapter.onError = spy;
+      await adapter.start();
+      await adapter.createSession({});
+      mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '1' } });
+      mockSessions[0]._emit('session.error', {
+        data: { errorType: 'query', message: 'API error' },
+      });
+      spy.mockClear();
+      mockSessions[0]._emit('assistant.turn_end', { data: {} });
+      // Should not double-report — session.error already surfaced
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -40,20 +40,31 @@ vi.mock('../../logger.js', () => {
 
 function createMockSession(sessionId: string) {
   const listeners = new Map<string, Function[]>();
+  const catchAllListeners: Function[] = [];
   return {
     sessionId,
     send: vi.fn(),
     abort: vi.fn().mockResolvedValue(undefined),
-    disconnect: vi.fn(),
+    disconnect: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue(undefined),
     getMessages: vi.fn().mockResolvedValue([]),
-    on: vi.fn((event: string, handler: Function) => {
-      if (!listeners.has(event)) listeners.set(event, []);
-      listeners.get(event)!.push(handler);
+    on: vi.fn((...args: unknown[]) => {
+      if (args.length === 2) {
+        // Typed form: on(eventType, handler)
+        const [event, handler] = args as [string, Function];
+        if (!listeners.has(event)) listeners.set(event, []);
+        listeners.get(event)!.push(handler);
+      } else if (args.length === 1 && typeof args[0] === 'function') {
+        // Catch-all form: on(handler)
+        catchAllListeners.push(args[0] as Function);
+      }
     }),
     // Test helper: fire a fake SDK event
     _emit(event: string, data: unknown) {
       for (const fn of listeners.get(event) ?? []) fn(data);
+      // Also dispatch to catch-all listeners with {type, data} shape
+      const eventObj = { type: event, ...(typeof data === 'object' && data !== null ? data : { data }) };
+      for (const fn of catchAllListeners) fn(eventObj);
     },
     _listeners: listeners,
   };
@@ -623,31 +634,64 @@ describe('CopilotAdapter', () => {
       expect(spy).toHaveBeenCalledWith(sessionId, { message: 'Model "opus" is not available.' });
     });
 
-    it('fires onError on involuntary model change', async () => {
+    it('disconnects and errors on model mismatch in tools_updated', async () => {
+      const errorSpy = vi.fn();
+      const idleSpy = vi.fn();
+      adapter.onError = errorSpy;
+      adapter.onIdle = idleSpy;
+      await adapter.start();
+      await adapter.createSession({ model: 'claude-opus-4.6' });
+      mockSessions[0]._emit('session.tools_updated', {
+        data: { model: 'goldeneye' },
+      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ message: expect.stringContaining('unavailable') }),
+      );
+      expect(idleSpy).toHaveBeenCalled();
+      // Session should be removed from adapter — next getSession would throw
+      expect(mockSessions[0].abort).toHaveBeenCalled();
+      expect(mockSessions[0].disconnect).toHaveBeenCalled();
+    });
+
+    it('does not disconnect when tools_updated matches expected model', async () => {
       const errorSpy = vi.fn();
       adapter.onError = errorSpy;
       await adapter.start();
       await adapter.createSession({ model: 'claude-opus-4.6' });
-      mockSessions[0]._emit('session.model_change', {
-        data: { previousModel: 'claude-opus-4.6', newModel: 'goldeneye' },
+      mockSessions[0]._emit('session.tools_updated', {
+        data: { model: 'claude-opus-4.6' },
       });
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({ message: expect.stringContaining('goldeneye') }),
-      );
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(mockSessions[0].abort).not.toHaveBeenCalled();
     });
 
-    it('does not fire onError on expected model change', async () => {
+    it('does not disconnect when user changed model via setSessionModel', async () => {
       const errorSpy = vi.fn();
       adapter.onError = errorSpy;
       await adapter.start();
       const { sessionId } = await adapter.createSession({ model: 'claude-opus-4.6' });
-      // User explicitly changes model
       await adapter.setSessionModel(sessionId, 'gpt-4.1');
-      mockSessions[0]._emit('session.model_change', {
-        data: { previousModel: 'claude-opus-4.6', newModel: 'gpt-4.1' },
+      mockSessions[0]._emit('session.tools_updated', {
+        data: { model: 'gpt-4.1' },
       });
       expect(errorSpy).not.toHaveBeenCalled();
+      expect(mockSessions[0].abort).not.toHaveBeenCalled();
+    });
+
+    it('uses original user-requested model in error message after fallback', async () => {
+      const errorSpy = vi.fn();
+      adapter.onError = errorSpy;
+      adapter.onIdle = vi.fn();
+      await adapter.start();
+      await adapter.createSession({ model: 'claude-opus-4.6-1m' });
+      mockSessions[0]._emit('session.tools_updated', {
+        data: { model: 'goldeneye' },
+      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ message: expect.stringContaining('claude-opus-4.6-1m') }),
+      );
     });
 
     it('does not fire empty-turn error when session.error already reported', async () => {

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -109,8 +109,6 @@ export abstract class AgentAdapter {
   onSessionEnded: ((sessionId: string, event: SessionEndedEvent) => void) | null = null;
   /** Called when the agent produces a title for a session (e.g. via SDK event). */
   onTitleChanged: ((sessionId: string, title: string) => void) | null = null;
-  /** Called when the SDK changes the session model (e.g. involuntary fallback). */
-  onModelChanged: ((sessionId: string, model: string) => void) | null = null;
   /** Called with updated cumulative token usage for a session */
   onUsageUpdate: ((sessionId: string, usage: SessionUsage) => void) | null = null;
 

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -109,6 +109,8 @@ export abstract class AgentAdapter {
   onSessionEnded: ((sessionId: string, event: SessionEndedEvent) => void) | null = null;
   /** Called when the agent produces a title for a session (e.g. via SDK event). */
   onTitleChanged: ((sessionId: string, title: string) => void) | null = null;
+  /** Called when the SDK changes the session model (e.g. involuntary fallback). */
+  onModelChanged: ((sessionId: string, model: string) => void) | null = null;
   /** Called with updated cumulative token usage for a session */
   onUsageUpdate: ((sessionId: string, usage: SessionUsage) => void) | null = null;
 

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -938,8 +938,10 @@ export class CopilotAdapter extends AgentAdapter {
       const message = (data.message as string) ?? 'Unknown session error';
       const errorType = data.errorType as string | undefined;
       logger.error({ sessionId, errorType, statusCode: data.statusCode }, `session.error: ${message}`);
-      this.turnErrorReported.set(sessionId, true);
-      this.onError?.(sessionId, { message });
+      if (!this.turnErrorReported.get(sessionId)) {
+        this.turnErrorReported.set(sessionId, true);
+        this.onError?.(sessionId, { message });
+      }
     });
 
     // session.tools_updated is ephemeral and not in the typed event union,
@@ -963,11 +965,11 @@ export class CopilotAdapter extends AgentAdapter {
         this.sessions.delete(sessionId);
       }
 
-      this.turnErrorReported.set(sessionId, true);
       this.onError?.(sessionId, {
-        message: `${requested} is unavailable — session paused to prevent history corruption. Send a message to retry.`,
+        message: `${requested} is currently unavailable. Session paused — send a message to retry.`,
       });
       this.onIdle?.(sessionId);
+      this.cleanupSessionPermissions(sessionId);
     });
 
     session.on('session.info', (event) => {

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -259,6 +259,8 @@ export class CopilotAdapter extends AgentAdapter {
   private pendingToolArgs = new Map<string, Record<string, unknown>>();
   /** Expected model per session — detects involuntary model fallbacks by the CLI */
   private expectedModels = new Map<string, string>();
+  /** User's originally requested model — never updated on involuntary fallbacks */
+  private userRequestedModels = new Map<string, string>();
   /** Whether the current turn has produced any output (message or tool call) */
   private turnHasOutput = new Map<string, boolean>();
   /** Whether an error was already reported for the current turn */
@@ -448,7 +450,10 @@ export class CopilotAdapter extends AgentAdapter {
     this.wireEvents(sid, session);
 
     logger.info(`session created: ${sid} (model: ${config.model ?? 'default'})`);
-    if (config.model) this.expectedModels.set(sid, config.model);
+    if (config.model) {
+      this.expectedModels.set(sid, config.model);
+      this.userRequestedModels.set(sid, config.model);
+    }
     this.onSessionCreated?.({
       sessionId: sid,
       agent: 'copilot',
@@ -717,6 +722,7 @@ export class CopilotAdapter extends AgentAdapter {
       return;
     }
     this.expectedModels.set(sessionId, model);
+    this.userRequestedModels.set(sessionId, model);
     await entry.session.setModel(model);
     logger.info({ sessionId, model }, 'Session model changed');
   }
@@ -738,6 +744,7 @@ export class CopilotAdapter extends AgentAdapter {
     this.pendingModeSignals.delete(sessionId);
     this.sessionUsage.delete(sessionId);
     this.expectedModels.delete(sessionId);
+    this.userRequestedModels.delete(sessionId);
     this.turnHasOutput.delete(sessionId);
     this.turnErrorReported.delete(sessionId);
     this.clearIdleTimer(sessionId);
@@ -919,7 +926,11 @@ export class CopilotAdapter extends AgentAdapter {
     session.on('assistant.turn_start', () => {
       this.clearIdleTimer(sessionId);
       this.turnHasOutput.set(sessionId, false);
-      this.turnErrorReported.set(sessionId, false);
+      // Only reset if no error was reported before this turn started
+      // (session.error can fire before turn_start in error recovery paths)
+      if (!this.turnErrorReported.get(sessionId)) {
+        this.turnErrorReported.set(sessionId, false);
+      }
     });
 
     session.on('session.error', (event) => {
@@ -938,10 +949,11 @@ export class CopilotAdapter extends AgentAdapter {
       const expected = this.expectedModels.get(sessionId);
 
       if (expected && newModel !== expected) {
-        logger.warn({ sessionId, expected, previousModel, newModel }, 'Involuntary model fallback detected');
+        const requested = this.userRequestedModels.get(sessionId) ?? expected;
+        logger.warn({ sessionId, requested, previousModel, newModel }, 'Involuntary model fallback detected');
         this.expectedModels.set(sessionId, newModel);
         this.onError?.(sessionId, {
-          message: `Model changed from ${expected} to ${newModel} (requested model may be unavailable)`,
+          message: `Model changed from ${requested} to ${newModel} (requested model may be unavailable)`,
         });
       } else {
         logger.info({ sessionId, previousModel, newModel }, 'Session model changed (SDK)');

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -257,6 +257,12 @@ export class CopilotAdapter extends AgentAdapter {
   private idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** Track tool start args by toolCallId for correlating with tool_complete */
   private pendingToolArgs = new Map<string, Record<string, unknown>>();
+  /** Expected model per session — detects involuntary model fallbacks by the CLI */
+  private expectedModels = new Map<string, string>();
+  /** Whether the current turn has produced any output (message or tool call) */
+  private turnHasOutput = new Map<string, boolean>();
+  /** Whether an error was already reported for the current turn */
+  private turnErrorReported = new Map<string, boolean>();
   /**
    * Grace period (ms) after assistant.turn_end before firing a fallback idle.
    * The Copilot CLI has a known bug where session.idle is sometimes not emitted
@@ -442,7 +448,7 @@ export class CopilotAdapter extends AgentAdapter {
     this.wireEvents(sid, session);
 
     logger.info(`session created: ${sid} (model: ${config.model ?? 'default'})`);
-
+    if (config.model) this.expectedModels.set(sid, config.model);
     this.onSessionCreated?.({
       sessionId: sid,
       agent: 'copilot',
@@ -710,6 +716,7 @@ export class CopilotAdapter extends AgentAdapter {
       logger.warn({ sessionId }, 'setSessionModel: session not found');
       return;
     }
+    this.expectedModels.set(sessionId, model);
     await entry.session.setModel(model);
     logger.info({ sessionId, model }, 'Session model changed');
   }
@@ -730,6 +737,9 @@ export class CopilotAdapter extends AgentAdapter {
     this.sessionModes.delete(sessionId);
     this.pendingModeSignals.delete(sessionId);
     this.sessionUsage.delete(sessionId);
+    this.expectedModels.delete(sessionId);
+    this.turnHasOutput.delete(sessionId);
+    this.turnErrorReported.delete(sessionId);
     this.clearIdleTimer(sessionId);
   }
 
@@ -826,11 +836,13 @@ export class CopilotAdapter extends AgentAdapter {
     session.on('assistant.message', (event) => {
       // Skip empty messages (SDK sends these before tool calls)
       if (event.data.content) {
+        this.turnHasOutput.set(sessionId, true);
         this.onMessage?.(sessionId, { content: event.data.content });
       }
     });
 
     session.on('tool.execution_start', (event) => {
+      this.turnHasOutput.set(sessionId, true);
       const data = event.data as Record<string, unknown>;
       if (data.mcpServerName) {
         logger.info({ mcpServer: data.mcpServerName, mcpTool: data.mcpToolName }, `[MCP tool] ${data.mcpServerName}/${data.mcpToolName}`);
@@ -906,6 +918,37 @@ export class CopilotAdapter extends AgentAdapter {
 
     session.on('assistant.turn_start', () => {
       this.clearIdleTimer(sessionId);
+      this.turnHasOutput.set(sessionId, false);
+      this.turnErrorReported.set(sessionId, false);
+    });
+
+    session.on('session.error', (event) => {
+      const data = event.data as Record<string, unknown>;
+      const message = (data.message as string) ?? 'Unknown session error';
+      const errorType = data.errorType as string | undefined;
+      logger.error({ sessionId, errorType, statusCode: data.statusCode }, `session.error: ${message}`);
+      this.turnErrorReported.set(sessionId, true);
+      this.onError?.(sessionId, { message });
+    });
+
+    session.on('session.model_change', (event) => {
+      const data = event.data as Record<string, unknown>;
+      const previousModel = data.previousModel as string | undefined;
+      const newModel = data.newModel as string;
+      const expected = this.expectedModels.get(sessionId);
+
+      if (expected && newModel !== expected) {
+        logger.warn({ sessionId, expected, previousModel, newModel }, 'Involuntary model fallback detected');
+        this.expectedModels.set(sessionId, newModel);
+        this.onError?.(sessionId, {
+          message: `Model changed from ${expected} to ${newModel} (requested model may be unavailable)`,
+        });
+      } else {
+        logger.info({ sessionId, previousModel, newModel }, 'Session model changed (SDK)');
+        this.expectedModels.set(sessionId, newModel);
+      }
+      // Notify so the arm updates the model badge
+      this.onModelChanged?.(sessionId, newModel);
     });
 
     session.on('session.info', (event) => {
@@ -928,10 +971,21 @@ export class CopilotAdapter extends AgentAdapter {
       const data = event.data as Record<string, unknown>;
       const reason = data?.reason;
       if (reason === 'error') {
+        this.turnErrorReported.set(sessionId, true);
         this.onError?.(sessionId, {
           message: (data?.error as string) ?? 'Unknown agent error',
         });
       }
+
+      // Detect empty turns — the agent started a turn but produced no output
+      // and no error was reported via session.error or turn_end.reason
+      if (!this.turnHasOutput.get(sessionId) && !this.turnErrorReported.get(sessionId)) {
+        logger.warn({ sessionId }, 'Empty turn detected — agent produced no output');
+        this.onError?.(sessionId, {
+          message: 'Agent produced no output. The session may need to be restarted or the model may be unavailable.',
+        });
+      }
+
       // Fallback: schedule idle in case the SDK doesn't emit session.idle
       // (known CLI bug — github/copilot-sdk#794). Cancelled if turn_start
       // or session.idle arrives first.

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -942,25 +942,32 @@ export class CopilotAdapter extends AgentAdapter {
       this.onError?.(sessionId, { message });
     });
 
-    session.on('session.model_change', (event) => {
-      const data = event.data as Record<string, unknown>;
-      const previousModel = data.previousModel as string | undefined;
-      const newModel = data.newModel as string;
-      const expected = this.expectedModels.get(sessionId);
+    // session.tools_updated is ephemeral and not in the typed event union,
+    // so we use the generic catch-all handler form.
+    session.on((event: { type: string; data?: Record<string, unknown> }) => {
+      if (event.type !== 'session.tools_updated') return;
+      const actualModel = event.data?.model as string | undefined;
+      if (!actualModel) return;
 
-      if (expected && newModel !== expected) {
-        const requested = this.userRequestedModels.get(sessionId) ?? expected;
-        logger.warn({ sessionId, requested, previousModel, newModel }, 'Involuntary model fallback detected');
-        this.expectedModels.set(sessionId, newModel);
-        this.onError?.(sessionId, {
-          message: `Model changed from ${requested} to ${newModel} (requested model may be unavailable)`,
-        });
-      } else {
-        logger.info({ sessionId, previousModel, newModel }, 'Session model changed (SDK)');
-        this.expectedModels.set(sessionId, newModel);
+      const expected = this.expectedModels.get(sessionId);
+      if (!expected || actualModel === expected) return;
+
+      const requested = this.userRequestedModels.get(sessionId) ?? expected;
+      logger.warn({ sessionId, requested, actualModel }, 'Model mismatch detected — aborting to prevent history pollution');
+
+      // Abort the in-flight turn and disconnect before any polluted events are produced
+      const entry = this.sessions.get(sessionId);
+      if (entry) {
+        entry.session.abort().catch(() => {});
+        entry.session.disconnect().catch(() => {});
+        this.sessions.delete(sessionId);
       }
-      // Notify so the arm updates the model badge
-      this.onModelChanged?.(sessionId, newModel);
+
+      this.turnErrorReported.set(sessionId, true);
+      this.onError?.(sessionId, {
+        message: `${requested} is unavailable — session paused to prevent history corruption. Send a message to retry.`,
+      });
+      this.onIdle?.(sessionId);
     });
 
     session.on('session.info', (event) => {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -414,26 +414,41 @@ export class RelayClient {
           this.sessionManager.markActive(sessionId);
           this.send({ type: 'active', sessionId, payload: {} });
           this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments)
-            .catch((err) => logger.error({ err, sessionId }, 'sendMessage failed'));
+            .catch((err) => {
+              logger.error({ err, sessionId }, 'sendMessage failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver message: ${(err as Error).message}` } });
+            });
           break;
         case 'approve':
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'approve')
-            .catch((err) => logger.error({ err, sessionId }, 'respondToPermission failed'));
+            .catch((err) => {
+              logger.error({ err, sessionId }, 'respondToPermission failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to approve permission: ${(err as Error).message}` } });
+            });
           this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'approved' } });
           break;
         case 'deny':
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'deny')
-            .catch((err) => logger.error({ err, sessionId }, 'respondToPermission failed'));
+            .catch((err) => {
+              logger.error({ err, sessionId }, 'respondToPermission failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to deny permission: ${(err as Error).message}` } });
+            });
           this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'denied' } });
           break;
         case 'always_allow':
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'always_allow')
-            .catch((err) => logger.error({ err, sessionId }, 'respondToPermission failed'));
+            .catch((err) => {
+              logger.error({ err, sessionId }, 'respondToPermission failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to set always-allow: ${(err as Error).message}` } });
+            });
           this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'always_allowed' } });
           break;
         case 'answer':
           this.adapter.respondToQuestion(sessionId, msg.payload.questionId, msg.payload.answer, false)
-            .catch((err) => logger.error({ err, sessionId }, 'respondToQuestion failed'));
+            .catch((err) => {
+              logger.error({ err, sessionId }, 'respondToQuestion failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver answer: ${(err as Error).message}` } });
+            });
           this.send({ type: 'question_resolved', sessionId, payload: { questionId: msg.payload.questionId, answer: msg.payload.answer } });
           break;
         case 'kill_session':
@@ -446,7 +461,10 @@ export class RelayClient {
               this.sessionManager.markIdle(sessionId);
               this.send({ type: 'idle', sessionId, payload: { reason: 'aborted' } });
             })
-            .catch((err) => logger.error({ err, sessionId }, 'abortSession failed'));
+            .catch((err) => {
+              logger.error({ err, sessionId }, 'abortSession failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to abort session: ${(err as Error).message}` } });
+            });
           break;
         case 'delete_session':
           this.adapter.killSession(sessionId)
@@ -509,7 +527,10 @@ export class RelayClient {
         case 'set_session_model': {
           const { model, reasoningEffort } = msg.payload;
           this.adapter.setSessionModel(sessionId, model, reasoningEffort)
-            .catch((err) => logger.error({ err, sessionId }, 'setSessionModel failed'));
+            .catch((err) => {
+              logger.error({ err, sessionId }, 'setSessionModel failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to change model: ${(err as Error).message}` } });
+            });
           this.sessionManager.setModel(sessionId, model);
           this.send({
             type: 'session_model_set',
@@ -994,6 +1015,16 @@ export class RelayClient {
           payload: { title: meta?.title, autoTitle: title },
         });
       }
+    };
+
+    // SDK model change — update session metadata and notify arms
+    this.adapter.onModelChanged = (sessionId, model) => {
+      this.sessionManager.setModel(sessionId, model);
+      this.send({
+        type: 'session_model_set',
+        sessionId,
+        payload: { model },
+      });
     };
   }
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1016,16 +1016,6 @@ export class RelayClient {
         });
       }
     };
-
-    // SDK model change — update session metadata and notify arms
-    this.adapter.onModelChanged = (sessionId, model) => {
-      this.sessionManager.setModel(sessionId, model);
-      this.send({
-        type: 'session_model_set',
-        sessionId,
-        payload: { model },
-      });
-    };
   }
 
   // ── Session resume on reconnect ─────────────────────


### PR DESCRIPTION
## Problem

Kraki silently swallows errors at multiple layers. The worst case: a user sends messages, the agent hits a backend error, and the user sees nothing — just an idle session with no response.

**Production incident**: The Copilot CLI got "Model claude-opus-4.6-1m is not available" on resume, silently fell back to goldeneye (a different model), ran 17 turns with goldeneye's `apply_patch` / `custom_call_*` tool format, then when the daemon restarted and resumed with opus again, every message silently failed with `CAPIError: 400 tool call must have a tool call ID and function name` — because the history contained goldeneye-specific tool calls that Claude couldn't parse. The user saw three messages go unanswered with no error.

## Three systemic gaps fixed

### 1. SDK events not wired
The adapter only caught errors through `turn_end.reason === 'error'` (which isn't always set). Now wires:
- **`session.error`** — catches model-not-available, API 400s, quota errors, rate limits
- **`session.model_change`** — detects involuntary model fallbacks (e.g. opus→goldeneye) vs user-initiated changes

### 2. Fire-and-forget `.catch` in relay-client
`sendMessage()`, permission responses, model changes, abort — all used `.catch(logger.error)` with no broadcast back to the arm. Now each broadcasts an `error` message to the session so the user sees the failure.

### 3. No empty-turn detection
When a turn completed with zero output (no `agent_message`, no tools), the session just went idle silently. Now tracks `turnHasOutput` per session and fires a diagnostic error if a turn ends with nothing.

## Changes

| File | What |
|------|------|
| `adapters/base.ts` | Add `onModelChanged` callback |
| `adapters/copilot.ts` | Wire `session.error`, `session.model_change`, empty-turn detection; track `expectedModels`, `turnHasOutput`, `turnErrorReported` |
| `relay-client.ts` | Surface failures in all `.catch` handlers; wire `onModelChanged` |
| `copilot.test.ts` | 5 new tests for session.error, model change (involuntary + expected), empty turn, no double-report |

## Test results

`pnpm validate` passes — lint ✅, build ✅, 100 adapter tests (was 95) ✅, all 330+ tests pass.

## Not included (P2, deferred)

- E2E encryption failure surfacing (protocol design question — can't encrypt the error itself)
- `session.warning` surfacing (low severity)