### PR TITLE
feat(tentacle): filter out report_intent tool calls

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -940,9 +940,11 @@ export class CopilotAdapter extends AgentAdapter {
     });
 
     session.on('tool.execution_start', (event) => {
+      const data = event.data as unknown as Record<string, unknown>;
+      // report_intent is a UI hint only — drop it from the message stream.
+      if (data.toolName === 'report_intent') return;
       this.turnHasOutput.set(sessionId, true);
       this.cycleHasOutput.set(sessionId, true);
-      const data = event.data as unknown as Record<string, unknown>;
       if (data.mcpServerName) {
         logger.info({ mcpServer: data.mcpServerName, mcpTool: data.mcpToolName }, `[MCP tool] ${data.mcpServerName}/${data.mcpToolName}`);
       }
@@ -958,6 +960,7 @@ export class CopilotAdapter extends AgentAdapter {
 
     session.on('tool.execution_complete', (event) => {
       const data = event.data as unknown as Record<string, unknown>;
+      if (data.toolName === 'report_intent') return;
       const rawResult = data.result;
       const toolCallId = data.toolCallId as string | undefined;
       // SDK sends result as { content: string, contents?: [...] } or as a plain string.


### PR DESCRIPTION
Drop `report_intent` tool start/complete events at the adapter source. It's a UI hint with no real work, so suppressing it keeps the session view clean and saves bandwidth (no encrypted blob, no replay buffer entry).

- Filter in `tool.execution_start` and `tool.execution_complete` handlers
- Logs unaffected (per request)
- Permission path unchanged (`report_intent` is unpermissioned)
- Bumps tentacle to 0.15.4

All 364 tentacle tests pass, lint clean.