### PR TITLE
fix: load all sessions when preview timestamps unavailable

### DIFF
--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -297,6 +297,10 @@ export class KrakiWSClient {
    *
    * Pass 1: active + pinned + <24h → fetch last 50 (always, outside budget)
    * Pass 2: if budget remains, fill next-most-recent with 50 each
+   *
+   * When no sessions have preview timestamps (tentacle hasn't sent them),
+   * recency can't be determined — fall back to loading all sessions so
+   * session state, pending permissions, and unread counts stay correct.
    */
   private runWarmup(
     sessions: import('@kraki/protocol').SessionDigest[],
@@ -304,6 +308,22 @@ export class KrakiWSClient {
   ): void {
     const now = Date.now();
     const { WARMUP_BUDGET, WARMUP_RECENCY_MS, WARMUP_PER_SESSION } = KrakiWSClient;
+
+    // If no session has a preview, we can't determine recency — load all.
+    const hasPreviewTimestamps = sessions.some(ts => {
+      const p = (ts as Record<string, unknown>).preview as { timestamp?: string } | undefined;
+      return !!p?.timestamp;
+    });
+
+    if (!hasPreviewTimestamps) {
+      for (const ts of sessions) {
+        if (ts.lastSeq <= 0) continue;
+        const fromSeq = Math.max(1, ts.lastSeq - WARMUP_PER_SESSION + 1);
+        messageProvider.fetchRange(ts.id, fromSeq, ts.lastSeq, { initial: true });
+      }
+      logger.info('warm-up: no preview timestamps, loading all', { sessions: sessions.filter(s => s.lastSeq > 0).length });
+      return;
+    }
 
     // Classify sessions
     type WarmupEntry = { id: string; lastSeq: number; previewTs: number };

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -373,11 +373,20 @@ export class CopilotAdapter extends AgentAdapter {
 
   async start(): Promise<void> {
     // Resolve GitHub token from `gh` CLI to bypass macOS Keychain prompts.
+    // Skip gho_ (OAuth) tokens — they are session-scoped Copilot CLI tokens
+    // that can't authenticate a separately spawned copilot process.
     let githubToken = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+    if (githubToken?.startsWith('gho_')) {
+      logger.debug('Ignoring session-scoped gho_ token from environment');
+      githubToken = undefined;
+    }
     if (!githubToken) {
       try {
-        githubToken = execSync('gh auth token', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim() || undefined;
-        if (githubToken) logger.debug('Using GitHub token from `gh auth token`');
+        const cliToken = execSync('gh auth token', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim() || undefined;
+        if (cliToken && !cliToken.startsWith('gho_')) {
+          githubToken = cliToken;
+          logger.debug('Using GitHub token from `gh auth token`');
+        }
       } catch {
         // gh CLI unavailable — SDK will use its own auth chain
       }
@@ -735,17 +744,24 @@ export class CopilotAdapter extends AgentAdapter {
   }
 
   async listModels(): Promise<string[]> {
-    if (!this.client) return [];
+    if (!this.client) {
+      logger.debug('listModels: client not initialized');
+      return [];
+    }
     try {
       const models = await this.client.listModels();
       return models.map((m: { id: string }) => m.id);
-    } catch {
+    } catch (err) {
+      logger.warn({ err: (err as Error).message }, 'listModels failed');
       return [];
     }
   }
 
   async listModelDetails(): Promise<import('@kraki/protocol').ModelDetail[]> {
-    if (!this.client) return [];
+    if (!this.client) {
+      logger.debug('listModelDetails: client not initialized');
+      return [];
+    }
     try {
       const models = await this.client.listModels();
       return models.map((m) => ({
@@ -755,7 +771,8 @@ export class CopilotAdapter extends AgentAdapter {
         ...(m.supportedReasoningEfforts && { supportedReasoningEfforts: m.supportedReasoningEfforts }),
         ...(m.defaultReasoningEffort && { defaultReasoningEffort: m.defaultReasoningEffort }),
       }));
-    } catch {
+    } catch (err) {
+      logger.warn({ err: (err as Error).message }, 'listModelDetails failed');
       return [];
     }
   }

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -66,7 +66,7 @@ export async function startWorker(): Promise<WorkerResult> {
     process.exit(1);
   }
 
-  // 2. Resolve auth token
+  // 2. Resolve relay auth token
   let token: string | undefined;
 
   if (config.authMethod === 'github_token') {
@@ -111,17 +111,28 @@ export async function startWorker(): Promise<WorkerResult> {
     try { await adapter.stop(); } catch { /* already dead */ }
   }
 
-  // 5. Fetch available models for device capabilities
+  // 5. Fetch available models for device capabilities (retry once after delay
+  //    in case the SDK connection isn't fully ready immediately after start)
   let models: string[] = [];
   let modelDetails: import('@kraki/protocol').ModelDetail[] = [];
   if (adapterReady) {
-    try {
-      modelDetails = await adapter.listModelDetails();
-      models = modelDetails.map(m => m.id);
-      logger.debug({ count: models.length }, 'Fetched available models');
-    } catch {
-      logger.warn('Could not fetch available models');
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        modelDetails = await adapter.listModelDetails();
+        models = modelDetails.map(m => m.id);
+        if (models.length > 0) break;
+        if (attempt === 0) {
+          logger.debug('Model list empty, retrying after delay…');
+          await new Promise(r => setTimeout(r, 2000));
+        }
+      } catch {
+        logger.warn('Could not fetch available models');
+        if (attempt === 0) {
+          await new Promise(r => setTimeout(r, 2000));
+        }
+      }
     }
+    logger.debug({ count: models.length }, 'Fetched available models');
   }
 
   // 6. Connect to relay via RelayClient

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -82,12 +82,22 @@ export function resolveDaemonLaunch(
   seaMode = isSea(),
 ): DaemonLaunchSpec {
   if (seaMode) {
+    const {
+      COPILOT_SDK_AUTH_TOKEN: _,
+      COPILOT_AGENT_SESSION_ID: _2,
+      COPILOT_CLI: _3,
+      GITHUB_TOKEN: seaInheritedGhToken,
+      ...seaCleanEnv
+    } = process.env;
+    if (seaInheritedGhToken && !seaInheritedGhToken.startsWith('gho_')) {
+      seaCleanEnv.GITHUB_TOKEN = seaInheritedGhToken;
+    }
     return {
       runtime: process.execPath,
       args: [INTERNAL_DAEMON_WORKER_COMMAND],
       cwd: process.cwd(),
       env: {
-        ...process.env,
+        ...seaCleanEnv,
         NODE_ENV: 'production',
       },
       workerPath: process.execPath,
@@ -108,6 +118,25 @@ export function resolveDaemonLaunch(
     ? [join(workspaceRoot, 'node_modules', '.bin'), join(packageRoot, 'node_modules', '.bin')]
     : [join(packageRoot, 'node_modules', '.bin')];
 
+  // Strip Copilot-specific env vars so the daemon's Copilot SDK instance
+  // uses its own auth chain instead of inheriting a session-scoped token
+  // from a parent Copilot CLI process (which can't be used for models.list).
+  const {
+    COPILOT_SDK_AUTH_TOKEN: _,
+    COPILOT_AGENT_SESSION_ID: _2,
+    COPILOT_CLI: _3,
+    // GITHUB_TOKEN from a parent Copilot CLI is a session-scoped gho_ token
+    // that won't work for a separately spawned copilot process. The daemon's
+    // adapter resolves its own token via `gh auth token` or the SDK's creds.
+    GITHUB_TOKEN: inheritedGhToken,
+    ...cleanEnv
+  } = process.env;
+  // Only strip GITHUB_TOKEN if it looks session-scoped (gho_ prefix).
+  // A real PAT (ghp_) or fine-grained token (github_pat_) should pass through.
+  if (inheritedGhToken && !inheritedGhToken.startsWith('gho_')) {
+    cleanEnv.GITHUB_TOKEN = inheritedGhToken;
+  }
+
   return {
     runtime: process.execPath,
     args: isTsSource
@@ -115,9 +144,9 @@ export function resolveDaemonLaunch(
       : [entryPath, INTERNAL_DAEMON_WORKER_COMMAND],
     cwd: isTsSource ? workspaceRoot : packageRoot,
     env: {
-      ...process.env,
+      ...cleanEnv,
       NODE_ENV: 'production',
-      PATH: [...binPaths, process.env.PATH ?? ''].filter(Boolean).join(delimiter),
+      PATH: [...binPaths, cleanEnv.PATH ?? ''].filter(Boolean).join(delimiter),
     },
     workerPath: entryPath,
   };


### PR DESCRIPTION
When session_list has no preview timestamps, the budget warm-up can't determine recency and skips sessions  causing stale session state (idle shown for active sessions).arbitrarily 

Falls back to loading all sessions when no previews are present.