### PR TITLE
chore: bump head to 0.12.0 for delivery assurance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - 'head-v*'
   workflow_dispatch:
     inputs:
       mode:
@@ -135,26 +136,34 @@ jobs:
           set -euo pipefail
           TAG="${{ steps.meta.outputs.release_tag }}"
 
-          if [[ "$TAG" == v* ]]; then
+          if [[ "$TAG" == head-v* ]]; then
+            TAG_VERSION="${TAG#head-v}"
+            PKG_VERSION=$(node -p "require('./packages/head/package.json').version")
+            PKG_NAME="@kraki/head"
+          elif [[ "$TAG" == v* ]]; then
             TAG_VERSION="${TAG#v}"
             PKG_VERSION=$(node -p "require('./packages/tentacle/package.json').version")
+            PKG_NAME="@kraki/tentacle"
           else
-            echo "Unknown tag prefix: $TAG (expected v*)"
+            echo "Unknown tag prefix: $TAG (expected v* or head-v*)"
             exit 1
           fi
 
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            echo "Tag version ($TAG_VERSION) does not match $PKG_NAME version ($PKG_VERSION)"
             exit 1
           fi
-          echo "Version: $PKG_VERSION ✅"
+          echo "Version: $PKG_NAME@$PKG_VERSION ✅"
 
   # ─── Build Tentacle Binary ───────────────────────────────
 
   build-binary:
     name: Build Binary (${{ matrix.label }})
     needs: prepare
-    if: startsWith(github.ref_name, 'v') || github.event_name == 'workflow_dispatch'
+    # Skip for head-only releases — the binary build is tentacle-specific.
+    if: |
+      (startsWith(github.ref_name, 'v') && !startsWith(github.ref_name, 'head-v'))
+      || (github.event_name == 'workflow_dispatch' && !startsWith(github.event.inputs.tag, 'head-v'))
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -497,7 +506,10 @@ jobs:
     needs:
       - prepare
       - build-binary
-    if: startsWith(github.ref_name, 'v') || github.event_name == 'workflow_dispatch'
+    # Skip for head-only releases — there are no tentacle binaries to publish.
+    if: |
+      (startsWith(github.ref_name, 'v') && !startsWith(github.ref_name, 'head-v'))
+      || (github.event_name == 'workflow_dispatch' && !startsWith(github.event.inputs.tag, 'head-v'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `@kraki/head` to 0.12.0 to publish the delivery assurance code from #99.

Also extends `release.yml` to support head-only releases via a `head-v*` tag prefix. Tentacle-specific jobs (binary build, asset publish) are gated off for head-only releases. The `publish-npm` job already skips already-published versions so it works unchanged.

After merge: tag `head-v0.12.0` to publish `@kraki/head@0.12.0` to npm.

Production relay still needs a manual restart  this PR + tag only ships the package, not the deploy.