### PR TITLE
fix(macos): raise launchctl grace window to cover cold-launch signature verify

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -28,7 +28,16 @@ import {
   clearDaemonPid,
 } from './config.js';
 
-const STARTUP_GRACE_MS = 1500;
+// How long to wait for a regular spawned child to finish bootstrapping
+// before declaring success. No signature verification involved.
+const SPAWN_GRACE_MS = 1500;
+
+// How long to wait for a launchctl-spawned daemon to write its PID file.
+// Cold-launching a freshly-installed SEA binary on macOS takes ~2s for
+// signature verification + Node SEA bundle parse. Empirically a fresh
+// binary's first launch is ~1.9s, so we keep comfortable headroom for
+// slower machines / busy disks. After this, a CSM block is plausible.
+const LAUNCHCTL_GRACE_MS = 8000;
 const LAUNCHD_LABEL_BASE = 'cloud.corelli.kraki';
 
 /**
@@ -155,7 +164,7 @@ export function resolveDaemonLaunch(
 function waitForDaemonBootstrap(
   child: ChildProcess,
   bootstrapLogPath: string,
-  timeoutMs = STARTUP_GRACE_MS,
+  timeoutMs = SPAWN_GRACE_MS,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
@@ -224,7 +233,7 @@ export function getDaemonStatus(): DaemonStatus {
 export class MacOSCodeSignatureError extends Error {
   constructor(bootstrapLogPath: string) {
     super(
-      `macOS blocked the daemon process (code signature provenance). ` +
+      `Daemon did not start within ${LAUNCHCTL_GRACE_MS}ms (CSM block or slow first-launch verify). ` +
       `Falling back to in-process daemon. Check ${bootstrapLogPath}`,
     );
     this.name = 'MacOSCodeSignatureError';
@@ -307,7 +316,7 @@ ${envXml}
   execSync(`launchctl load "${plistPath}"`, { stdio: 'ignore' });
 
   // The daemon-worker writes its own PID on startup. Poll for it.
-  const deadline = Date.now() + STARTUP_GRACE_MS;
+  const deadline = Date.now() + LAUNCHCTL_GRACE_MS;
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, 200));
     const pid = loadDaemonPid();


### PR DESCRIPTION
## Problem

Every `kraki update` on macOS falls through to running the daemon in the foreground:

```
Restarting daemon…
Starting in foreground (macOS code signature restriction)…
🦑 Kraki started (PID 25871)
Running in foreground — press Ctrl+C or run `kraki stop` to quit
```

This has been hit and partially patched several times (adcbb3f, cbde637, 841bae3, 0e95892, 21df632, 8e9e453, 3245ab4, cb54885) — most recently by accepting the foreground fallback as a workaround.

## Root cause (verified empirically)

The fallback isn't actually triggered by macOS CSM blocking the binary. The binary IS notarized, Apple's notarization servers ARE reachable, and the launchctl-spawned process DOES start successfully — it just takes too long.

Measured on a clean download of the v0.15.2 `kraki-cli-macos-arm64`:

| Scenario | Time |
|---|---|
| First-ever launch of fresh binary | **1.94s** |
| Same binary, second run via launchctl | 0.90s |
| Warm direct exec | 0.06s |

The 1.94s cold-launch comfortably exceeds the 1500ms `STARTUP_GRACE_MS`, so the launcher's PID-file poll loop times out before `saveDaemonPid()` runs → `MacOSCodeSignatureError` thrown → foreground fallback.

The previous `xattr -cr` strip on the temp file (#21df632) doesn't help here because `copyFileSync` writes a fresh file at the install path; the kernel re-applies `com.apple.provenance` from the writer process. But that's actually a non-issue for current macOS — the notarization ticket lookup succeeds within ~1s; we just weren't waiting long enough.

## Change

Split the single `STARTUP_GRACE_MS = 1500` into two constants:

- `SPAWN_GRACE_MS` (1500ms) — unchanged. Used in the regular child-process spawn path (Linux/Windows/macOS-dev). No signature verification involved.
- `LAUNCHCTL_GRACE_MS` (8000ms) — new. Used only in the launchctl path on macOS SEA. Covers cold-launch signature verification with headroom for slow disks.

Also reword `MacOSCodeSignatureError`'s message to reflect what actually triggers it (kept the class name for back-compat).

## Tests

```
pnpm --filter @kraki/tentacle test
✓ 18 files passed
✓ 364 tests passed
```

`pnpm lint` clean.