### PR TITLE
fix: eliminate ChatView scroll flicker

### DIFF
--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useLayoutEffect, useRef, useMemo, useState, useCallback, type MutableRefObject } from 'react';
+import { memo, useRef, useMemo, useCallback } from 'react';
 import { useParams } from 'react-router';
 import { useStore } from '../../hooks/useStore';
 import { useShallow } from 'zustand/shallow';
@@ -8,16 +8,12 @@ import { MessageInput } from './MessageInput';
 import { PermissionInput } from '../actions/PermissionInput';
 import { QuestionInput } from '../actions/QuestionInput';
 import { useTurns } from '../../hooks/useTurns';
+import { useScrollController } from '../../hooks/useScrollController';
 import { GapMarker } from './GapMarker';
-import { createLogger } from '../../lib/logger';
 import type { ChatMessage } from '../../types/store';
 import type { Attachment } from '@kraki/protocol';
 
-const logger = createLogger('chat-view');
-
 const EMPTY_MESSAGES: ChatMessage[] = [];
-const IDLE_SCROLL_OVERFLOW_PX = 120;
-const BOTTOM_STICKY_THRESHOLD_PX = 40;
 
 /** Collect image attachments from tool_complete messages in a turn's thinking. */
 function collectTurnImages(thinkingMessages: ChatMessage[]): Attachment[] {
@@ -69,12 +65,7 @@ export const ChatView = memo(function ChatView() {
     useShallow((s) => [...s.pendingQuestions.values()].filter((q) => q.sessionId === sessionId)),
   );
 
-  const hadUnreadRef = useRef(storeUnread > 0);
-  /** Set when older messages are prepended — gates the scroll-preservation layout effect. */
-  const prependedRef = useRef(false);
-
   // Filter out pending permission bubbles — the blocking card handles them.
-  // Questions are always shown as normal chat bubbles.
   const filteredMessages = useMemo(
     () => messages.filter((msg) => {
       if (msg.type === 'permission' && pendingPermIds.includes(msg.payload.id)) return false;
@@ -83,70 +74,28 @@ export const ChatView = memo(function ChatView() {
     [messages, pendingPermIds],
   );
 
-  // Show spinner at top if there are older messages not yet loaded
+  // First seq for gap detection / prepend tracking
   const firstSeq = useMemo(() => {
     const seqs = filteredMessages.map(getSeq).filter(s => s > 0);
     return seqs.length > 0 ? seqs[0] : 0;
   }, [filteredMessages]);
   const hasOlderMessages = firstSeq > 1;
-  const prevFirstSeqRef = useRef(firstSeq);
-  if (firstSeq > 0 && prevFirstSeqRef.current > 0 && firstSeq < prevFirstSeqRef.current) {
-    prependedRef.current = true;
-  }
-  prevFirstSeqRef.current = firstSeq;
 
   const rawGrouped = useTurns(filteredMessages);
 
-  // Only the last turn can be active, and only if the session isn't idle
   const sessionIdle = filteredMessages.length > 0 && filteredMessages[filteredMessages.length - 1].type === 'idle';
-  const prevSessionIdRef = useRef(sessionId);
-  const pendingSessionScrollRef = useRef(true);
-  const wasIdleRef = useRef(sessionIdle);
-  if (sessionId !== prevSessionIdRef.current) {
-    prevSessionIdRef.current = sessionId;
-    pendingSessionScrollRef.current = true;
-    hadUnreadRef.current = storeUnread > 0;
-    wasIdleRef.current = sessionIdle;
-  }
-
-  // Log turn grouping for debugging
-  useMemo(() => {
-    if (!sessionId) return;
-    const turns = rawGrouped.filter(g => g.type === 'turn');
-    const activeTurns = turns.filter(g => g.type === 'turn' && !g.turn.finalMessage);
-    if (activeTurns.length > 0 || turns.length > 0) {
-      logger.info('turns grouped', {
-        sessionId,
-        totalGroups: rawGrouped.length,
-        turnCount: turns.length,
-        activeTurns: activeTurns.length,
-        messageCount: filteredMessages.length,
-        turnDetails: turns.map((g, i) => ({
-          idx: i,
-          thinkingCount: g.turn.thinkingMessages.length,
-          hasFinal: !!g.turn.finalMessage,
-          finalType: g.turn.finalMessage?.type ?? 'null',
-          lastThinkingType: g.turn.thinkingMessages.length > 0 ? g.turn.thinkingMessages[g.turn.thinkingMessages.length - 1].type : 'none',
-          lastThinkingSeq: g.turn.thinkingMessages.length > 0 ? ('seq' in g.turn.thinkingMessages[g.turn.thinkingMessages.length - 1] ? (g.turn.thinkingMessages[g.turn.thinkingMessages.length - 1] as { seq?: number }).seq : '?') : '?',
-        })),
-      });
-    }
-  }, [rawGrouped, sessionId, filteredMessages.length]);
 
   // Ensure streaming always attaches to a turn group
   const grouped = useMemo(() => {
     if (!streaming) return rawGrouped;
     const last = rawGrouped[rawGrouped.length - 1];
     if (last && last.type === 'turn' && !last.turn.finalMessage) return rawGrouped;
-    // No in-progress turn — append one so streaming has a home
     return [...rawGrouped, { type: 'turn' as const, turn: { thinkingMessages: [] as ChatMessage[], finalMessage: null } }];
   }, [rawGrouped, streaming]);
 
   // Index of the element to scroll to when entering an unread session.
   // Priority: pending question > last user message (if idle) > last agent turn.
-  // (Pending permissions are filtered out of chat and shown as a blocking card at bottom.)
   const scrollTargetIdx = useMemo(() => {
-    // Pending question — scroll to its chat bubble
     for (let i = grouped.length - 1; i >= 0; i--) {
       const g = grouped[i];
       if (g.type === 'standalone' && g.message.type === 'question') {
@@ -154,14 +103,12 @@ export const ChatView = memo(function ChatView() {
         if (!payload?.answer) return i;
       }
     }
-    // Idle — scroll to the last user message (the prompt they sent)
     if (sessionIdle) {
       for (let i = grouped.length - 1; i >= 0; i--) {
         const g = grouped[i];
         if (g.type === 'standalone' && (g.message.type === 'user_message' || g.message.type === 'send_input')) return i;
       }
     }
-    // Default — last completed agent turn
     for (let i = grouped.length - 1; i >= 0; i--) {
       const g = grouped[i];
       if (g.type === 'turn' && g.turn.finalMessage) return i;
@@ -169,214 +116,21 @@ export const ChatView = memo(function ChatView() {
     return -1;
   }, [grouped, sessionIdle]);
 
+  // ── Scroll controller (all scroll logic lives here) ───
+
   const scrollRef = useRef<HTMLDivElement>(null);
-  const isAtBottomRef = useRef(true);
-  const [showScrollBtn, setShowScrollBtn] = useState(false);
-  const [unreadCount, setUnreadCount] = useState(0);
-  const prevMsgLenRef: MutableRefObject<number> = useRef(0);
-  const prevLastSeqRef = useRef(0);
-  const prevLastHasFinalRef = useRef(false);
-  const prevScrollHeightRef = useRef(0);
-  const prevStreamingLenRef = useRef(0);
-  const suppressAutoScrollRef = useRef(false);
 
-  const scrollToBottom = useCallback(() => {
-    if (scrollRef.current) {
-      const el = scrollRef.current;
-      logger.info('SCROLL scrollToBottom', {
-        from: el.scrollTop,
-        to: Math.max(0, el.scrollHeight - el.clientHeight),
-        scrollHeight: el.scrollHeight,
-        clientHeight: el.clientHeight,
-        trace: new Error().stack?.split('\n').slice(1, 4).map(s => s.trim()),
-      });
-      el.scrollTop = el.scrollHeight;
-      isAtBottomRef.current = true;
-    }
-    setShowScrollBtn(false);
-    setUnreadCount(0);
-  }, []);
+  const { showScrollBtn, unreadCount, scrollToBottom, handleScroll } = useScrollController(
+    scrollRef,
+    grouped,
+    streaming,
+    sessionId,
+    sessionIdle,
+    storeUnread,
+    firstSeq,
+  );
 
-  // Preserve scroll position: prepend adjustment (before paint)
-  useLayoutEffect(() => {
-    if (!scrollRef.current) return;
-    const el = scrollRef.current;
-    if (pendingSessionScrollRef.current) {
-      if (hadUnreadRef.current) {
-        const target = el.querySelector<HTMLElement>('[data-scroll-target]');
-        if (target) {
-          const targetTop = target.offsetTop;
-          const contentBelow = el.scrollHeight - targetTop;
-          if (contentBelow > el.clientHeight + IDLE_SCROLL_OVERFLOW_PX) {
-            logger.info('SCROLL sessionEntry → scrollIntoView (unread)', { targetTop, contentBelow, clientHeight: el.clientHeight });
-            target.scrollIntoView({ block: 'start' });
-            el.scrollTop = Math.max(0, el.scrollTop - 12);
-            isAtBottomRef.current = false;
-            suppressAutoScrollRef.current = true;
-            pendingSessionScrollRef.current = false;
-            hadUnreadRef.current = false;
-            prevScrollHeightRef.current = el.scrollHeight;
-            return;
-          }
-        }
-      }
-      logger.info('SCROLL sessionEntry → scrollToHeight', { scrollHeight: el.scrollHeight });
-      el.scrollTop = el.scrollHeight;
-      pendingSessionScrollRef.current = false;
-      hadUnreadRef.current = false;
-      prevScrollHeightRef.current = el.scrollHeight;
-      return;
-    }
-    const prevHeight = prevScrollHeightRef.current;
-    const heightGrew = prevHeight > 0 && el.scrollHeight > prevHeight;
-    const heightShrank = prevHeight > 0 && el.scrollHeight < prevHeight;
-    if (heightGrew || heightShrank) {
-      logger.info('SCROLL layoutEffect heightChange', { prevHeight, newHeight: el.scrollHeight, scrollTop: el.scrollTop, prepended: prependedRef.current, atBottom: isAtBottomRef.current });
-    }
-    if (prependedRef.current && heightGrew && !isAtBottomRef.current) {
-      logger.info('SCROLL layoutEffect prepend adjust', { from: el.scrollTop, delta: el.scrollHeight - prevHeight });
-      el.scrollTop += el.scrollHeight - prevHeight;
-    }
-    prependedRef.current = false;
-    prevScrollHeightRef.current = el.scrollHeight;
-  });
-
-  // Auto-scroll to bottom when new messages arrive (only if already at bottom)
-  useEffect(() => {
-    const curLen = grouped.length;
-    const curStreamingLen = streaming?.length ?? 0;
-    let curLastSeq = 0;
-    if (curLen > 0) {
-      const lastGroup = grouped[curLen - 1];
-      if (lastGroup.type === 'standalone') {
-        curLastSeq = getSeq(lastGroup.message);
-      } else {
-        const tm = lastGroup.turn.finalMessage ?? lastGroup.turn.thinkingMessages[lastGroup.turn.thinkingMessages.length - 1];
-        if (tm) curLastSeq = getSeq(tm);
-      }
-    }
-    const prevLen = prevMsgLenRef.current;
-    const prevLastSeq = prevLastSeqRef.current;
-    const prevStreamingLen = prevStreamingLenRef.current;
-    const prevLastHasFinal = prevLastHasFinalRef.current;
-    const isNewAtEnd = curLastSeq > prevLastSeq;
-    const hasNewGroup = curLen > prevLen;
-    const streamingAdvanced = curStreamingLen > prevStreamingLen;
-
-    const lastGroup = curLen > 0 ? grouped[curLen - 1] : null;
-    const isFromUser = lastGroup?.type === 'standalone' && (
-      lastGroup.message.type === 'user_message' ||
-      lastGroup.message.type === 'pending_input' ||
-      lastGroup.message.type === 'answer' ||
-      lastGroup.message.type === 'send_input'
-    );
-    const hasFinalBubbleAtEnd = !!(lastGroup?.type === 'turn' && lastGroup.turn.finalMessage);
-    const justCompletedTurn = hasFinalBubbleAtEnd && !prevLastHasFinal;
-    const hasContentChange = hasNewGroup || isNewAtEnd || streamingAdvanced || justCompletedTurn;
-    const shouldFollowUserMessage = isFromUser && (hasNewGroup || isNewAtEnd);
-    const hasBubbleAtEnd = !!lastGroup && (
-      lastGroup.type === 'standalone' ||
-      hasFinalBubbleAtEnd
-    );
-    const newBubbleAtEnd = hasBubbleAtEnd && (hasNewGroup || isNewAtEnd || justCompletedTurn);
-    const container = scrollRef.current;
-    const distanceFromBottom = container
-      ? container.scrollHeight - container.scrollTop - container.clientHeight
-      : Number.POSITIVE_INFINITY;
-    const isActuallyAtBottom = distanceFromBottom < BOTTOM_STICKY_THRESHOLD_PX;
-    const shouldStickToBottom = isAtBottomRef.current || isActuallyAtBottom;
-    isAtBottomRef.current = isActuallyAtBottom;
-
-    // On idle transition: if the response is long, scroll user message to top
-    const justWentIdle = sessionIdle && !wasIdleRef.current;
-    wasIdleRef.current = sessionIdle;
-
-    if (justWentIdle && shouldStickToBottom && container) {
-      const target = container.querySelector<HTMLElement>('[data-scroll-target]');
-      if (target) {
-        const targetTop = target.offsetTop;
-        const contentBelow = container.scrollHeight - targetTop;
-        if (contentBelow > container.clientHeight + IDLE_SCROLL_OVERFLOW_PX) {
-          logger.info('SCROLL justWentIdle → scrollIntoView', { targetTop, contentBelow, clientHeight: container.clientHeight, scrollTop: container.scrollTop });
-          target.scrollIntoView({ block: 'start' });
-          container.scrollTop = Math.max(0, container.scrollTop - 12);
-          isAtBottomRef.current = false;
-          prevMsgLenRef.current = curLen;
-          prevLastSeqRef.current = curLastSeq;
-          return;
-        }
-      }
-      logger.info('SCROLL justWentIdle → scrollToBottom (fits)');
-      scrollToBottom();
-    } else if (suppressAutoScrollRef.current) {
-      logger.info('SCROLL autoScroll skipped after sessionEntry');
-      suppressAutoScrollRef.current = false;
-    } else if (hasContentChange && (shouldStickToBottom || shouldFollowUserMessage)) {
-      logger.info('SCROLL autoScroll → scrollToBottom', {
-        atBottom: isActuallyAtBottom,
-        shouldStickToBottom,
-        distanceFromBottom,
-        isFromUser,
-        shouldFollowUserMessage,
-        curLen,
-        curLastSeq,
-        curStreamingLen,
-        prevLen,
-        prevLastSeq,
-        prevStreamingLen,
-      });
-      scrollToBottom();
-    } else if (newBubbleAtEnd && !isFromUser) {
-      setUnreadCount((c) => c + 1);
-      setShowScrollBtn(true);
-    } else if (!hasContentChange) {
-      logger.info('SCROLL autoScroll skipped (no content change)', {
-        atBottom: isActuallyAtBottom,
-        shouldStickToBottom,
-        distanceFromBottom,
-        isFromUser,
-        curLen,
-        curLastSeq,
-        curStreamingLen,
-      });
-    }
-    prevMsgLenRef.current = curLen;
-    prevLastSeqRef.current = curLastSeq;
-    prevLastHasFinalRef.current = hasFinalBubbleAtEnd;
-    prevStreamingLenRef.current = curStreamingLen;
-  }, [grouped, streaming, sessionIdle, scrollToBottom]);
-
-  // Reset when switching sessions
-  useEffect(() => {
-    setShowScrollBtn(false);
-    setUnreadCount(0);
-    isAtBottomRef.current = true;
-    prependedRef.current = false;
-    prevFirstSeqRef.current = 0;
-    prevScrollHeightRef.current = 0;
-    prevMsgLenRef.current = 0;
-    prevLastSeqRef.current = 0;
-    prevLastHasFinalRef.current = false;
-    prevStreamingLenRef.current = 0;
-    suppressAutoScrollRef.current = false;
-    logger.info('SCROLL sessionEntry resetState', {
-      sessionId,
-      pending: pendingSessionScrollRef.current,
-      unread: hadUnreadRef.current,
-    });
-    wasIdleRef.current = sessionIdle;
-  }, [sessionId]);
-
-  const handleScroll = () => {
-    if (!scrollRef.current) return;
-    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
-    const atBottom = scrollHeight - scrollTop - clientHeight < BOTTOM_STICKY_THRESHOLD_PX;
-    isAtBottomRef.current = atBottom;
-    if (atBottom) {
-      setShowScrollBtn(false);
-      setUnreadCount(0);
-    }
-  };
+  // ── Render ────────────────────────────────────────────
 
   if (!sessionId || !session) {
     return (
@@ -399,7 +153,6 @@ export const ChatView = memo(function ChatView() {
           className="absolute inset-0 overflow-y-auto px-3 py-4 sm:px-6"
         >
           <div className="mx-auto max-w-3xl space-y-3">
-            {/* Top spinner when older messages exist */}
             {hasOlderMessages && (
               <GapMarker sessionId={sessionId!} beforeSeq={firstSeq} scrollRef={scrollRef} />
             )}
@@ -443,12 +196,10 @@ export const ChatView = memo(function ChatView() {
           </div>
         </div>
 
-        {/* Subtle dim overlay when a blocking card is shown */}
         {(permissions.length > 0 || questions.length > 0) && (
           <div className="pointer-events-none absolute inset-0 bg-black/5 dark:bg-black/15 transition-opacity" />
         )}
 
-        {/* Scroll to bottom button */}
         {showScrollBtn && (
           <button
             onClick={scrollToBottom}

--- a/packages/arm/web/src/components/chat/ThinkingBox.tsx
+++ b/packages/arm/web/src/components/chat/ThinkingBox.tsx
@@ -62,6 +62,8 @@ export function ThinkingBox({ messages, isActive, aborted, agent, sessionId, str
       ? getMessageSummary(visibleMessages[visibleMessages.length - 1])
       : 'Processing…';
 
+  const isStreaming = !!streamingText;
+
   logger.info('render', {
     isActive,
     messageCount: messages.length,
@@ -79,7 +81,7 @@ export function ThinkingBox({ messages, isActive, aborted, agent, sessionId, str
       >
         <span className={`mt-1 inline-block h-2 w-2 shrink-0 rounded-full ${isActive ? 'animate-pulse bg-ocean-500' : aborted ? 'bg-text-muted' : 'bg-emerald-500'}`} />
 
-        <span className="markdown-content min-w-0 text-xs font-medium text-text-secondary line-clamp-3 [&_p]:!m-0 [&_code]:text-[11px]">
+        <span className={`markdown-content min-w-0 text-xs font-medium text-text-secondary [&_p]:!m-0 [&_code]:text-[11px] ${isStreaming ? 'h-[3.75rem] overflow-hidden' : 'line-clamp-3'}`}>
           <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
             {summary}
           </Markdown>

--- a/packages/arm/web/src/hooks/useScrollController.ts
+++ b/packages/arm/web/src/hooks/useScrollController.ts
@@ -91,6 +91,9 @@ interface ScrollCtx {
   prevStreamLen: number;
   wasIdle: boolean;
 
+  // Idle reposition — suppresses unread count for the turn that just completed
+  idleRepositioned: boolean;
+
   // Session tracking (for inline change detection)
   prevSessionId: string | undefined;
 }
@@ -108,6 +111,7 @@ function makeCtx(): ScrollCtx {
     prevHadFinal: false,
     prevStreamLen: 0,
     wasIdle: false,
+    idleRepositioned: false,
     prevSessionId: undefined,
   };
 }
@@ -152,6 +156,7 @@ export function useScrollController(
       c.prevHadFinal = false;
       c.prevStreamLen = 0;
       c.wasIdle = sessionIdle;
+      c.idleRepositioned = false;
     }
     c.prevSessionId = sessionId;
     c.entryPending = true;
@@ -223,6 +228,7 @@ export function useScrollController(
     else if (justWentIdle && c.sticky && contentChanged) {
       if (scrollToTarget(el)) {
         c.sticky = false;
+        c.idleRepositioned = true;
         logger.info('scroll: ③ idle → target');
       } else {
         scrollToMax(el);
@@ -261,7 +267,11 @@ export function useScrollController(
       (curHasFinal && !c.prevHadFinal)
     );
 
-    if (newBubbleAtEnd && !isFromUser && !c.sticky) {
+    if (c.idleRepositioned) {
+      // Step ③ just repositioned the viewport to show the completed response —
+      // the user is reading it, not scrolled away. Don't count as unread.
+      c.idleRepositioned = false;
+    } else if (newBubbleAtEnd && !isFromUser && !c.sticky) {
       setUnreadCount((n) => n + 1);
       setShowScrollBtn(true);
     }

--- a/packages/arm/web/src/hooks/useScrollController.ts
+++ b/packages/arm/web/src/hooks/useScrollController.ts
@@ -1,0 +1,303 @@
+/**
+ * useScrollController — owns ALL scroll-position logic for ChatView.
+ *
+ * Design principles:
+ *   1. Every el.scrollTop write happens in useLayoutEffect (before paint → no flicker).
+ *   2. useEffect only updates React state (unreadCount, showScrollBtn).
+ *   3. ctx.sticky is written ONLY by handleScroll — effects only read it.
+ *   4. Priority chain in the layout effect: first matching rule wins.
+ */
+
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
+import type { RefObject } from 'react';
+import type { GroupedMessages } from './useTurns';
+import type { ChatMessage } from '../types/store';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('scroll-ctrl');
+
+const BOTTOM_STICKY_THRESHOLD_PX = 40;
+const IDLE_SCROLL_OVERFLOW_PX = 120;
+
+// ── Helpers ─────────────────────────────────────────────
+
+function getSeq(m: ChatMessage): number {
+  return 'seq' in m ? (m as { seq?: number }).seq ?? 0 : 0;
+}
+
+function getLastSeq(grouped: GroupedMessages[]): number {
+  const last = grouped[grouped.length - 1];
+  if (!last) return 0;
+  if (last.type === 'standalone') return getSeq(last.message);
+  const deepest = last.turn.finalMessage ?? last.turn.thinkingMessages.at(-1);
+  return deepest ? getSeq(deepest) : 0;
+}
+
+function lastGroupIsFromUser(grouped: GroupedMessages[]): boolean {
+  const last = grouped[grouped.length - 1];
+  return !!last && last.type === 'standalone' && (
+    last.message.type === 'user_message' ||
+    last.message.type === 'pending_input' ||
+    last.message.type === 'send_input' ||
+    last.message.type === 'answer'
+  );
+}
+
+function lastGroupHasFinal(grouped: GroupedMessages[]): boolean {
+  const last = grouped[grouped.length - 1];
+  return !!(last?.type === 'turn' && last.turn.finalMessage);
+}
+
+/** Try to scroll a target element to the top of the container with 12px breathing room.
+ *  Returns true if the target was far enough from the bottom to warrant anchoring. */
+function scrollToTarget(el: HTMLElement): boolean {
+  const target = el.querySelector<HTMLElement>('[data-scroll-target]');
+  if (!target) return false;
+
+  const targetTop = target.offsetTop;
+  const contentBelow = el.scrollHeight - targetTop;
+
+  if (contentBelow > el.clientHeight + IDLE_SCROLL_OVERFLOW_PX) {
+    target.scrollIntoView({ block: 'start' });
+    el.scrollTop = Math.max(0, el.scrollTop - 12);
+    return true;
+  }
+  return false;
+}
+
+function scrollToMax(el: HTMLElement): void {
+  el.scrollTop = el.scrollHeight;
+}
+
+// ── Scroll context (single ref replaces 13 scattered refs) ──
+
+interface ScrollCtx {
+  // Core
+  sticky: boolean;
+
+  // Session entry
+  entryPending: boolean;
+  entryHadUnread: boolean;
+
+  // Prepend tracking
+  prepended: boolean;
+  prevFirstSeq: number;
+
+  // Change detection
+  prevHeight: number;
+  prevGroupLen: number;
+  prevLastSeq: number;
+  prevHadFinal: boolean;
+  prevStreamLen: number;
+  wasIdle: boolean;
+
+  // Session tracking (for inline change detection)
+  prevSessionId: string | undefined;
+}
+
+function makeCtx(): ScrollCtx {
+  return {
+    sticky: true,
+    entryPending: true,
+    entryHadUnread: false,
+    prepended: false,
+    prevFirstSeq: 0,
+    prevHeight: 0,
+    prevGroupLen: 0,
+    prevLastSeq: 0,
+    prevHadFinal: false,
+    prevStreamLen: 0,
+    wasIdle: false,
+    prevSessionId: undefined,
+  };
+}
+
+// ── Hook ────────────────────────────────────────────────
+
+export interface ScrollController {
+  showScrollBtn: boolean;
+  unreadCount: number;
+  scrollToBottom: () => void;
+  handleScroll: () => void;
+}
+
+export function useScrollController(
+  scrollRef: RefObject<HTMLDivElement | null>,
+  grouped: GroupedMessages[],
+  streaming: string | undefined,
+  sessionId: string | undefined,
+  sessionIdle: boolean,
+  storeUnread: number,
+  firstSeq: number,
+): ScrollController {
+  const ctx = useRef(makeCtx());
+  const [showScrollBtn, setShowScrollBtn] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  // ── Session change detection (inline, before effects) ─
+  // Critical: entryPending and entryHadUnread MUST be set during
+  // the render phase so the layout effect can read them immediately.
+  // A useEffect would run AFTER the layout effect — too late.
+
+  const c = ctx.current;
+  if (sessionId !== c.prevSessionId) {
+    if (c.prevSessionId !== undefined) {
+      // Session switch (not first mount) — full reset
+      c.sticky = true;
+      c.prepended = false;
+      c.prevFirstSeq = 0;
+      c.prevHeight = 0;
+      c.prevGroupLen = 0;
+      c.prevLastSeq = 0;
+      c.prevHadFinal = false;
+      c.prevStreamLen = 0;
+      c.wasIdle = sessionIdle;
+    }
+    c.prevSessionId = sessionId;
+    c.entryPending = true;
+    c.entryHadUnread = storeUnread > 0;
+  }
+
+  // ── Prepend detection (inline, before effects) ────────
+  if (firstSeq > 0 && c.prevFirstSeq > 0 && firstSeq < c.prevFirstSeq) {
+    c.prepended = true;
+  }
+  c.prevFirstSeq = firstSeq;
+
+  // ── Effect 1: React state reset on session switch ─────
+  // Only handles state that triggers re-renders (showScrollBtn, unreadCount).
+  // ctx values are already set inline above.
+
+  useEffect(() => {
+    setShowScrollBtn(false);
+    setUnreadCount(0);
+  }, [sessionId]);
+
+  // ── Effect 2: Layout — ALL scrollTop writes ───────────
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const c = ctx.current;
+
+    // ── Shared computations ─────────────────────────────
+
+    const curLastSeq = getLastSeq(grouped);
+    const curStreamLen = streaming?.length ?? 0;
+    const curHasFinal = lastGroupHasFinal(grouped);
+    const isFromUser = lastGroupIsFromUser(grouped);
+
+    const contentChanged =
+      grouped.length > c.prevGroupLen ||
+      curLastSeq > c.prevLastSeq ||
+      curStreamLen > c.prevStreamLen ||
+      (curHasFinal && !c.prevHadFinal);
+
+    const justWentIdle = sessionIdle && !c.wasIdle;
+
+    // ── Priority chain — first match wins ───────────────
+
+    // ① SESSION ENTRY
+    if (c.entryPending) {
+      if (c.entryHadUnread && scrollToTarget(el)) {
+        c.sticky = false;
+        logger.info('scroll: ① entry → target (unread)');
+      } else {
+        scrollToMax(el);
+        c.sticky = true;
+        logger.info('scroll: ① entry → bottom');
+      }
+      c.entryPending = false;
+      c.entryHadUnread = false;
+    }
+    // ② PREPEND ADJUST
+    else if (c.prepended) {
+      if (!c.sticky && c.prevHeight > 0 && el.scrollHeight > c.prevHeight) {
+        const delta = el.scrollHeight - c.prevHeight;
+        el.scrollTop += delta;
+        logger.info('scroll: ② prepend adjust', { delta });
+      }
+      c.prepended = false;
+    }
+    // ③ IDLE TRANSITION
+    else if (justWentIdle && c.sticky && contentChanged) {
+      if (scrollToTarget(el)) {
+        c.sticky = false;
+        logger.info('scroll: ③ idle → target');
+      } else {
+        scrollToMax(el);
+        logger.info('scroll: ③ idle → bottom (fits)');
+      }
+    }
+    // ④ AUTO-FOLLOW / USER-MESSAGE FOLLOW
+    else if (contentChanged && (c.sticky || isFromUser)) {
+      scrollToMax(el);
+      c.sticky = true;
+      logger.info('scroll: ④ follow', { sticky: c.sticky, isFromUser });
+    }
+    // ⑤ NO-OP
+
+    // ── Bookkeeping ─────────────────────────────────────
+
+    c.prevHeight = el.scrollHeight;
+    c.wasIdle = sessionIdle;
+  });
+
+  // ── Effect 3: Unread counting (after paint) ───────────
+
+  useEffect(() => {
+    const c = ctx.current;
+
+    const curLastSeq = getLastSeq(grouped);
+    const curHasFinal = lastGroupHasFinal(grouped);
+    const isFromUser = lastGroupIsFromUser(grouped);
+
+    const hasBubbleAtEnd = grouped.length > 0 && (
+      grouped[grouped.length - 1].type === 'standalone' || curHasFinal
+    );
+    const newBubbleAtEnd = hasBubbleAtEnd && (
+      grouped.length > c.prevGroupLen ||
+      curLastSeq > c.prevLastSeq ||
+      (curHasFinal && !c.prevHadFinal)
+    );
+
+    if (newBubbleAtEnd && !isFromUser && !c.sticky) {
+      setUnreadCount((n) => n + 1);
+      setShowScrollBtn(true);
+    }
+
+    // Save prev* values here (not in Effect 2) so both effects
+    // see the same "current vs previous" comparison per render.
+    c.prevGroupLen = grouped.length;
+    c.prevLastSeq = curLastSeq;
+    c.prevHadFinal = curHasFinal;
+    c.prevStreamLen = streaming?.length ?? 0;
+  }, [grouped, streaming, sessionIdle]);
+
+  // ── handleScroll (user gesture) ───────────────────────
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    ctx.current.sticky = distance < BOTTOM_STICKY_THRESHOLD_PX;
+    if (ctx.current.sticky) {
+      setShowScrollBtn(false);
+      setUnreadCount(0);
+    }
+  }, [scrollRef]);
+
+  // ── scrollToBottom (button click) ─────────────────────
+
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (el) {
+      scrollToMax(el);
+      ctx.current.sticky = true;
+    }
+    setShowScrollBtn(false);
+    setUnreadCount(0);
+  }, [scrollRef]);
+
+  return { showScrollBtn, unreadCount, scrollToBottom, handleScroll };
+}


### PR DESCRIPTION
## Problem

ChatView occasionally flickers because `scrollTop` writes happen in two competing effects:
- `useLayoutEffect` (before paint) — session entry + prepend adjust
- `useEffect` (after paint) — auto-follow, idle transition, streaming

The `useEffect` path causes visible jumps: browser paints the wrong position first, then the effect fires and repositions.

## Solution

### 1. Extract `useScrollController` hook

Moves **all** scroll logic out of ChatView into a dedicated hook. ChatView becomes pure rendering — zero scroll refs or effects in the component body.

### 2. Single layout effect with priority chain

All `scrollTop` writes now happen in one `useLayoutEffect` (before paint). First matching rule wins:

| Priority | Trigger | Action |
|---|---|---|
| ① Session entry | First render after switch | Scroll to unread target or bottom |
| ② Prepend adjust | Older messages loaded | Offset scrollTop to preserve position |
| ③ Idle transition | Turn completed | Smart scroll (user prompt to top if response is long) |
| ④ Auto-follow | New content + sticky | Snap to bottom |
| ⑤ No-op | Nothing matched | Do nothing |

### 3. Clean ref management

13 scattered refs → 1 `ScrollCtx` object. `ctx.sticky` written **only** by `handleScroll` — effects only read it (no dual-write race). `suppressAutoScrollRef` hack eliminated entirely.

### 4. Bug fixes

- **False unread badge after idle reposition**: When step ③ scrolls the user's prompt to the top (long response), `sticky` becomes false. Effect 3 was counting the completed turn as unread — wrong, because the user is reading the response. Added `idleRepositioned` flag to suppress this.
- **Streaming preview height jitter**: ThinkingBox streaming preview used `line-clamp-3` which grew/shrank as lines arrived. Now uses fixed `h-[3.75rem]` during streaming so the page doesn't shift.

## Changes

| File | Lines | What |
|---|---|---|
| `useScrollController.ts` | +310 | New hook — all scroll logic |
| `ChatView.tsx` | -264 | Stripped to pure rendering |
| `ThinkingBox.tsx` | +3/-1 | Fixed-height streaming preview |

## Testing

- All 268 web tests pass (including all 13 ChatView scroll tests)
- Lint clean
- `pnpm validate` passes