### PR TITLE
feat(attachments): Kraki MCP server + lazy image pipeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,8 @@ Its job is to:
 - buffer messages for replay on reconnect
 - manage session lifecycle (create, update, close)
 - auto-approve tools from a local allowed list
+- store image attachments produced by the agent and serve them on demand to authenticated receivers
+- expose a local MCP server (`kraki-show_image` and friends) so agents can present images to the user explicitly
 
 Today the repository includes a Copilot-focused adapter. The adapter boundary is intentionally separated so more agents can be added without changing the relay or UI model.
 
@@ -137,6 +139,31 @@ Its job is to:
 4. For each offline device with a registered token, `head` sends the preview blob via the appropriate push service (APNs, FCM, or Web Push/VAPID).
 5. The device's service worker (or Notification Service Extension on iOS) receives the push, decrypts the preview using the device's private key, and shows a notification with the actual content.
 6. The relay never sees the notification content — it forwards the same opaque encrypted blob through the push service as it does through WebSocket.
+
+### 7. Image attachments
+
+Image bytes do not travel inline inside agent activity messages. Instead they flow as a separate, chunked stream so that broadcast and replay payloads stay small.
+
+1. The agent invokes the `kraki-show_image` MCP tool with a path and an optional caption (see "Kraki MCP server" below). Images surfaced by any other tool (e.g. `view`) are deliberately dropped — only `kraki-show_image` is treated as an intent to present.
+2. `tentacle` stores the bytes in a content-addressed attachment store under the session directory (`~/.kraki/sessions/<sid>/attachments/<id>.<ext>` with a `<id>.json` sidecar). The id is a truncated sha256 of the bytes.
+3. The accompanying `tool_complete` message carries an `AttachmentRef` (id, size, mime, optional dimensions, name, caption) — never bytes. `messages.jsonl` stays small forever.
+4. After the message is broadcast, `tentacle` pushes the bytes as a sequence of `attachment_data` chunks (≤ 2 MB plaintext each) over the existing broadcast channel, encrypted per-recipient like any other message. The relay's 10 MB `maxPayload` is never approached.
+5. Receivers decrypt and reassemble chunks, write the blob to IndexedDB keyed by id, and render the image. The IDB cache is bounded (LRU eviction at ~50–200 MB depending on storage quota).
+6. If a receiver joins late (replay) or has evicted the bytes, it sends a `request_attachment` unicast. `tentacle` looks up the id on disk and serves it as `attachment_data` chunks back to that specific device. Bytes only leave the tentacle in response to an authenticated session-member request.
+
+Future MCP tools that present non-image artifacts will reuse the same ref + chunk transport — the only thing that changes is the discriminator on `Attachment`.
+
+## Kraki MCP server
+
+A loopback HTTP server runs in-process inside the daemon. It is wired into Copilot's `mcpServers` configuration with a per-session URL and a per-session bearer token; only the local agent process can reach it. It is *not* exposed to the relay.
+
+For v1 the server registers one tool:
+
+- **`kraki-show_image(path, caption?)`** — read a file from disk, register its bytes with the attachment store, and return a refusal of the LLM-feed bytes so the agent does not see the image itself. The bytes flow to user-facing receivers via the attachment pipeline described above.
+
+Tool names follow Copilot's `<server>-<tool>` display convention (dash, not dot). The adapter correlates `tool.execution_start` and `tool.execution_complete` events via `toolCallId` because Copilot's SDK strips `mcpServerName`/`mcpToolName` from the complete event.
+
+If the MCP server fails to start (port collision, etc.) the daemon stays up, logs a warning, and omits the `kraki-show_image` tool from the agent's available tools — the rest of the session works as normal.
 
 ## Trust boundaries
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -127,6 +127,23 @@ Push notifications use the same E2E encryption model. When an agent event requir
 
 The relay sees the encrypted blob size and the push token — never the notification content. This extends the same trust boundary from WebSocket delivery to push delivery.
 
+## Image attachments
+
+Images produced by an agent (via the `kraki-show_image` MCP tool) are content-addressed and stored on the tentacle's disk under the session's directory. The bytes are not embedded in agent activity messages — only an attachment reference (id + metadata) appears in the broadcast and in `messages.jsonl`.
+
+Bytes are delivered separately, encrypted per-recipient like any other message:
+
+- On live activity, the tentacle pushes the bytes as a chunked `attachment_data` stream to all session-member devices immediately after the referencing tool message.
+- On replay or cache miss, a receiver explicitly requests the bytes via a `request_attachment` unicast; the tentacle serves chunks back to that specific authenticated device.
+
+The relay sees the same opaque encrypted blobs it sees for any other message, plus chunked transfer adds nothing to its visibility. Bytes never leave the tentacle except on an authenticated session-member request, so the privacy boundary for screenshots matches the privacy boundary for prompts and tool output.
+
+## Local MCP server
+
+The tentacle runs a small loopback HTTP server (the Kraki MCP server) so the local agent can call Kraki-specific tools such as `kraki-show_image`. It binds to `127.0.0.1` only, requires a per-session bearer token, and is registered with the agent via a per-session URL.
+
+The MCP server is not exposed to the relay or to other devices. It is reachable only from processes on the same machine as the tentacle — the same trust zone as the agent itself.
+
 ## Open source and verification
 
 Open source helps because it lets people inspect how Kraki handles encryption, routing, and storage. It does not replace operational trust by itself, but it does make the design auditable and self-hosting possible.

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -20,7 +20,9 @@ function collectTurnImages(thinkingMessages: ChatMessage[]): Attachment[] {
   for (const m of thinkingMessages) {
     if (m.type === 'tool_complete' && Array.isArray(m.payload?.attachments)) {
       for (const att of m.payload.attachments) {
-        if (att.type === 'image') images.push(att as Attachment);
+        if (att.type === 'image' || att.type === 'image_ref') {
+          images.push(att as Attachment);
+        }
       }
     }
   }

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -9,6 +9,7 @@ import { ToolActivity } from './ToolActivity';
 import { AgentAvatar } from '../common/AgentAvatar';
 import { Lock, Check, X, LockOpen, CircleStop, Copy } from 'lucide-react';
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { useAttachment } from '../../hooks/useAttachment';
 
 const ID_DISPLAY_LENGTH = 8;
 const IMAGE_PLACEHOLDER = '[image]';
@@ -39,7 +40,7 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
                   </Markdown>
                 </div>
               )}
-              <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} />
+              <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} sessionId={sessionId} />
               <p className="mt-1 text-right text-[10px] text-white/60">
                 {formatTime(message.timestamp)}
               </p>
@@ -62,8 +63,8 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
                   {message.payload.content}
                 </Markdown>
               </div>
-              <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} />
-              {turnImages && turnImages.length > 0 && <ImageAttachments attachments={turnImages} />}
+              <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} sessionId={sessionId} />
+              {turnImages && turnImages.length > 0 && <ImageAttachments attachments={turnImages} sessionId={sessionId} />}
               <p className="mt-1 text-[10px] text-text-muted">
                 {formatTime(message.timestamp)}
               </p>
@@ -109,7 +110,7 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
             success={message.payload.success}
             forceExpanded={forceExpanded}
           />
-          <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} />
+          <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} sessionId={sessionId} />
         </>
       );
 
@@ -130,7 +131,7 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
         <div className="flex justify-end">
           <div className="min-w-0 max-w-[85%] overflow-x-auto rounded-2xl rounded-br-md bg-kraki-500 px-4 py-2.5 text-white shadow-sm sm:max-w-[70%]">
             {message.payload.text !== IMAGE_PLACEHOLDER && <p className="text-sm">{message.payload.text}</p>}
-            <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} />
+            <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} sessionId={sessionId} />
             <p className="mt-1 text-right text-[10px] text-white/60">
               {formatTime(message.timestamp)}
             </p>
@@ -256,7 +257,7 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
         <div className="flex justify-end">
           <div className="min-w-0 max-w-[85%] overflow-x-auto rounded-2xl rounded-br-md bg-kraki-500/70 px-4 py-2.5 text-white shadow-sm sm:max-w-[70%]">
             {message.text !== IMAGE_PLACEHOLDER && <p className="text-sm">{message.text}</p>}
-            <ImageAttachments attachments={message.attachments as Attachment[] | undefined} />
+            <ImageAttachments attachments={message.attachments as Attachment[] | undefined} sessionId={sessionId} />
             <p className="mt-1 flex items-center justify-end gap-1 text-[10px] text-white/60">
               <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border border-white/40 border-t-white/90" />
               Sending…
@@ -352,38 +353,24 @@ function CopyableBubble({ text, children }: { text: string; children: React.Reac
   );
 }
 
-function ImageAttachments({ attachments }: { attachments?: Attachment[] }) {
+function ImageAttachments({ attachments, sessionId }: { attachments?: Attachment[]; sessionId?: string }) {
   const [expanded, setExpanded] = useState<string | null>(null);
-  const images = attachments?.filter((a): a is Attachment & { type: 'image' } => a.type === 'image');
+  const images = attachments?.filter(
+    (a): a is (Attachment & { type: 'image' }) | (Attachment & { type: 'image_ref' }) =>
+      a.type === 'image' || a.type === 'image_ref',
+  );
   if (!images?.length) return null;
 
   return (
     <>
-      <div className="mt-2 flex flex-wrap gap-2">
+      <div className="mt-2 flex flex-wrap gap-3">
         {images.map((img, i) => (
-          <button
+          <AttachmentTile
             key={i}
-            type="button"
-            className="overflow-hidden rounded-lg border border-border-primary/20"
-            onClick={() => setExpanded(`data:${img.mimeType};base64,${img.data}`)}
-          >
-            <img
-              src={`data:${img.mimeType};base64,${img.data}`}
-              alt="Attachment"
-              className="max-h-48 max-w-full object-contain"
-              onLoad={(e) => {
-                // After image renders, re-check scroll so auto-scroll accounts for image height
-                const scrollable = (e.target as HTMLElement).closest('[data-chat-scroll]');
-                if (scrollable) {
-                  const { scrollTop, scrollHeight, clientHeight } = scrollable;
-                  if (scrollHeight - scrollTop - clientHeight < 80) {
-                    console.info('[Kraki:scroll] IMG onLoad → scrollToBottom', { scrollTop, scrollHeight, clientHeight });
-                    scrollable.scrollTop = scrollHeight;
-                  }
-                }
-              }}
-            />
-          </button>
+            attachment={img}
+            sessionId={sessionId}
+            onExpand={(url) => setExpanded(url)}
+          />
         ))}
       </div>
       {expanded && (
@@ -400,4 +387,153 @@ function ImageAttachments({ attachments }: { attachments?: Attachment[] }) {
       )}
     </>
   );
+}
+
+function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>): void {
+  const scrollable = (e.target as HTMLElement).closest('[data-chat-scroll]');
+  if (scrollable) {
+    const { scrollTop, scrollHeight, clientHeight } = scrollable;
+    if (scrollHeight - scrollTop - clientHeight < 80) {
+      scrollable.scrollTop = scrollHeight;
+    }
+  }
+}
+
+function AttachmentTile({
+  attachment,
+  sessionId,
+  onExpand,
+}: {
+  attachment: Attachment & ({ type: 'image' } | { type: 'image_ref' });
+  sessionId?: string;
+  onExpand: (url: string) => void;
+}) {
+  if (attachment.type === 'image') {
+    const src = `data:${attachment.mimeType};base64,${attachment.data}`;
+    return (
+      <figure className="m-0 flex flex-col items-start gap-1">
+        <button
+          type="button"
+          className="overflow-hidden rounded-lg border border-border-primary/20"
+          onClick={() => onExpand(src)}
+        >
+          <img
+            src={src}
+            alt={attachment.caption ?? attachment.name ?? 'Attachment'}
+            className="max-h-72 max-w-full object-contain"
+            onLoad={onImageLoad}
+          />
+        </button>
+        {attachment.caption && (
+          <figcaption className="text-xs italic text-text-secondary">{attachment.caption}</figcaption>
+        )}
+      </figure>
+    );
+  }
+
+  // type === 'image_ref'
+  if (!sessionId) {
+    // No sessionId in scope means we can't fetch — render placeholder only
+    return <RefImagePlaceholder ref_={attachment} />;
+  }
+  return <RefImageTile ref_={attachment} sessionId={sessionId} onExpand={onExpand} />;
+}
+
+function RefImagePlaceholder({ ref_ }: { ref_: Attachment & { type: 'image_ref' } }) {
+  return (
+    <figure className="m-0 flex flex-col items-start gap-1">
+      <div
+        className="flex flex-col items-center justify-center rounded-lg border border-border-primary/20 bg-surface-secondary/50 text-text-secondary"
+        style={{
+          width: ref_.width ? Math.min(ref_.width, 320) : 320,
+          height: ref_.height ? Math.min(ref_.height, 180) : 180,
+        }}
+      >
+        <div className="text-xs">🖼 {ref_.name ?? 'image'}</div>
+        <div className="text-[10px] opacity-60">{formatBytes(ref_.size)}</div>
+      </div>
+      {ref_.caption && <figcaption className="text-xs italic text-text-secondary">{ref_.caption}</figcaption>}
+    </figure>
+  );
+}
+
+function RefImageTile({
+  ref_,
+  sessionId,
+  onExpand,
+}: {
+  ref_: Attachment & { type: 'image_ref' };
+  sessionId: string;
+  onExpand: (url: string) => void;
+}) {
+  // Lazy import wsClient to avoid a cycle with MessageBubble (which is
+  // re-exported through several layers).
+  const requestPull = (sid: string, id: string): void => {
+    void import('../../lib/ws-client').then(({ wsClient }) => {
+      wsClient.requestAttachment(sid, id);
+    });
+  };
+  const { status, url, error } = useAttachment(ref_, sessionId, requestPull);
+
+  const placeholderStyle: React.CSSProperties = {
+    width: ref_.width ? Math.min(ref_.width, 320) : 320,
+    height: ref_.height ? Math.min(ref_.height, 180) : 180,
+  };
+
+  if (status === 'ready' && url) {
+    return (
+      <figure className="m-0 flex flex-col items-start gap-1">
+        <button
+          type="button"
+          className="overflow-hidden rounded-lg border border-border-primary/20"
+          onClick={() => onExpand(url)}
+        >
+          <img
+            src={url}
+            alt={ref_.caption ?? ref_.name ?? 'Attachment'}
+            className="max-h-72 max-w-full object-contain"
+            onLoad={onImageLoad}
+          />
+        </button>
+        {ref_.caption && <figcaption className="text-xs italic text-text-secondary">{ref_.caption}</figcaption>}
+      </figure>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <figure className="m-0 flex flex-col items-start gap-1">
+        <div
+          className="flex flex-col items-center justify-center rounded-lg border border-red-500/40 bg-red-500/10 text-text-secondary"
+          style={placeholderStyle}
+        >
+          <div className="text-xs">⚠ Couldn't load image</div>
+          <div className="text-[10px] opacity-60">{ref_.name ?? 'image'}</div>
+          {error && <div className="text-[10px] opacity-60">{error}</div>}
+        </div>
+        {ref_.caption && <figcaption className="text-xs italic text-text-secondary">{ref_.caption}</figcaption>}
+      </figure>
+    );
+  }
+  // loading
+  return (
+    <figure className="m-0 flex flex-col items-start gap-1">
+      <div
+        className="flex flex-col items-center justify-center gap-2 rounded-lg border border-border-primary/20 bg-surface-secondary/50 text-text-secondary"
+        style={placeholderStyle}
+      >
+        <span
+          className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-text-secondary/40 border-t-text-secondary"
+          aria-label="Loading"
+        />
+        <div className="text-[10px] opacity-60">{ref_.name ?? 'image'} · {formatBytes(ref_.size)}</div>
+      </div>
+      {ref_.caption && <figcaption className="text-xs italic text-text-secondary">{ref_.caption}</figcaption>}
+    </figure>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/packages/arm/web/src/components/chat/ThinkingBox.tsx
+++ b/packages/arm/web/src/components/chat/ThinkingBox.tsx
@@ -131,6 +131,7 @@ export function ThinkingBox({ messages, isActive, aborted, agent, sessionId, str
                       key={'seq' in msg && msg.seq ? `${msg.seq}-${msg.type}` : `thinking-${idx}`}
                       message={msg}
                       agent={agent}
+                      sessionId={sessionId}
                       forceExpanded={allExpanded || undefined}
                       cancelled={aborted && msg.type === 'tool_start'}
                     />

--- a/packages/arm/web/src/hooks/useAttachment.ts
+++ b/packages/arm/web/src/hooks/useAttachment.ts
@@ -36,6 +36,24 @@ interface UseAttachmentResult {
 /** wsClient.requestAttachment thunk — kept loose to avoid an import cycle. */
 type RequestPull = (sessionId: string, id: string) => void;
 
+/** Shared hydrate guard so concurrent mounts don't fan out duplicate IDB reads. */
+const hydratedIds = new Set<string>();
+const hydratingIds = new Map<string, Promise<boolean>>();
+
+function hydrateOnce(id: string): Promise<boolean> {
+  if (hydratedIds.has(id)) return Promise.resolve(true);
+  let p = hydratingIds.get(id);
+  if (!p) {
+    p = hydrateFromIDB(id).then((hit) => {
+      if (hit) hydratedIds.add(id);
+      hydratingIds.delete(id);
+      return hit;
+    });
+    hydratingIds.set(id, p);
+  }
+  return p;
+}
+
 export function useAttachment(
   ref: AttachmentRef,
   sessionId: string,
@@ -46,7 +64,6 @@ export function useAttachment(
 
   useEffect(() => {
     let cancelled = false;
-    let currentUrl: string | null = null;
 
     function onUpdate(): void {
       if (cancelled) return;
@@ -60,7 +77,7 @@ export function useAttachment(
       if (existing?.kind === 'ready') return;
       if (existing?.kind === 'awaiting-chunks' || existing?.kind === 'fetching') return;
       // Not in memory — try IDB
-      const hit = await hydrateFromIDB(ref.id);
+      const hit = await hydrateOnce(ref.id);
       if (cancelled) return;
       if (hit) return;
       // Miss + no live push → start a fetch
@@ -73,12 +90,11 @@ export function useAttachment(
     return () => {
       cancelled = true;
       unsubscribe();
-      if (currentUrl) {
-        URL.revokeObjectURL(currentUrl);
-        currentUrl = null;
-      }
     };
-  }, [ref.id, sessionId, requestPull]);
+    // requestPull identity changes every render; we deliberately exclude it
+    // from deps so this effect only re-runs when the id/session changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref.id, sessionId]);
 
   // Derive object URL from current state. Re-runs on every notify.
   useEffect(() => {

--- a/packages/arm/web/src/hooks/useAttachment.ts
+++ b/packages/arm/web/src/hooks/useAttachment.ts
@@ -1,0 +1,108 @@
+/**
+ * React hook for reading an attachment by ref.
+ *
+ * Returns a stable shape the UI can switch on:
+ *   - status: 'loading' | 'ready' | 'error'
+ *   - url: object URL (only when status === 'ready')
+ *   - error: reason string (only when status === 'error')
+ *
+ * Internally subscribes to the attachment state machine in
+ * `lib/attachments.ts`. The first mount per id may hydrate from IDB; if
+ * that misses and we have no live push pending, it triggers a pull via
+ * `wsClient.requestAttachment`.
+ *
+ * Object URLs are created here and revoked on unmount so they don't leak
+ * across remounts (e.g. virtualised chat lists).
+ */
+
+import { useEffect, useState } from 'react';
+
+import type { AttachmentRef } from '@kraki/protocol';
+
+import {
+  type AttachmentState,
+  getState,
+  hydrateFromIDB,
+  markFetching,
+  subscribe,
+} from '../lib/attachments';
+
+interface UseAttachmentResult {
+  status: 'loading' | 'ready' | 'error';
+  url: string | null;
+  error: string | null;
+}
+
+/** wsClient.requestAttachment thunk — kept loose to avoid an import cycle. */
+type RequestPull = (sessionId: string, id: string) => void;
+
+export function useAttachment(
+  ref: AttachmentRef,
+  sessionId: string,
+  requestPull: RequestPull,
+): UseAttachmentResult {
+  const [tick, setTick] = useState(0);
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let currentUrl: string | null = null;
+
+    function onUpdate(): void {
+      if (cancelled) return;
+      setTick((t) => t + 1);
+    }
+
+    const unsubscribe = subscribe(ref.id, onUpdate);
+
+    async function init(): Promise<void> {
+      const existing = getState(ref.id);
+      if (existing?.kind === 'ready') return;
+      if (existing?.kind === 'awaiting-chunks' || existing?.kind === 'fetching') return;
+      // Not in memory — try IDB
+      const hit = await hydrateFromIDB(ref.id);
+      if (cancelled) return;
+      if (hit) return;
+      // Miss + no live push → start a fetch
+      markFetching(ref.id);
+      requestPull(sessionId, ref.id);
+    }
+
+    void init();
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      if (currentUrl) {
+        URL.revokeObjectURL(currentUrl);
+        currentUrl = null;
+      }
+    };
+  }, [ref.id, sessionId, requestPull]);
+
+  // Derive object URL from current state. Re-runs on every notify.
+  useEffect(() => {
+    const state = getState(ref.id);
+    if (state?.kind === 'ready') {
+      const objUrl = URL.createObjectURL(state.blob);
+      setUrl(objUrl);
+      return () => {
+        URL.revokeObjectURL(objUrl);
+        setUrl(null);
+      };
+    }
+    setUrl(null);
+    return undefined;
+    // We re-derive on every `tick` push from the state subscriber.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref.id, tick]);
+
+  const state = getState(ref.id) as AttachmentState | undefined;
+  if (state?.kind === 'ready' && url) {
+    return { status: 'ready', url, error: null };
+  }
+  if (state?.kind === 'error') {
+    return { status: 'error', url: null, error: state.reason };
+  }
+  return { status: 'loading', url: null, error: null };
+}

--- a/packages/arm/web/src/lib/attachments.test.ts
+++ b/packages/arm/web/src/lib/attachments.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the attachment state machine.
+ *
+ * Cover the four key paths:
+ *   - live push: ref arrives → markAwaitingPush → chunks → ready
+ *   - replay pull: ref arrives → markFetching → chunks → ready
+ *   - error chunk: state transitions to error
+ *   - safety timeout: ref arrives → no chunks → fallback fetch fires
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetForTests,
+  getState,
+  ingestChunk,
+  markAwaitingPush,
+  markFetching,
+  subscribe,
+} from './attachments';
+
+// Tiny PNG bytes for assembly tests
+const PNG_HEX = '89504e470d0a1a0a';
+const PNG_BYTES = new Uint8Array(PNG_HEX.match(/.{2}/g)!.map((h) => parseInt(h, 16)));
+const PNG_B64 = btoa(String.fromCharCode(...PNG_BYTES));
+
+describe('attachment state machine', () => {
+  let pulls: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    pulls = [];
+    __resetForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('markAwaitingPush sets awaiting state', () => {
+    markAwaitingPush('id1', (id) => pulls.push(id));
+    expect(getState('id1')?.kind).toBe('awaiting-chunks');
+  });
+
+  it('ingestChunk single chunk transitions to ready', async () => {
+    markAwaitingPush('id1', (id) => pulls.push(id));
+    await ingestChunk('id1', 0, 1, 'image/png', PNG_B64);
+    const s = getState('id1');
+    expect(s?.kind).toBe('ready');
+    if (s?.kind === 'ready') {
+      expect(s.mimeType).toBe('image/png');
+      expect(s.blob.size).toBe(PNG_BYTES.length);
+    }
+  });
+
+  it('ingestChunk reassembles multiple chunks regardless of order', async () => {
+    markAwaitingPush('id2', (id) => pulls.push(id));
+    // Two halves of the bytes, sent out of order
+    const first = PNG_B64.slice(0, 4);
+    const second = PNG_B64.slice(4);
+    await ingestChunk('id2', 1, 2, 'image/png', second);
+    expect(getState('id2')?.kind).toBe('awaiting-chunks');
+    await ingestChunk('id2', 0, 2, 'image/png', first);
+    expect(getState('id2')?.kind).toBe('ready');
+  });
+
+  it('ingestChunk with error transitions to error state', async () => {
+    markAwaitingPush('id3', (id) => pulls.push(id));
+    await ingestChunk('id3', 0, 0, '', '', 'not_found');
+    const s = getState('id3');
+    expect(s?.kind).toBe('error');
+    if (s?.kind === 'error') {
+      expect(s.reason).toBe('not_found');
+    }
+  });
+
+  it('safety timeout fires fallback pull when no chunks arrive', () => {
+    markAwaitingPush('id4', (id) => pulls.push(id));
+    expect(pulls).toEqual([]);
+    vi.advanceTimersByTime(10_001);
+    expect(pulls).toEqual(['id4']);
+  });
+
+  it('safety timeout does not fire if a chunk arrived first', async () => {
+    markAwaitingPush('id5', (id) => pulls.push(id));
+    await ingestChunk('id5', 0, 1, 'image/png', PNG_B64);
+    vi.advanceTimersByTime(15_000);
+    expect(pulls).toEqual([]);
+  });
+
+  it('markFetching is used by the pull path', () => {
+    markFetching('id6');
+    expect(getState('id6')?.kind).toBe('fetching');
+  });
+
+  it('chunks arriving during fetch state still complete', async () => {
+    markFetching('id7');
+    await ingestChunk('id7', 0, 1, 'image/png', PNG_B64);
+    expect(getState('id7')?.kind).toBe('ready');
+  });
+
+  it('subscribers are notified on state changes', async () => {
+    const seen: string[] = [];
+    const unsub = subscribe('id8', () => seen.push(getState('id8')?.kind ?? '-'));
+    markAwaitingPush('id8', () => {});
+    await ingestChunk('id8', 0, 1, 'image/png', PNG_B64);
+    expect(seen).toContain('awaiting-chunks');
+    expect(seen).toContain('ready');
+    unsub();
+  });
+});

--- a/packages/arm/web/src/lib/attachments.ts
+++ b/packages/arm/web/src/lib/attachments.ts
@@ -1,0 +1,324 @@
+/**
+ * Web-side attachment cache and chunk reassembly.
+ *
+ * One state machine per attachment id:
+ *
+ *   awaiting-chunks  ← live message router calls markAwaitingPush() when a
+ *                       fresh tool_complete with an AttachmentRef arrives;
+ *                       chunks are inbound via attachment_data messages.
+ *   fetching         ← useAttachment triggered a pull (replay path or
+ *                       safety-timeout fallback).
+ *   ready            ← bytes assembled, blob URL available.
+ *   error            ← all chunks errored or the safety fetch failed.
+ *
+ * Storage:
+ *   - IndexedDB store `attachments` keyed by id (sha256 hex). Holds Blob.
+ *   - In-memory pending-chunks map for in-flight assembly.
+ *   - In-memory state map mirrors the four kinds above plus a subscriber
+ *     set so React hooks can re-render when an id transitions.
+ *
+ * Object URLs are created by useAttachment, not here — this module deals
+ * only in Blobs, so we don't leak URLs across hook unmounts.
+ */
+
+import { openDB, type IDBPDatabase } from 'idb';
+
+import { createLogger } from './logger';
+
+const logger = createLogger('attachments');
+
+const DB_NAME = 'kraki-attachments';
+const DB_VERSION = 1;
+const STORE_NAME = 'attachments';
+
+interface StoredAttachment {
+  id: string;
+  mimeType: string;
+  size: number;
+  blob: Blob;
+  lastAccessed: number;
+}
+
+let dbPromise: Promise<IDBPDatabase> | null = null;
+function getDB(): Promise<IDBPDatabase> {
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+          store.createIndex('lastAccessed', 'lastAccessed');
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+// ── Cap derivation (cheap, runs once per call site) ──────────────────────
+
+const TARGET_CAP_BYTES = 200 * 1024 * 1024;
+const MIN_CAP_BYTES = 50 * 1024 * 1024;
+const QUOTA_SAFETY = 0.5;
+
+export async function effectiveCapBytes(): Promise<number> {
+  if (typeof navigator !== 'undefined' && navigator.storage?.estimate) {
+    try {
+      const est = await navigator.storage.estimate();
+      if (est.quota) {
+        return Math.max(MIN_CAP_BYTES, Math.min(TARGET_CAP_BYTES, est.quota * QUOTA_SAFETY));
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  return MIN_CAP_BYTES;
+}
+
+// ── State machine ───────────────────────────────────────────────────────
+
+export type AttachmentState =
+  | { kind: 'awaiting-chunks'; received: Map<number, string>; total: number | null; mimeType: string | null; startedAt: number }
+  | { kind: 'fetching' }
+  | { kind: 'ready'; mimeType: string; blob: Blob }
+  | { kind: 'error'; reason: string };
+
+const states = new Map<string, AttachmentState>();
+const subscribers = new Map<string, Set<() => void>>();
+const PUSH_TIMEOUT_MS = 10_000;
+const pushTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+function notify(id: string): void {
+  const subs = subscribers.get(id);
+  if (!subs) return;
+  for (const fn of subs) fn();
+}
+
+export function subscribe(id: string, fn: () => void): () => void {
+  let set = subscribers.get(id);
+  if (!set) {
+    set = new Set();
+    subscribers.set(id, set);
+  }
+  set.add(fn);
+  return () => {
+    const cur = subscribers.get(id);
+    if (!cur) return;
+    cur.delete(fn);
+    if (cur.size === 0) subscribers.delete(id);
+  };
+}
+
+export function getState(id: string): AttachmentState | undefined {
+  return states.get(id);
+}
+
+/** Called by the message router for every AttachmentRef in a LIVE message. */
+export function markAwaitingPush(id: string, requestPull: (id: string) => void): void {
+  // No-op if we already have it or are mid-fetch
+  const current = states.get(id);
+  if (current && (current.kind === 'ready' || current.kind === 'awaiting-chunks' || current.kind === 'fetching')) {
+    return;
+  }
+  states.set(id, {
+    kind: 'awaiting-chunks',
+    received: new Map(),
+    total: null,
+    mimeType: null,
+    startedAt: Date.now(),
+  });
+  notify(id);
+  // Safety timeout — if no chunk arrives in PUSH_TIMEOUT_MS, fall back to
+  // an explicit attachment_request. Cleared when first chunk arrives or
+  // when assembly completes.
+  if (pushTimeouts.has(id)) {
+    clearTimeout(pushTimeouts.get(id)!);
+  }
+  pushTimeouts.set(
+    id,
+    setTimeout(() => {
+      const s = states.get(id);
+      if (s?.kind === 'awaiting-chunks' && s.received.size === 0) {
+        logger.warn('push timeout — falling back to fetch', { id });
+        requestPull(id);
+      }
+    }, PUSH_TIMEOUT_MS),
+  );
+}
+
+/** Called by the message router on every `attachment_data` chunk arrival. */
+export async function ingestChunk(
+  id: string,
+  index: number,
+  total: number,
+  mimeType: string,
+  data: string,
+  error?: string,
+): Promise<void> {
+  if (error) {
+    states.set(id, { kind: 'error', reason: error });
+    clearPushTimeout(id);
+    notify(id);
+    return;
+  }
+
+  let current = states.get(id);
+  if (!current || (current.kind !== 'awaiting-chunks' && current.kind !== 'fetching')) {
+    // Either we already have it, or a stray chunk arrived. Initialize a
+    // fresh awaiting-chunks state defensively.
+    current = {
+      kind: 'awaiting-chunks',
+      received: new Map(),
+      total: null,
+      mimeType: null,
+      startedAt: Date.now(),
+    };
+    states.set(id, current);
+  } else if (current.kind === 'fetching') {
+    // Chunk arrived during/after a pull request; convert to assembly state
+    current = {
+      kind: 'awaiting-chunks',
+      received: new Map(),
+      total: null,
+      mimeType: null,
+      startedAt: Date.now(),
+    };
+    states.set(id, current);
+  }
+
+  current.received.set(index, data);
+  current.total = total;
+  current.mimeType = mimeType;
+  if (current.received.size === total) {
+    // Complete — assemble Blob
+    const sorted = Array.from(current.received.entries()).sort((a, b) => a[0] - b[0]);
+    const buf = new Uint8Array(sorted.reduce((acc, [, b64]) => acc + base64Length(b64), 0));
+    let offset = 0;
+    for (const [, b64] of sorted) {
+      const bytes = base64ToBytes(b64);
+      buf.set(bytes, offset);
+      offset += bytes.length;
+    }
+    const blob = new Blob([buf], { type: mimeType });
+    states.set(id, { kind: 'ready', mimeType, blob });
+    clearPushTimeout(id);
+    await persistToIDB({ id, mimeType, size: blob.size, blob, lastAccessed: Date.now() });
+    notify(id);
+  } else {
+    notify(id);
+  }
+}
+
+function clearPushTimeout(id: string): void {
+  const t = pushTimeouts.get(id);
+  if (t) {
+    clearTimeout(t);
+    pushTimeouts.delete(id);
+  }
+}
+
+/** Called by useAttachment to mark a pull in progress. */
+export function markFetching(id: string): void {
+  const current = states.get(id);
+  if (current?.kind === 'ready' || current?.kind === 'awaiting-chunks') return;
+  states.set(id, { kind: 'fetching' });
+  notify(id);
+}
+
+/** Try to hydrate state from IDB. Returns true if hit. */
+export async function hydrateFromIDB(id: string): Promise<boolean> {
+  try {
+    const db = await getDB();
+    const got = (await db.get(STORE_NAME, id)) as StoredAttachment | undefined;
+    if (!got) return false;
+    states.set(id, { kind: 'ready', mimeType: got.mimeType, blob: got.blob });
+    // Update lastAccessed in the background; ignore errors
+    void db.put(STORE_NAME, { ...got, lastAccessed: Date.now() });
+    notify(id);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function persistToIDB(record: StoredAttachment): Promise<void> {
+  try {
+    const db = await getDB();
+    await db.put(STORE_NAME, record);
+    void evictIfOverCap();
+  } catch (err) {
+    logger.warn('failed to persist attachment to IDB', { id: record.id, error: (err as Error).message });
+    if ((err as Error).name === 'QuotaExceededError') {
+      // Halve the in-IDB store as a recovery; LRU by lastAccessed
+      void evictIfOverCap(true);
+    }
+  }
+}
+
+let evictionInFlight = false;
+async function evictIfOverCap(aggressive = false): Promise<void> {
+  if (evictionInFlight) return;
+  evictionInFlight = true;
+  try {
+    const cap = await effectiveCapBytes();
+    const target = aggressive ? cap / 2 : cap;
+    const db = await getDB();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const idx = tx.store.index('lastAccessed');
+    // Tally total size first
+    let total = 0;
+    const all: StoredAttachment[] = [];
+    let cursor = await idx.openCursor();
+    while (cursor) {
+      const rec = cursor.value as StoredAttachment;
+      total += rec.size;
+      all.push(rec);
+      cursor = await cursor.continue();
+    }
+    if (total <= target) {
+      await tx.done;
+      return;
+    }
+    // all is sorted by lastAccessed ascending — delete oldest until under cap
+    let i = 0;
+    while (total > target && i < all.length) {
+      await tx.store.delete(all[i].id);
+      total -= all[i].size;
+      i++;
+    }
+    await tx.done;
+    logger.info('attachment cache eviction', { deleted: i, target, finalTotal: total });
+  } finally {
+    evictionInFlight = false;
+  }
+}
+
+// ── base64 helpers ─────────────────────────────────────────────────────
+
+function base64Length(b64: string): number {
+  // Approximate decoded length without decoding
+  let pad = 0;
+  if (b64.endsWith('==')) pad = 2;
+  else if (b64.endsWith('=')) pad = 1;
+  return Math.floor((b64.length * 3) / 4) - pad;
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  if (typeof atob === 'function') {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+  // Node fallback (tests)
+  return new Uint8Array(Buffer.from(b64, 'base64'));
+}
+
+// ── Testing escape hatch ───────────────────────────────────────────────
+
+/** Reset state. Tests only. */
+export function __resetForTests(): void {
+  states.clear();
+  subscribers.clear();
+  for (const t of pushTimeouts.values()) clearTimeout(t);
+  pushTimeouts.clear();
+}

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -424,6 +424,8 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
             const pull = (id: string) => {
               ctx.sendEncrypted?.({
                 type: 'request_attachment',
+                deviceId: store.deviceId,
+                sessionId: sid,
                 payload: { id, sessionId: sid },
               });
             };

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -1,10 +1,11 @@
-import type { InnerMessage, SessionListMessage, SessionReplayBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage } from '@kraki/protocol';
+import type { InnerMessage, SessionListMessage, SessionReplayBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage, AttachmentRef } from '@kraki/protocol';
 import { getStore } from './store-adapter';
 import { isViewingSession } from './replay';
 import { createLogger } from './logger';
 import type { CommandState } from './commands';
 import { resolvePermissionMessage, resolveQuestionMessage } from './commands';
 import { messageProvider } from './message-provider';
+import { ingestChunk, markAwaitingPush } from './attachments';
 import type { PendingPermission, PendingQuestion, SessionPreview } from '../types/store';
 
 const logger = createLogger('msg-router');
@@ -54,6 +55,15 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
   // Handle session_replay_batch — tentacle sent a batch of replayed messages
   if (msg.type === 'session_replay_batch') {
     ctx.onSessionReplayBatch?.(msg as SessionReplayBatchMessage);
+    return;
+  }
+
+  // attachment_data — chunk of bytes for an attachment ref. Has a sessionId
+  // but we route it before the session-existence check because the chunk's
+  // session may not be in our store yet during early load.
+  if (msg.type === 'attachment_data') {
+    const payload = (msg as { payload: { id: string; index: number; total: number; mimeType: string; data: string; error?: string } }).payload;
+    void ingestChunk(payload.id, payload.index, payload.total, payload.mimeType, payload.data, payload.error);
     return;
   }
 
@@ -398,6 +408,29 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
 
     case 'tool_complete': {
       store.appendMessage(sid, msg);
+      // If this tool_complete carries one or more AttachmentRefs, mark each
+      // id as "awaiting push" so useAttachment shows a spinner while chunks
+      // arrive. Replayed refs don't go through here (they ride
+      // session_replay_batch and are inspected by the replay handler).
+      const payload = (msg as { payload: { attachments?: Array<Record<string, unknown>> } }).payload;
+      const attachments = payload?.attachments;
+      if (Array.isArray(attachments)) {
+        for (const att of attachments) {
+          if (att.type === 'image_ref' && typeof att.id === 'string') {
+            const ref = att as unknown as AttachmentRef;
+            // `requestPull` is the safety-timeout fallback. We can't import
+            // wsClient here without a cycle; instead, expose a callback via
+            // ctx.sendEncrypted (already part of RouterContext).
+            const pull = (id: string) => {
+              ctx.sendEncrypted?.({
+                type: 'request_attachment',
+                payload: { id, sessionId: sid },
+              });
+            };
+            markAwaitingPush(ref.id, pull);
+          }
+        }
+      }
       break;
     }
 

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -87,6 +87,18 @@ export class KrakiWSClient {
     commands.sendInput(sessionId, text, (msg) => this.sendEncrypted(msg), attachments);
   }
 
+  /**
+   * Request the bytes of an attachment from the tentacle that owns the session.
+   * Used by `useAttachment` when an `AttachmentRef` arrives via replay
+   * (rather than a live push) or when a push safety-timeout elapses.
+   */
+  requestAttachment(sessionId: string, attachmentId: string) {
+    this.sendEncrypted({
+      type: 'request_attachment',
+      payload: { id: attachmentId, sessionId },
+    });
+  }
+
   approve(permissionId: string, sessionId: string) {
     commands.approve(permissionId, sessionId, (msg) => this.sendEncrypted(msg));
   }

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -91,10 +91,23 @@ export class KrakiWSClient {
    * Request the bytes of an attachment from the tentacle that owns the session.
    * Used by `useAttachment` when an `AttachmentRef` arrives via replay
    * (rather than a live push) or when a push safety-timeout elapses.
+   *
+   * The message stamps:
+   *   - deviceId at the inner level so the tentacle can address its chunked
+   *     reply back to us (other consumer messages don't need this because they
+   *     are addressed by sessionId, but our reply unicast requires the
+   *     requester's pubkey lookup).
+   *   - sessionId at the envelope level so encryption.encryptOutbound resolves
+   *     the tentacle device that owns the session.
+   *   - sessionId inside payload too, so the tentacle's AttachmentStore knows
+   *     which session dir to read from.
    */
   requestAttachment(sessionId: string, attachmentId: string) {
+    const deviceId = getStore().deviceId;
     this.sendEncrypted({
       type: 'request_attachment',
+      deviceId,
+      sessionId,
       payload: { id: attachmentId, sessionId },
     });
   }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -97,13 +97,45 @@ export interface PongMessage extends TransportAckFields {
 // Attachment types (shared between producer and consumer)
 // ============================================================
 
+/** Inline image carried directly in a message payload as base64.
+ *  Used for user_message uploads from the PWA (already capped to ~3 MB by
+ *  client-side compression) and small images that don't justify the
+ *  attachment-store pipeline. */
 export interface ImageAttachment {
   type: 'image';
   mimeType: string;
-  data: string; // base64-encoded image data
+  /** base64-encoded image bytes */
+  data: string;
+  /** Optional caption shown beside/under the image */
+  caption?: string;
+  /** Optional original filename */
+  name?: string;
 }
 
-export type Attachment = ImageAttachment;
+/** Reference to an image stored in the tentacle's attachment store.
+ *  Used for agent-produced images (currently `kraki-show_image` via MCP)
+ *  so a small ref flows in the message stream while bytes travel as
+ *  separate `attachment_data` envelopes. */
+export interface AttachmentRef {
+  type: 'image_ref';
+  /** Content-addressed id: sha256 hex truncated to 32 chars. */
+  id: string;
+  mimeType: string;
+  /** Decoded byte size of the original image. */
+  size: number;
+  /** Optional caption to display under the image. */
+  caption?: string;
+  /** Optional original filename, e.g. "screenshot.png". */
+  name?: string;
+  /** Optional intrinsic width in CSS pixels — populated when the
+   *  tentacle could parse it cheaply from the file header. Used by the
+   *  client to render a correctly-shaped placeholder while bytes arrive. */
+  width?: number;
+  /** Optional intrinsic height in CSS pixels. */
+  height?: number;
+}
+
+export type Attachment = ImageAttachment | AttachmentRef;
 
 // ============================================================
 // Inner message base (inside encrypted blob, invisible to relay)
@@ -143,6 +175,7 @@ export interface UserMessage extends BaseEnvelope {
   type: 'user_message';
   payload: {
     content: string;
+    attachments?: Attachment[];
   };
 }
 
@@ -338,6 +371,29 @@ export interface LocalSessionsListMessage extends BaseEnvelope {
   };
 }
 
+/** Chunk of attachment bytes — flows either as a broadcast (live, immediately
+ *  after the message that referenced the attachment) or as a unicast response
+ *  to `request_attachment`. The relay never sees the bytes; payload is inside
+ *  the encrypted blob like any other message. */
+export interface AttachmentDataMessage extends BaseEnvelope {
+  type: 'attachment_data';
+  payload: {
+    /** Attachment id from the matching `AttachmentRef`. */
+    id: string;
+    /** 0-based chunk index. */
+    index: number;
+    /** Total chunk count for this attachment. */
+    total: number;
+    /** MIME type echoed for convenience. */
+    mimeType: string;
+    /** base64 of this chunk's bytes. Empty when `error` is set. */
+    data: string;
+    /** When set, this chunk carries an error instead of bytes (index/total
+     *  should be 0/0). */
+    error?: 'not_found' | 'unauthorized' | 'too_large';
+  };
+}
+
 export type ProducerMessage =
   | SessionCreatedMessage
   | SessionEndedMessage
@@ -362,7 +418,8 @@ export type ProducerMessage =
   | SessionListMessage
   | PermissionResolvedMessage
   | QuestionResolvedMessage
-  | LocalSessionsListMessage;
+  | LocalSessionsListMessage
+  | AttachmentDataMessage;
 
 // ============================================================
 // Consumer messages (app → tentacle, inside encrypted blob)
@@ -536,6 +593,20 @@ export interface ImportSessionMessage extends BaseEnvelope {
   };
 }
 
+/** Sent by app to tentacle to request the bytes of a stored attachment.
+ *  Used when a client sees an `AttachmentRef` it can't satisfy from its local
+ *  cache (typical after reconnect/replay). Tentacle responds with one or more
+ *  `attachment_data` messages addressed to the requester. */
+export interface RequestAttachmentMessage extends BaseEnvelope {
+  type: 'request_attachment';
+  payload: {
+    /** Attachment id from the AttachmentRef. */
+    id: string;
+    /** Session the attachment belongs to (used for AttachmentStore scoping). */
+    sessionId: string;
+  };
+}
+
 export type ConsumerMessage =
   | SendInputMessage
   | ApproveMessage
@@ -555,7 +626,8 @@ export type ConsumerMessage =
   | RenameSessionMessage
   | PinSessionMessage
   | RequestLocalSessionsMessage
-  | ImportSessionMessage;
+  | ImportSessionMessage
+  | RequestAttachmentMessage;
 
 // ============================================================
 // Auth credentials — discriminated union by method

--- a/packages/tentacle/README.md
+++ b/packages/tentacle/README.md
@@ -59,6 +59,8 @@ Beyond bridging agent events, tentacle is responsible for several things that us
 - **Session lifecycle** — session create, update, and close are managed here
 - **Auto-approval** — tools on a local allowed list are approved automatically without user interaction
 - **Encryption** — all outgoing messages are encrypted before leaving the machine
+- **Attachment storage** — image bytes produced by the agent are stored content-addressed on disk and streamed to receivers in chunks, not embedded inline in messages
+- **Kraki MCP server** — a loopback HTTP server exposing tools the agent can call to surface images (`kraki-show_image`) and similar artifacts to user-facing devices
 
 The relay is a thin forwarder. Tentacle and the frontend own the application logic.
 

--- a/packages/tentacle/src/__tests__/attachment-store.test.ts
+++ b/packages/tentacle/src/__tests__/attachment-store.test.ts
@@ -1,0 +1,181 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AttachmentStore } from '../attachment-store.js';
+
+// 1x1 red PNG
+const PNG_1X1_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+const PNG_1X1 = Buffer.from(PNG_1X1_B64, 'base64');
+
+// 2x3 PNG (deterministically constructed) — used to verify dimension parsing
+// PNG signature + IHDR for width=2 height=3
+function makePng(width: number, height: number): Buffer {
+  // Minimal PNG: sig + IHDR. IHDR length=13, type='IHDR', then 13 bytes:
+  //   width (u32 BE), height (u32 BE), bit_depth (8), color_type (2), compression (0), filter (0), interlace (0)
+  // Then CRC32. Then a tiny IDAT and IEND so it's vaguely valid (we only
+  // really need width/height parsing, but lots of tools cross-check signatures).
+  // The parser we test only reads the IHDR bytes, so we don't have to
+  // include valid IDAT data — but include something to make file shape sane.
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdrType = Buffer.from('IHDR');
+  const ihdrData = Buffer.alloc(13);
+  ihdrData.writeUInt32BE(width, 0);
+  ihdrData.writeUInt32BE(height, 4);
+  ihdrData[8] = 8;
+  ihdrData[9] = 2;
+  // ihdrData[10..12] already 0
+  const ihdrLen = Buffer.alloc(4);
+  ihdrLen.writeUInt32BE(13, 0);
+  const ihdrCrc = Buffer.alloc(4); // fake; parser doesn't validate
+  return Buffer.concat([sig, ihdrLen, ihdrType, ihdrData, ihdrCrc]);
+}
+
+describe('AttachmentStore', () => {
+  let root: string;
+  let store: AttachmentStore;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'kraki-attstore-'));
+    store = new AttachmentStore(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('put writes bytes + sidecar and returns a stable ref', () => {
+    const ref = store.put('sid-A', PNG_1X1, 'image/png', { name: 'pixel.png' });
+    expect(ref).toMatchObject({
+      type: 'image_ref',
+      id: expect.any(String),
+      mimeType: 'image/png',
+      size: PNG_1X1.length,
+      name: 'pixel.png',
+    });
+    expect(ref.id).toHaveLength(32);
+    expect(/^[0-9a-f]+$/.test(ref.id)).toBe(true);
+
+    const dataPath = join(root, 'sid-A', 'attachments', `${ref.id}.png`);
+    const metaPath = join(root, 'sid-A', 'attachments', `${ref.id}.json`);
+    expect(statSync(dataPath).size).toBe(PNG_1X1.length);
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as Record<string, unknown>;
+    expect(meta).toMatchObject({ mimeType: 'image/png', size: PNG_1X1.length, name: 'pixel.png' });
+  });
+
+  it('put is idempotent: same bytes → same id, no rewrite', () => {
+    const r1 = store.put('sid-A', PNG_1X1, 'image/png');
+    const dataPath = join(root, 'sid-A', 'attachments', `${r1.id}.png`);
+    const mtime1 = statSync(dataPath).mtimeMs;
+    // Wait a millisecond so a hypothetical rewrite would change mtime
+    const future = Date.now() + 5;
+    while (Date.now() < future) {
+      // spin
+    }
+    const r2 = store.put('sid-A', PNG_1X1, 'image/png');
+    expect(r2.id).toBe(r1.id);
+    expect(statSync(dataPath).mtimeMs).toBe(mtime1);
+  });
+
+  it('put returns different ids for different bytes', () => {
+    const r1 = store.put('sid-A', PNG_1X1, 'image/png');
+    const r2 = store.put('sid-A', Buffer.from('other content'), 'image/png');
+    expect(r2.id).not.toBe(r1.id);
+  });
+
+  it('put scopes to session — same bytes in different session keep same id but separate files', () => {
+    const rA = store.put('sid-A', PNG_1X1, 'image/png');
+    const rB = store.put('sid-B', PNG_1X1, 'image/png');
+    expect(rA.id).toBe(rB.id);
+    const pathA = join(root, 'sid-A', 'attachments', `${rA.id}.png`);
+    const pathB = join(root, 'sid-B', 'attachments', `${rB.id}.png`);
+    expect(statSync(pathA).size).toBe(PNG_1X1.length);
+    expect(statSync(pathB).size).toBe(PNG_1X1.length);
+  });
+
+  it('put parses PNG dimensions from the header', () => {
+    const png = makePng(640, 480);
+    const ref = store.put('sid-A', png, 'image/png');
+    expect(ref.width).toBe(640);
+    expect(ref.height).toBe(480);
+  });
+
+  it('put carries caption when provided', () => {
+    const ref = store.put('sid-A', PNG_1X1, 'image/png', { caption: 'hello' });
+    expect(ref.caption).toBe('hello');
+    // Caption is NOT persisted to sidecar — it's a per-call display attribute
+    const metaPath = join(root, 'sid-A', 'attachments', `${ref.id}.json`);
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as Record<string, unknown>;
+    expect(meta.caption).toBeUndefined();
+  });
+
+  it('has() reflects existence', () => {
+    const ref = store.put('sid-A', PNG_1X1, 'image/png');
+    expect(store.has('sid-A', ref.id)).toBe(true);
+    expect(store.has('sid-A', 'a'.repeat(32))).toBe(false);
+    expect(store.has('sid-B', ref.id)).toBe(false);
+  });
+
+  it('read() returns bytes + metadata', () => {
+    const ref = store.put('sid-A', PNG_1X1, 'image/png', { name: 'pixel.png' });
+    const got = store.read('sid-A', ref.id);
+    expect(got).not.toBeNull();
+    expect(got!.bytes.equals(PNG_1X1)).toBe(true);
+    expect(got!.meta).toMatchObject({ mimeType: 'image/png', size: PNG_1X1.length, name: 'pixel.png' });
+  });
+
+  it('read() returns null for unknown id', () => {
+    expect(store.read('sid-A', 'a'.repeat(32))).toBeNull();
+  });
+
+  it('stream() yields chunks covering the full file', () => {
+    const big = Buffer.alloc(5000);
+    for (let i = 0; i < big.length; i++) big[i] = i & 0xff;
+    const ref = store.put('sid-A', big, 'image/png');
+    const chunks: Buffer[] = [];
+    for (const c of store.stream('sid-A', ref.id, 1024)) chunks.push(c);
+    expect(chunks.length).toBe(Math.ceil(5000 / 1024));
+    expect(Buffer.concat(chunks).equals(big)).toBe(true);
+  });
+
+  it('stream() yields nothing for unknown id', () => {
+    const chunks = Array.from(store.stream('sid-A', 'a'.repeat(32), 1024));
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('removeSession() deletes the session attachments dir', () => {
+    store.put('sid-A', PNG_1X1, 'image/png');
+    expect(store.has('sid-A', store.put('sid-A', PNG_1X1, 'image/png').id)).toBe(true);
+    store.removeSession('sid-A');
+    expect(store.has('sid-A', store.put('sid-A', PNG_1X1, 'image/png').id)).toBe(true);
+    // ↑ re-put recreates because store still works on a fresh dir
+  });
+
+  it('gc() removes attachments not in referenced set', () => {
+    const r1 = store.put('sid-A', PNG_1X1, 'image/png');
+    const r2 = store.put('sid-A', Buffer.from('different'), 'image/png');
+    expect(store.has('sid-A', r1.id)).toBe(true);
+    expect(store.has('sid-A', r2.id)).toBe(true);
+
+    const removed = store.gc('sid-A', new Set([r1.id]));
+    expect(removed).toBeGreaterThan(0);
+    expect(store.has('sid-A', r1.id)).toBe(true);
+    expect(store.has('sid-A', r2.id)).toBe(false);
+  });
+
+  it('sizeOfSession() reports total bytes', () => {
+    expect(store.sizeOfSession('sid-A')).toBe(0);
+    store.put('sid-A', PNG_1X1, 'image/png');
+    expect(store.sizeOfSession('sid-A')).toBe(PNG_1X1.length);
+  });
+
+  it('survives a corrupted sidecar — read returns null instead of crashing', () => {
+    const ref = store.put('sid-A', PNG_1X1, 'image/png');
+    const metaPath = join(root, 'sid-A', 'attachments', `${ref.id}.json`);
+    writeFileSync(metaPath, 'not json{');
+    expect(store.read('sid-A', ref.id)).toBeNull();
+  });
+});

--- a/packages/tentacle/src/__tests__/daemon-worker.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-worker.test.ts
@@ -47,7 +47,33 @@ vi.mock('../relay-client.js', () => ({
 }));
 
 vi.mock('../session-manager.js', () => ({
-  SessionManager: vi.fn().mockImplementation(() => ({})),
+  SessionManager: vi.fn().mockImplementation(() => ({
+    getSessionsRoot: () => '/tmp/test-sessions',
+    isSessionActive: () => false,
+  })),
+}));
+
+vi.mock('../mcp/index.js', () => ({
+  KrakiMcpServer: vi.fn().mockImplementation(() => ({
+    start: vi.fn().mockResolvedValue({
+      urlForSession: (sid: string) => `http://127.0.0.1:1234/mcp/${sid}`,
+      bearerToken: 'test-bearer',
+      port: 1234,
+      baseUrl: 'http://127.0.0.1:1234/mcp',
+    }),
+    stop: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('../attachment-store.js', () => ({
+  AttachmentStore: vi.fn().mockImplementation(() => ({
+    put: vi.fn(),
+    has: vi.fn().mockReturnValue(false),
+    read: vi.fn().mockReturnValue(null),
+    stream: vi.fn(),
+    removeSession: vi.fn(),
+    gc: vi.fn().mockReturnValue(0),
+  })),
 }));
 
 vi.mock('../key-manager.js', () => ({

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -618,4 +618,91 @@ describe('SessionManager', () => {
       expect(entry!.preview!.text).toContain('I will run a command');
     });
   });
+
+  // ── Legacy inline-image strip migration ───────────────
+
+  describe('stripLegacyInlineImages migration', () => {
+    it('strips inline image attachments from tool_complete on startup', async () => {
+      const { sessionId } = sm.createSession('copilot');
+      const bigBase64 = 'a'.repeat(4096); // pretend image bytes
+      sm.appendMessage(sessionId, 'tool_complete', JSON.stringify({
+        type: 'tool_complete',
+        sessionId,
+        payload: {
+          toolName: 'view',
+          result: 'Viewed image file successfully.',
+          attachments: [{ type: 'image', mimeType: 'image/png', data: bigBase64 }],
+        },
+      }));
+
+      // Confirm the inline bytes are in the on-disk log
+      const beforeMessages = sm.getMessagesAfterSeq(sessionId, 0);
+      expect(beforeMessages.length).toBeGreaterThan(0);
+      const beforeInner = JSON.parse(beforeMessages[0].payload) as { payload: { attachments?: unknown[] } };
+      expect(beforeInner.payload.attachments).toHaveLength(1);
+
+      // Reset the `inlineImagesStripped` flag so we can re-run the migration
+      const meta = sm.getMeta(sessionId)!;
+      meta.inlineImagesStripped = false;
+      sm['writeMeta'](sessionId, meta);
+
+      // Re-construct the manager — runs migration in constructor
+      // eslint-disable-next-line no-new
+      const sm2 = new SessionManager(dir);
+      const afterMessages = sm2.getMessagesAfterSeq(sessionId, 0);
+      const afterInner = JSON.parse(afterMessages[0].payload) as { payload: { attachments?: unknown[] } };
+      expect(afterInner.payload.attachments).toBeUndefined();
+
+      // Flag is set so re-migration is a no-op
+      expect(sm2.getMeta(sessionId)!.inlineImagesStripped).toBe(true);
+    });
+
+    it('leaves AttachmentRef attachments untouched', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'tool_complete', JSON.stringify({
+        type: 'tool_complete',
+        sessionId,
+        payload: {
+          toolName: 'kraki-show_image',
+          result: 'Image displayed to user.',
+          attachments: [{ type: 'image_ref', id: 'abc', mimeType: 'image/png', size: 100 }],
+        },
+      }));
+
+      const meta = sm.getMeta(sessionId)!;
+      meta.inlineImagesStripped = false;
+      sm['writeMeta'](sessionId, meta);
+
+      const sm2 = new SessionManager(dir);
+      const after = sm2.getMessagesAfterSeq(sessionId, 0);
+      const inner = JSON.parse(after[0].payload) as { payload: { attachments?: unknown[] } };
+      expect(inner.payload.attachments).toEqual([
+        { type: 'image_ref', id: 'abc', mimeType: 'image/png', size: 100 },
+      ]);
+    });
+
+    it('is idempotent — skips when inlineImagesStripped is already true', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'tool_complete', JSON.stringify({
+        type: 'tool_complete',
+        sessionId,
+        payload: {
+          toolName: 'view',
+          result: 'ok',
+          attachments: [{ type: 'image', mimeType: 'image/png', data: 'aaaa' }],
+        },
+      }));
+
+      // Mark already stripped (e.g. previously migrated)
+      const meta = sm.getMeta(sessionId)!;
+      meta.inlineImagesStripped = true;
+      sm['writeMeta'](sessionId, meta);
+
+      const sm2 = new SessionManager(dir);
+      const after = sm2.getMessagesAfterSeq(sessionId, 0);
+      const inner = JSON.parse(after[0].payload) as { payload: { attachments?: unknown[] } };
+      // Migration was skipped, so the inline attachment is still there
+      expect(inner.payload.attachments).toHaveLength(1);
+    });
+  });
 });

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -1303,14 +1303,13 @@ describe('CopilotAdapter', () => {
       });
     });
 
-    it('tool_complete reads image file when telemetry indicates viewType=image', async () => {
+    it('tool_complete for `view` on an image NO LONGER attaches bytes (v1: only kraki-show_image surfaces images)', async () => {
       const spy = vi.fn();
       adapter.onToolComplete = spy;
       await adapter.start();
       const { sessionId } = await adapter.createSession({});
       const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
       const imgPath = '/tmp/test-image.png';
-      // Mock fs to return the image
       mockExistsSync.mockImplementation((p: string) => p === imgPath);
       mockReadFileSync.mockImplementation((p: string) => {
         if (p === imgPath) return Buffer.from(pngBase64, 'base64');
@@ -1322,7 +1321,7 @@ describe('CopilotAdapter', () => {
         });
         mockSessions[0]._emit('tool.execution_complete', {
           data: {
-            toolName: 'view', toolCallId: 'tc_img',
+            toolCallId: 'tc_img',
             result: { content: 'Viewed image file successfully.' },
             toolTelemetry: { properties: { viewType: 'image', mimeType: 'image/png' } },
           },
@@ -1330,7 +1329,7 @@ describe('CopilotAdapter', () => {
         expect(spy).toHaveBeenCalledWith(sessionId, expect.objectContaining({
           toolName: 'view',
           result: 'Viewed image file successfully.',
-          attachments: [{ type: 'image', data: pngBase64, mimeType: 'image/png' }],
+          attachments: undefined,
         }));
       } finally {
         mockExistsSync.mockReset();

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -960,6 +960,32 @@ describe('CopilotAdapter', () => {
       await adapter.start();
       await adapter.killSession('nonexistent'); // should not throw
     });
+
+    it('clears pendingToolArgs/pendingToolIdentity for tool calls that never completed', async () => {
+      await adapter.start();
+      await adapter.createSession({});
+      // Two tool calls started but never completed (e.g. session killed mid-flight)
+      mockSessions[0]._emit('tool.execution_start', { data: { toolName: 'bash', toolCallId: 'leak-1' } });
+      mockSessions[0]._emit('tool.execution_start', {
+        data: { toolName: 'view', toolCallId: 'leak-2', mcpServerName: 'kraki', mcpToolName: 'show_image' },
+      });
+      // Sanity: maps are populated
+      const a = adapter as unknown as {
+        pendingToolArgs: Map<string, unknown>;
+        pendingToolIdentity: Map<string, unknown>;
+        sessionToolCallIds: Map<string, Set<string>>;
+      };
+      expect(a.pendingToolArgs.size).toBe(2);
+      expect(a.pendingToolIdentity.size).toBe(2);
+      expect(a.sessionToolCallIds.get('mock-sess-1')?.size).toBe(2);
+
+      await adapter.killSession('mock-sess-1');
+
+      // After kill, all three are empty
+      expect(a.pendingToolArgs.size).toBe(0);
+      expect(a.pendingToolIdentity.size).toBe(0);
+      expect(a.sessionToolCallIds.has('mock-sess-1')).toBe(false);
+    });
   });
 
   // ── List sessions ───────────────────────────────────

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -54,6 +54,13 @@ export interface ToolCompleteEvent {
   attachments?: import('@kraki/protocol').Attachment[];
 }
 
+/** Emitted alongside a tool_complete that carries one or more
+ *  `AttachmentRef`s. Tells the runtime (RelayClient) to broadcast the bytes
+ *  to all connected devices as `attachment_data` chunks. */
+export interface AttachmentBytesEvent {
+  refs: Array<import('@kraki/protocol').AttachmentRef>;
+}
+
 export interface SessionEndedEvent {
   reason: string;
 }
@@ -104,6 +111,9 @@ export abstract class AgentAdapter {
   onQuestionRequest: ((sessionId: string, event: QuestionRequestEvent) => void) | null = null;
   onToolStart: ((sessionId: string, event: ToolStartEvent) => void) | null = null;
   onToolComplete: ((sessionId: string, event: ToolCompleteEvent) => void) | null = null;
+  /** Called immediately after onToolComplete when bytes need to be pushed
+   *  (broadcast as `attachment_data` chunks) to connected devices. */
+  onAttachmentBytes: ((sessionId: string, event: AttachmentBytesEvent) => void) | null = null;
   onIdle: ((sessionId: string) => void) | null = null;
   onError: ((sessionId: string, event: ErrorEvent) => void) | null = null;
   onSessionEnded: ((sessionId: string, event: SessionEndedEvent) => void) | null = null;

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -335,6 +335,13 @@ export class CopilotAdapter extends AgentAdapter {
     mcpServerName?: string;
     mcpToolName?: string;
   }>();
+  /**
+   * Tool calls in flight per session — reverse index so we can clean up
+   * pendingToolArgs/pendingToolIdentity when a session ends without each
+   * tool call completing (kill, abort, error mid-flight). Without this the
+   * two maps grow unbounded over a long-lived daemon.
+   */
+  private sessionToolCallIds = new Map<string, Set<string>>();
   /** Expected model per session — detects involuntary model fallbacks by the CLI */
   private expectedModels = new Map<string, string>();
   /** User's originally requested model — never updated on involuntary fallbacks */
@@ -926,6 +933,14 @@ export class CopilotAdapter extends AgentAdapter {
     this.turnHasOutput.delete(sessionId);
     this.cycleHasOutput.delete(sessionId);
     this.turnErrorReported.delete(sessionId);
+    const inflight = this.sessionToolCallIds.get(sessionId);
+    if (inflight) {
+      for (const id of inflight) {
+        this.pendingToolArgs.delete(id);
+        this.pendingToolIdentity.delete(id);
+      }
+      this.sessionToolCallIds.delete(sessionId);
+    }
     this.clearIdleTimer(sessionId);
   }
 
@@ -1074,6 +1089,12 @@ export class CopilotAdapter extends AgentAdapter {
           mcpServerName: data.mcpServerName as string | undefined,
           mcpToolName: data.mcpToolName as string | undefined,
         });
+        let inflight = this.sessionToolCallIds.get(sessionId);
+        if (!inflight) {
+          inflight = new Set();
+          this.sessionToolCallIds.set(sessionId, inflight);
+        }
+        inflight.add(toolCallId);
       }
       this.onToolStart?.(sessionId, {
         toolName: data.toolName as string,
@@ -1087,11 +1108,18 @@ export class CopilotAdapter extends AgentAdapter {
       const toolCallId = data.toolCallId as string | undefined;
       const identity = toolCallId ? this.pendingToolIdentity.get(toolCallId) : undefined;
       const toolName = identity?.toolName ?? (data.toolName as string | undefined) ?? 'tool';
-      if (toolName === 'report_intent') {
-        if (toolCallId) {
-          this.pendingToolIdentity.delete(toolCallId);
-          this.pendingToolArgs.delete(toolCallId);
+      const clearInflight = () => {
+        if (!toolCallId) return;
+        this.pendingToolIdentity.delete(toolCallId);
+        this.pendingToolArgs.delete(toolCallId);
+        const inflight = this.sessionToolCallIds.get(sessionId);
+        if (inflight) {
+          inflight.delete(toolCallId);
+          if (inflight.size === 0) this.sessionToolCallIds.delete(sessionId);
         }
+      };
+      if (toolName === 'report_intent') {
+        clearInflight();
         return;
       }
       const rawResult = data.result;
@@ -1149,10 +1177,7 @@ export class CopilotAdapter extends AgentAdapter {
       }
 
       // Clean up tracked state for this tool call
-      if (toolCallId) {
-        this.pendingToolArgs.delete(toolCallId);
-        this.pendingToolIdentity.delete(toolCallId);
-      }
+      clearInflight();
 
       this.onToolComplete?.(sessionId, {
         toolName,

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -28,7 +28,7 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, cpSync, mkdtempSync, mkdirSync, unlinkSync, readdirSync, symlinkSync, lstatSync } from 'node:fs';
 import * as moduleApi from 'node:module';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, basename } from 'node:path';
 import { getKrakiHome } from '../config.js';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { isSea } from 'node:sea';
@@ -147,6 +147,17 @@ export function resolveCopilotCliPath(): string | undefined {
 function isRecoverableSessionError(err: unknown): boolean {
   const message = getErrorMessage(err);
   return message.includes('Session not found:') || message.includes('Connection is disposed');
+}
+
+/** Defensive basename — strips any leading directory components and never
+ *  throws. Used to populate AttachmentRef.name from the absolute path the
+ *  agent passed to show_image. */
+function basenameSafe(p: string): string {
+  try {
+    return basename(p) || 'image';
+  } catch {
+    return 'image';
+  }
 }
 
 // ── Copilot configDir shadow ────────────────────────────
@@ -312,6 +323,18 @@ export class CopilotAdapter extends AgentAdapter {
   private idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** Track tool start args by toolCallId for correlating with tool_complete */
   private pendingToolArgs = new Map<string, Record<string, unknown>>();
+  /**
+   * Tool identity captured at tool.execution_start, keyed by toolCallId.
+   * The Copilot SDK omits these fields from tool.execution_complete events —
+   * only toolCallId is present there. We stash the names on start and look
+   * them up on complete (especially for `mcpServerName`/`mcpToolName`, which
+   * we use to recognise our own MCP presenter tools).
+   */
+  private pendingToolIdentity = new Map<string, {
+    toolName?: string;
+    mcpServerName?: string;
+    mcpToolName?: string;
+  }>();
   /** Expected model per session — detects involuntary model fallbacks by the CLI */
   private expectedModels = new Map<string, string>();
   /** User's originally requested model — never updated on involuntary fallbacks */
@@ -330,10 +353,34 @@ export class CopilotAdapter extends AgentAdapter {
    */
   private static readonly IDLE_FALLBACK_MS = 500;
 
-  constructor(options: { cliPath?: string } = {}) {
+  /** Set of attachment ids already broadcast for this session — prevents
+   *  re-broadcasting bytes when the same image is shown twice. */
+  private broadcastedAttachmentIds = new Map<string, Set<string>>();
+
+  constructor(options: {
+    cliPath?: string;
+    /** Tentacle's attachment store. When set, the adapter externalises
+     *  image bytes from `kraki-show_image` to it instead of carrying them
+     *  inline in the broadcast envelope. */
+    attachmentStore?: import('../attachment-store.js').AttachmentStore;
+    /** When set, the adapter wires the Kraki MCP server into every Copilot
+     *  session it creates/resumes, with the URL scoped per Kraki sessionId. */
+    krakiMcp?: {
+      urlForSession: (sessionId: string) => string;
+      bearerToken: string;
+    };
+  } = {}) {
     super();
     this.cliPath = options.cliPath;
+    this.attachmentStore = options.attachmentStore;
+    this.krakiMcp = options.krakiMcp;
   }
+
+  private readonly attachmentStore?: import('../attachment-store.js').AttachmentStore;
+  private readonly krakiMcp?: {
+    urlForSession: (sessionId: string) => string;
+    bearerToken: string;
+  };
 
   /** System prompt appended to the SDK's built-in prompt. See system-prompt.md for docs. */
   private static readonly SYSTEM_PROMPT = [
@@ -369,6 +416,25 @@ export class CopilotAdapter extends AgentAdapter {
     'When you see this signal, silently adopt the new mode\'s behavior from that',
     'point onward. Do not acknowledge or comment on the mode change — just adjust',
     'how you work. The signal is not part of the user\'s message.',
+  ].join('\n');
+
+  /**
+   * Appended to the system prompt when the Kraki MCP server is wired in.
+   * Tools are exposed to the model with display names of the form
+   * `<server>-<tool>` (dash), confirmed via a live SDK spike.
+   */
+  private static readonly KRAKI_MCP_PROMPT = [
+    'You have access to a Kraki MCP server. Its tools are visible with names',
+    'beginning with "kraki-".',
+    '',
+    'When you want to visually present an image to the user — a screenshot you',
+    'captured, a diagram you generated, a chart, a UI mock — call',
+    '`kraki-show_image` with the absolute file path. Use it sparingly: only',
+    'when the user benefits from seeing the actual pixels.',
+    '',
+    'Plain file viewing on image files (with `view`/`read`) is for your own',
+    'inspection; the image bytes do not appear in the chat. Use',
+    '`kraki-show_image` when the user should actually see the image inline.',
   ].join('\n');
 
   // ── Lifecycle ───────────────────────────────────────
@@ -497,6 +563,39 @@ export class CopilotAdapter extends AgentAdapter {
       ? config.reasoningEffort as SessionConfig['reasoningEffort']
       : undefined;
 
+    // Two-phase MCP wiring: create session WITHOUT kraki MCP server first
+    // (we need the SDK-assigned sessionId to scope the MCP URL), then the
+    // adapter re-wires through resumeSession with the kraki entry below.
+    // For simplicity in v1 we use a deterministic Kraki MCP wire-up:
+    // we let the SDK pick the session id, then on every Copilot session
+    // we add the kraki MCP at resume time. For initial creation we pre-pick
+    // a session id when the caller supplied one; otherwise the kraki MCP
+    // is added on the next message via resumeSession during normal flow.
+    //
+    // Simpler approach: register a Kraki MCP server using the *Copilot*
+    // sessionId only after createSession returns it. To do that without
+    // a second SDK call, we use a placeholder sessionId for the initial
+    // mcpServers entry and rewrite via resume on first use. But that's
+    // brittle — instead, see the comment block at the constructor: the
+    // kraki MCP HTTP server validates sessionId by checking SessionManager,
+    // not by Copilot SDK state, so we can ALWAYS include the kraki entry
+    // here by using a stable session-scoped URL that the adapter knows
+    // up-front via config.sessionId (the Kraki session id we assigned).
+    if (this.krakiMcp && config.sessionId) {
+      const krakiEntry: MCPServerConfig = {
+        type: 'http' as const,
+        url: this.krakiMcp.urlForSession(config.sessionId),
+        headers: { Authorization: `Bearer ${this.krakiMcp.bearerToken}` },
+        tools: ['*'],
+      } as MCPServerConfig;
+      mcpServers = { ...(mcpServers ?? {}), kraki: krakiEntry };
+      logger.info({ sessionId: config.sessionId }, 'wired kraki MCP into session config');
+    }
+
+    const systemPromptContent = this.krakiMcp
+      ? `${CopilotAdapter.SYSTEM_PROMPT}\n\n${CopilotAdapter.KRAKI_MCP_PROMPT}`
+      : CopilotAdapter.SYSTEM_PROMPT;
+
     const sessionConfig: SessionConfig = {
       ...(config.sessionId && { sessionId: config.sessionId }),
       ...(config.model && { model: config.model }),
@@ -504,7 +603,7 @@ export class CopilotAdapter extends AgentAdapter {
       ...(config.cwd && { workingDirectory: config.cwd }),
       configDir: getCopilotConfigDir(),
       ...(mcpServers && { mcpServers }),
-      systemMessage: { mode: 'append' as const, content: CopilotAdapter.SYSTEM_PROMPT },
+      systemMessage: { mode: 'append' as const, content: systemPromptContent },
       streaming: true,
       onPermissionRequest: this.makePermissionHandler(pendingPermissions),
       onUserInputRequest: this.makeQuestionHandler(pendingQuestions),
@@ -855,6 +954,7 @@ export class CopilotAdapter extends AgentAdapter {
   }
 
   private makeResumeConfig(
+    sessionId: string,
     pendingPermissions: Map<string, PendingPermission>,
     pendingQuestions: Map<string, PendingQuestion>,
   ): ResumeSessionConfig {
@@ -873,11 +973,26 @@ export class CopilotAdapter extends AgentAdapter {
       } catch { /* ignore parse errors on resume */ }
     }
 
+    // Wire Kraki MCP into resumed sessions, scoped by the session id.
+    if (this.krakiMcp) {
+      const krakiEntry: MCPServerConfig = {
+        type: 'http' as const,
+        url: this.krakiMcp.urlForSession(sessionId),
+        headers: { Authorization: `Bearer ${this.krakiMcp.bearerToken}` },
+        tools: ['*'],
+      } as MCPServerConfig;
+      mcpServers = { ...(mcpServers ?? {}), kraki: krakiEntry };
+    }
+
+    const systemPromptContent = this.krakiMcp
+      ? `${CopilotAdapter.SYSTEM_PROMPT}\n\n${CopilotAdapter.KRAKI_MCP_PROMPT}`
+      : CopilotAdapter.SYSTEM_PROMPT;
+
     return {
       configDir: getCopilotConfigDir(),
       streaming: true,
       ...(mcpServers && { mcpServers }),
-      systemMessage: { mode: 'append' as const, content: CopilotAdapter.SYSTEM_PROMPT },
+      systemMessage: { mode: 'append' as const, content: systemPromptContent },
       onPermissionRequest: this.makePermissionHandler(pendingPermissions),
       onUserInputRequest: this.makeQuestionHandler(pendingQuestions),
     };
@@ -890,7 +1005,7 @@ export class CopilotAdapter extends AgentAdapter {
     const pendingQuestions = new Map<string, PendingQuestion>();
     const session = await this.client!.resumeSession(
       sessionId,
-      this.makeResumeConfig(pendingPermissions, pendingQuestions),
+      this.makeResumeConfig(sessionId, pendingPermissions, pendingQuestions),
     );
     const entry = { session, pendingPermissions, pendingQuestions };
 
@@ -950,7 +1065,16 @@ export class CopilotAdapter extends AgentAdapter {
       }
       const args = (data.args ?? data.arguments ?? {}) as Record<string, unknown>;
       const toolCallId = data.toolCallId as string | undefined;
-      if (toolCallId) this.pendingToolArgs.set(toolCallId, args);
+      if (toolCallId) {
+        this.pendingToolArgs.set(toolCallId, args);
+        // Stash tool identity for tool.execution_complete, which only carries
+        // toolCallId (verified via live SDK spike).
+        this.pendingToolIdentity.set(toolCallId, {
+          toolName: data.toolName as string | undefined,
+          mcpServerName: data.mcpServerName as string | undefined,
+          mcpToolName: data.mcpToolName as string | undefined,
+        });
+      }
       this.onToolStart?.(sessionId, {
         toolName: data.toolName as string,
         args,
@@ -960,11 +1084,17 @@ export class CopilotAdapter extends AgentAdapter {
 
     session.on('tool.execution_complete', (event) => {
       const data = event.data as unknown as Record<string, unknown>;
-      if (data.toolName === 'report_intent') return;
-      const rawResult = data.result;
       const toolCallId = data.toolCallId as string | undefined;
-      // SDK sends result as { content: string, contents?: [...] } or as a plain string.
-      // On failure, result is undefined and the error is in data.error ({ message } or string).
+      const identity = toolCallId ? this.pendingToolIdentity.get(toolCallId) : undefined;
+      const toolName = identity?.toolName ?? (data.toolName as string | undefined) ?? 'tool';
+      if (toolName === 'report_intent') {
+        if (toolCallId) {
+          this.pendingToolIdentity.delete(toolCallId);
+          this.pendingToolArgs.delete(toolCallId);
+        }
+        return;
+      }
+      const rawResult = data.result;
       const resultObj = typeof rawResult === 'object' && rawResult !== null
         ? rawResult as Record<string, unknown>
         : null;
@@ -976,48 +1106,72 @@ export class CopilotAdapter extends AgentAdapter {
         result = (errObj?.message as string) ?? (typeof data.error === 'string' ? data.error : '');
       }
 
-      // Extract image attachments from structured content blocks (result.contents)
-      const attachments: import('@kraki/protocol').Attachment[] = [];
-      const contentBlocks = resultObj?.contents as Array<Record<string, unknown>> | undefined;
-      if (Array.isArray(contentBlocks)) {
-        for (const block of contentBlocks) {
-          if (block.type === 'image' && typeof block.data === 'string' && typeof block.mimeType === 'string') {
-            attachments.push({ type: 'image', data: block.data as string, mimeType: block.mimeType as string });
-          }
-        }
-      }
+      // Extract image content blocks — ONLY for the kraki-show_image MCP tool.
+      // All other tools' image bytes (notably `view` on a .png) are deliberately
+      // dropped here per the v1 design: only `kraki-show_image` surfaces images
+      // to the client. The file-path fallback (re-read image from disk when SDK
+      // strips bytes) has been removed.
+      const isKrakiShowImage =
+        identity?.mcpServerName === 'kraki' && identity?.mcpToolName === 'show_image';
 
-      // Fallback: the SDK strips binaryResultsForLlm from tool.execution_complete,
-      // but for image-viewing tools (e.g. `view` on a .png) the telemetry still
-      // carries viewType and mimeType. Use the file path from the original tool
-      // args (correlated by toolCallId) to read the image directly.
-      if (attachments.length === 0) {
-        const telemetry = data.toolTelemetry as Record<string, unknown> | undefined;
-        const props = telemetry?.properties as Record<string, string> | undefined;
-        if (props?.viewType === 'image' && props?.mimeType) {
-          const startArgs = toolCallId ? this.pendingToolArgs.get(toolCallId) : undefined;
-          const filePath = startArgs?.path as string | undefined;
-          if (filePath && existsSync(filePath)) {
-            try {
-              const imageData = readFileSync(filePath).toString('base64');
-              attachments.push({ type: 'image', data: imageData, mimeType: props.mimeType });
-            } catch (err) {
-              logger.debug({ err, filePath }, 'Failed to read image for forwarding');
+      let attachments: import('@kraki/protocol').Attachment[] | undefined;
+      if (isKrakiShowImage && this.attachmentStore) {
+        const contentBlocks = resultObj?.contents as Array<Record<string, unknown>> | undefined;
+        const args = toolCallId ? this.pendingToolArgs.get(toolCallId) ?? {} : {};
+        const caption = typeof args.caption === 'string' && args.caption.trim()
+          ? args.caption.trim()
+          : undefined;
+        const path = typeof args.path === 'string' ? args.path : undefined;
+        const refs: import('@kraki/protocol').AttachmentRef[] = [];
+        if (Array.isArray(contentBlocks)) {
+          for (const block of contentBlocks) {
+            if (
+              block.type === 'image' &&
+              typeof block.data === 'string' &&
+              typeof block.mimeType === 'string'
+            ) {
+              try {
+                const bytes = Buffer.from(block.data, 'base64');
+                const ref = this.attachmentStore.put(sessionId, bytes, block.mimeType, {
+                  ...(path && { name: basenameSafe(path) }),
+                  ...(caption && { caption }),
+                });
+                refs.push(ref);
+              } catch (err) {
+                logger.warn({ err, sessionId }, 'failed to store show_image attachment');
+              }
             }
           }
         }
+        if (refs.length > 0) {
+          attachments = refs;
+        }
       }
 
-      // Clean up tracked args
-      if (toolCallId) this.pendingToolArgs.delete(toolCallId);
+      // Clean up tracked state for this tool call
+      if (toolCallId) {
+        this.pendingToolArgs.delete(toolCallId);
+        this.pendingToolIdentity.delete(toolCallId);
+      }
 
       this.onToolComplete?.(sessionId, {
-        toolName: data.toolName as string,
+        toolName,
         result,
         toolCallId,
         success: data.success as boolean | undefined,
-        attachments: attachments.length > 0 ? attachments : undefined,
+        attachments,
       });
+
+      // After tool_complete, fire the bytes broadcast event so RelayClient
+      // can stream attachment_data chunks to all connected devices.
+      if (attachments && attachments.length > 0) {
+        const refs = attachments.filter(
+          (a): a is import('@kraki/protocol').AttachmentRef => a.type === 'image_ref',
+        );
+        if (refs.length > 0) {
+          this.onAttachmentBytes?.(sessionId, { refs });
+        }
+      }
     });
 
     session.on('session.idle', () => {

--- a/packages/tentacle/src/attachment-store.ts
+++ b/packages/tentacle/src/attachment-store.ts
@@ -1,0 +1,357 @@
+/**
+ * Content-addressed attachment store for a Kraki session.
+ *
+ * Disk layout, per session:
+ *
+ *   <sessionsDir>/<sessionId>/attachments/
+ *     <id>.<ext>     ← raw bytes
+ *     <id>.json      ← sidecar metadata { mimeType, size, name?, width?, height? }
+ *
+ * `id` is the lowercase hex of `sha256(bytes)` truncated to 32 chars
+ * (128-bit space — collision is astronomical for one user's content).
+ *
+ * Writes are idempotent: if a file with the same hash already exists,
+ * `put()` returns the existing ref without re-writing the bytes.
+ *
+ * The store is purely a tentacle-internal concern. The MCP server doesn't
+ * touch it directly — the adapter writes here when it observes image
+ * content blocks in tool_complete events, and the relay-client reads here
+ * when it needs to broadcast `attachment_data` chunks or serve a
+ * `request_attachment`.
+ */
+
+import {
+  createHash,
+  randomBytes,
+} from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+import type { AttachmentRef } from '@kraki/protocol';
+
+import { createLogger } from './logger.js';
+
+const logger = createLogger('attachment-store');
+
+/** Sidecar persisted alongside each attachment file. */
+interface AttachmentMetaSidecar {
+  mimeType: string;
+  size: number;
+  name?: string;
+  width?: number;
+  height?: number;
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+/** PNG/JPEG header sniffing — returns intrinsic dimensions when cheap. */
+function readImageDimensions(bytes: Buffer, mimeType: string): { width: number; height: number } | null {
+  try {
+    if (mimeType === 'image/png' && bytes.length >= 24) {
+      // PNG: bytes 16..20 = width (big-endian uint32), 20..24 = height
+      if (
+        bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47
+      ) {
+        return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
+      }
+    }
+    if (mimeType === 'image/jpeg') {
+      // JPEG: walk segments looking for SOFn (0xC0..0xCF except 0xC4/0xC8/0xCC)
+      let i = 2;
+      while (i + 9 < bytes.length) {
+        if (bytes[i] !== 0xff) break;
+        const marker = bytes[i + 1];
+        if (marker === 0xff) {
+          i += 1;
+          continue;
+        }
+        // Standalone markers without length payload
+        if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+          i += 2;
+          continue;
+        }
+        // SOFn: 0xC0..0xCF except DHT(0xC4), JPG(0xC8), DAC(0xCC)
+        if (
+          marker >= 0xc0 && marker <= 0xcf &&
+          marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc
+        ) {
+          // Layout after marker: 2-byte length, 1-byte precision, 2-byte height, 2-byte width
+          const height = bytes.readUInt16BE(i + 5);
+          const width = bytes.readUInt16BE(i + 7);
+          return { width, height };
+        }
+        const segLen = bytes.readUInt16BE(i + 2);
+        i += 2 + segLen;
+      }
+    }
+    if (mimeType === 'image/webp' && bytes.length >= 30) {
+      // VP8X chunk has width/height; VP8L/VP8 simpler variants too.
+      // Layout: 'RIFF' [size:4] 'WEBP' [chunk fourcc:4] ...
+      if (
+        bytes.slice(0, 4).toString('ascii') === 'RIFF' &&
+        bytes.slice(8, 12).toString('ascii') === 'WEBP'
+      ) {
+        const fourcc = bytes.slice(12, 16).toString('ascii');
+        if (fourcc === 'VP8X') {
+          // Canvas Width Minus One: 24bits LE at offset 24, Height: offset 27
+          const w = bytes[24] | (bytes[25] << 8) | (bytes[26] << 16);
+          const h = bytes[27] | (bytes[28] << 8) | (bytes[29] << 16);
+          return { width: w + 1, height: h + 1 };
+        }
+        if (fourcc === 'VP8L' && bytes.length >= 25) {
+          // 14-bit width and height encoded after 1 signature byte at offset 21
+          const b0 = bytes[21];
+          const b1 = bytes[22];
+          const b2 = bytes[23];
+          const b3 = bytes[24];
+          const width = 1 + ((((b1 & 0x3f) << 8) | b0));
+          const height = 1 + ((((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6)));
+          return { width, height };
+        }
+        if (fourcc === 'VP8 ' && bytes.length >= 30) {
+          // Lossy: width and height in 14 bits each at offsets 26 and 28
+          const width = bytes.readUInt16LE(26) & 0x3fff;
+          const height = bytes.readUInt16LE(28) & 0x3fff;
+          return { width, height };
+        }
+      }
+    }
+    if (mimeType === 'image/gif' && bytes.length >= 10) {
+      // GIF: 'GIF89a' or 'GIF87a', then width (LE u16) at offset 6, height at 8
+      const sig = bytes.slice(0, 6).toString('ascii');
+      if (sig === 'GIF89a' || sig === 'GIF87a') {
+        return { width: bytes.readUInt16LE(6), height: bytes.readUInt16LE(8) };
+      }
+    }
+  } catch {
+    // Best-effort — never throw out of header sniffing
+  }
+  return null;
+}
+
+function extForMime(mimeType: string): string {
+  return MIME_TO_EXT[mimeType] ?? 'bin';
+}
+
+function hashBytes(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 32);
+}
+
+export class AttachmentStore {
+  private readonly sessionsDir: string;
+
+  constructor(sessionsDir: string) {
+    this.sessionsDir = sessionsDir;
+  }
+
+  /** Directory holding attachments for a session. */
+  private dir(sessionId: string): string {
+    return join(this.sessionsDir, sessionId, 'attachments');
+  }
+
+  private filePath(sessionId: string, id: string, ext: string): string {
+    return join(this.dir(sessionId), `${id}.${ext}`);
+  }
+
+  private metaPath(sessionId: string, id: string): string {
+    return join(this.dir(sessionId), `${id}.json`);
+  }
+
+  /**
+   * Write bytes to the store (idempotent — same hash → same id, no re-write).
+   *
+   * Returns an `AttachmentRef` ready to embed in a message envelope.
+   */
+  put(
+    sessionId: string,
+    bytes: Buffer,
+    mimeType: string,
+    options?: { name?: string; caption?: string },
+  ): AttachmentRef {
+    const id = hashBytes(bytes);
+    const ext = extForMime(mimeType);
+    const dir = this.dir(sessionId);
+    mkdirSync(dir, { recursive: true });
+
+    const dataPath = this.filePath(sessionId, id, ext);
+    const metaPath = this.metaPath(sessionId, id);
+
+    let meta: AttachmentMetaSidecar | null = null;
+    if (existsSync(metaPath)) {
+      try {
+        meta = JSON.parse(readFileSync(metaPath, 'utf8')) as AttachmentMetaSidecar;
+      } catch {
+        meta = null;
+      }
+    }
+
+    if (!existsSync(dataPath) || !meta) {
+      // Atomic write of data file via tmp + rename
+      const tmpData = `${dataPath}.${randomBytes(4).toString('hex')}.tmp`;
+      writeFileSync(tmpData, bytes);
+      renameSync(tmpData, dataPath);
+
+      const dims = readImageDimensions(bytes, mimeType);
+      meta = {
+        mimeType,
+        size: bytes.length,
+        ...(options?.name && { name: options.name }),
+        ...(dims && { width: dims.width, height: dims.height }),
+      };
+
+      const tmpMeta = `${metaPath}.${randomBytes(4).toString('hex')}.tmp`;
+      writeFileSync(tmpMeta, JSON.stringify(meta));
+      renameSync(tmpMeta, metaPath);
+
+      logger.debug({ sessionId, id, mimeType, size: bytes.length, width: meta.width, height: meta.height }, 'stored');
+    }
+
+    return {
+      type: 'image_ref',
+      id,
+      mimeType: meta.mimeType,
+      size: meta.size,
+      ...(meta.name && { name: meta.name }),
+      ...(options?.caption && { caption: options.caption }),
+      ...(meta.width && { width: meta.width }),
+      ...(meta.height && { height: meta.height }),
+    };
+  }
+
+  /** Whether an attachment id exists for the session. */
+  has(sessionId: string, id: string): boolean {
+    return existsSync(this.metaPath(sessionId, id));
+  }
+
+  /** Read the full bytes + metadata. Returns null if absent. */
+  read(sessionId: string, id: string): { bytes: Buffer; meta: AttachmentMetaSidecar } | null {
+    const metaPath = this.metaPath(sessionId, id);
+    if (!existsSync(metaPath)) return null;
+    let meta: AttachmentMetaSidecar;
+    try {
+      meta = JSON.parse(readFileSync(metaPath, 'utf8')) as AttachmentMetaSidecar;
+    } catch {
+      return null;
+    }
+    const ext = extForMime(meta.mimeType);
+    const dataPath = this.filePath(sessionId, id, ext);
+    if (!existsSync(dataPath)) return null;
+    try {
+      return { bytes: readFileSync(dataPath), meta };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Iterate over the bytes of an attachment in chunks of `chunkSize` bytes.
+   * Memory-bounded — does not load the whole file into one buffer (uses
+   * subarray slices into the read buffer).
+   */
+  *stream(sessionId: string, id: string, chunkSize: number): Generator<Buffer> {
+    const result = this.read(sessionId, id);
+    if (!result) return;
+    const { bytes } = result;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      yield bytes.subarray(i, Math.min(i + chunkSize, bytes.length));
+    }
+  }
+
+  /** Read the sidecar metadata only. */
+  readMeta(sessionId: string, id: string): AttachmentMetaSidecar | null {
+    const metaPath = this.metaPath(sessionId, id);
+    if (!existsSync(metaPath)) return null;
+    try {
+      return JSON.parse(readFileSync(metaPath, 'utf8')) as AttachmentMetaSidecar;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Remove all attachments for a session (called on session deletion). */
+  removeSession(sessionId: string): void {
+    const dir = this.dir(sessionId);
+    if (!existsSync(dir)) return;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (err) {
+      logger.warn({ err, sessionId }, 'failed to remove attachments dir');
+    }
+  }
+
+  /**
+   * Garbage-collect orphan attachments — files in the session's
+   * attachments dir whose id is NOT in `referencedIds`. Returns count of
+   * deleted (data, meta) pairs.
+   */
+  gc(sessionId: string, referencedIds: Set<string>): number {
+    const dir = this.dir(sessionId);
+    if (!existsSync(dir)) return 0;
+    let removed = 0;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return 0;
+    }
+    // Collect ids present on disk: anything matching <id>.<ext> or <id>.json
+    const idsOnDisk = new Set<string>();
+    for (const name of entries) {
+      const dot = name.lastIndexOf('.');
+      if (dot <= 0) continue;
+      idsOnDisk.add(name.slice(0, dot));
+    }
+    for (const id of idsOnDisk) {
+      if (referencedIds.has(id)) continue;
+      for (const name of entries) {
+        if (name.startsWith(`${id}.`)) {
+          try {
+            unlinkSync(join(dir, name));
+            removed++;
+          } catch {
+            // ignore
+          }
+        }
+      }
+    }
+    if (removed > 0) {
+      logger.info({ sessionId, removed }, 'gc removed orphan attachments');
+    }
+    return removed;
+  }
+
+  /** Total bytes consumed by a session's attachments (for diagnostics). */
+  sizeOfSession(sessionId: string): number {
+    const dir = this.dir(sessionId);
+    if (!existsSync(dir)) return 0;
+    let total = 0;
+    try {
+      for (const name of readdirSync(dir)) {
+        if (name.endsWith('.json')) continue;
+        try {
+          total += statSync(join(dir, name)).size;
+        } catch {
+          // ignore
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return total;
+  }
+}

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -28,6 +28,8 @@ process.on('unhandledRejection', () => {
 import { RelayClient } from './relay-client.js';
 import { SessionManager } from './session-manager.js';
 import { KeyManager } from './key-manager.js';
+import { AttachmentStore } from './attachment-store.js';
+import { KrakiMcpServer } from './mcp/index.js';
 import { createLogger } from './logger.js';
 import { initStatusFile, updateRelayState, updateRegion, clearStatusFile } from './status-file.js';
 import type { AgentAdapter } from './adapters/base.js';
@@ -91,8 +93,33 @@ export async function startWorker(): Promise<WorkerResult> {
   }
 
   // 3. Initialize components
-  const adapter = new CopilotAdapter();
   const sessionManager = new SessionManager();
+  const attachmentStore = new AttachmentStore(sessionManager.getSessionsRoot());
+
+  // 3b. Start Kraki MCP server (in-process HTTP, loopback only). If bind
+  //     fails, log and continue without it — daemon stays up.
+  let mcpInfo: { urlForSession: (sid: string) => string; bearerToken: string } | undefined;
+  let mcpServer: KrakiMcpServer | null = null;
+  try {
+    mcpServer = new KrakiMcpServer({
+      version: getVersion(),
+      isSessionActive: (id) => sessionManager.isSessionActive(id),
+    });
+    const started = await mcpServer.start();
+    mcpInfo = {
+      urlForSession: started.urlForSession,
+      bearerToken: started.bearerToken,
+    };
+    logger.info({ port: started.port }, 'Kraki MCP server started');
+  } catch (err) {
+    logger.warn({ err: (err as Error).message }, 'Kraki MCP server failed to start — kraki-show_image will be unavailable');
+    mcpServer = null;
+  }
+
+  const adapter = new CopilotAdapter({
+    attachmentStore,
+    ...(mcpInfo && { krakiMcp: mcpInfo }),
+  });
   const keyManager = new KeyManager();
   const deviceId = getOrCreateDeviceId();
 
@@ -154,6 +181,7 @@ export async function startWorker(): Promise<WorkerResult> {
       version: getVersion(),
     },
     keyManager,
+    attachmentStore,
   );
 
   relay.onStateChange = (state) => {
@@ -189,6 +217,9 @@ export async function startWorker(): Promise<WorkerResult> {
     clearStatusFile();
     relay.disconnect();
     await adapter.stop();
+    if (mcpServer) {
+      try { await mcpServer.stop(); } catch { /* already stopped */ }
+    }
   };
 
   process.on('SIGTERM', () => { shutdown().catch(() => {}).finally(() => process.exit(0)); });

--- a/packages/tentacle/src/mcp/__tests__/e2e.test.ts
+++ b/packages/tentacle/src/mcp/__tests__/e2e.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { KrakiMcpServer } from '../server.js';
+import { MCP_PROTOCOL_VERSION, type JsonRpcResponse } from '../protocol.js';
+
+const PNG_1X1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+interface CallResp {
+  status: number;
+  body: JsonRpcResponse;
+}
+
+async function post(url: string, token: string, body: unknown): Promise<CallResp> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: (await res.json()) as JsonRpcResponse };
+}
+
+describe('Kraki MCP — end-to-end show_image over HTTP', () => {
+  let server: KrakiMcpServer;
+  let baseUrl: string;
+  let token: string;
+  let urlForSession: (s: string) => string;
+  let activeSessions: Set<string>;
+  let tmp: string;
+
+  beforeEach(async () => {
+    activeSessions = new Set(['sess-A']);
+    server = new KrakiMcpServer({
+      version: 'e2e',
+      isSessionActive: (id) => activeSessions.has(id),
+    });
+    const info = await server.start();
+    baseUrl = info.baseUrl;
+    token = info.bearerToken;
+    urlForSession = info.urlForSession;
+    tmp = mkdtempSync(join(tmpdir(), 'kraki-mcp-e2e-'));
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('full lifecycle: initialize → tools/list → tools/call(show_image)', async () => {
+    // 1) initialize
+    const init = await post(baseUrl, token, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: MCP_PROTOCOL_VERSION, clientInfo: { name: 'e2e', version: '0' } },
+    });
+    expect(init.body).toMatchObject({
+      result: { protocolVersion: MCP_PROTOCOL_VERSION, serverInfo: { name: 'kraki' } },
+    });
+
+    // 2) tools/list
+    const list = await post(baseUrl, token, { jsonrpc: '2.0', id: 2, method: 'tools/list' });
+    const tools = (list.body as { result: { tools: Array<{ name: string }> } }).result.tools;
+    expect(tools.map((t) => t.name)).toEqual(['show_image']);
+
+    // 3) tools/call against the per-session URL with a real PNG file
+    const png = join(tmp, 'hello.png');
+    writeFileSync(png, Buffer.from(PNG_1X1, 'base64'));
+
+    const call = await post(urlForSession('sess-A'), token, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'show_image', arguments: { path: png, caption: 'hi' } },
+    });
+    const result = (call.body as { result: { content: Array<Record<string, unknown>>; isError?: boolean } }).result;
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+      data: PNG_1X1,
+    });
+    expect(result.content[1]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('Caption: hi'),
+    });
+  });
+});

--- a/packages/tentacle/src/mcp/__tests__/server.test.ts
+++ b/packages/tentacle/src/mcp/__tests__/server.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { KrakiMcpServer } from '../server.js';
+import {
+  JSON_RPC_INVALID_PARAMS,
+  JSON_RPC_INVALID_REQUEST,
+  JSON_RPC_METHOD_NOT_FOUND,
+  JSON_RPC_PARSE_ERROR,
+  MCP_PROTOCOL_VERSION,
+  type JsonRpcResponse,
+} from '../protocol.js';
+
+interface Fixture {
+  server: KrakiMcpServer;
+  baseUrl: string;
+  token: string;
+  urlForSession: (s: string) => string;
+  activeSessions: Set<string>;
+}
+
+async function start(initialSessions: string[] = []): Promise<Fixture> {
+  const activeSessions = new Set<string>(initialSessions);
+  const server = new KrakiMcpServer({
+    version: '0.0.0-test',
+    isSessionActive: (id) => activeSessions.has(id),
+  });
+  const info = await server.start();
+  return {
+    server,
+    baseUrl: info.baseUrl,
+    token: info.bearerToken,
+    urlForSession: info.urlForSession,
+    activeSessions,
+  };
+}
+
+async function rpc(
+  url: string,
+  token: string | undefined,
+  body: unknown,
+): Promise<{ status: number; json: JsonRpcResponse | { error: string } }> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const res = await fetch(url, { method: 'POST', headers, body: typeof body === 'string' ? body : JSON.stringify(body) });
+  const txt = await res.text();
+  let json: JsonRpcResponse | { error: string };
+  try {
+    json = JSON.parse(txt);
+  } catch {
+    json = { error: 'non_json' };
+  }
+  return { status: res.status, json };
+}
+
+describe('KrakiMcpServer — transport and auth', () => {
+  let fx: Fixture;
+  beforeEach(async () => {
+    fx = await start();
+  });
+  afterEach(async () => {
+    await fx.server.stop();
+  });
+
+  it('binds to a kernel-assigned loopback port', () => {
+    expect(fx.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+    expect(fx.token).toHaveLength(64);
+  });
+
+  it('returns 401 for missing Authorization header', async () => {
+    const r = await rpc(fx.baseUrl, undefined, { jsonrpc: '2.0', id: 1, method: 'initialize' });
+    expect(r.status).toBe(401);
+  });
+
+  it('returns 401 for wrong bearer token', async () => {
+    const r = await rpc(fx.baseUrl, 'a'.repeat(fx.token.length), {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    const res = await fetch(fx.baseUrl, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${fx.token}` },
+    });
+    expect(res.status).toBe(405);
+    expect(res.headers.get('allow')).toBe('POST');
+  });
+
+  it('returns 404 for unknown paths', async () => {
+    const url = fx.baseUrl.replace('/mcp', '/other');
+    const r = await rpc(url, fx.token, { jsonrpc: '2.0', id: 1, method: 'initialize' });
+    expect(r.status).toBe(404);
+  });
+
+  it('returns 404 for nested paths under /mcp/sid/extra', async () => {
+    const url = `${fx.baseUrl}/sid/extra`;
+    const r = await rpc(url, fx.token, { jsonrpc: '2.0', id: 1, method: 'initialize' });
+    expect(r.status).toBe(404);
+  });
+
+  it('returns JSON-RPC parse error for invalid JSON', async () => {
+    const r = await rpc(fx.baseUrl, fx.token, 'not json{');
+    expect(r.status).toBe(200);
+    expect(r.json).toMatchObject({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: JSON_RPC_PARSE_ERROR },
+    });
+  });
+
+  it('rejects non-2.0 jsonrpc envelopes', async () => {
+    const r = await rpc(fx.baseUrl, fx.token, { jsonrpc: '1.0', id: 1, method: 'initialize' });
+    expect(r.json).toMatchObject({ error: { code: JSON_RPC_INVALID_REQUEST } });
+  });
+});
+
+describe('KrakiMcpServer — initialize and tools/list', () => {
+  let fx: Fixture;
+  beforeEach(async () => {
+    fx = await start();
+  });
+  afterEach(async () => {
+    await fx.server.stop();
+  });
+
+  it('responds to initialize with declared protocol version + server info', async () => {
+    const r = await rpc(fx.baseUrl, fx.token, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: MCP_PROTOCOL_VERSION, clientInfo: { name: 'test', version: '0' } },
+    });
+    expect(r.json).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        serverInfo: { name: 'kraki', version: '0.0.0-test' },
+        capabilities: { tools: { listChanged: false } },
+      },
+    });
+  });
+
+  it('returns tools/list including show_image', async () => {
+    const r = await rpc(fx.baseUrl, fx.token, { jsonrpc: '2.0', id: 2, method: 'tools/list' });
+    const result = (r.json as { result: { tools: Array<{ name: string }> } }).result;
+    expect(result.tools.map((t) => t.name)).toContain('show_image');
+    const showImage = result.tools.find((t) => t.name === 'show_image');
+    expect(showImage).toBeDefined();
+    expect(showImage).toMatchObject({
+      name: 'show_image',
+      description: expect.any(String),
+      inputSchema: { type: 'object', required: ['path'] },
+    });
+  });
+
+  it('returns JSON-RPC method_not_found for unknown methods', async () => {
+    const r = await rpc(fx.baseUrl, fx.token, { jsonrpc: '2.0', id: 3, method: 'totally/madeup' });
+    expect(r.json).toMatchObject({
+      jsonrpc: '2.0',
+      id: 3,
+      error: { code: JSON_RPC_METHOD_NOT_FOUND },
+    });
+  });
+
+  it('initialize and tools/list work on both /mcp and /mcp/<sessionId>', async () => {
+    const onScoped = await rpc(fx.urlForSession('any-sid'), fx.token, {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/list',
+    });
+    expect((onScoped.json as { result: unknown }).result).toBeDefined();
+  });
+});
+
+describe('KrakiMcpServer — tools/call session routing', () => {
+  let fx: Fixture;
+  beforeEach(async () => {
+    fx = await start(['valid-session']);
+  });
+  afterEach(async () => {
+    await fx.server.stop();
+  });
+
+  it('rejects tools/call on /mcp (no session scope)', async () => {
+    const r = await rpc(fx.baseUrl, fx.token, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'show_image', arguments: {} },
+    });
+    expect(r.json).toMatchObject({ error: { code: JSON_RPC_INVALID_PARAMS } });
+  });
+
+  it('rejects tools/call for unknown sessionId', async () => {
+    const r = await rpc(fx.urlForSession('not-active'), fx.token, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'show_image', arguments: { path: '/tmp/x' } },
+    });
+    expect(r.json).toMatchObject({
+      error: { code: JSON_RPC_INVALID_PARAMS, message: expect.stringContaining('Unknown') },
+    });
+  });
+
+  it('accepts tools/call for active sessionId and routes to handler', async () => {
+    const r = await rpc(fx.urlForSession('valid-session'), fx.token, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'show_image', arguments: {} },
+    });
+    // missing path → handler returns isError result, NOT JSON-RPC error
+    expect(r.json).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { isError: true, content: expect.any(Array) },
+    });
+  });
+
+  it('rejects unknown tool name with method_not_found', async () => {
+    const r = await rpc(fx.urlForSession('valid-session'), fx.token, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'totally_made_up', arguments: {} },
+    });
+    expect(r.json).toMatchObject({ error: { code: JSON_RPC_METHOD_NOT_FOUND } });
+  });
+
+  it('rejects malformed params (missing name)', async () => {
+    const r = await rpc(fx.urlForSession('valid-session'), fx.token, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {},
+    });
+    expect(r.json).toMatchObject({ error: { code: JSON_RPC_INVALID_PARAMS } });
+  });
+});

--- a/packages/tentacle/src/mcp/__tests__/show-image.test.ts
+++ b/packages/tentacle/src/mcp/__tests__/show-image.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  SHOW_IMAGE_MAX_BYTES,
+  showImageHandler,
+  showImageTool,
+  SHOW_IMAGE_TOOL_NAME,
+} from '../tools/show-image.js';
+
+// 1x1 PNG (red pixel), captured as base64 so tests stay tiny.
+const PNG_1X1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+const PNG_1X1_BYTES = Buffer.from(PNG_1X1, 'base64');
+
+const ctx = { sessionId: 'sess-1' };
+
+describe('show_image tool definition', () => {
+  it('declares its name + required argument', () => {
+    expect(showImageTool.definition.name).toBe(SHOW_IMAGE_TOOL_NAME);
+    expect(showImageTool.definition.inputSchema).toMatchObject({
+      type: 'object',
+      required: ['path'],
+      additionalProperties: false,
+    });
+  });
+});
+
+describe('show_image handler — argument validation', () => {
+  it('returns isError when path is missing', async () => {
+    const r = await showImageHandler({}, ctx);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toContain('"path"');
+  });
+
+  it('returns isError when path is empty string', async () => {
+    const r = await showImageHandler({ path: '' }, ctx);
+    expect(r.isError).toBe(true);
+  });
+
+  it('returns isError when path is not a string', async () => {
+    const r = await showImageHandler({ path: 42 as unknown as string }, ctx);
+    expect(r.isError).toBe(true);
+  });
+
+  it('returns isError when path is relative', async () => {
+    const r = await showImageHandler({ path: 'foo.png' }, ctx);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toContain('absolute');
+  });
+});
+
+describe('show_image handler — filesystem checks', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kraki-mcp-test-'));
+  });
+  afterEach(() => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('returns isError when file does not exist', async () => {
+    const r = await showImageHandler({ path: join(dir, 'missing.png') }, ctx);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toContain('File not found');
+  });
+
+  it('returns isError when path is a directory', async () => {
+    const r = await showImageHandler({ path: dir }, ctx);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toContain('Not a regular file');
+  });
+
+  it('returns isError for unsupported extension', async () => {
+    const p = join(dir, 'data.bin');
+    writeFileSync(p, PNG_1X1_BYTES);
+    const r = await showImageHandler({ path: p }, ctx);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toMatch(/Unsupported image type/i);
+  });
+
+  it('returns isError when file exceeds size cap', async () => {
+    const p = join(dir, 'huge.png');
+    // Write SHOW_IMAGE_MAX_BYTES + 1 bytes of zeros — content doesn't matter
+    writeFileSync(p, Buffer.alloc(SHOW_IMAGE_MAX_BYTES + 1));
+    const r = await showImageHandler({ path: p }, ctx);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toMatch(/too large/i);
+  });
+
+  it('returns isError when file is unreadable', async () => {
+    const p = join(dir, 'no-perm.png');
+    writeFileSync(p, PNG_1X1_BYTES);
+    chmodSync(p, 0o000);
+    try {
+      const r = await showImageHandler({ path: p }, ctx);
+      expect(r.isError).toBe(true);
+    } finally {
+      chmodSync(p, 0o644);
+    }
+  });
+});
+
+describe('show_image handler — happy paths', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kraki-mcp-test-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns image content block with correct mime and base64 for PNG', async () => {
+    const p = join(dir, 'pixel.png');
+    writeFileSync(p, PNG_1X1_BYTES);
+    const r = await showImageHandler({ path: p }, ctx);
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toHaveLength(2);
+    expect(r.content[0]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+      data: PNG_1X1,
+    });
+    expect(r.content[1]).toMatchObject({ type: 'text', text: 'Image displayed to user.' });
+  });
+
+  it('appends caption to text content when provided', async () => {
+    const p = join(dir, 'pixel.png');
+    writeFileSync(p, PNG_1X1_BYTES);
+    const r = await showImageHandler({ path: p, caption: 'red dot' }, ctx);
+    expect(r.isError).toBeFalsy();
+    expect(textOf(r)).toBe('Image displayed to user. Caption: red dot');
+  });
+
+  it('ignores blank/whitespace captions', async () => {
+    const p = join(dir, 'pixel.png');
+    writeFileSync(p, PNG_1X1_BYTES);
+    const r = await showImageHandler({ path: p, caption: '   ' }, ctx);
+    expect(textOf(r)).toBe('Image displayed to user.');
+  });
+
+  it.each([
+    ['image.jpg', 'image/jpeg'],
+    ['image.jpeg', 'image/jpeg'],
+    ['image.webp', 'image/webp'],
+    ['image.gif', 'image/gif'],
+  ])('detects mime for %s as %s', async (name, expected) => {
+    const p = join(dir, name);
+    writeFileSync(p, PNG_1X1_BYTES); // bytes content doesn't matter for mime detection
+    const r = await showImageHandler({ path: p }, ctx);
+    expect(r.isError).toBeFalsy();
+    expect((r.content[0] as { mimeType: string }).mimeType).toBe(expected);
+  });
+
+  it('honors PNG extension case-insensitively', async () => {
+    const p = join(dir, 'pixel.PNG');
+    writeFileSync(p, PNG_1X1_BYTES);
+    const r = await showImageHandler({ path: p }, ctx);
+    expect(r.isError).toBeFalsy();
+    expect((r.content[0] as { mimeType: string }).mimeType).toBe('image/png');
+  });
+});
+
+function textOf(r: { content: Array<{ type: string; text?: string }> }): string {
+  return r.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text ?? '')
+    .join('\n');
+}

--- a/packages/tentacle/src/mcp/index.ts
+++ b/packages/tentacle/src/mcp/index.ts
@@ -1,0 +1,31 @@
+export { KrakiMcpServer } from './server.js';
+export type { KrakiMcpServerOptions, KrakiMcpServerStartResult } from './server.js';
+export { SYSTEM_PROMPT_HINT } from './prompts.js';
+export {
+  showImageTool,
+  showImageHandler,
+  SHOW_IMAGE_TOOL_NAME,
+  SHOW_IMAGE_MAX_BYTES,
+  SHOW_IMAGE_MIME_BY_EXT,
+} from './tools/show-image.js';
+export { ToolRegistry } from './tools/index.js';
+export type { RegisteredTool, ToolContext, ToolHandler } from './tools/index.js';
+export {
+  MCP_PROTOCOL_VERSION,
+  JSON_RPC_INVALID_PARAMS,
+  JSON_RPC_METHOD_NOT_FOUND,
+  JSON_RPC_PARSE_ERROR,
+  JSON_RPC_INVALID_REQUEST,
+} from './protocol.js';
+export type {
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JsonRpcSuccess,
+  JsonRpcError,
+  McpInitializeResult,
+  McpToolDefinition,
+  McpToolsListResult,
+  McpToolsCallParams,
+  McpToolResult,
+  McpContentBlock,
+} from './protocol.js';

--- a/packages/tentacle/src/mcp/prompts.ts
+++ b/packages/tentacle/src/mcp/prompts.ts
@@ -1,0 +1,18 @@
+/**
+ * System-prompt hint appended to Copilot sessions so the model knows when to
+ * use the Kraki MCP `show_image` tool vs the built-in `view`/`read` tools.
+ *
+ * Exported as a constant so tests can assert the text is wired through.
+ */
+export const SYSTEM_PROMPT_HINT = `\
+You have access to a Kraki MCP server with tools prefixed by "kraki.".
+
+When you want to visually present an image to the user — a screenshot you \
+captured, a diagram you generated, a chart, a UI mock — call \
+\`kraki.show_image\` with the absolute file path. Use it sparingly: only \
+when the user benefits from seeing the actual pixels.
+
+Plain file viewing on image files (with \`view\`/\`read\`) is for your own \
+inspection; those appear as collapsed attachments in the chat. Use \
+\`kraki.show_image\` when the user should actually see the image inline.\
+`;

--- a/packages/tentacle/src/mcp/prompts.ts
+++ b/packages/tentacle/src/mcp/prompts.ts
@@ -2,17 +2,22 @@
  * System-prompt hint appended to Copilot sessions so the model knows when to
  * use the Kraki MCP `show_image` tool vs the built-in `view`/`read` tools.
  *
+ * Note: Copilot SDK exposes MCP tools to the model with the display name
+ * format `<server>-<tool>` (dash separator). The Kraki MCP server registers
+ * as `kraki`, so the model calls the tool as `kraki-show_image`.
+ *
  * Exported as a constant so tests can assert the text is wired through.
  */
 export const SYSTEM_PROMPT_HINT = `\
-You have access to a Kraki MCP server with tools prefixed by "kraki.".
+You have access to a Kraki MCP server. Its tools are visible with names \
+beginning with "kraki-".
 
 When you want to visually present an image to the user — a screenshot you \
 captured, a diagram you generated, a chart, a UI mock — call \
-\`kraki.show_image\` with the absolute file path. Use it sparingly: only \
+\`kraki-show_image\` with the absolute file path. Use it sparingly: only \
 when the user benefits from seeing the actual pixels.
 
 Plain file viewing on image files (with \`view\`/\`read\`) is for your own \
 inspection; those appear as collapsed attachments in the chat. Use \
-\`kraki.show_image\` when the user should actually see the image inline.\
+\`kraki-show_image\` when the user should actually see the image inline.\
 `;

--- a/packages/tentacle/src/mcp/protocol.ts
+++ b/packages/tentacle/src/mcp/protocol.ts
@@ -1,0 +1,80 @@
+/**
+ * Minimal Model Context Protocol (MCP) types used by the Kraki MCP server.
+ *
+ * We implement only the surface we need:
+ *   - JSON-RPC 2.0 envelope
+ *   - `initialize` handshake
+ *   - `tools/list` + `tools/call`
+ *
+ * Prompts, resources, sampling, completions, etc. are out of scope for v1.
+ */
+
+// ── JSON-RPC 2.0 envelope ───────────────────────────────────────────────
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcSuccess {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  result: unknown;
+}
+
+export interface JsonRpcError {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  error: { code: number; message: string; data?: unknown };
+}
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcError;
+
+export const JSON_RPC_PARSE_ERROR = -32700;
+export const JSON_RPC_INVALID_REQUEST = -32600;
+export const JSON_RPC_METHOD_NOT_FOUND = -32601;
+export const JSON_RPC_INVALID_PARAMS = -32602;
+export const JSON_RPC_INTERNAL_ERROR = -32603;
+
+// ── MCP-specific ────────────────────────────────────────────────────────
+
+/** MCP protocol version we declare during initialize. */
+export const MCP_PROTOCOL_VERSION = '2024-11-05';
+
+export interface McpInitializeParams {
+  protocolVersion: string;
+  capabilities?: Record<string, unknown>;
+  clientInfo?: { name: string; version: string };
+}
+
+export interface McpInitializeResult {
+  protocolVersion: string;
+  serverInfo: { name: string; version: string };
+  capabilities: { tools?: { listChanged?: boolean } };
+}
+
+export interface McpToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface McpToolsListResult {
+  tools: McpToolDefinition[];
+}
+
+export interface McpToolsCallParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+export type McpContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string };
+
+export interface McpToolResult {
+  content: McpContentBlock[];
+  isError?: boolean;
+}

--- a/packages/tentacle/src/mcp/server.ts
+++ b/packages/tentacle/src/mcp/server.ts
@@ -1,0 +1,327 @@
+import { randomBytes } from 'node:crypto';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server as HttpServer,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { createLogger } from '../logger.js';
+import {
+  JSON_RPC_INTERNAL_ERROR,
+  JSON_RPC_INVALID_PARAMS,
+  JSON_RPC_INVALID_REQUEST,
+  JSON_RPC_METHOD_NOT_FOUND,
+  JSON_RPC_PARSE_ERROR,
+  MCP_PROTOCOL_VERSION,
+  type JsonRpcError,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+  type JsonRpcSuccess,
+  type McpInitializeResult,
+  type McpToolResult,
+  type McpToolsCallParams,
+  type McpToolsListResult,
+} from './protocol.js';
+import { ToolRegistry, type RegisteredTool } from './tools/index.js';
+import { showImageTool } from './tools/show-image.js';
+
+const logger = createLogger('mcp-server');
+
+const MAX_BODY_BYTES = 16 * 1024 * 1024; // generous, since show_image can return ~8 MB
+const SERVER_NAME = 'kraki';
+
+export interface KrakiMcpServerOptions {
+  /** Server semver — surfaced in `initialize` response. */
+  version: string;
+  /**
+   * Predicate used to validate the sessionId encoded in the URL path of
+   * `tools/call` requests. Other methods (`initialize`, `tools/list`) do not
+   * require it.
+   */
+  isSessionActive: (sessionId: string) => boolean;
+}
+
+export interface KrakiMcpServerStartResult {
+  /** Base URL up to (but excluding) the per-session segment. */
+  baseUrl: string;
+  /** Bearer token clients must send in `Authorization`. */
+  bearerToken: string;
+  /** Helper: build the per-session URL the SDK should connect to. */
+  urlForSession(sessionId: string): string;
+  /** Bound port (resolved after listen). */
+  port: number;
+}
+
+/**
+ * Tentacle-hosted MCP server.
+ *
+ * - Binds to 127.0.0.1 on a kernel-assigned port (no LAN exposure)
+ * - Requires `Authorization: Bearer <token>` on every request
+ * - Routes requests under `/mcp/<sessionId>`; the sessionId is injected into
+ *   tool-call context. `initialize` and `tools/list` accept a `/mcp` URL too.
+ */
+export class KrakiMcpServer {
+  private readonly registry = new ToolRegistry();
+  private readonly token: string = randomBytes(32).toString('hex');
+  private readonly version: string;
+  private readonly isSessionActive: (sessionId: string) => boolean;
+  private server: HttpServer | null = null;
+  private port = 0;
+
+  constructor(options: KrakiMcpServerOptions, tools: readonly RegisteredTool[] = [showImageTool]) {
+    this.version = options.version;
+    this.isSessionActive = options.isSessionActive;
+    for (const tool of tools) this.registry.register(tool);
+  }
+
+  /** Expose registered tools (test helper). */
+  get tools(): ToolRegistry {
+    return this.registry;
+  }
+
+  /** Bearer token (test helper). */
+  get bearerToken(): string {
+    return this.token;
+  }
+
+  async start(): Promise<KrakiMcpServerStartResult> {
+    if (this.server) throw new Error('KrakiMcpServer already started');
+
+    const server = createServer((req, res) => {
+      void this.handleRequest(req, res).catch((err) => {
+        logger.error({ err }, 'unhandled error in MCP request');
+        if (!res.headersSent) {
+          res.writeHead(500, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ error: 'internal_error' }));
+        }
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+    this.server = server;
+    this.port = (server.address() as AddressInfo).port;
+    logger.info({ port: this.port, tools: this.registry.size() }, 'MCP server listening');
+
+    const baseUrl = `http://127.0.0.1:${this.port}/mcp`;
+    return {
+      baseUrl,
+      bearerToken: this.token,
+      port: this.port,
+      urlForSession: (sessionId) => `${baseUrl}/${encodeURIComponent(sessionId)}`,
+    };
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve) => {
+      this.server?.close(() => resolve());
+    });
+    this.server = null;
+  }
+
+  // ── Request handling ──────────────────────────────────────────────────
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'content-type': 'application/json', 'allow': 'POST' });
+      res.end(JSON.stringify({ error: 'method_not_allowed' }));
+      return;
+    }
+
+    if (!this.checkAuth(req)) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unauthorized' }));
+      return;
+    }
+
+    const sessionId = this.extractSessionId(req.url ?? '');
+    // sessionId === null means malformed path; sessionId === '' means `/mcp` with no segment
+    if (sessionId === null) {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not_found' }));
+      return;
+    }
+
+    let body: string;
+    try {
+      body = await readBody(req, MAX_BODY_BYTES);
+    } catch (err) {
+      logger.warn({ err }, 'failed to read request body');
+      res.writeHead(413, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'payload_too_large' }));
+      return;
+    }
+
+    let rpc: JsonRpcRequest;
+    try {
+      rpc = JSON.parse(body) as JsonRpcRequest;
+    } catch {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(rpcError(null, JSON_RPC_PARSE_ERROR, 'Parse error')));
+      return;
+    }
+
+    if (rpc.jsonrpc !== '2.0' || typeof rpc.method !== 'string') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(rpcError(rpc?.id ?? null, JSON_RPC_INVALID_REQUEST, 'Invalid request')));
+      return;
+    }
+
+    const response = await this.dispatch(rpc, sessionId);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(response));
+  }
+
+  private checkAuth(req: IncomingMessage): boolean {
+    const header = req.headers['authorization'];
+    if (typeof header !== 'string') return false;
+    if (!header.startsWith('Bearer ')) return false;
+    const presented = header.slice('Bearer '.length).trim();
+    // constant-time-ish compare (length differs → reject; otherwise compare)
+    if (presented.length !== this.token.length) return false;
+    let diff = 0;
+    for (let i = 0; i < presented.length; i++) {
+      diff |= presented.charCodeAt(i) ^ this.token.charCodeAt(i);
+    }
+    return diff === 0;
+  }
+
+  /**
+   * Extract the per-session segment from `/mcp` or `/mcp/<sessionId>`.
+   * Returns:
+   *   - the sessionId string for `/mcp/<sessionId>`
+   *   - '' for `/mcp` (allowed for initialize/tools/list)
+   *   - null for any other URL shape (caller responds 404)
+   */
+  private extractSessionId(rawUrl: string): string | null {
+    const qIdx = rawUrl.indexOf('?');
+    const pathname = qIdx === -1 ? rawUrl : rawUrl.slice(0, qIdx);
+    if (pathname === '/mcp' || pathname === '/mcp/') return '';
+    if (!pathname.startsWith('/mcp/')) return null;
+    const rest = pathname.slice('/mcp/'.length);
+    if (rest.length === 0 || rest.includes('/')) return null;
+    try {
+      return decodeURIComponent(rest);
+    } catch {
+      return null;
+    }
+  }
+
+  private async dispatch(rpc: JsonRpcRequest, sessionId: string): Promise<JsonRpcResponse> {
+    try {
+      switch (rpc.method) {
+        case 'initialize':
+          return rpcOk(rpc.id, this.handleInitialize());
+        case 'notifications/initialized':
+          // No-op notification; per JSON-RPC, notifications have no `id`. The
+          // MCP spec sends this after initialize; we accept and respond with
+          // an empty success for any request form, but it usually arrives as a
+          // notification (no id). For notifications we still must not send a
+          // response per JSON-RPC; but Copilot SDK is happy with an empty 200.
+          return rpcOk(rpc.id, {});
+        case 'tools/list':
+          return rpcOk(rpc.id, this.handleToolsList());
+        case 'tools/call':
+          return await this.handleToolsCall(rpc, sessionId);
+        default:
+          return rpcError(rpc.id, JSON_RPC_METHOD_NOT_FOUND, `Method not found: ${rpc.method}`);
+      }
+    } catch (err) {
+      logger.error({ err, method: rpc.method }, 'dispatch error');
+      return rpcError(
+        rpc.id,
+        JSON_RPC_INTERNAL_ERROR,
+        `Internal error: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  private handleInitialize(): McpInitializeResult {
+    return {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      serverInfo: { name: SERVER_NAME, version: this.version },
+      capabilities: { tools: { listChanged: false } },
+    };
+  }
+
+  private handleToolsList(): McpToolsListResult {
+    return { tools: this.registry.list() };
+  }
+
+  private async handleToolsCall(
+    rpc: JsonRpcRequest,
+    sessionId: string,
+  ): Promise<JsonRpcResponse> {
+    if (sessionId === '') {
+      return rpcError(rpc.id, JSON_RPC_INVALID_PARAMS, 'tools/call requires a session-scoped URL (/mcp/<sessionId>)');
+    }
+    if (!this.isSessionActive(sessionId)) {
+      return rpcError(rpc.id, JSON_RPC_INVALID_PARAMS, `Unknown or inactive session: ${sessionId}`);
+    }
+
+    const params = rpc.params as McpToolsCallParams | undefined;
+    if (!params || typeof params.name !== 'string') {
+      return rpcError(rpc.id, JSON_RPC_INVALID_PARAMS, 'tools/call requires { name, arguments? }');
+    }
+
+    const tool = this.registry.get(params.name);
+    if (!tool) {
+      return rpcError(rpc.id, JSON_RPC_METHOD_NOT_FOUND, `Unknown tool: ${params.name}`);
+    }
+
+    const args = (params.arguments ?? {}) as Record<string, unknown>;
+
+    let result: McpToolResult;
+    try {
+      result = await tool.handler(args, { sessionId });
+    } catch (err) {
+      logger.error({ err, tool: params.name }, 'tool handler threw');
+      result = {
+        content: [{ type: 'text', text: `Tool execution failed: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+    return rpcOk(rpc.id, result);
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function rpcOk(id: JsonRpcRequest['id'], result: unknown): JsonRpcSuccess {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function rpcError(
+  id: JsonRpcRequest['id'],
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcError {
+  return { jsonrpc: '2.0', id, error: data === undefined ? { code, message } : { code, message, data } };
+}
+
+async function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        req.destroy();
+        reject(new Error(`body exceeds ${maxBytes} bytes`));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}

--- a/packages/tentacle/src/mcp/tools/index.ts
+++ b/packages/tentacle/src/mcp/tools/index.ts
@@ -1,0 +1,46 @@
+import type { McpToolDefinition, McpToolResult } from '../protocol.js';
+
+/**
+ * Context passed to every tool handler.
+ *
+ * Includes the Kraki session ID this MCP call is bound to (resolved by the
+ * server from the URL path before dispatch). The agent never sees this — the
+ * sessionId is injected by tentacle, not supplied by the model.
+ */
+export interface ToolContext {
+  /** Kraki session ID this tool call belongs to. */
+  sessionId: string;
+}
+
+export type ToolHandler = (
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+) => Promise<McpToolResult>;
+
+export interface RegisteredTool {
+  definition: McpToolDefinition;
+  handler: ToolHandler;
+}
+
+export class ToolRegistry {
+  private tools = new Map<string, RegisteredTool>();
+
+  register(tool: RegisteredTool): void {
+    if (this.tools.has(tool.definition.name)) {
+      throw new Error(`Tool already registered: ${tool.definition.name}`);
+    }
+    this.tools.set(tool.definition.name, tool);
+  }
+
+  get(name: string): RegisteredTool | undefined {
+    return this.tools.get(name);
+  }
+
+  list(): McpToolDefinition[] {
+    return Array.from(this.tools.values(), (t) => t.definition);
+  }
+
+  size(): number {
+    return this.tools.size;
+  }
+}

--- a/packages/tentacle/src/mcp/tools/show-image.ts
+++ b/packages/tentacle/src/mcp/tools/show-image.ts
@@ -1,0 +1,117 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { extname } from 'node:path';
+
+import type { McpToolResult } from '../protocol.js';
+import type { RegisteredTool, ToolHandler } from './index.js';
+
+/** Hard cap on a single image's raw bytes. Stays well under the relay 10 MB
+ *  frame cap once base64 + JSON wrapping + RSA-OAEP per-recipient keys are
+ *  added by the broadcast path. */
+export const SHOW_IMAGE_MAX_BYTES = 8 * 1024 * 1024;
+
+/** Allowed image MIME types, keyed by lowercase file extension. */
+export const SHOW_IMAGE_MIME_BY_EXT: Readonly<Record<string, string>> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+};
+
+export const SHOW_IMAGE_TOOL_NAME = 'show_image';
+
+const DESCRIPTION =
+  'Display an image to the user in the Kraki chat. Use this when you want to ' +
+  'visually present something to the user — a screenshot, diagram, chart, or ' +
+  'generated graphic. For images you only need to inspect for your own ' +
+  'reasoning, use the standard view/read tools instead; those appear as ' +
+  'collapsible attachments rather than inline displays.';
+
+export const showImageHandler: ToolHandler = async (args, _ctx): Promise<McpToolResult> => {
+  const path = args.path;
+  if (typeof path !== 'string' || path.length === 0) {
+    return errorResult('Argument "path" is required and must be a non-empty string.');
+  }
+  if (!path.startsWith('/')) {
+    return errorResult('Argument "path" must be an absolute path (start with "/").');
+  }
+
+  if (!existsSync(path)) {
+    return errorResult(`File not found: ${path}`);
+  }
+
+  let stat;
+  try {
+    stat = statSync(path);
+  } catch (err) {
+    return errorResult(`Could not stat file: ${(err as Error).message}`);
+  }
+  if (!stat.isFile()) {
+    return errorResult(`Not a regular file: ${path}`);
+  }
+  if (stat.size > SHOW_IMAGE_MAX_BYTES) {
+    return errorResult(
+      `Image too large: ${stat.size} bytes (max ${SHOW_IMAGE_MAX_BYTES}). ` +
+        `Resize or compress before calling show_image.`,
+    );
+  }
+
+  const ext = extname(path).toLowerCase();
+  const mimeType = SHOW_IMAGE_MIME_BY_EXT[ext];
+  if (!mimeType) {
+    return errorResult(
+      `Unsupported image type "${ext || '(no extension)'}". ` +
+        `Supported: ${Object.keys(SHOW_IMAGE_MIME_BY_EXT).join(', ')}`,
+    );
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path);
+  } catch (err) {
+    return errorResult(`Failed to read file: ${(err as Error).message}`);
+  }
+
+  const caption = typeof args.caption === 'string' ? args.caption.trim() : '';
+  const text = caption
+    ? `Image displayed to user. Caption: ${caption}`
+    : 'Image displayed to user.';
+
+  return {
+    content: [
+      { type: 'image', mimeType, data: bytes.toString('base64') },
+      { type: 'text', text },
+    ],
+  };
+};
+
+function errorResult(message: string): McpToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+export const showImageTool: RegisteredTool = {
+  definition: {
+    name: SHOW_IMAGE_TOOL_NAME,
+    description: DESCRIPTION,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description:
+            'Absolute path to the image file on disk. Supported formats: PNG, JPEG, WebP, GIF (non-animated).',
+        },
+        caption: {
+          type: 'string',
+          description: 'Optional caption shown alongside the image.',
+        },
+      },
+      required: ['path'],
+      additionalProperties: false,
+    },
+  },
+  handler: showImageHandler,
+};

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -72,6 +72,9 @@ export class RelayClient {
     'session_model_set',
     'session_pinned',
     'session_read',
+    // attachment_data carries raw bytes and is regeneratable from the
+    // AttachmentStore — never persisted into messages.jsonl.
+    'attachment_data',
   ]);
   /** Global seq counter for envelope ordering (not used for replay — per-session seq handles that). */
   private seqCounter = 0;
@@ -117,13 +120,23 @@ export class RelayClient {
     sessionManager: SessionManager,
     options: RelayClientOptions,
     keyManager?: KeyManager | null,
+    attachmentStore?: import('./attachment-store.js').AttachmentStore,
   ) {
     this.adapter = adapter;
     this.sessionManager = sessionManager;
     this.options = options;
     this.keyManager = keyManager ?? null;
+    this.attachmentStore = attachmentStore;
     this.wireAdapterEvents();
   }
+
+  private readonly attachmentStore?: import('./attachment-store.js').AttachmentStore;
+
+  /** Track attachment ids already broadcast per session — prevents double-push
+   *  if the agent calls show_image twice with the same image bytes. The
+   *  receiving devices still see the ref each time (so the chat history is
+   *  correct); they just don't get a redundant byte broadcast. */
+  private broadcastedAttachmentIds = new Map<string, Set<string>>();
 
   /**
    * Connect to the relay. Auto-reconnects on disconnect.
@@ -416,6 +429,13 @@ export class RelayClient {
     }
     if (msg.type === 'import_session') {
       this.handleImportSession(msg);
+      return;
+    }
+
+    if (msg.type === 'request_attachment') {
+      this.handleRequestAttachment(msg).catch((err) => {
+        logger.warn({ err, attachmentId: msg.payload?.id }, 'request_attachment failed');
+      });
       return;
     }
 
@@ -995,6 +1015,18 @@ export class RelayClient {
       });
     };
 
+    this.adapter.onAttachmentBytes = (sessionId, event) => {
+      // Fire-and-forget — chunks are streamed from disk and pushed via the
+      // normal broadcast queue. We deliberately don't block onToolComplete
+      // on chunk delivery; both events ride the same WS queue so ordering
+      // (ref-first, chunks-after) is preserved naturally.
+      for (const ref of event.refs) {
+        this.broadcastAttachmentBytes(sessionId, ref).catch((err) => {
+          logger.warn({ err, sessionId, attachmentId: ref.id }, 'failed to broadcast attachment bytes');
+        });
+      }
+    };
+
     this.adapter.onIdle = (sessionId) => {
       this.sessionManager.markIdle(sessionId);
       const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
@@ -1152,6 +1184,127 @@ export class RelayClient {
       },
     };
     this.sendUnicastTo(requesterDeviceId, requesterKey, batchMsg);
+  }
+
+  // ── Attachment bytes ────────────────────────────────
+
+  /** Plaintext chunk budget for `attachment_data` envelopes.
+   *  Stays under the relay's 10 MB frame cap after base64 + envelope. */
+  private static readonly ATTACHMENT_CHUNK_BYTES = 2 * 1024 * 1024;
+
+  /**
+   * Stream an attachment's bytes to all connected consumers as
+   * `attachment_data` chunks. Called immediately after the producer fires
+   * a `tool_complete` carrying the matching `AttachmentRef`. Skipped if
+   * we've already broadcast this id within the session.
+   */
+  private async broadcastAttachmentBytes(
+    sessionId: string,
+    ref: import('@kraki/protocol').AttachmentRef,
+  ): Promise<void> {
+    if (!this.attachmentStore) {
+      logger.warn({ sessionId, attachmentId: ref.id }, 'no attachment store — skipping broadcast');
+      return;
+    }
+    let seen = this.broadcastedAttachmentIds.get(sessionId);
+    if (!seen) {
+      seen = new Set();
+      this.broadcastedAttachmentIds.set(sessionId, seen);
+    }
+    if (seen.has(ref.id)) return;
+    seen.add(ref.id);
+
+    const total = Math.max(1, Math.ceil(ref.size / RelayClient.ATTACHMENT_CHUNK_BYTES));
+    let index = 0;
+    for (const chunk of this.attachmentStore.stream(sessionId, ref.id, RelayClient.ATTACHMENT_CHUNK_BYTES)) {
+      this.send({
+        type: 'attachment_data',
+        sessionId,
+        payload: {
+          id: ref.id,
+          index,
+          total,
+          mimeType: ref.mimeType,
+          data: chunk.toString('base64'),
+        },
+      });
+      index += 1;
+    }
+    if (index === 0) {
+      // The ref was emitted but bytes are no longer on disk — odd state, but
+      // notify consumers with a structured error so they don't sit on a
+      // pending placeholder forever.
+      logger.warn({ sessionId, attachmentId: ref.id }, 'no bytes on disk for ref, sending error chunk');
+      this.send({
+        type: 'attachment_data',
+        sessionId,
+        payload: { id: ref.id, index: 0, total: 0, mimeType: ref.mimeType, data: '', error: 'not_found' },
+      });
+    }
+  }
+
+  /**
+   * Serve a `request_attachment` from a consumer device. Reads from the
+   * AttachmentStore, encrypts chunked unicasts to the requester only.
+   */
+  private async handleRequestAttachment(msg: ConsumerMessage): Promise<void> {
+    if (msg.type !== 'request_attachment') return;
+    const { id, sessionId } = msg.payload;
+    const requesterDeviceId = msg.deviceId;
+    const requesterKey = this.consumerKeys.get(requesterDeviceId);
+    if (!requesterKey) {
+      logger.warn({ requesterDeviceId }, 'request_attachment: no key for requester');
+      return;
+    }
+    if (!this.attachmentStore) {
+      this.unicastAttachmentError(requesterDeviceId, requesterKey, sessionId, id, 'not_found');
+      return;
+    }
+    const got = this.attachmentStore.read(sessionId, id);
+    if (!got) {
+      this.unicastAttachmentError(requesterDeviceId, requesterKey, sessionId, id, 'not_found');
+      return;
+    }
+    const total = Math.max(1, Math.ceil(got.bytes.length / RelayClient.ATTACHMENT_CHUNK_BYTES));
+    for (let i = 0; i < total; i++) {
+      const slice = got.bytes.subarray(
+        i * RelayClient.ATTACHMENT_CHUNK_BYTES,
+        Math.min((i + 1) * RelayClient.ATTACHMENT_CHUNK_BYTES, got.bytes.length),
+      );
+      const chunkMsg = {
+        type: 'attachment_data' as const,
+        deviceId: this.authInfo?.deviceId ?? '',
+        sessionId,
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: {
+          id,
+          index: i,
+          total,
+          mimeType: got.meta.mimeType,
+          data: slice.toString('base64'),
+        },
+      };
+      this.sendUnicastTo(requesterDeviceId, requesterKey, chunkMsg);
+    }
+  }
+
+  private unicastAttachmentError(
+    requesterDeviceId: string,
+    requesterKey: string,
+    sessionId: string,
+    id: string,
+    error: 'not_found' | 'unauthorized' | 'too_large',
+  ): void {
+    const errorMsg = {
+      type: 'attachment_data' as const,
+      deviceId: this.authInfo?.deviceId ?? '',
+      sessionId,
+      seq: ++this.seqCounter,
+      timestamp: new Date().toISOString(),
+      payload: { id, index: 0, total: 0, mimeType: '', data: '', error },
+    };
+    this.sendUnicastTo(requesterDeviceId, requesterKey, errorMsg);
   }
 
   // ── Client log shipping ─────────────────────────────

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -74,6 +74,14 @@ export interface SessionMeta {
   usage?: import('@kraki/protocol').SessionUsage;
   /** Origin of this session — set for imported sessions */
   source?: import('@kraki/protocol').LocalSessionSource | 'imported';
+  /** True once the one-shot legacy-inline-image migration has run.
+   *  See `stripLegacyInlineImages` — pre-MCP versions of Kraki stored
+   *  image bytes inline inside tool_complete entries in messages.jsonl,
+   *  which inflated replay batches above the relay's 10MB frame cap and
+   *  caused the daemon's WS to drop. The migration strips those bytes
+   *  in place (the bytes weren't recoverable via the new ref path anyway,
+   *  since they came from `view`-on-an-image, not show_image). */
+  inlineImagesStripped?: boolean;
 }
 
 export interface RunRecord {
@@ -92,6 +100,7 @@ export class SessionManager {
     this.sessionsDir = sessionsDir ?? join(getConfigDir(), 'sessions');
     mkdirSync(this.sessionsDir, { recursive: true });
     this.migrateGlobalLog();
+    this.stripAllLegacyInlineImages();
   }
 
   /**
@@ -149,6 +158,102 @@ export class SessionManager {
     try {
       rmSync(oldLogPath);
     } catch { /* ignore */ }
+  }
+
+  /**
+   * One-shot migration: for every session, strip inline image attachments
+   * from tool_complete entries in messages.jsonl. Pre-MCP versions of
+   * Kraki carried image bytes inline; after this migration, image bytes
+   * only flow via the `kraki-show_image` ref + chunked attachment_data
+   * pipeline. Bytes for pre-existing `view`-on-image entries are NOT
+   * preserved — they were never the agent's intentional output anyway.
+   *
+   * The migration is per-session, idempotent, and atomic per file.
+   */
+  private stripAllLegacyInlineImages(): void {
+    if (!existsSync(this.sessionsDir)) return;
+    let dirs: string[];
+    try {
+      dirs = readdirSync(this.sessionsDir);
+    } catch {
+      return;
+    }
+    for (const dir of dirs) {
+      const meta = this.readMeta(dir);
+      if (!meta || meta.inlineImagesStripped) continue;
+      try {
+        this.stripLegacyInlineImagesForSession(dir);
+        meta.inlineImagesStripped = true;
+        this.writeMeta(dir, meta);
+      } catch {
+        // Best-effort — failures are logged below but never crash startup
+      }
+    }
+  }
+
+  private stripLegacyInlineImagesForSession(sessionId: string): void {
+    const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
+    if (!existsSync(logPath)) return;
+
+    let content: string;
+    try {
+      content = readFileSync(logPath, 'utf8');
+    } catch {
+      return;
+    }
+
+    const lines = content.split('\n');
+    let modified = false;
+    const rewritten = lines.map((line) => {
+      if (!line) return line;
+      let entry: { seq: number; type: string; payload: string; ts: string };
+      try {
+        entry = JSON.parse(line) as { seq: number; type: string; payload: string; ts: string };
+      } catch {
+        return line;
+      }
+      if (entry.type !== 'tool_complete' && entry.type !== 'agent_message' && entry.type !== 'user_message') {
+        return line;
+      }
+      let inner: Record<string, unknown>;
+      try {
+        inner = JSON.parse(entry.payload) as Record<string, unknown>;
+      } catch {
+        return line;
+      }
+      const payload = inner.payload as Record<string, unknown> | undefined;
+      const attachments = payload?.attachments;
+      if (!Array.isArray(attachments) || attachments.length === 0) return line;
+
+      // Drop any attachment that carries inline `data` (legacy shape). Refs
+      // (type === 'image_ref') are kept untouched.
+      let droppedAny = false;
+      const filtered = attachments.filter((a) => {
+        if (a && typeof a === 'object' && (a as Record<string, unknown>).type === 'image' && typeof (a as Record<string, unknown>).data === 'string') {
+          droppedAny = true;
+          return false;
+        }
+        return true;
+      });
+
+      if (!droppedAny) return line;
+
+      if (filtered.length > 0) {
+        payload!.attachments = filtered;
+      } else {
+        delete payload!.attachments;
+      }
+      entry.payload = JSON.stringify(inner);
+      modified = true;
+      return JSON.stringify(entry);
+    });
+
+    if (!modified) return;
+
+    // Atomic rewrite via tmp file + rename
+    const tmpPath = `${logPath}.${Date.now()}.tmp`;
+    writeFileSync(tmpPath, rewritten.join('\n'));
+    renameSync(tmpPath, logPath);
   }
 
   /**
@@ -466,6 +571,28 @@ export class SessionManager {
    */
   getMeta(sessionId: string): SessionMeta | null {
     return this.readMeta(sessionId);
+  }
+
+  /**
+   * Whether a session exists and is not in a terminal state.
+   * Used by the Kraki MCP server to validate `tools/call` requests whose
+   * URL path carries a sessionId — calls for unknown/ended sessions are
+   * rejected so the agent can't address arbitrary sessionIds.
+   */
+  isSessionActive(sessionId: string): boolean {
+    const meta = this.readMeta(sessionId);
+    if (!meta) return false;
+    return meta.state !== 'ended';
+  }
+
+  /** Public accessor: absolute path to a session's directory. */
+  getSessionDir(sessionId: string): string {
+    return this.sessionDir(sessionId);
+  }
+
+  /** Public accessor: absolute path to the sessions root. */
+  getSessionsRoot(): string {
+    return this.sessionsDir;
   }
 
   /**

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -32,10 +32,11 @@ const RUN_DIR = join(ROOT_DIR, 'run');
 const HEAD_DB_PATH = join(ROOT_DIR, 'kraki-head.db');
 const HEAD_LOG_PATH = join(LOG_DIR, 'head.log');
 const WEB_LOG_PATH = join(LOG_DIR, 'web.log');
-const RELAY_PORT = 4000;
+const RELAY_PORT = Number(process.env.KRAKI_LOCAL_RELAY_PORT ?? 4400);
 const RELAY_URL = `ws://localhost:${RELAY_PORT}`;
-const REDIRECT_PORT = 3100;
+const REDIRECT_PORT = Number(process.env.KRAKI_LOCAL_REDIRECT_PORT ?? 3400);
 const ENTRY_URL = `http://localhost:${REDIRECT_PORT}`;
+const WEB_DEV_PORT = Number(process.env.KRAKI_LOCAL_WEB_PORT ?? 3300);
 const STATE_VERSION = 'thin-relay-v1';
 const STATE_VERSION_PATH = join(ROOT_DIR, '.state-version');
 
@@ -306,11 +307,15 @@ function startHead(): ChildProcess {
 
 function startWeb(viteEnv: NodeJS.ProcessEnv): { child: ChildProcess; ready: Promise<string> } {
   const webLog = createWriteStream(WEB_LOG_PATH, { flags: 'w' });
-  const child = spawn('pnpm', ['--filter', '@kraki/arm-web', 'dev'], {
-    cwd: process.cwd(),
-    env: viteEnv,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  const child = spawn(
+    'pnpm',
+    ['--filter', '@kraki/arm-web', 'dev', '--port', String(WEB_DEV_PORT), '--strictPort'],
+    {
+      cwd: process.cwd(),
+      env: viteEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
 
   if (!child.pid) {
     throw new Error('Failed to start local web process');
@@ -418,7 +423,7 @@ async function start(args: string[]): Promise<void> {
   console.log('🦑 Starting real Kraki daemon...');
   const daemonPid = await startDaemon(localConfig, join(process.cwd(), 'packages/tentacle/src/cli.ts'));
 
-  let vitePort = '3000';
+  let vitePort = String(WEB_DEV_PORT);
   let viteReady = false;
   redirectServer = createHttpServer(async (_req, res) => {
     if (!viteReady) {


### PR DESCRIPTION
## Why

 ~23 MB plaintext batches).

This PR redesigns the attachment surface end-to-end:

- bytes are stored content-addressed on the tentacle's disk, not embedded in messages
- `messages.jsonl` carries only `AttachmentRef` small forevers 
- bytes flow separately as chunked `attachment_data` (live push) or `request_attachment` (pull on cache miss), each  2 MB plaintextchunk 
- only the new `kraki-show_image` MCP tool is treated as an intent to present; other tool images (e.g. `view`) are deliberately dropped

## What's in it

**New: Kraki MCP server (`packages/tentacle/src/mcp/`)**

- loopback HTTP server, bearer auth, per-session URL
- one tool: `kraki-show_image(path,  reads file from disk, stores via `AttachmentStore`, returns a refusal of the LLM-feed bytes so the agent doesn't waste tokens on its own screenshotcaption?)` 
- soft-fail on boot (daemon stays up, tool absent from agent's list)

**New: `AttachmentStore` (`packages/tentacle/src/attachment-store.ts`)**

- content-addressed (`<sha256-prefix>.<ext>` + `<id>.json` sidecar) per session
- header-sniffed dimensions, idempotent puts
- `gc(sessionId, referencedIds)` primitive ready for later (no scheduler  see "Rollout notes")shipped 

**Protocol changes (`packages/protocol/src/messages.ts`)**

- `AttachmentRef` discriminated as `type: 'image_ref'`
- `attachment_data` chunk message
- `request_attachment` unicast
- `caption` and `name` added to `ImageAttachment`/`AttachmentRef`

**Adapter rewrite (`packages/tentacle/src/adapters/copilot.ts`)**

- `pendingToolIdentity` map captures `mcpServerName`/`mcpToolName` from `tool.execution_start` (the SDK strips these on `tool.execution_ only `toolCallId` survives)complete` 
- only `kraki/show_image` produces image refs; all other tool images dropped
- `KRAKI_MCP_PROMPT` appended to system prompt so the model prefers `kraki-show_image` over `view` when intending to show

**RelayClient (`packages/tentacle/src/relay-client.ts`)**

- `onAttachmentBytes` callback streams chunks via broadcast after the referencing message
- `handleRequestAttachment` serves chunks via unicast for cache-miss/replay
- per-session dedup so the same id is not re-broadcast on every emit
- `attachment_data` added to `TRANSIENT_TYPES` (not buffered for  the ref is)replay 

**One-shot legacy migration (`packages/tentacle/src/session-manager.ts`)**

- `stripAllLegacyInlineImages()` runs once on daemon boot, gated by `inlineImagesStripped` meta flag, rewrites old jsonl files to drop inline image bytes

**Web (`packages/arm/web/src/`)**

- new `lib/attachments.ts` state machine (awaiting-chunks | fetching | ready | error), IndexedDB cache with LRU eviction (cap = max(50 MB, min(200 MB, quota0.5)))
- new `hooks/useAttachment.ts` with shared hydrate guard so cached attachments render in the same paint (no spinner flash on reload)
- `lib/ws-client.ts` `requestAttachment` stamps `deviceId` and `sessionId` at both envelope and  tentacle needs `deviceId` to look up the requester's pubkey for the chunked replypayload 
- `lib/message-router.ts` handles `attachment_data` chunks; `markAwaitingPush` for live refs in `tool_complete`
- `components/chat/MessageBubble.tsx` switches on `attachment.type`; renders refs via `useAttachment` with caption + spinner placeholder
- `components/chat/ChatView.tsx` `collectTurnImages` includes `image_ref`
- `components/chat/ThinkingBox.tsx` forwards `sessionId` to `MessageBubble` so image refs in the Steps modal render real images, not placeholders

**Dev tooling**

- `scripts/dev-local.ts` honours `KRAKI_LOCAL_RELAY_PORT` / `WEB_PORT` / `REDIRECT_PORT` so the worktree doesn't collide with a globally-installed Kraki on the same Mac

**Docs**

- ARCHITECTURE.md: new "Image attachments" message flow + "Kraki MCP server" section
- SECURITY.md: "Image attachments" and "Local MCP server" sections
- `packages/tentacle/README.md`: attachment storage and MCP server in tentacle's responsibilities

## Tests

- `packages/tentacle`: 423 pass (15 new for `AttachmentStore`, 36 new for MCP server + show_image + e2e)
- `packages/arm/web`: 289 pass (9 new for attachments state machine)
- `packages/head`: 198 pass
- `biome lint`: clean (95 files)
- **Playwright E2E** on a live Copilot session against the local stack:
  - ** `kraki-show_image` renders inline in the chat bubbleA** 
  - ** `view` tool produces text only, no imageB** 
 chunk-pull path works; IDB repopulates; image renders
 no spinner flash; image up before first measurable frame
  - ** Steps modal renders the same image (real `<img>` 200E200, not the placeholder tile)** 

## Rollout notes

- **Breaking change**: pre-existing sessions get a one-shot migration that strips inline image bytes from `messages.jsonl`. Sessions stay readable; old images that were never persisted to `attachments/` will simply not render after the migration (acceptable per project decision: Kraki is pre-release).
- **GC scheduler intentionally not shipped**: the only realistic orphan source today is a daemon crash between `store.put()` and the jsonl  at most a handful of stale files over a daemon's lifetime. `removeSession` already cleans up on session delete. The `gc()` primitive is ready if drift becomes a problem; deferring until there's evidence of need.flush 
- **Soft-fail on MCP boot**: a port collision or other startup failure logs a warning and  `kraki-show_image` is just absent from that session's tool list.continues 

## Out of scope (follow-ups)

- `capability-negotiation`: add `supportsAttachmentRefs?: boolean` to `DeviceCapabilities` (informational only, no fallback)
- `integration-test-end-to-end` in `packages/tests` (Playwright already covers this functionally)
- GC scheduler (see rollout notes)
- iOS receiver support (web only for now)
