### PR TITLE
fix(head): keep connection alive on delivery-retry exhaustion (0.12.1)

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",

--- a/packages/head/src/__tests__/delivery.test.ts
+++ b/packages/head/src/__tests__/delivery.test.ts
@@ -287,7 +287,7 @@ describe('Delivery assurance — retry behavior', () => {
     expect(env.server.getDeliveryState(app.deviceId)!.ackSupported).toBe(false);
   }, 15000);
 
-  it('closes connection after MAX_RETRIES exceeded', async () => {
+  it('marks entries giveUp after MAX_RETRIES but keeps the connection alive', async () => {
     const tentacle = await connectDevice(env.port, 'Laptop', 'tentacle');
     const app = await connectDevice(env.port, 'Phone', 'app');
 
@@ -295,25 +295,87 @@ describe('Delivery assurance — retry behavior', () => {
     app.send({ type: 'ping', ack: 0 });
     await new Promise(r => setTimeout(r, 30));
 
-    tentacle.send({ type: 'broadcast', blob: 'doomed', keys: { [app.deviceId]: 'k' } });
+    tentacle.send({ type: 'broadcast', blob: 'stuck', keys: { [app.deviceId]: 'k' } });
     await app.waitFor('broadcast', 2000);
 
-    // Track when the connection closes.
+    // Connection should NEVER close from retry exhaustion.
     let closed = false;
     app.ws.on('close', () => { closed = true; });
 
-    // Wait past RETRY_AFTER_MS, then force 4 retry passes (3 retries + 1 to trigger close).
+    // 4 retry passes with intervals > RETRY_AFTER_MS — retries=1, 2, 3, then giveUp.
     for (let i = 0; i < 4; i++) {
       await new Promise(r => setTimeout(r, 5100));
       env.server.forceRetryPass();
-      if (closed) break;
     }
 
-    await new Promise(r => setTimeout(r, 200));
-    expect(closed).toBe(true);
-    // Connection removed from head's map.
-    expect(env.server.getDeliveryState(app.deviceId)).toBeUndefined();
+    // Connection still up.
+    expect(closed).toBe(false);
+    const state = env.server.getDeliveryState(app.deviceId);
+    expect(state).toBeDefined();
+    expect(state!.inFlightCount).toBe(1);
+    expect(state!.givenUpCount).toBe(1);
+
+    // Future retry passes are no-ops for given-up entries — no further sends.
+    const sendsBefore = app.messages.filter(m => m.type === 'broadcast').length;
+    await new Promise(r => setTimeout(r, 5100));
+    env.server.forceRetryPass();
+    await new Promise(r => setTimeout(r, 50));
+    const sendsAfter = app.messages.filter(m => m.type === 'broadcast').length;
+    expect(sendsAfter).toBe(sendsBefore);
   }, 30000);
+
+  it('peer ack after give-up still prunes the buffer cleanly', async () => {
+    const tentacle = await connectDevice(env.port, 'Laptop', 'tentacle');
+    const app = await connectDevice(env.port, 'Phone', 'app');
+    app.send({ type: 'ping', ack: 0 });
+    await new Promise(r => setTimeout(r, 30));
+
+    tentacle.send({ type: 'broadcast', blob: 'stuck', keys: { [app.deviceId]: 'k' } });
+    await app.waitFor('broadcast', 2000);
+    const stuckSeq = env.server.getDeliveryState(app.deviceId)!.relaySeqCounter;
+
+    // Exhaust retries → give up.
+    for (let i = 0; i < 4; i++) {
+      await new Promise(r => setTimeout(r, 5100));
+      env.server.forceRetryPass();
+    }
+    expect(env.server.getDeliveryState(app.deviceId)!.givenUpCount).toBe(1);
+
+    // Peer eventually pings with cumulative ack covering the given-up entry.
+    app.send({ type: 'ping', ack: stuckSeq });
+    await new Promise(r => setTimeout(r, 50));
+
+    const state = env.server.getDeliveryState(app.deviceId)!;
+    expect(state.inFlightCount).toBe(0);
+    expect(state.givenUpCount).toBe(0);
+    expect(state.lastAckedSeq).toBe(stuckSeq);
+  }, 30000);
+
+  it('buffer-full evicts oldest entry silently, does not kill connection', async () => {
+    const tentacle = await connectDevice(env.port, 'Laptop', 'tentacle');
+    const app = await connectDevice(env.port, 'Phone', 'app');
+    app.send({ type: 'ping', ack: 0 });
+    await new Promise(r => setTimeout(r, 30));
+
+    let closed = false;
+    app.ws.on('close', () => { closed = true; });
+
+    // MAX_IN_FLIGHT = 200. Send 205 broadcasts without acking — the first
+    // few entries should silently evict to make room.
+    for (let i = 0; i < 205; i++) {
+      tentacle.send({ type: 'broadcast', blob: `m${i}`, keys: { [app.deviceId]: 'k' } });
+    }
+    // Drain just enough to let head finish forwarding.
+    await new Promise(r => setTimeout(r, 500));
+
+    expect(closed).toBe(false);
+    const state = env.server.getDeliveryState(app.deviceId);
+    expect(state).toBeDefined();
+    // Buffer is capped at 200 even though 205 were sent.
+    expect(state!.inFlightCount).toBeLessThanOrEqual(200);
+    // The counter shows 205 — head stamped all of them.
+    expect(state!.relaySeqCounter).toBeGreaterThanOrEqual(205);
+  }, 15000);
 });
 
 describe('Delivery assurance — head dedup', () => {

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -32,6 +32,12 @@ interface InFlightEntry {
   /** Date.now() when first sent. Updated on each retry. */
   sentAt: number;
   retries: number;
+  /** True once retries are exhausted. Head stops re-sending this entry but
+   *  keeps it in the buffer; a future ack will still prune it cleanly. The
+   *  message bytes may or may not have reached the peer — recovery is
+   *  delegated to application-level per-session replay if the content is
+   *  actually missing. */
+  giveUp?: boolean;
 }
 
 interface ClientState {
@@ -227,19 +233,16 @@ export class HeadServer {
     }
     const payload = JSON.stringify(stamped);
 
-    // Evict oldest if buffer full. With MAX_RETRIES=3 and 5s retry, hitting
-    // MAX_IN_FLIGHT means the peer is pathologically slow — force reconnect.
+    // Buffer full: evict the oldest entry silently and continue.
+    // Connection is NOT killed — peer may simply be temporarily throttled
+    // (e.g. backgrounded browser tab). The 30s protocol-level ping/pong is
+    // the source of truth for liveness, not delivery exhaustion.
     if (state.inFlight.length >= MAX_IN_FLIGHT) {
-      getLogger().warn('In-flight buffer full, forcing reconnect', {
+      getLogger().warn('In-flight buffer full, evicting oldest entry', {
         deviceId: state.deviceId,
         inFlight: state.inFlight.length,
       });
-      if (state.deviceId) {
-        this.removeConnection(state.deviceId);
-      } else {
-        try { ws.close(); } catch { /* ignore */ }
-      }
-      return;
+      state.inFlight.shift();
     }
 
     state.inFlight.push({
@@ -311,8 +314,9 @@ export class HeadServer {
   }
 
   /** Walk all connections; re-send unacked messages that have aged past
-   *  RETRY_AFTER_MS. Close connections whose oldest unacked message has
-   *  exceeded MAX_RETRIES (forces clean reconnect via existing replay path). */
+   *  RETRY_AFTER_MS. When MAX_RETRIES is exceeded, mark the entry giveUp
+   *  but keep the connection alive — liveness is decided by the 30s
+   *  protocol-level ping/pong, not by delivery-retry exhaustion. */
   private runRetryPass(): void {
     const logger = getLogger();
     const now = Date.now();
@@ -325,22 +329,28 @@ export class HeadServer {
       if (ws.readyState !== WebSocket.OPEN) continue;
 
       state.lastRetryAt = now;
-      let killConnection = false;
+      let sendFailed = false;
 
       for (const entry of state.inFlight) {
+        if (entry.giveUp) continue;
         // Already acked? (Shouldn't normally happen — processAck prunes —
         // but guard against races.)
         if (entry.relaySeq <= state.lastAckedSeq) continue;
         if (now - entry.sentAt < RETRY_AFTER_MS) continue;
 
         if (entry.retries >= MAX_RETRIES) {
-          logger.warn('Max retries exceeded, closing connection', {
+          // Give up retrying this entry. Don't kill the connection — the
+          // peer may just be temporarily throttled (e.g. backgrounded
+          // browser tab). If the peer later catches up and acks, this
+          // entry is pruned normally. If the bytes were truly lost, the
+          // application layer's per-session replay handles content recovery.
+          logger.debug('Giving up retries for entry', {
             deviceId,
             relaySeq: entry.relaySeq,
             retries: entry.retries,
           });
-          killConnection = true;
-          break;
+          entry.giveUp = true;
+          continue;
         }
 
         entry.retries += 1;
@@ -353,12 +363,15 @@ export class HeadServer {
             attempt: entry.retries,
           });
         } catch {
-          killConnection = true;
+          // ws.send threw — the underlying socket is dead. Close it so the
+          // close handler can clean up. This is a transport failure, not a
+          // delivery-retry failure.
+          sendFailed = true;
           break;
         }
       }
 
-      if (killConnection) {
+      if (sendFailed) {
         this.removeConnection(deviceId);
       }
     }
@@ -1460,6 +1473,7 @@ export class HeadServer {
   /** Test hook: inspect delivery state for an online device. Not used in prod. */
   getDeliveryState(deviceId: string): {
     inFlightCount: number;
+    givenUpCount: number;
     relaySeqCounter: number;
     lastAckedSeq: number;
     ackSupported: boolean;
@@ -1471,6 +1485,7 @@ export class HeadServer {
     if (!state) return undefined;
     return {
       inFlightCount: state.inFlight.length,
+      givenUpCount: state.inFlight.filter(e => e.giveUp).length,
       relaySeqCounter: state.relaySeqCounter,
       lastAckedSeq: state.lastAckedSeq,
       ackSupported: state.ackSupported,

--- a/packages/tests/src/delivery.e2e.test.ts
+++ b/packages/tests/src/delivery.e2e.test.ts
@@ -467,16 +467,20 @@ describe('E2E delivery assurance', () => {
     expect((userMsg!.payload as { content: string }).content).toBe('I approve');
   });
 
-  it('drops connection after MAX_RETRIES and tentacle stops seeing the app online', async () => {
+  it('throttled-but-alive peer stays connected through retry exhaustion (no flapping)', async () => {
+    // This is the regression test for the v0.12.0 bug where a backgrounded
+    // browser tab would get its connection killed every ~30s. The peer is
+    // ALIVE (TCP fine, would auto-pong if pinged) but its application-level
+    // acks are deferred. Head must not kill the connection on retry-exhaustion.
     const tentacle = await connectTentaclePeer(env.port);
     const app = await connectAppPeer(env.port);
     await waitMs(50);
-    // Make head consider app ack-capable, but then start dropping everything.
     app.sendPing();
     await waitMs(30);
     expect(env.head.getDeliveryState(app.deviceId)!.ackSupported).toBe(true);
 
-    // App will drop everything from now on.
+    // App simulates throttled JS: receives messages at the wire level but
+    // can't ack (acks are dropped on the app side here).
     app.dropNext(1000);
 
     let appClosed = false;
@@ -488,23 +492,69 @@ describe('E2E delivery assurance', () => {
       deviceId: tentacle.deviceId,
       seq: 1,
       timestamp: new Date().toISOString(),
-      payload: { content: 'doomed' },
+      payload: { content: 'eventually-acked' },
     });
 
-    // 4 retry passes spaced past RETRY_AFTER_MS.
+    // Burn through the retry budget.
     for (let i = 0; i < 4; i++) {
       await waitMs(5100);
       env.head.forceRetryPass();
-      if (appClosed) break;
     }
-    await waitMs(200);
 
-    expect(appClosed).toBe(true);
-    expect(env.head.getDeliveryState(app.deviceId)).toBeUndefined();
+    // Crucial: connection is NOT closed. App remains online from head's POV.
+    expect(appClosed).toBe(false);
+    const state = env.head.getDeliveryState(app.deviceId);
+    expect(state).toBeDefined();
+    expect(state!.givenUpCount).toBeGreaterThanOrEqual(1);
 
-    // Tentacle should have been notified that the app left.
-    const left = tentacle.rawMessages.find(m => m.type === 'device_left');
-    expect(left).toBeDefined();
+    // Tentacle did NOT receive a spurious device_left.
+    const left = tentacle.rawMessages.find(m => m.type === 'device_left' && (m as { deviceId?: string }).deviceId === app.deviceId);
+    expect(left).toBeUndefined();
+  }, 30000);
+
+  it('peer that catches up after give-up gets its buffer pruned correctly', async () => {
+    // Models: tab was backgrounded, head gave up retrying. Tab thaws,
+    // sends a ping with cumulative ack. Head must drain the buffer.
+    const tentacle = await connectTentaclePeer(env.port);
+    const app = await connectAppPeer(env.port);
+    await waitMs(50);
+    app.sendPing();
+    await waitMs(30);
+
+    app.dropNext(1000);
+    tentacle.broadcast({
+      type: 'agent_message',
+      sessionId: 's',
+      deviceId: tentacle.deviceId,
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: { content: 'arrived-eventually' },
+    });
+
+    // Exhaust retries.
+    for (let i = 0; i < 4; i++) {
+      await waitMs(5100);
+      env.head.forceRetryPass();
+    }
+
+    let state = env.head.getDeliveryState(app.deviceId)!;
+    expect(state.givenUpCount).toBeGreaterThanOrEqual(1);
+    const stuckSeq = state.relaySeqCounter;
+
+    // Tab "thaws": app now acks everything cumulatively.
+    app.dropNext(0);
+    // Force the ping to carry the highest relaySeq head has stamped.
+    // The peer's lastReceivedRelaySeq advanced via the dropped frames'
+    // bookkeeping in connectAppPeer — even dropped frames updated the
+    // tracker before being discarded? They didn't: we drop before tracking.
+    // Send a synthetic ping with explicit ack at stuckSeq.
+    app.ws.send(JSON.stringify({ type: 'ping', ack: stuckSeq }));
+    await waitMs(100);
+
+    state = env.head.getDeliveryState(app.deviceId)!;
+    expect(state.inFlightCount).toBe(0);
+    expect(state.givenUpCount).toBe(0);
+    expect(state.lastAckedSeq).toBe(stuckSeq);
   }, 30000);
 
   it('arm→head direction: tentacle never sees duplicates even if arm retries same relaySeq', async () => {


### PR DESCRIPTION
## Problem

In production (PR #103 = `@kraki/head@0.12.0` deployed to `kraki-cn.corelli.cloud`), every connected client was getting its WebSocket killed every ~30 seconds. Affected all 4 of the user's connected devices simultaneously — two tentacles and two web app instances. Pre-existing pending_messages queue ballooned because the loop kept refilling it.

## Root cause

In 0.12.0's retry pass, exceeding `MAX_RETRIES` calls `removeConnection()`, killing the WebSocket. The intent was "force a clean reconnect" — but this conflated two separate concerns:

- **Liveness**: is the peer alive? Answered by 30s protocol-level `ws.ping()` / pong. Browsers auto-pong even when JS is throttled.
- **Delivery**: did this specific application-level message get acked? Answered by `relaySeq` / `ack` piggyback.

Browsers and mobile OSes aggressively throttle JS timers in backgrounded tabs (often to ≥60s `setInterval` cadence). A throttled-but-alive peer still receives messages at the OS level but can't fire its 10s ack ping. Head's retry pass burns through 3 retries in 20s, finds none acked, kills the connection. Tab thaws moments later, reconnects, gets a burst of pending messages, can't ack fast enough, dies again. Indefinite flapping.

## Fix

Decouple liveness from delivery in `runRetryPass`:

- On retry exhaustion: mark the entry `giveUp = true` instead of killing the connection. Leave it in the buffer; a future ack still prunes it cleanly.
- On in-flight buffer full: evict the oldest entry silently instead of killing the connection.
- Connection death now decided exclusively by the existing 30s ping/pong path. Backgrounded tabs stay connected because the OS-level WebSocket layer pongs autonomously.

If the bytes were truly lost (not just delayed), the application layer's per-session replay handles content recovery — this was already the design contract. The relay layer is best-effort.

## Behavior matrix

| Network condition | 0.12.0 | 0.12.1 |
|---|---|---|
| Healthy connection | Works | Works (no change) |
| Single dropped frame | Auto-recovered ✓ | Auto-recovered ✓ |
| Backgrounded tab >30s | **Killed, reconnect, repeat** | Stays connected, drains on thaw |
| Cross-border slow ack | **Killed every ~30s** | Stays connected |
| Truly dead WebSocket (OS-killed) | Killed in 20s | Killed in ~30s (liveness path) |

## Code change

Minimal — two behavioral edits + a `giveUp?: boolean` field on `InFlightEntry`:

```diff
- killConnection = true; break;
+ entry.giveUp = true; continue;
```

```diff
- if (state.deviceId) this.removeConnection(state.deviceId);
+ state.inFlight.shift();  // evict oldest silently
```

Plus a `giveUp` skip in the retry-pass loop body, and `givenUpCount` in the test inspector.

No protocol change. No schema change. Patch bump only.

## Tests

- Updated `delivery.test.ts`: 2 new tests (`marks entries giveUp ... keeps the connection alive`, `peer ack after give-up still prunes the buffer cleanly`, `buffer-full evicts oldest entry silently`). 200/200 head tests pass.
- Updated `delivery.e2e.test.ts`: replaced the "drops connection after MAX_RETRIES" test with a regression test for the throttled-but-alive scenario, plus a second test for the give-up-then-ack pruning path. 9/9 E2E delivery tests pass.

## Deploy plan

After merge:
1. Tag `head-v0.12.1`
2. `release.yml` publishes `@kraki/head@0.12.1` to npm
3. SSH to `kraki-cn.corelli.cloud` and run `scripts/deploy-edge-relay.sh 0.12.1`

Rollback: `npm install -g @kraki/head@0.11.2` (skip 0.12.0 — it's the broken one).

Closes the regression introduced in #103.
