### PR TITLE
fix(copilot): track empty-output detection per cycle, not per turn

### DIFF
--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -598,20 +598,41 @@ describe('CopilotAdapter', () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
-    it('fires onError for empty turn (no output)', async () => {
+    it('fires onError for empty cycle (no output until idle)', async () => {
       const spy = vi.fn();
       adapter.onError = spy;
       await adapter.start();
-      await adapter.createSession({});
-      // Simulate an empty turn: start → end with no message or tool
+      const { sessionId } = await adapter.createSession({});
+      // Simulate user sending a message that produces nothing through to idle
+      await adapter.sendMessage(sessionId, 'hi');
       mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '1' } });
       mockSessions[0]._emit('assistant.turn_end', {
         data: { reason: 'complete' },
       });
+      mockSessions[0]._emit('session.idle', {});
       expect(spy).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ message: expect.stringContaining('no output') }),
       );
+    });
+
+    it('does not fire onError for empty turn when previous turn in same cycle had output', async () => {
+      const spy = vi.fn();
+      adapter.onError = spy;
+      await adapter.start();
+      const { sessionId } = await adapter.createSession({});
+      // User sends a message that triggers a tool, then agent stays silent
+      await adapter.sendMessage(sessionId, 'silently run echo');
+      mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '1' } });
+      mockSessions[0]._emit('tool.execution_start', { data: { toolName: 'bash', toolCallId: 't1' } });
+      mockSessions[0]._emit('tool.execution_complete', { data: { toolName: 'bash', toolCallId: 't1' } });
+      mockSessions[0]._emit('assistant.turn_end', { data: { reason: 'complete' } });
+      // Second turn: model decides to stay silent (no output)
+      mockSessions[0]._emit('assistant.turn_start', { data: { turnId: '2' } });
+      mockSessions[0]._emit('assistant.turn_end', { data: { reason: 'complete' } });
+      mockSessions[0]._emit('session.idle', {});
+      // No error — the cycle had output (the tool ran)
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('does not throw when callbacks are null', async () => {

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -635,6 +635,30 @@ describe('CopilotAdapter', () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    it('detects empty cycle in second user message even after first cycle errored', async () => {
+      const spy = vi.fn();
+      adapter.onError = spy;
+      await adapter.start();
+      const { sessionId } = await adapter.createSession({});
+
+      // Cycle 1: user message → session.error fires
+      await adapter.sendMessage(sessionId, 'first');
+      mockSessions[0]._emit('session.error', {
+        data: { errorType: 'rate_limit', message: 'Rate limited' },
+      });
+      mockSessions[0]._emit('session.idle', {});
+      spy.mockClear();
+
+      // Cycle 2: user message → session goes idle with no output (silent fail)
+      await adapter.sendMessage(sessionId, 'second');
+      mockSessions[0]._emit('session.idle', {});
+      // Should fire empty-cycle error — not suppressed by previous cycle's error flag
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ message: expect.stringContaining('no output') }),
+      );
+    });
+
     it('does not throw when callbacks are null', async () => {
       await adapter.start();
       await adapter.createSession({});

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -576,8 +576,9 @@ export class CopilotAdapter extends AgentAdapter {
   }
 
   async sendMessage(sessionId: string, text: string, attachments?: import('@kraki/protocol').Attachment[]): Promise<void> {
-    // Reset cycle output tracking — a new user message starts a fresh cycle
+    // Reset per-cycle tracking — a new user message starts a fresh cycle
     this.cycleHasOutput.set(sessionId, false);
+    this.turnErrorReported.set(sessionId, false);
 
     // Prepend mode-switch signal if mode changed since last message
     const pendingMode = this.pendingModeSignals.get(sessionId);
@@ -915,6 +916,16 @@ export class CopilotAdapter extends AgentAdapter {
   // ── SDK → callback wiring ─────────────────────────
 
   private wireEvents(sessionId: string, session: CopilotSession): void {
+    // Initialize per-cycle state for this session. Without this, resumed/forked
+    // sessions (where sendMessage hasn't been called yet) would have undefined
+    // cycleHasOutput and skip empty-cycle detection.
+    if (!this.cycleHasOutput.has(sessionId)) {
+      this.cycleHasOutput.set(sessionId, false);
+    }
+    if (!this.turnErrorReported.has(sessionId)) {
+      this.turnErrorReported.set(sessionId, false);
+    }
+
     session.on('assistant.message_delta', (event) => {
       this.onMessageDelta?.(sessionId, { content: event.data.deltaContent });
     });

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -318,6 +318,8 @@ export class CopilotAdapter extends AgentAdapter {
   private userRequestedModels = new Map<string, string>();
   /** Whether the current turn has produced any output (message or tool call) */
   private turnHasOutput = new Map<string, boolean>();
+  /** Whether the current user-message-to-idle cycle had any output */
+  private cycleHasOutput = new Map<string, boolean>();
   /** Whether an error was already reported for the current turn */
   private turnErrorReported = new Map<string, boolean>();
   /**
@@ -574,6 +576,9 @@ export class CopilotAdapter extends AgentAdapter {
   }
 
   async sendMessage(sessionId: string, text: string, attachments?: import('@kraki/protocol').Attachment[]): Promise<void> {
+    // Reset cycle output tracking — a new user message starts a fresh cycle
+    this.cycleHasOutput.set(sessionId, false);
+
     // Prepend mode-switch signal if mode changed since last message
     const pendingMode = this.pendingModeSignals.get(sessionId);
     if (pendingMode) {
@@ -819,6 +824,7 @@ export class CopilotAdapter extends AgentAdapter {
     this.expectedModels.delete(sessionId);
     this.userRequestedModels.delete(sessionId);
     this.turnHasOutput.delete(sessionId);
+    this.cycleHasOutput.delete(sessionId);
     this.turnErrorReported.delete(sessionId);
     this.clearIdleTimer(sessionId);
   }
@@ -917,12 +923,14 @@ export class CopilotAdapter extends AgentAdapter {
       // Skip empty messages (SDK sends these before tool calls)
       if (event.data.content) {
         this.turnHasOutput.set(sessionId, true);
+        this.cycleHasOutput.set(sessionId, true);
         this.onMessage?.(sessionId, { content: event.data.content });
       }
     });
 
     session.on('tool.execution_start', (event) => {
       this.turnHasOutput.set(sessionId, true);
+      this.cycleHasOutput.set(sessionId, true);
       const data = event.data as unknown as Record<string, unknown>;
       if (data.mcpServerName) {
         logger.info({ mcpServer: data.mcpServerName, mcpTool: data.mcpToolName }, `[MCP tool] ${data.mcpServerName}/${data.mcpToolName}`);
@@ -1000,6 +1008,20 @@ export class CopilotAdapter extends AgentAdapter {
 
     session.on('session.idle', () => {
       this.clearIdleTimer(sessionId);
+
+      // Detect empty cycles — the entire user-message-to-idle cycle had no output
+      // and no error was reported. This catches silent SDK failures (e.g. CLI bug
+      // github/copilot-sdk#794) without false-firing when the agent intentionally
+      // stays silent (e.g. user said "don't say anything").
+      const hasOutput = this.cycleHasOutput.get(sessionId);
+      const hadError = this.turnErrorReported.get(sessionId);
+      if (hasOutput === false && !hadError) {
+        logger.warn({ sessionId }, 'Empty cycle detected — agent produced no output for entire user message');
+        this.onError?.(sessionId, {
+          message: 'Agent produced no output. The session may need to be restarted or the model may be unavailable.',
+        });
+      }
+
       this.onIdle?.(sessionId);
     });
 
@@ -1079,14 +1101,9 @@ export class CopilotAdapter extends AgentAdapter {
         });
       }
 
-      // Detect empty turns — the agent started a turn but produced no output
-      // and no error was reported via session.error or turn_end.reason
-      if (!this.turnHasOutput.get(sessionId) && !this.turnErrorReported.get(sessionId)) {
-        logger.warn({ sessionId }, 'Empty turn detected — agent produced no output');
-        this.onError?.(sessionId, {
-          message: 'Agent produced no output. The session may need to be restarted or the model may be unavailable.',
-        });
-      }
+      // Empty-cycle detection moved to session.idle — see handler above.
+      // Per-turn detection over-fires when agent intentionally stays silent
+      // (e.g. user said "don't say anything" after a tool ran in a prior turn).
 
       // Fallback: schedule idle in case the SDK doesn't emit session.idle
       // (known CLI bug — github/copilot-sdk#794). Cancelled if turn_start


### PR DESCRIPTION
## Problem

The Copilot SDK splits agent work into multiple turns within a single user message. The previous per-turn empty-output detection in `assistant.turn_end` over-fired with a false "Agent produced no output" error when the agent legitimately ended a turn with no output but had output in earlier turns of the same cycle.

Repro: user sends "Run echo 222 then don't say anything". The SDK splits this into two turns:
 has output 
 flagged as failure 

## Why per-turn detection is wrong

`assistant.turn_end` carries no `reason` field in the SDK schema, so we can't distinguish "intentional empty model response" from "silent SDK failure" at the turn-end event.

What we actually want to know: did the agent do anything between user message and idle?

## Fix

Move detection from `assistant.turn_end` to `session.idle` and track output across the entire user-message-to-idle cycle:

- New `cycleHasOutput` map, reset on `sendMessage`
- Set to `true` on any `assistant.message` (with content) or `tool.execution_start`
- On `session.idle`, fire error only if `cycleHasOutput === false` and no `session.error` was reported

Permission/question responses don't reset since they continue the same cycle.

## Test changes

- Updated empty-detection test to assert cycle-level behavior
- Added new test for tool-ran-then-silent flow (no false error)
- All 363 tentacle tests pass; biome lint clean

## Still catches real failures

- Silent SDK failures where `session.idle` fires with zero output (#794)
- Anthropic BYOK turn-event gaps (# `session.idle` still fires1064) 
- Cases where `session.error` doesn't fire but cycle is genuinely empty

## No longer false-fires on

- "Don't say anything" / silent-tool-only turns
- Multi-turn flows where any single turn has no output but the cycle as a whole did
