### PR TITLE
chore(deploy): add edge relay deploy + backup scripts

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -56,3 +56,73 @@ The web app will automatically show a "Push notifications" toggle in Settings wh
 ## Local web development
 
 For local web development, put browser-only overrides like `VITE_WS_URL=ws://localhost:4000` in `packages/arm/web/.env.development.local`, not `packages/arm/web/.env`. Vite loads `.env` during production builds too, so using the dev-only filename avoids accidentally baking localhost into a deploy.
+
+## Updating a running relay
+
+When you're hosting `@kraki/head` long-term as a systemd service, use the helper scripts under `scripts/` to update and back up the relay safely.
+
+### One-time setup
+
+Make `/etc/kraki/relay.env` the canonical config and reference it from systemd. **Do not** keep secrets inside the npm package directory — `npm install -g @kraki/head@X` wipes the package contents on every upgrade and would take your config with it.
+
+```ini
+# /etc/systemd/system/kraki-relay.service
+[Service]
+EnvironmentFile=/etc/kraki/relay.env
+ExecStart=/usr/local/bin/kraki-relay --port 4000 --db /var/lib/kraki/kraki-relay.db
+KillSignal=SIGTERM
+TimeoutStopSec=15
+Restart=on-failure
+RestartSec=5
+```
+
+`/etc/kraki/relay.env` should be `chmod 600`, owned by root, and contain at minimum the keys listed under "Start the relay" plus any optional features you've enabled (GitHub OAuth, push, multi-region edge config).
+
+### Deploying a new version
+
+`scripts/deploy-edge-relay.sh <version>` runs the full upgrade on the relay host. It:
+
+1. Takes a WAL-safe SQLite snapshot of the live DB plus a copy of the env file and systemd unit into `/root/kraki-backups/pre-<version>-<timestamp>/`.
+2. Verifies the snapshot with `PRAGMA integrity_check`.
+3. `npm install -g @kraki/head@<version>` and checks `kraki-relay --version` matches.
+4. `systemctl restart kraki-relay`, waits for the service to become active, and hits `http://127.0.0.1:4000/` to confirm the new version is serving.
+5. On any failure between install and post-restart health check, automatically reinstalls the previous version, restores the env file and unit from the snapshot, and reloads systemd.
+
+The snapshot path is printed on both success and failure so you always have a manual rollback target. Old snapshots are pruned after 30 days.
+
+Run on the host:
+
+```bash
+sudo /usr/local/sbin/deploy-edge-relay.sh 0.12.0
+```
+
+(or invoke `scripts/deploy-edge-relay.sh` directly from a checkout — the script doesn't depend on the repo).
+
+### Daily database backups
+
+`scripts/backup-relay-db.sh` performs a WAL-safe `sqlite3 .backup` of the live DB and prunes copies older than 14 days. Install it once on the relay host:
+
+```bash
+sudo install -m 0755 scripts/backup-relay-db.sh /usr/local/sbin/kraki-backup-relay-db.sh
+
+sudo tee /etc/cron.daily/kraki-backup >/dev/null <<'EOF'
+#!/bin/sh
+/usr/local/sbin/kraki-backup-relay-db.sh
+EOF
+sudo chmod +x /etc/cron.daily/kraki-backup
+```
+
+Backups land in `/root/kraki-backups/kraki-relay-YYYYMMDD.db`. Each one is integrity-checked before promotion; corrupt copies are discarded rather than retained.
+
+### Capping journald
+
+If you're seeing the relay's journal grow without bound, cap it system-wide:
+
+```ini
+# /etc/systemd/journald.conf
+SystemMaxUse=200M
+SystemMaxFileSize=50M
+MaxRetentionSec=2week
+```
+
+Then `sudo systemctl restart systemd-journald`. This only affects log writes and does not disturb the relay process.

--- a/scripts/backup-relay-db.sh
+++ b/scripts/backup-relay-db.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# WAL-safe daily backup of the kraki-relay SQLite DB.
+#
+# Usage (run as root, typically from /etc/cron.daily):
+#   backup-relay-db.sh
+#
+# Behaviour:
+#   - Uses sqlite3 .backup (NOT cp) so it's safe to run while the relay is live.
+#   - Writes /root/kraki-backups/kraki-relay-YYYYMMDD.db (overwrites if same day).
+#   - Verifies the backup with PRAGMA integrity_check; refuses to retain a corrupt copy.
+#   - Deletes backups older than 14 days.
+
+set -eu
+
+DB=/var/lib/kraki/kraki-relay.db
+BACKUP_DIR=/root/kraki-backups
+RETENTION_DAYS=14
+
+if [ ! -f "$DB" ]; then
+  echo "DB not found: $DB" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 not installed" >&2
+  exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+
+STAMP=$(date +%Y%m%d)
+OUT="$BACKUP_DIR/kraki-relay-$STAMP.db"
+TMP="$OUT.tmp"
+
+# WAL-safe online backup.
+sqlite3 "$DB" ".backup '$TMP'"
+
+# Integrity check before promoting.
+RESULT=$(sqlite3 "$TMP" "PRAGMA integrity_check;" 2>&1 || true)
+if [ "$RESULT" != "ok" ]; then
+  echo "integrity check failed for $TMP:" >&2
+  echo "$RESULT" >&2
+  rm -f "$TMP"
+  exit 1
+fi
+
+mv -f "$TMP" "$OUT"
+chmod 600 "$OUT"
+
+# Retention sweep: drop daily backups older than RETENTION_DAYS.
+find "$BACKUP_DIR" -maxdepth 1 -type f -name 'kraki-relay-*.db' -mtime "+$RETENTION_DAYS" -delete 2>/dev/null || true
+
+echo "backup ok: $OUT"

--- a/scripts/deploy-edge-relay.sh
+++ b/scripts/deploy-edge-relay.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Deploy a new version of @kraki/head to this relay host.
+#
+# Idempotent and safe to re-run. Snapshots the live state before touching
+# anything, and auto-rolls-back if the restarted relay doesn't come up
+# healthy.
+#
+# Usage (run as root on the relay host):
+#   deploy-edge-relay.sh <version>      # e.g. deploy-edge-relay.sh 0.12.0
+#
+# Assumptions about the host layout (see SELF-HOSTING.md):
+#   - systemd unit:         /etc/systemd/system/kraki-relay.service
+#   - canonical env file:   /etc/kraki/relay.env  (referenced by unit's EnvironmentFile=)
+#   - SQLite DB:            /var/lib/kraki/kraki-relay.db
+#   - npm global install of @kraki/head provides /usr/local/bin/kraki-relay
+#   - relay listens on 127.0.0.1:4000 (nginx in front handles TLS)
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 <version>" >&2
+  echo "  example: $0 0.12.0" >&2
+  exit 2
+fi
+
+UNIT=/etc/systemd/system/kraki-relay.service
+ENV_FILE=/etc/kraki/relay.env
+DB=/var/lib/kraki/kraki-relay.db
+BACKUP_ROOT=/root/kraki-backups
+RELAY_BIN=/usr/local/bin/kraki-relay
+HEALTH_URL=http://127.0.0.1:4000/
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "must be run as root" >&2
+  exit 2
+fi
+
+for tool in sqlite3 npm systemctl curl; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "missing required tool: $tool" >&2
+    exit 2
+  fi
+done
+
+current_version() {
+  if [ -x "$RELAY_BIN" ]; then
+    "$RELAY_BIN" --version 2>/dev/null | tr -d '[:space:]' || true
+  fi
+}
+
+CURRENT_VERSION="$(current_version || true)"
+echo "current installed version: ${CURRENT_VERSION:-unknown}"
+echo "target version:           $VERSION"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+SNAP="$BACKUP_ROOT/pre-$VERSION-$TS"
+mkdir -p "$SNAP"
+chmod 700 "$SNAP"
+
+echo "==> snapshotting to $SNAP"
+
+# WAL-safe DB backup. .backup leaves the live DB untouched.
+sqlite3 "$DB" ".backup '$SNAP/kraki-relay.db'"
+
+# Sanity-check the backup is openable.
+sqlite3 "$SNAP/kraki-relay.db" "PRAGMA integrity_check;" >"$SNAP/integrity_check.txt"
+if ! grep -q '^ok$' "$SNAP/integrity_check.txt"; then
+  echo "DB backup integrity check failed — aborting" >&2
+  cat "$SNAP/integrity_check.txt" >&2
+  exit 1
+fi
+
+# Copy env and unit file. Capture install metadata.
+cp -p "$ENV_FILE" "$SNAP/relay.env" 2>/dev/null || echo "WARN: $ENV_FILE missing"
+cp -p "$UNIT" "$SNAP/kraki-relay.service"
+{ echo "previous_version=${CURRENT_VERSION:-unknown}"; \
+  echo "target_version=$VERSION"; \
+  echo "timestamp=$TS"; \
+  echo "host=$(hostname)"; } >"$SNAP/manifest"
+
+echo "snapshot ready: $SNAP"
+
+# Best-effort retention sweep for full pre-deploy snapshots (keep 30 days).
+find "$BACKUP_ROOT" -maxdepth 1 -type d -name 'pre-*' -mtime +30 -exec rm -rf {} \; 2>/dev/null || true
+
+# ---- install ----
+
+echo "==> npm install -g @kraki/head@$VERSION"
+npm install -g "@kraki/head@$VERSION"
+
+INSTALLED_VERSION="$(current_version || true)"
+if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
+  echo "ERROR: kraki-relay --version reports '$INSTALLED_VERSION', expected '$VERSION'" >&2
+  echo "       (snapshot kept at $SNAP)" >&2
+  exit 1
+fi
+echo "installed binary reports version $INSTALLED_VERSION"
+
+# ---- restart ----
+
+rollback() {
+  local reason="$1"
+  echo "==> ROLLBACK ($reason)"
+  if [ -n "${CURRENT_VERSION:-}" ] && [ "$CURRENT_VERSION" != "$VERSION" ]; then
+    npm install -g "@kraki/head@$CURRENT_VERSION" || true
+  fi
+  cp -p "$SNAP/kraki-relay.service" "$UNIT"
+  if [ -f "$SNAP/relay.env" ]; then
+    cp -p "$SNAP/relay.env" "$ENV_FILE"
+    chmod 600 "$ENV_FILE"
+  fi
+  systemctl daemon-reload
+  systemctl restart kraki-relay || true
+  sleep 2
+  systemctl status kraki-relay --no-pager -n 10 || true
+  echo "rolled back. snapshot: $SNAP" >&2
+  exit 1
+}
+
+echo "==> systemctl restart kraki-relay"
+if ! systemctl restart kraki-relay; then
+  rollback "systemctl restart failed"
+fi
+
+sleep 3
+
+if ! systemctl is-active --quiet kraki-relay; then
+  systemctl status kraki-relay --no-pager -n 20 || true
+  rollback "service not active after restart"
+fi
+
+# Health check via local HTTP. New head reports {"name":"@kraki/head","version":"X","status":"ok"}.
+HEALTH_BODY=""
+for attempt in 1 2 3 4 5; do
+  if HEALTH_BODY="$(curl -sf --max-time 3 "$HEALTH_URL" 2>/dev/null)"; then
+    break
+  fi
+  sleep 1
+done
+
+if [ -z "$HEALTH_BODY" ]; then
+  rollback "health endpoint $HEALTH_URL not responding"
+fi
+
+if ! echo "$HEALTH_BODY" | grep -q "\"version\":\"$VERSION\""; then
+  echo "health endpoint reports unexpected body:" >&2
+  echo "  $HEALTH_BODY" >&2
+  rollback "health body does not advertise version $VERSION"
+fi
+
+echo
+echo "deploy OK: kraki-relay $VERSION running, /127.0.0.1:4000/ healthy"
+echo "snapshot: $SNAP"
+echo
+echo "manual rollback (within 30 days of snapshot):"
+echo "  npm install -g @kraki/head@${CURRENT_VERSION:-<prev>}"
+echo "  cp $SNAP/kraki-relay.service $UNIT"
+echo "  cp $SNAP/relay.env $ENV_FILE && chmod 600 $ENV_FILE"
+echo "  systemctl daemon-reload && systemctl restart kraki-relay"


### PR DESCRIPTION
Adds operational scripts for safe self-hosted relay maintenance, plus a SELF-HOSTING.md section that documents them. No code changes — pure additions, not part of the published packages.

## What's here

- `scripts/deploy-edge-relay.sh <version>`: snapshots live DB (WAL-safe `sqlite3 .backup`) + env + systemd unit, runs `npm install -g @kraki/head@<version>`, restarts the service, hits `http://127.0.0.1:4000/` to confirm the new version is serving, and **auto-rolls-back** on any failure (reinstall previous version, restore env and unit, daemon-reload, restart).
- `scripts/backup-relay-db.sh`: WAL-safe `sqlite3 .backup` of the relay DB, `PRAGMA integrity_check` before promotion, 14-day retention. Suitable for `/etc/cron.daily/`.
- `SELF-HOSTING.md`: new "Updating a running relay" section covering the canonical `EnvironmentFile=/etc/kraki/relay.env` layout, both scripts, and journald caps. Calls out the `npm install` wipes-package-contents footgun explicitly.

## Why

Previous updates of the China edge relay were manual, undocumented, and footgun-laden — `npm install -g @kraki/head@X` overwrites the package directory contents, so keeping the runtime `.env` inside the package install dir means it gets deleted on every upgrade. The scripts and docs codify a safer flow.

## Risk

None on the published packages — these are repo-only additions and don't ship in any tarball. CI is unaffected.