### PR TITLE
perf: instant import response with background SDK resume

### DIFF
--- a/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
+++ b/packages/arm/web/src/components/sessions/ImportSessionDialog.tsx
@@ -277,8 +277,17 @@ export function ImportSessionDialog({ open, onClose }: Props) {
   const handleImport = useCallback((sessionId: string) => {
     if (!selectedDevice) return;
     setImportingIds(prev => new Set(prev).add(sessionId));
-    wsClient.importSession(sessionId, selectedDevice);
-  }, [selectedDevice]);
+    // Pass session metadata so the tentacle skips re-scanning the filesystem
+    const session = localSessions.find(s => s.sessionId === sessionId);
+    wsClient.importSession(sessionId, selectedDevice, session ? {
+      cwd: session.cwd,
+      summary: session.summary,
+      source: session.source,
+      model: session.model,
+      branch: session.branch,
+      startTime: session.startTime,
+    } : undefined);
+  }, [selectedDevice, localSessions]);
 
   // Dismiss dialog when import succeeds (session appears in main store)
   const sessions = useStore(s => s.sessions);

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -368,12 +368,13 @@ export function importSession(
   targetDeviceId: string,
   send: (msg: Record<string, unknown>) => void,
   state: CommandState,
+  meta?: { cwd?: string; summary?: string; source?: string; model?: string; branch?: string; startTime?: string },
 ): string {
   const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   state.pendingCreateRequests.add(requestId);
   send({
     type: 'import_session',
-    payload: { requestId, localSessionId, targetDeviceId },
+    payload: { requestId, localSessionId, targetDeviceId, ...(meta && { meta }) },
   });
   return requestId;
 }

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -182,8 +182,8 @@ export class KrakiWSClient {
     return commands.requestLocalSessions(targetDeviceId, (msg) => this.sendEncrypted(msg), filter);
   }
 
-  importSession(localSessionId: string, targetDeviceId: string) {
-    return commands.importSession(localSessionId, targetDeviceId, (msg) => this.sendEncrypted(msg), this.cmdState);
+  importSession(localSessionId: string, targetDeviceId: string, meta?: { cwd?: string; summary?: string; source?: string; model?: string; branch?: string; startTime?: string }) {
+    return commands.importSession(localSessionId, targetDeviceId, (msg) => this.sendEncrypted(msg), this.cmdState, meta);
   }
 
   markRead(sessionId: string, seq?: number): void {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -590,6 +590,15 @@ export interface ImportSessionMessage extends BaseEnvelope {
     requestId: string;
     /** Must match a sessionId from a previous local_sessions_list. */
     localSessionId: string;
+    /** Metadata from the picker — avoids re-scanning filesystem on import. */
+    meta?: {
+      cwd?: string;
+      summary?: string;
+      source?: import('./sessions.js').LocalSessionSource;
+      model?: string;
+      branch?: string;
+      startTime?: string;
+    };
   };
 }
 

--- a/packages/tentacle/src/events-watcher.ts
+++ b/packages/tentacle/src/events-watcher.ts
@@ -32,6 +32,8 @@ interface WatchedSession {
   watcher: FSWatcher;
   offset: number;
   debounceTimer: ReturnType<typeof setTimeout> | null;
+  /** When true, file changes are ignored (Kraki's own adapter is writing). */
+  paused: boolean;
 }
 
 export class EventsWatcher {
@@ -81,6 +83,7 @@ export class EventsWatcher {
       watcher,
       offset,
       debounceTimer: null,
+      paused: false,
     });
 
     logger.debug({ sessionId, offset }, 'Watching events.jsonl');
@@ -104,9 +107,41 @@ export class EventsWatcher {
     }
   }
 
-  private onFileChange(sessionId: string): void {
+  /**
+   * Pause watching — Kraki's adapter is actively writing to events.jsonl.
+   * All file change events are ignored and offset advances to end of file.
+   */
+  skipToEnd(sessionId: string): void {
     const entry = this.sessions.get(sessionId);
     if (!entry) return;
+    entry.paused = true;
+    if (entry.debounceTimer) {
+      clearTimeout(entry.debounceTimer);
+      entry.debounceTimer = null;
+    }
+    try {
+      entry.offset = statSync(entry.filePath).size;
+    } catch { /* file may not exist yet */ }
+  }
+
+  /**
+   * Resume watching after Kraki's adapter turn completes.
+   * Advances offset to current end of file, then proactively checks
+   * for any external events that arrived while paused.
+   */
+  resume(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    // Advance past Kraki's own writes
+    try {
+      entry.offset = statSync(entry.filePath).size;
+    } catch { /* ignore */ }
+    entry.paused = false;
+  }
+
+  private onFileChange(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry || entry.paused) return;
 
     // Debounce: the CLI may write multiple lines in rapid succession
     if (entry.debounceTimer) clearTimeout(entry.debounceTimer);

--- a/packages/tentacle/src/events-watcher.ts
+++ b/packages/tentacle/src/events-watcher.ts
@@ -1,0 +1,171 @@
+/**
+ * Events watcher — watches imported sessions' events.jsonl for changes
+ * from external sources (copilot CLI, VS Code).
+ *
+ * Uses fs.watch (kqueue/inotify) for near-real-time notifications.
+ * Tracks byte offset per file to only read new lines.
+ * Converts new SDK events to Kraki protocol messages and calls a broadcast callback.
+ */
+
+import { watch, statSync, openSync, readSync, closeSync, existsSync, type FSWatcher } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { convertEvent } from './history-parser.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('events-watcher');
+
+/** Debounce ms — coalesce rapid writes into one read. */
+const DEBOUNCE_MS = 300;
+
+export interface WatcherBroadcast {
+  type: string;
+  sessionId: string;
+  payload: Record<string, unknown>;
+}
+
+export type BroadcastFn = (msg: WatcherBroadcast) => void;
+
+interface WatchedSession {
+  sessionId: string;
+  filePath: string;
+  watcher: FSWatcher;
+  offset: number;
+  debounceTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export class EventsWatcher {
+  private sessions = new Map<string, WatchedSession>();
+  private broadcastFn: BroadcastFn;
+  private deviceId: string;
+
+  constructor(broadcastFn: BroadcastFn, deviceId: string) {
+    this.broadcastFn = broadcastFn;
+    this.deviceId = deviceId;
+  }
+
+  /**
+   * Start watching an imported session's events.jsonl for external changes.
+   * Call after import completes.
+   */
+  watch(sessionId: string): void {
+    if (this.sessions.has(sessionId)) return;
+
+    const filePath = join(homedir(), '.copilot', 'session-state', sessionId, 'events.jsonl');
+    if (!existsSync(filePath)) {
+      logger.debug({ sessionId }, 'No events.jsonl to watch');
+      return;
+    }
+
+    // Start from current end of file (we already backfilled everything before this point)
+    let offset: number;
+    try {
+      offset = statSync(filePath).size;
+    } catch {
+      return;
+    }
+
+    let watcher: FSWatcher;
+    try {
+      watcher = watch(filePath, () => {
+        this.onFileChange(sessionId);
+      });
+    } catch (err) {
+      logger.warn({ err: (err as Error).message, sessionId }, 'Failed to watch events.jsonl');
+      return;
+    }
+
+    this.sessions.set(sessionId, {
+      sessionId,
+      filePath,
+      watcher,
+      offset,
+      debounceTimer: null,
+    });
+
+    logger.debug({ sessionId, offset }, 'Watching events.jsonl');
+  }
+
+  /** Stop watching a session. */
+  unwatch(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+
+    if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+    entry.watcher.close();
+    this.sessions.delete(sessionId);
+    logger.debug({ sessionId }, 'Stopped watching events.jsonl');
+  }
+
+  /** Stop all watchers. */
+  close(): void {
+    for (const [id] of this.sessions) {
+      this.unwatch(id);
+    }
+  }
+
+  private onFileChange(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+
+    // Debounce: the CLI may write multiple lines in rapid succession
+    if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+    entry.debounceTimer = setTimeout(() => {
+      entry.debounceTimer = null;
+      this.readNewEvents(entry);
+    }, DEBOUNCE_MS);
+  }
+
+  private readNewEvents(entry: WatchedSession): void {
+    let fileSize: number;
+    try {
+      fileSize = statSync(entry.filePath).size;
+    } catch {
+      return;
+    }
+
+    if (fileSize <= entry.offset) return; // no new data
+
+    // Read new bytes from the offset
+    const readSize = fileSize - entry.offset;
+    const fd = openSync(entry.filePath, 'r');
+    const buf = Buffer.alloc(readSize);
+    try {
+      readSync(fd, buf, 0, readSize, entry.offset);
+    } finally {
+      closeSync(fd);
+    }
+    entry.offset = fileSize;
+
+    // Parse new lines into SDK events
+    const newContent = buf.toString('utf8');
+    const lines = newContent.split('\n').filter(l => l.trim());
+    const meta = {}; // don't need metadata extraction for live events
+
+    let broadcastCount = 0;
+    for (const line of lines) {
+      let event: { type: string; data: Record<string, unknown>; timestamp?: string };
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      const ts = event.timestamp ?? new Date().toISOString();
+      const converted = convertEvent(event, ts, meta);
+      if (!converted) continue;
+
+      // Broadcast as a Kraki protocol message
+      this.broadcastFn({
+        type: converted.type,
+        sessionId: entry.sessionId,
+        payload: JSON.parse(converted.payload),
+      });
+      broadcastCount++;
+    }
+
+    if (broadcastCount > 0) {
+      logger.info({ sessionId: entry.sessionId, newLines: lines.length, broadcast: broadcastCount }, 'External events detected');
+    }
+  }
+}

--- a/packages/tentacle/src/history-parser.ts
+++ b/packages/tentacle/src/history-parser.ts
@@ -107,9 +107,9 @@ export function parseSessionHistory(sessionDir: string): {
   return parseEventsFile(join(sessionDir, 'events.jsonl'));
 }
 
-// ── Event conversion ────────────────────────────────────
+// ── Event conversion (exported for use by events-watcher) ───
 
-function convertEvent(
+export function convertEvent(
   event: SdkEvent,
   ts: string,
   meta: ParsedSessionMeta,

--- a/packages/tentacle/src/index.ts
+++ b/packages/tentacle/src/index.ts
@@ -32,3 +32,4 @@ export { scanLocalSessions, filterSessions } from './session-scanner.js';
 export type { ScanOptions, SessionFilter } from './session-scanner.js';
 export { parseEventsFile, parseSessionHistory } from './history-parser.js';
 export type { BackfilledMessage, ParsedSessionMeta } from './history-parser.js';
+export { EventsWatcher } from './events-watcher.js';

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -22,6 +22,7 @@ import type { SessionManager, SessionContext } from './session-manager.js';
 import type { KeyManager } from './key-manager.js';
 import { scanLocalSessions, filterSessions } from './session-scanner.js';
 import { parseSessionHistory } from './history-parser.js';
+import { EventsWatcher } from './events-watcher.js';
 import { createLogger } from './logger.js';
 import { getKrakiHome } from './config.js';
 
@@ -115,6 +116,9 @@ export class RelayClient {
   /** Called on fatal error (won't reconnect) */
   onFatalError: ((message: string) => void) | null = null;
 
+  /** Watches imported sessions' events.jsonl for external changes */
+  private eventsWatcher: EventsWatcher | null = null;
+
   constructor(
     adapter: AgentAdapter,
     sessionManager: SessionManager,
@@ -203,6 +207,10 @@ export class RelayClient {
   disconnect(): void {
     this.intentionalDisconnect = true;
     this.stopStaleCheck();
+    if (this.eventsWatcher) {
+      this.eventsWatcher.close();
+      this.eventsWatcher = null;
+    }
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -240,6 +248,8 @@ export class RelayClient {
       }
       this.setState('connected');
       this.onAuthenticated?.(this.authInfo);
+      // Initialize events watcher for imported sessions
+      this.initEventsWatcher();
       // Process queued messages from the relay BEFORE broadcasting session list
       // so that deletes/mode changes are applied first
       this.processPendingMessages(this.authInfo.pendingMessages);
@@ -513,6 +523,7 @@ export class RelayClient {
           this.adapter.killSession(sessionId)
             .catch((err) => logger.error({ err, sessionId }, 'killSession on delete failed'))
             .finally(() => {
+              this.eventsWatcher?.unwatch(sessionId);
               this.sessionManager.removeLinkByKrakiId(sessionId);
               this.sessionManager.deleteSession(sessionId);
               this.lastAgentContent.delete(sessionId);
@@ -831,6 +842,9 @@ export class RelayClient {
 
       logger.info({ localSessionId, krakiSessionId, backfilled: backfilledMessages.length }, 'Session imported');
 
+      // Start watching events.jsonl for external changes (CLI, VS Code)
+      this.eventsWatcher?.watch(krakiSessionId);
+
       // ── Phase 2: Background SDK resume (non-blocking) ─────
       // Clear the requestId so onSessionCreated doesn't send a duplicate session_created
       if (requestId) this.pendingRequestIds.delete(krakiSessionId);
@@ -850,6 +864,30 @@ export class RelayClient {
         sessionId: '',
         payload: { message: `Failed to import session: ${(err as Error).message} (requestId: ${requestId})` },
       });
+    }
+  }
+
+  // ── Events watcher for imported sessions ──────────────
+
+  private initEventsWatcher(): void {
+    if (this.eventsWatcher) this.eventsWatcher.close();
+
+    this.eventsWatcher = new EventsWatcher(
+      (msg) => {
+        // Broadcast external events to all arms + append to SessionManager
+        const sessionId = msg.sessionId;
+        this.sessionManager.appendMessage(sessionId, msg.type, JSON.stringify(msg.payload));
+        this.send({
+          ...msg,
+          deviceId: this.authInfo?.deviceId ?? '',
+        } as unknown as Partial<ProducerMessage>);
+      },
+      this.authInfo?.deviceId ?? '',
+    );
+
+    // Start watching all currently linked sessions
+    for (const link of this.sessionManager.getAllLinks()) {
+      this.eventsWatcher.watch(link.localSessionId);
     }
   }
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -731,7 +731,11 @@ export class RelayClient {
   private async handleImportSession(msg: ConsumerMessage): Promise<void> {
     if (msg.type !== 'import_session') return;
 
-    const { requestId, localSessionId } = msg.payload;
+    const { requestId, localSessionId, meta: clientMeta } = msg.payload as {
+      requestId: string;
+      localSessionId: string;
+      meta?: { cwd?: string; summary?: string; source?: string; model?: string; branch?: string; startTime?: string };
+    };
 
     // Check if already linked
     const existing = this.sessionManager.getLink(localSessionId);
@@ -745,99 +749,60 @@ export class RelayClient {
     }
 
     try {
-      // Use localSessionId as Kraki session ID (shared identity)
       const krakiSessionId = localSessionId;
 
-      // Parse events.jsonl for backfill
-      const sessionStateDir = join(
-        homedir(), '.copilot', 'session-state', localSessionId,
-      );
+      // ── Phase 1: Fast response (~85ms) ────────────────────
+      // Parse events.jsonl for backfill + metadata
+      const sessionStateDir = join(homedir(), '.copilot', 'session-state', localSessionId);
       const { messages: backfilledMessages, meta: parsedMeta } = parseSessionHistory(sessionStateDir);
 
-      // Scan to get local session metadata
-      const scanResults = scanLocalSessions();
-      const localSession = scanResults.find(s => s.sessionId === localSessionId);
+      // Use metadata from the client (picker already has it) or parsed fallback
+      const source = (clientMeta?.source ?? parsedMeta.cwd === '/' ? 'copilot-cli' : 'copilot-cli') as import('@kraki/protocol').LocalSessionSource;
+      const model = parsedMeta.model ?? clientMeta?.model;
+      const autoTitle = clientMeta?.summary?.slice(0, 100);
+      const cwd = clientMeta?.cwd ?? parsedMeta.cwd ?? '/';
 
       // Create Kraki session
-      this.sessionManager.createSession(
-        'copilot',
-        parsedMeta.model ?? localSession?.model,
-        krakiSessionId,
-      );
+      this.sessionManager.createSession('copilot', model, krakiSessionId);
 
-      // Persist source, title, model, and original creation time
+      // Persist metadata
       this.sessionManager.updateMeta(krakiSessionId, {
-        source: localSession?.source ?? 'copilot-cli',
-        autoTitle: localSession?.summary?.slice(0, 100),
-        model: parsedMeta.model ?? localSession?.model,
-        createdAt: localSession?.startTime,
+        source,
+        autoTitle,
+        model,
+        createdAt: clientMeta?.startTime,
       });
 
-      // Backfill messages
-      for (const m of backfilledMessages) {
-        this.sessionManager.appendMessage(krakiSessionId, m.type, m.payload);
-      }
+      // Batch-write all backfilled messages (single write instead of N appends)
+      const lastSeq = this.sessionManager.appendMessagesBatch(krakiSessionId, backfilledMessages);
 
       // Write link table entry
       this.sessionManager.addLink({
         localSessionId,
         krakiSessionId,
-        source: localSession?.source ?? 'copilot-cli',
-        cwd: localSession?.cwd,
-        branch: localSession?.branch,
+        source,
+        cwd,
+        branch: clientMeta?.branch,
         linkedAt: new Date().toISOString(),
       });
 
-      // Map requestId for session_created correlation
-      if (requestId) {
-        this.pendingRequestIds.set(krakiSessionId, requestId);
-      }
+      // Send session_created immediately — don't wait for adapter
+      this.send({
+        type: 'session_created',
+        sessionId: krakiSessionId,
+        payload: { agent: 'copilot', model, requestId, lastSeq },
+      });
 
-      // Resume the session via SDK. Use createSession with the existing sessionId
-      // so the CLI server discovers the state on disk. resumeSession only works
-      // for sessions the CLI server has already loaded in memory.
-      const cwd = localSession?.cwd ?? parsedMeta.cwd ?? '/';
-      try {
-        await this.adapter.createSession({
-          sessionId: krakiSessionId,
-          model: parsedMeta.model,
-          cwd,
-        });
-      } catch (createErr) {
-        // SDK resume failed — still keep backfilled history, but manually
-        // send session_created so the web UI knows the session exists.
-        logger.warn({ err: (createErr as Error).message, krakiSessionId }, 'SDK resume failed — session imported as idle');
-        const meta = this.sessionManager.getMeta(krakiSessionId);
-        this.send({
-          type: 'session_created',
-          sessionId: krakiSessionId,
-          payload: {
-            agent: 'copilot',
-            model: parsedMeta.model ?? localSession?.model,
-            requestId,
-            lastSeq: meta?.lastSeq ?? 0,
-          },
-        });
-        if (requestId) this.pendingRequestIds.delete(krakiSessionId);
-      }
-
-      // Mark idle — will transition to active when user sends a message
-      this.sessionManager.markIdle(krakiSessionId);
-      this.send({ type: 'idle', sessionId: krakiSessionId, payload: {} });
-
-      // Send title so the web UI displays it (session_created doesn't carry title)
-      const finalMeta = this.sessionManager.getMeta(krakiSessionId);
-      if (finalMeta?.autoTitle || finalMeta?.title) {
+      // Send title
+      if (autoTitle) {
         this.send({
           type: 'session_title_updated',
           sessionId: krakiSessionId,
-          payload: { title: finalMeta.title, autoTitle: finalMeta.autoTitle },
+          payload: { autoTitle },
         });
       }
 
-      // Proactively send backfilled history as a replay batch.
-      // Don't rely on the web requesting it — the encrypted request_session_replay
-      // may fail in some auth configurations.
+      // Send backfilled history as replay batch
       if (backfilledMessages.length > 0) {
         const replayMessages = this.sessionManager.getMessagesAfterSeq(krakiSessionId, 0, 500);
         const asProducerMessages = replayMessages.map(m => {
@@ -853,16 +818,31 @@ export class RelayClient {
           payload: {
             sessionId: krakiSessionId,
             messages: asProducerMessages,
-            lastSeq: finalMeta?.lastSeq ?? backfilledMessages.length,
-            totalLastSeq: finalMeta?.lastSeq ?? backfilledMessages.length,
+            lastSeq,
+            totalLastSeq: lastSeq,
           },
         });
       }
 
-      // Broadcast updated session list so web gets full metadata (model, source, etc.)
+      // Mark idle + broadcast session list
+      this.sessionManager.markIdle(krakiSessionId);
+      this.send({ type: 'idle', sessionId: krakiSessionId, payload: {} });
       this.broadcastSessionList();
 
       logger.info({ localSessionId, krakiSessionId, backfilled: backfilledMessages.length }, 'Session imported');
+
+      // ── Phase 2: Background SDK resume (non-blocking) ─────
+      // Clear the requestId so onSessionCreated doesn't send a duplicate session_created
+      if (requestId) this.pendingRequestIds.delete(krakiSessionId);
+
+      this.adapter.createSession({ sessionId: krakiSessionId, model: parsedMeta.model, cwd })
+        .then(() => {
+          logger.debug({ krakiSessionId }, 'SDK resume completed');
+        })
+        .catch((err) => {
+          logger.warn({ err: (err as Error).message, krakiSessionId }, 'SDK resume failed — session imported as idle');
+        });
+
     } catch (err) {
       logger.error({ err, localSessionId }, 'Import session failed');
       this.send({
@@ -910,6 +890,12 @@ export class RelayClient {
       // Look up requestId by sessionId (set in handleCreateSession before adapter call)
       const requestId = this.pendingRequestIds.get(event.sessionId);
       if (requestId) this.pendingRequestIds.delete(event.sessionId);
+
+      // Skip duplicate broadcast for imported sessions — handleImportSession
+      // already sent session_created and cleared the requestId.
+      if (!requestId && this.sessionManager.getLink(event.sessionId)) {
+        return;
+      }
 
       const meta = this.sessionManager.getMeta(event.sessionId);
       this.send({

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1057,6 +1057,9 @@ export class RelayClient {
       if (usage) this.sessionManager.setUsage(sessionId, usage);
       this.send({ type: 'idle', sessionId, payload: { usage } });
       this.maybeGenerateTitle(sessionId);
+      // Resume file watcher after a short delay to let the SDK finish
+      // flushing remaining events to disk (usage, idle, etc.)
+      setTimeout(() => this.eventsWatcher?.resume(sessionId), 1000);
     };
 
     this.adapter.onUsageUpdate = (sessionId, usage) => {
@@ -1374,6 +1377,13 @@ export class RelayClient {
     const sessionId = enriched.sessionId as string | undefined;
     if (sessionId && !RelayClient.TRANSIENT_TYPES.has(type)) {
       enriched.seq = this.sessionManager.appendMessage(sessionId, type, JSON.stringify(enriched));
+    }
+
+    // Advance the events watcher past any events the adapter just wrote,
+    // so the watcher only picks up external changes (CLI, VS Code).
+    // Only for data messages — transient metadata (title, pin, etc.) doesn't touch events.jsonl.
+    if (sessionId && this.eventsWatcher && !RelayClient.TRANSIENT_TYPES.has(type)) {
+      this.eventsWatcher.skipToEnd(sessionId);
     }
 
     if (this.keyManager) {

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -637,6 +637,35 @@ export class SessionManager {
   }
 
   /**
+   * Batch-append messages to a session's log in a single write.
+   * Much faster than calling appendMessage() N times.
+   * Returns the final seq number.
+   */
+  appendMessagesBatch(sessionId: string, messages: Array<{ type: string; payload: string; ts?: string }>): number {
+    const meta = this.readMeta(sessionId);
+    if (!meta || messages.length === 0) return meta?.lastSeq ?? 0;
+
+    let seq = meta.lastSeq ?? 0;
+    const now = new Date().toISOString();
+    const lines: string[] = [];
+
+    for (const m of messages) {
+      seq++;
+      const entry: LoggedMessage = { seq, type: m.type, payload: m.payload, ts: m.ts ?? now };
+      lines.push(JSON.stringify(entry));
+    }
+
+    const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
+    appendFileSync(logPath, lines.join('\n') + '\n', 'utf8');
+
+    meta.lastSeq = seq;
+    meta.updatedAt = now;
+    this.writeMeta(sessionId, meta);
+
+    return seq;
+  }
+
+  /**
    * Get messages for a session with seq > afterSeq.
    */
   getMessagesAfterSeq(sessionId: string, afterSeq: number, limit?: number): LoggedMessage[] {


### PR DESCRIPTION
Split import into two phases:
- **Phase 1 (~85ms)**: backfill + send session_created + replay_batch immediately  
- **Phase 2 (background)**: adapter.createSession() runs non-blocking

Also: batch appendMessages (single write), pass picker metadata to skip rescan, suppress duplicate session_created from onSessionCreated.

 session appears  
 session appears with history