### PR TITLE
feat(protocol): lazy tool args + result via ContentRef + headline

### DIFF
--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/arm-web",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Kraki web receiver \u2014 view and control your agents from any browser",
   "type": "module",
   "scripts": {

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -20,7 +20,7 @@ function collectTurnImages(thinkingMessages: ChatMessage[]): Attachment[] {
   for (const m of thinkingMessages) {
     if (m.type === 'tool_complete' && Array.isArray(m.payload?.attachments)) {
       for (const att of m.payload.attachments) {
-        if (att.type === 'image' || att.type === 'image_ref') {
+        if (att.type === 'image' || att.type === 'content_ref') {
           images.push(att as Attachment);
         }
       }

--- a/packages/arm/web/src/components/chat/MessageBubble.test.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.test.tsx
@@ -77,17 +77,18 @@ describe('MessageBubble', () => {
   });
 
   describe('tool_start', () => {
-    it('renders tool start with name', () => {
-      renderMsg(makeMsg('tool_start', { toolName: 'shell', args: { command: 'ls' } }));
+    it('renders tool start with name and headline', () => {
+      renderMsg(makeMsg('tool_start', { toolName: 'shell', headline: '$ ls' }));
       expect(screen.getByText('shell')).toBeInTheDocument();
-      expect(screen.getByText(/shell/)).toBeInTheDocument();
+      expect(screen.getByText('$ ls')).toBeInTheDocument();
     });
   });
 
   describe('tool_complete', () => {
-    it('renders tool complete with name', () => {
-      renderMsg(makeMsg('tool_complete', { toolName: 'read_file', args: { path: 'a.ts' }, result: 'content' }));
+    it('renders tool complete with name and headline', () => {
+      renderMsg(makeMsg('tool_complete', { toolName: 'read_file', headline: 'a.ts' }));
       expect(screen.getByText('read_file')).toBeInTheDocument();
+      expect(screen.getByText('a.ts')).toBeInTheDocument();
     });
   });
 

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -14,6 +14,15 @@ import { useAttachment } from '../../hooks/useAttachment';
 const ID_DISPLAY_LENGTH = 8;
 const IMAGE_PLACEHOLDER = '[image]';
 
+/** Shared pull thunk for any ContentRef rendered inside a message bubble —
+ *  args/result on tool calls, images, etc. We lazy-import ws-client to
+ *  break the cycle (MessageBubble is re-exported through several layers). */
+const ATTACHMENT_PULL = (sid: string, id: string): void => {
+  void import('../../lib/ws-client').then(({ wsClient }) => {
+    wsClient.requestAttachment(sid, id);
+  });
+};
+
 const markdownComponents = {
   a: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a href={href} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
@@ -97,7 +106,16 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
       );
 
     case 'tool_start':
-      return <ToolActivity type="start" toolName={message.payload.toolName} args={message.payload.args as Record<string, unknown>} cancelled={cancelled} forceExpanded={forceExpanded} />;
+      return <ToolActivity
+        type="start"
+        toolName={message.payload.toolName}
+        headline={(message.payload as { headline?: string }).headline ?? ''}
+        argsRef={(message.payload as { argsRef?: import('@kraki/protocol').ContentRef }).argsRef}
+        sessionId={sessionId ?? ''}
+        requestPull={ATTACHMENT_PULL}
+        cancelled={cancelled}
+        forceExpanded={forceExpanded}
+      />;
 
     case 'tool_complete':
       return (
@@ -105,8 +123,11 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
           <ToolActivity
             type="complete"
             toolName={message.payload.toolName}
-            args={message.payload.args as Record<string, unknown>}
-            result={message.payload.result}
+            headline={(message.payload as { headline?: string }).headline ?? ''}
+            argsRef={(message.payload as { argsRef?: import('@kraki/protocol').ContentRef }).argsRef}
+            resultRef={(message.payload as { resultRef?: import('@kraki/protocol').ContentRef }).resultRef}
+            sessionId={sessionId ?? ''}
+            requestPull={ATTACHMENT_PULL}
             success={message.payload.success}
             forceExpanded={forceExpanded}
           />
@@ -356,8 +377,8 @@ function CopyableBubble({ text, children }: { text: string; children: React.Reac
 function ImageAttachments({ attachments, sessionId }: { attachments?: Attachment[]; sessionId?: string }) {
   const [expanded, setExpanded] = useState<string | null>(null);
   const images = attachments?.filter(
-    (a): a is (Attachment & { type: 'image' }) | (Attachment & { type: 'image_ref' }) =>
-      a.type === 'image' || a.type === 'image_ref',
+    (a): a is (Attachment & { type: 'image' }) | (Attachment & { type: 'content_ref' }) =>
+      a.type === 'image' || a.type === 'content_ref',
   );
   if (!images?.length) return null;
 
@@ -404,7 +425,7 @@ function AttachmentTile({
   sessionId,
   onExpand,
 }: {
-  attachment: Attachment & ({ type: 'image' } | { type: 'image_ref' });
+  attachment: Attachment & ({ type: 'image' } | { type: 'content_ref' });
   sessionId?: string;
   onExpand: (url: string) => void;
 }) {
@@ -431,7 +452,7 @@ function AttachmentTile({
     );
   }
 
-  // type === 'image_ref'
+  // type === 'content_ref'
   if (!sessionId) {
     // No sessionId in scope means we can't fetch — render placeholder only
     return <RefImagePlaceholder ref_={attachment} />;
@@ -439,7 +460,7 @@ function AttachmentTile({
   return <RefImageTile ref_={attachment} sessionId={sessionId} onExpand={onExpand} />;
 }
 
-function RefImagePlaceholder({ ref_ }: { ref_: Attachment & { type: 'image_ref' } }) {
+function RefImagePlaceholder({ ref_ }: { ref_: Attachment & { type: 'content_ref' } }) {
   return (
     <figure className="m-0 flex flex-col items-start gap-1">
       <div
@@ -462,18 +483,11 @@ function RefImageTile({
   sessionId,
   onExpand,
 }: {
-  ref_: Attachment & { type: 'image_ref' };
+  ref_: Attachment & { type: 'content_ref' };
   sessionId: string;
   onExpand: (url: string) => void;
 }) {
-  // Lazy import wsClient to avoid a cycle with MessageBubble (which is
-  // re-exported through several layers).
-  const requestPull = (sid: string, id: string): void => {
-    void import('../../lib/ws-client').then(({ wsClient }) => {
-      wsClient.requestAttachment(sid, id);
-    });
-  };
-  const { status, url, error } = useAttachment(ref_, sessionId, requestPull);
+  const { status, url, error } = useAttachment(ref_, sessionId, ATTACHMENT_PULL);
 
   const placeholderStyle: React.CSSProperties = {
     width: ref_.width ? Math.min(ref_.width, 320) : 320,

--- a/packages/arm/web/src/components/chat/ThinkingBox.tsx
+++ b/packages/arm/web/src/components/chat/ThinkingBox.tsx
@@ -175,20 +175,18 @@ function getMessageSummary(msg: ChatMessage): string {
   switch (msg.type) {
     case 'tool_start': {
       const toolName = msg.payload.toolName;
-      const args = msg.payload.args as Record<string, unknown>;
-      const detail = getToolDetail(args);
+      const headline = (msg.payload as { headline?: string }).headline ?? '';
       summary = toolName
-        ? `${toolName}${detail ? ` ${detail}` : ''}`
-        : (detail || 'Running…');
+        ? `${toolName}${headline ? ` ${headline}` : ''}`
+        : (headline || 'Running…');
       break;
     }
     case 'tool_complete': {
       const toolName = msg.payload.toolName;
-      const args = msg.payload.args as Record<string, unknown>;
-      const detail = getToolDetail(args);
+      const headline = (msg.payload as { headline?: string }).headline ?? '';
       summary = toolName
-        ? `${toolName}${detail ? ` ${detail}` : ''}`
-        : (detail || 'Done');
+        ? `${toolName}${headline ? ` ${headline}` : ''}`
+        : (headline || 'Done');
       break;
     }
     case 'agent_message': {
@@ -221,16 +219,8 @@ function getMessageSummary(msg: ChatMessage): string {
     type: msg.type,
     seq: 'seq' in msg ? (msg as { seq?: number }).seq : '?',
     toolName: msg.type === 'tool_start' || msg.type === 'tool_complete' ? msg.payload.toolName : undefined,
-    argKeys: msg.type === 'tool_start' || msg.type === 'tool_complete' ? Object.keys(msg.payload.args as Record<string, unknown> ?? {}) : undefined,
+    headline: msg.type === 'tool_start' || msg.type === 'tool_complete' ? (msg.payload as { headline?: string }).headline : undefined,
     summary: summary.slice(0, 80),
   });
   return summary;
-}
-
-function getToolDetail(args: Record<string, unknown>): string {
-  if (typeof args.command === 'string') return `$ ${args.command}`;
-  if (typeof args.path === 'string') return args.path;
-  if (typeof args.pattern === 'string') return args.pattern;
-  if (typeof args.url === 'string') return args.url;
-  return '';
 }

--- a/packages/arm/web/src/components/chat/ToolActivity.tsx
+++ b/packages/arm/web/src/components/chat/ToolActivity.tsx
@@ -1,31 +1,40 @@
 import { useState, lazy, Suspense } from 'react';
 import { Loader2, CheckCircle2, XCircle, CircleSlash, FileText, FileEdit, Terminal, Search, FolderSearch } from 'lucide-react';
+import type { ContentRef } from '@kraki/protocol';
+
+import { useAttachmentText } from '../../hooks/useAttachment';
 
 const ReactDiffViewer = lazy(() => import('react-diff-viewer-continued'));
 
 interface ToolActivityProps {
   type: 'start' | 'complete';
   toolName: string;
-  args: Record<string, unknown> | object;
-  result?: string;
+  /** Short user-facing preview composed by the tentacle. Always shown on
+   *  the chip header. Replaced by full args text in the expand body once
+   *  the argsRef resolves. */
+  headline: string;
+  /** Lazy ref to the full args JSON. */
+  argsRef?: ContentRef;
+  /** Lazy ref to the full result body (complete events only). */
+  resultRef?: ContentRef;
+  sessionId: string;
+  /** Fired with a sessionId/id when the cache misses and we need to pull. */
+  requestPull: (sessionId: string, id: string) => void;
   success?: boolean;
   cancelled?: boolean;
   forceExpanded?: boolean;
 }
 
-export function ToolActivity({ type, toolName, args, result, success, cancelled, forceExpanded }: ToolActivityProps) {
+export function ToolActivity({
+  type, toolName, headline, argsRef, resultRef,
+  sessionId, requestPull,
+  success, cancelled, forceExpanded,
+}: ToolActivityProps) {
   const [expanded, setExpanded] = useState(false);
   const isExpanded = forceExpanded ?? expanded;
   const isStart = type === 'start';
 
-  const summary = getToolSummary(toolName, args as Record<string, unknown>);
-  const resultPreview = result ? getResultPreview(result) : '';
   const ToolIcon = getToolIcon(toolName);
-  const detailLabel = getDetailLabel(toolName);
-  const argsDetail = getArgsDetail(toolName, args as Record<string, unknown>);
-
-  const editDiff = getEditDiff(toolName, args as Record<string, unknown>);
-  const isDark = typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
 
   return (
     <div className="my-1">
@@ -41,15 +50,13 @@ export function ToolActivity({ type, toolName, args, result, success, cancelled,
             ? <XCircle className="h-3.5 w-3.5 shrink-0 text-red-500" />
             : <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-500" />)
         }
+        <ToolIcon className="h-3.5 w-3.5 shrink-0 text-text-muted opacity-0" aria-hidden="true" />
         <span className="shrink-0 text-xs font-medium text-text-secondary">
           {isStart && 'Running '}
           <span className="font-mono text-ocean-600 dark:text-ocean-400">{toolName}</span>
         </span>
-        {summary && (
-          <span className="truncate font-mono text-[11px] text-text-muted">{summary}</span>
-        )}
-        {!isStart && resultPreview && !summary && (
-          <span className="truncate text-[11px] text-text-muted">{resultPreview}</span>
+        {headline && (
+          <span className="truncate font-mono text-[11px] text-text-muted">{headline}</span>
         )}
         <svg
           className={`h-3 w-3 shrink-0 text-text-muted transition-transform ${
@@ -66,55 +73,157 @@ export function ToolActivity({ type, toolName, args, result, success, cancelled,
 
       {isExpanded && (
         <div className="mt-1 space-y-2 rounded-lg bg-surface-tertiary p-3 text-xs">
-          {summary && (
+          {argsRef && (
+            <ToolArgsBody
+              toolName={toolName}
+              argsRef={argsRef}
+              sessionId={sessionId}
+              requestPull={requestPull}
+              headline={headline}
+            />
+          )}
+          {!argsRef && headline && (
             <div>
-              <p className="font-semibold text-text-muted">{detailLabel}</p>
-              <pre className="mt-1 overflow-x-auto font-mono text-text-secondary">
-                {summary}
+              <p className="font-semibold text-text-muted">{getDetailLabel(toolName)}</p>
+              <pre className="mt-1 overflow-x-auto font-mono text-text-secondary whitespace-pre-wrap">
+                {headline}
               </pre>
             </div>
           )}
-          {argsDetail && !editDiff && (
-            <div>
-              <p className="font-semibold text-text-muted">{argsDetail.label}</p>
-              <pre className="mt-1 max-h-40 overflow-auto text-text-secondary whitespace-pre-wrap font-mono">
-                {argsDetail.content}
-              </pre>
-            </div>
-          )}
-          {editDiff && (
-            <div className="overflow-hidden rounded text-[11px]">
-              <Suspense fallback={<pre className="p-2 text-text-muted">Loading diff…</pre>}>
-                <ReactDiffViewer
-                  oldValue={editDiff.oldStr}
-                  newValue={editDiff.newStr}
-                  splitView={false}
-                  hideLineNumbers={false}
-                  useDarkTheme={isDark}
-                  styles={{
-                    contentText: { fontSize: '11px', lineHeight: '1.5' },
-                  }}
-                />
-              </Suspense>
-            </div>
-          )}
-          {!summary && !argsDetail && Object.keys(args).length > 0 && (
-            <div>
-              <p className="font-semibold text-text-muted">Arguments</p>
-              <pre className="mt-1 overflow-x-auto text-text-secondary">
-                {JSON.stringify(args, null, 2)}
-              </pre>
-            </div>
-          )}
-          {result && (
-            <div>
-              <p className="font-semibold text-text-muted">Result</p>
-              <pre className="mt-1 max-h-60 overflow-auto text-text-secondary whitespace-pre-wrap">
-                {result}
-              </pre>
-            </div>
+          {resultRef && (
+            <ToolResultBody
+              resultRef={resultRef}
+              sessionId={sessionId}
+              requestPull={requestPull}
+            />
           )}
         </div>
+      )}
+    </div>
+  );
+}
+
+/** Lazy body for the args section. Shows a placeholder while fetching,
+ *  then renders the full args. Special-cases edit/create file dumps to
+ *  show a diff/preview instead of raw JSON. */
+function ToolArgsBody({
+  toolName, argsRef, sessionId, requestPull, headline,
+}: {
+  toolName: string;
+  argsRef: ContentRef;
+  sessionId: string;
+  requestPull: (sessionId: string, id: string) => void;
+  headline: string;
+}) {
+  const { status, text, error } = useAttachmentText(argsRef, sessionId, requestPull, true);
+
+  if (status === 'loading') {
+    return (
+      <div>
+        <p className="font-semibold text-text-muted">{getDetailLabel(toolName)}</p>
+        <pre className="mt-1 overflow-x-auto font-mono text-text-secondary whitespace-pre-wrap">
+          {headline}
+        </pre>
+        <p className="mt-1 flex items-center gap-1.5 text-[10px] text-text-muted">
+          <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border border-text-muted/40 border-t-text-muted/90" />
+          Loading full arguments…
+        </p>
+      </div>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <div>
+        <p className="font-semibold text-red-500">Arguments unavailable</p>
+        <p className="mt-1 text-[10px] text-text-muted">{error}</p>
+      </div>
+    );
+  }
+  // ready
+  let args: Record<string, unknown> = {};
+  try {
+    args = JSON.parse(text ?? '{}') as Record<string, unknown>;
+  } catch {
+    return (
+      <div>
+        <p className="font-semibold text-text-muted">Arguments</p>
+        <pre className="mt-1 max-h-60 overflow-auto text-text-secondary whitespace-pre-wrap font-mono">
+          {text}
+        </pre>
+      </div>
+    );
+  }
+  return <ToolArgsRendered toolName={toolName} args={args} />;
+}
+
+function ToolArgsRendered({ toolName, args }: { toolName: string; args: Record<string, unknown> }) {
+  const isDark = typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
+  const editDiff = getEditDiff(toolName, args);
+  const argsDetail = getArgsDetail(toolName, args);
+
+  if (editDiff) {
+    return (
+      <div className="overflow-hidden rounded text-[11px]">
+        <Suspense fallback={<pre className="p-2 text-text-muted">Loading diff…</pre>}>
+          <ReactDiffViewer
+            oldValue={editDiff.oldStr}
+            newValue={editDiff.newStr}
+            splitView={false}
+            hideLineNumbers={false}
+            useDarkTheme={isDark}
+            styles={{
+              contentText: { fontSize: '11px', lineHeight: '1.5' },
+            }}
+          />
+        </Suspense>
+      </div>
+    );
+  }
+  if (argsDetail) {
+    return (
+      <div>
+        <p className="font-semibold text-text-muted">{argsDetail.label}</p>
+        <pre className="mt-1 max-h-60 overflow-auto text-text-secondary whitespace-pre-wrap font-mono">
+          {argsDetail.content}
+        </pre>
+      </div>
+    );
+  }
+  // Fallback: pretty JSON.
+  return (
+    <div>
+      <p className="font-semibold text-text-muted">Arguments</p>
+      <pre className="mt-1 max-h-60 overflow-auto text-text-secondary whitespace-pre-wrap font-mono">
+        {JSON.stringify(args, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+function ToolResultBody({
+  resultRef, sessionId, requestPull,
+}: {
+  resultRef: ContentRef;
+  sessionId: string;
+  requestPull: (sessionId: string, id: string) => void;
+}) {
+  const { status, text, error } = useAttachmentText(resultRef, sessionId, requestPull, true);
+  return (
+    <div>
+      <p className="font-semibold text-text-muted">Result</p>
+      {status === 'loading' && (
+        <p className="mt-1 flex items-center gap-1.5 text-[10px] text-text-muted">
+          <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border border-text-muted/40 border-t-text-muted/90" />
+          Loading result…
+        </p>
+      )}
+      {status === 'error' && (
+        <p className="mt-1 text-[10px] text-red-500">Failed to load result: {error}</p>
+      )}
+      {status === 'ready' && (
+        <pre className="mt-1 max-h-60 overflow-auto text-text-secondary whitespace-pre-wrap">
+          {text}
+        </pre>
       )}
     </div>
   );
@@ -210,48 +319,19 @@ function getArgsDetail(toolName: string, args: Record<string, unknown>): { label
       if (path) return { label: 'Directory', content: path };
       return null;
     }
+    case 'shell':
+    case 'bash': {
+      const command = typeof args.command === 'string' ? args.command : undefined;
+      if (command) return { label: 'Command', content: `$ ${command}` };
+      return null;
+    }
+    case 'view':
+    case 'read_file': {
+      const path = typeof args.path === 'string' ? args.path : undefined;
+      if (path) return { label: 'Path', content: path };
+      return null;
+    }
     default:
       return null;
   }
-}
-
-function getToolSummary(toolName: string, args: Record<string, unknown>): string {
-  switch (toolName) {
-    case 'shell':
-    case 'bash':
-      return typeof args.command === 'string' ? `$ ${args.command}` : '';
-    case 'write_file':
-    case 'edit_file':
-    case 'edit':
-    case 'create_file':
-    case 'create':
-      return typeof args.path === 'string' ? args.path : '';
-    case 'read_file':
-    case 'view':
-      return typeof args.path === 'string' ? args.path : '';
-    case 'fetch_url':
-      return typeof args.url === 'string' ? args.url : '';
-    case 'mcp':
-      return typeof args.tool === 'string' ? `${args.server}/${args.tool}` : '';
-    case 'grep':
-    case 'search':
-      return typeof args.pattern === 'string' ? `/${args.pattern}/` : '';
-    case 'glob':
-      return typeof args.pattern === 'string' ? args.pattern : '';
-    default:
-      // Try to show the first string arg as preview
-      for (const v of Object.values(args)) {
-        if (typeof v === 'string' && v.length > 0 && v.length < 120) return v;
-      }
-      return '';
-  }
-}
-
-function getResultPreview(result: string): string {
-  const trimmed = result.trim();
-  if (!trimmed) return '';
-  // First non-empty line, truncated
-  const firstLine = trimmed.split('\n')[0].trim();
-  if (firstLine.length > 80) return firstLine.slice(0, 77) + '…';
-  return firstLine;
 }

--- a/packages/arm/web/src/components/components.test.tsx
+++ b/packages/arm/web/src/components/components.test.tsx
@@ -353,108 +353,54 @@ describe('StreamingText', () => {
 // ============================================================
 
 describe('ToolActivity', () => {
-  it('renders tool start', () => {
+  const noopPull = () => {};
+
+  it('renders tool start with headline', () => {
     renderWithRouter(
-      <ToolActivity type="start" toolName="shell" args={{ command: 'ls -la' }} />,
+      <ToolActivity type="start" toolName="shell" headline="$ ls -la" sessionId="s1" requestPull={noopPull} />,
     );
     expect(screen.getByText('shell')).toBeInTheDocument();
-    expect(screen.getByText(/shell/)).toBeInTheDocument();
+    expect(screen.getByText('$ ls -la')).toBeInTheDocument();
   });
 
-  it('renders tool complete', () => {
+  it('renders tool complete with headline', () => {
     renderWithRouter(
-      <ToolActivity type="complete" toolName="read_file" args={{ path: 'src/index.ts' }} result="content" />,
+      <ToolActivity type="complete" toolName="read_file" headline="src/index.ts" sessionId="s1" requestPull={noopPull} />,
     );
     expect(screen.getByText('read_file')).toBeInTheDocument();
+    expect(screen.getByText('src/index.ts')).toBeInTheDocument();
   });
 
-  it('shows summary for shell tool', () => {
+  it('renders empty headline gracefully', () => {
     renderWithRouter(
-      <ToolActivity type="start" toolName="shell" args={{ command: 'npm test' }} />,
-    );
-    expect(screen.getByText('$ npm test')).toBeInTheDocument();
-  });
-
-  it('shows summary for read_file tool', () => {
-    renderWithRouter(
-      <ToolActivity type="start" toolName="read_file" args={{ path: 'package.json' }} />,
-    );
-    expect(screen.getByText('package.json')).toBeInTheDocument();
-  });
-
-  it('expands to show args on click', async () => {
-    const user = userEvent.setup();
-    renderWithRouter(
-      <ToolActivity type="complete" toolName="shell" args={{ command: 'ls' }} result="file1\nfile2" />,
-    );
-    await user.click(screen.getByRole('button'));
-    expect(screen.getByText('Command')).toBeInTheDocument();
-    expect(screen.getByText('Result')).toBeInTheDocument();
-  });
-
-  it('does not show result section for start type', async () => {
-    const user = userEvent.setup();
-    renderWithRouter(
-      <ToolActivity type="start" toolName="shell" args={{ command: 'ls' }} />,
-    );
-    await user.click(screen.getByRole('button'));
-    expect(screen.getByText('Command')).toBeInTheDocument();
-    expect(screen.queryByText('Result')).not.toBeInTheDocument();
-  });
-
-  it('shows summary for fetch_url tool', () => {
-    renderWithRouter(
-      <ToolActivity type="start" toolName="fetch_url" args={{ url: 'https://example.com' }} />,
-    );
-    expect(screen.getByText('https://example.com')).toBeInTheDocument();
-  });
-
-  it('shows summary for mcp tool', () => {
-    renderWithRouter(
-      <ToolActivity type="start" toolName="mcp" args={{ server: 'myserver', tool: 'search', params: {} }} />,
-    );
-    expect(screen.getByText('myserver/search')).toBeInTheDocument();
-  });
-
-  it('shows empty summary for unknown tool', () => {
-    renderWithRouter(
-      <ToolActivity type="start" toolName="custom_tool" args={{ foo: 'bar' }} />,
+      <ToolActivity type="start" toolName="custom_tool" headline="" sessionId="s1" requestPull={noopPull} />,
     );
     expect(screen.getByText('custom_tool')).toBeInTheDocument();
   });
 
-  it('shows summary for write_file tool', () => {
+  it('expands to show body when clicked', async () => {
+    const user = userEvent.setup();
     renderWithRouter(
-      <ToolActivity type="start" toolName="write_file" args={{ path: 'src/app.ts', content: '...' }} />,
+      <ToolActivity type="complete" toolName="shell" headline="$ ls" sessionId="s1" requestPull={noopPull} />,
     );
-    expect(screen.getByText('src/app.ts')).toBeInTheDocument();
+    await user.click(screen.getByRole('button'));
+    // Without refs, the body just echoes the headline under "Command" label
+    expect(screen.getByText('Command')).toBeInTheDocument();
   });
 
-  it('handles shell tool with non-string command gracefully', () => {
+  it('does not show result section without resultRef', async () => {
+    const user = userEvent.setup();
     renderWithRouter(
-      <ToolActivity type="start" toolName="shell" args={{ command: 123 }} />,
+      <ToolActivity type="start" toolName="shell" headline="$ ls" sessionId="s1" requestPull={noopPull} />,
     );
-    expect(screen.getByText('shell')).toBeInTheDocument();
+    await user.click(screen.getByRole('button'));
+    expect(screen.queryByText('Result')).not.toBeInTheDocument();
   });
 
-  it('handles fetch_url with non-string url gracefully', () => {
+  it('renders tool with truncated headline', () => {
     renderWithRouter(
-      <ToolActivity type="start" toolName="fetch_url" args={{ url: null }} />,
+      <ToolActivity type="start" toolName="bash" headline={'$ ' + 'x'.repeat(197) + '…'} sessionId="s1" requestPull={noopPull} />,
     );
-    expect(screen.getByText('fetch_url')).toBeInTheDocument();
-  });
-
-  it('handles mcp with non-string tool gracefully', () => {
-    renderWithRouter(
-      <ToolActivity type="start" toolName="mcp" args={{ server: 's', tool: 42, params: {} }} />,
-    );
-    expect(screen.getByText('mcp')).toBeInTheDocument();
-  });
-
-  it('handles read_file with non-string path gracefully', () => {
-    renderWithRouter(
-      <ToolActivity type="start" toolName="read_file" args={{ path: undefined }} />,
-    );
-    expect(screen.getByText('read_file')).toBeInTheDocument();
+    expect(screen.getByText('bash')).toBeInTheDocument();
   });
 });

--- a/packages/arm/web/src/hooks/useAttachment.ts
+++ b/packages/arm/web/src/hooks/useAttachment.ts
@@ -17,7 +17,7 @@
 
 import { useEffect, useState } from 'react';
 
-import type { AttachmentRef } from '@kraki/protocol';
+import type { ContentRef } from '@kraki/protocol';
 
 import {
   type AttachmentState,
@@ -30,6 +30,12 @@ import {
 interface UseAttachmentResult {
   status: 'loading' | 'ready' | 'error';
   url: string | null;
+  error: string | null;
+}
+
+interface UseAttachmentTextResult {
+  status: 'loading' | 'ready' | 'error';
+  text: string | null;
   error: string | null;
 }
 
@@ -54,39 +60,34 @@ function hydrateOnce(id: string): Promise<boolean> {
   return p;
 }
 
-export function useAttachment(
-  ref: AttachmentRef,
+/** Common subscribe + auto-fetch effect shared by useAttachment and
+ *  useAttachmentText. */
+function useAttachmentLifecycle(
+  ref: ContentRef,
   sessionId: string,
   requestPull: RequestPull,
-): UseAttachmentResult {
+  enabled: boolean,
+): number {
   const [tick, setTick] = useState(0);
-  const [url, setUrl] = useState<string | null>(null);
-
   useEffect(() => {
+    if (!enabled) return undefined;
     let cancelled = false;
-
     function onUpdate(): void {
       if (cancelled) return;
       setTick((t) => t + 1);
     }
-
     const unsubscribe = subscribe(ref.id, onUpdate);
-
     async function init(): Promise<void> {
       const existing = getState(ref.id);
       if (existing?.kind === 'ready') return;
       if (existing?.kind === 'awaiting-chunks' || existing?.kind === 'fetching') return;
-      // Not in memory — try IDB
       const hit = await hydrateOnce(ref.id);
       if (cancelled) return;
       if (hit) return;
-      // Miss + no live push → start a fetch
       markFetching(ref.id);
       requestPull(sessionId, ref.id);
     }
-
     void init();
-
     return () => {
       cancelled = true;
       unsubscribe();
@@ -94,7 +95,17 @@ export function useAttachment(
     // requestPull identity changes every render; we deliberately exclude it
     // from deps so this effect only re-runs when the id/session changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref.id, sessionId]);
+  }, [ref.id, sessionId, enabled]);
+  return tick;
+}
+
+export function useAttachment(
+  ref: ContentRef,
+  sessionId: string,
+  requestPull: RequestPull,
+): UseAttachmentResult {
+  const tick = useAttachmentLifecycle(ref, sessionId, requestPull, true);
+  const [url, setUrl] = useState<string | null>(null);
 
   // Derive object URL from current state. Re-runs on every notify.
   useEffect(() => {
@@ -121,4 +132,43 @@ export function useAttachment(
     return { status: 'error', url: null, error: state.reason };
   }
   return { status: 'loading', url: null, error: null };
+}
+
+/** Sibling of {@link useAttachment} that decodes the bytes as UTF-8 text.
+ *  Use for tool result/args refs (mime `text/plain` or `application/json`).
+ *  Set `enabled=false` to skip the fetch entirely (e.g. while a collapsed
+ *  chip doesn't need the body yet). */
+export function useAttachmentText(
+  ref: ContentRef,
+  sessionId: string,
+  requestPull: RequestPull,
+  enabled = true,
+): UseAttachmentTextResult {
+  const tick = useAttachmentLifecycle(ref, sessionId, requestPull, enabled);
+  const [text, setText] = useState<string | null>(null);
+
+  useEffect(() => {
+    const state = getState(ref.id);
+    if (state?.kind === 'ready') {
+      let cancelled = false;
+      void state.blob.text().then((t) => {
+        if (!cancelled) setText(t);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    setText(null);
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref.id, tick]);
+
+  const state = getState(ref.id) as AttachmentState | undefined;
+  if (state?.kind === 'ready' && text !== null) {
+    return { status: 'ready', text, error: null };
+  }
+  if (state?.kind === 'error') {
+    return { status: 'error', text: null, error: state.reason };
+  }
+  return { status: 'loading', text: null, error: null };
 }

--- a/packages/arm/web/src/hooks/useTurns.ts
+++ b/packages/arm/web/src/hooks/useTurns.ts
@@ -158,15 +158,16 @@ export function groupMessagesIntoTurns(messages: ChatMessage[]): GroupedMessages
             const startMsg = currentThinking[startIdx];
             const startPayload = (startMsg as { payload?: Record<string, unknown> }).payload ?? {};
             const completePayload = (msg as { payload?: Record<string, unknown> }).payload ?? {};
-            const startArgs = (startPayload.args ?? {}) as Record<string, unknown>;
-            const completeArgs = (completePayload.args ?? {}) as Record<string, unknown>;
             currentThinking[startIdx] = {
               ...msg,
               seq: (startMsg as { seq?: number }).seq,
               payload: {
                 ...completePayload,
                 toolName: completePayload.toolName || startPayload.toolName,
-                args: { ...startArgs, ...completeArgs },
+                headline: completePayload.headline || startPayload.headline || '',
+                // Prefer ref/attachments from the complete event; carry forward
+                // argsRef from start so the chip can lazy-expand args.
+                argsRef: completePayload.argsRef || startPayload.argsRef,
               },
             } as ChatMessage;
           } else {

--- a/packages/arm/web/src/lib/attachments.ts
+++ b/packages/arm/web/src/lib/attachments.ts
@@ -4,7 +4,7 @@
  * One state machine per attachment id:
  *
  *   awaiting-chunks  ← live message router calls markAwaitingPush() when a
- *                       fresh tool_complete with an AttachmentRef arrives;
+ *                       fresh tool_complete with an ContentRef arrives;
  *                       chunks are inbound via attachment_data messages.
  *   fetching         ← useAttachment triggered a pull (replay path or
  *                       safety-timeout fallback).
@@ -112,7 +112,7 @@ export function getState(id: string): AttachmentState | undefined {
   return states.get(id);
 }
 
-/** Called by the message router for every AttachmentRef in a LIVE message. */
+/** Called by the message router for every ContentRef in a LIVE message. */
 export function markAwaitingPush(id: string, requestPull: (id: string) => void): void {
   // No-op if we already have it or are mid-fetch
   const current = states.get(id);

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -1,4 +1,4 @@
-import type { InnerMessage, SessionListMessage, SessionReplayBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage, AttachmentRef } from '@kraki/protocol';
+import type { InnerMessage, SessionListMessage, SessionReplayBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage, ContentRef } from '@kraki/protocol';
 import { getStore } from './store-adapter';
 import { isViewingSession } from './replay';
 import { createLogger } from './logger';
@@ -38,6 +38,22 @@ export interface RouterContext {
   onSessionReplayBatch?: (msg: SessionReplayBatchMessage) => void;
 }
 
+/** Build the request_attachment fallback callback used by markAwaitingPush. */
+function makePullCallback(
+  ctx: RouterContext,
+  store: ReturnType<typeof getStore>,
+  sid: string,
+): (id: string) => void {
+  return (id: string) => {
+    ctx.sendEncrypted?.({
+      type: 'request_attachment',
+      deviceId: store.deviceId,
+      sessionId: sid,
+      payload: { id, sessionId: sid },
+    });
+  };
+}
+
 export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
   const store = getStore();
 
@@ -57,7 +73,6 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
     ctx.onSessionReplayBatch?.(msg as SessionReplayBatchMessage);
     return;
   }
-
   // attachment_data — chunk of bytes for an attachment ref. Has a sessionId
   // but we route it before the session-existence check because the chunk's
   // session may not be in our store yet during early load.
@@ -406,29 +421,36 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
     case 'send_input':
       break;
 
+    case 'tool_start': {
+      store.appendMessage(sid, msg);
+      const payload = (msg as { payload: { argsRef?: ContentRef } }).payload;
+      if (payload?.argsRef && typeof payload.argsRef.id === 'string') {
+        const pull = makePullCallback(ctx, store, sid);
+        markAwaitingPush(payload.argsRef.id, pull);
+      }
+      break;
+    }
+
     case 'tool_complete': {
       store.appendMessage(sid, msg);
-      // If this tool_complete carries one or more AttachmentRefs, mark each
-      // id as "awaiting push" so useAttachment shows a spinner while chunks
-      // arrive. Replayed refs don't go through here (they ride
-      // session_replay_batch and are inspected by the replay handler).
-      const payload = (msg as { payload: { attachments?: Array<Record<string, unknown>> } }).payload;
+      const payload = (msg as { payload: {
+        attachments?: Array<Record<string, unknown>>;
+        argsRef?: ContentRef;
+        resultRef?: ContentRef;
+      } }).payload;
+      const pull = makePullCallback(ctx, store, sid);
+      if (payload?.argsRef && typeof payload.argsRef.id === 'string') {
+        markAwaitingPush(payload.argsRef.id, pull);
+      }
+      if (payload?.resultRef && typeof payload.resultRef.id === 'string') {
+        markAwaitingPush(payload.resultRef.id, pull);
+      }
+      // Image attachments still flow through the attachments array.
       const attachments = payload?.attachments;
       if (Array.isArray(attachments)) {
         for (const att of attachments) {
-          if (att.type === 'image_ref' && typeof att.id === 'string') {
-            const ref = att as unknown as AttachmentRef;
-            // `requestPull` is the safety-timeout fallback. We can't import
-            // wsClient here without a cycle; instead, expose a callback via
-            // ctx.sendEncrypted (already part of RouterContext).
-            const pull = (id: string) => {
-              ctx.sendEncrypted?.({
-                type: 'request_attachment',
-                deviceId: store.deviceId,
-                sessionId: sid,
-                payload: { id, sessionId: sid },
-              });
-            };
+          if (att.type === 'content_ref' && typeof att.id === 'string') {
+            const ref = att as unknown as ContentRef;
             markAwaitingPush(ref.id, pull);
           }
         }

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -89,7 +89,7 @@ export class KrakiWSClient {
 
   /**
    * Request the bytes of an attachment from the tentacle that owns the session.
-   * Used by `useAttachment` when an `AttachmentRef` arrives via replay
+   * Used by `useAttachment` when an `ContentRef` arrives via replay
    * (rather than a live push) or when a push safety-timeout elapses.
    *
    * The message stamps:

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -112,30 +112,33 @@ export interface ImageAttachment {
   name?: string;
 }
 
-/** Reference to an image stored in the tentacle's attachment store.
- *  Used for agent-produced images (currently `kraki-show_image` via MCP)
- *  so a small ref flows in the message stream while bytes travel as
- *  separate `attachment_data` envelopes. */
-export interface AttachmentRef {
-  type: 'image_ref';
+/** Reference to content stored in the tentacle's attachment store —
+ *  used as a lazy handle for image bytes, large tool output, large args,
+ *  etc. The ref flows inline in messages; bytes flow separately via
+ *  `attachment_data` chunks. */
+export interface ContentRef {
+  type: 'content_ref';
   /** Content-addressed id: sha256 hex truncated to 32 chars. */
   id: string;
   mimeType: string;
-  /** Decoded byte size of the original image. */
+  /** Decoded byte size of the underlying content. */
   size: number;
-  /** Optional caption to display under the image. */
+  /** Optional caption (used for image attachments). */
   caption?: string;
   /** Optional original filename, e.g. "screenshot.png". */
   name?: string;
   /** Optional intrinsic width in CSS pixels — populated when the
-   *  tentacle could parse it cheaply from the file header. Used by the
-   *  client to render a correctly-shaped placeholder while bytes arrive. */
+   *  tentacle could parse it cheaply from an image file header. */
   width?: number;
   /** Optional intrinsic height in CSS pixels. */
   height?: number;
 }
 
-export type Attachment = ImageAttachment | AttachmentRef;
+/** @deprecated Old name for {@link ContentRef}. Kept as alias during the
+ *  v0.17 transition so callers can be migrated in one step. */
+export type AttachmentRef = ContentRef;
+
+export type Attachment = ImageAttachment | ContentRef;
 
 // ============================================================
 // Inner message base (inside encrypted blob, invisible to relay)
@@ -213,7 +216,18 @@ export interface QuestionRequest extends BaseEnvelope {
 
 export interface ToolStartMessage extends BaseEnvelope {
   type: 'tool_start';
-  payload: ToolArgs & {
+  payload: {
+    toolName: string;
+    /** Short user-facing preview of the tool invocation, composed on
+     *  the tentacle side (≤ MAX_HEADLINE chars, ends with "…" if
+     *  truncated). Always present; safe to render immediately even on
+     *  cold replay. UX may upgrade to the full args text once
+     *  `argsRef` resolves. */
+    headline: string;
+    /** Lazy ref to the full args JSON. Present when args exceed a tiny
+     *  inline floor (so we don't pay a sha256 + round trip for trivial
+     *  args). Absent for trivially small args. */
+    argsRef?: ContentRef;
     /** Unique ID for this tool invocation (matches tool_complete) */
     toolCallId?: string;
   };
@@ -221,12 +235,25 @@ export interface ToolStartMessage extends BaseEnvelope {
 
 export interface ToolCompleteMessage extends BaseEnvelope {
   type: 'tool_complete';
-  payload: ToolArgs & {
-    result: string;
+  payload: {
+    toolName: string;
+    /** Same headline as the matching `tool_start`, repeated for
+     *  replay-completeness (a client that joins after `tool_start` has
+     *  been buffered out should still see a chip header). */
+    headline: string;
+    /** Lazy ref to the full result body. Always present except when the
+     *  tool produced no result text at all. Results are uniformly lazy
+     *  so the wire shape stays predictable and replay batches stay flat. */
+    resultRef?: ContentRef;
+    /** Lazy ref to the full args JSON, repeated for replay convenience. */
+    argsRef?: ContentRef;
     /** Unique ID matching the tool_start */
     toolCallId?: string;
     /** Whether the tool execution succeeded (default true if absent) */
     success?: boolean;
+    /** Images produced by the tool (e.g. from `kraki-show_image`).
+     *  Separate from `resultRef` because images render as a grid below
+     *  the chip rather than as an expandable text body. */
     attachments?: Attachment[];
   };
 }

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/attachment-store.test.ts
+++ b/packages/tentacle/src/__tests__/attachment-store.test.ts
@@ -50,7 +50,7 @@ describe('AttachmentStore', () => {
   it('put writes bytes + sidecar and returns a stable ref', () => {
     const ref = store.put('sid-A', PNG_1X1, 'image/png', { name: 'pixel.png' });
     expect(ref).toMatchObject({
-      type: 'image_ref',
+      type: 'content_ref',
       id: expect.any(String),
       mimeType: 'image/png',
       size: PNG_1X1.length,

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -61,6 +61,10 @@ vi.mock('../logger.js', () => ({
 }));
 
 import { RelayClient } from '../relay-client.js';
+import { AttachmentStore } from '../attachment-store.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 function createAdapter(): Record<string, unknown> {
   return {
@@ -607,5 +611,130 @@ describe('RelayClient delivery assurance', () => {
     const pong = ws2.sent.map(s => JSON.parse(s)).find(m => m.type === 'pong');
     expect(pong).toBeDefined();
     expect(pong.ack).toBeUndefined(); // state cleared, no stale ack
+  });
+});
+
+describe('RelayClient tool message lazy-load shape', () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    vi.useFakeTimers();
+  });
+
+  function buildClientWithStore() {
+    const tmp = mkdtempSync(join(tmpdir(), 'kraki-lazy-test-'));
+    const store = new AttachmentStore(tmp);
+
+    const adapter = createAdapter();
+    const sm = createSessionManager();
+    // No keyManager → relay-client bypasses E2E encryption and sends messages
+    // directly. This matches how existing relay-client tests work and lets us
+    // inspect the wire shape from ws.sent.
+    const client = new RelayClient(adapter, sm, {
+      relayUrl: 'ws://localhost:4000',
+      authMethod: 'open',
+      device: { name: 'Test', role: 'tentacle' },
+      reconnectDelay: 10,
+    }, null, store);
+    client.connect();
+    sockets[0].emit('open');
+    sockets[0].emit('message', Buffer.from(JSON.stringify({
+      type: 'auth_ok',
+      deviceId: 'dev_t',
+      authMethod: 'open',
+      user: { id: 'u1', login: 'test', provider: 'open' },
+      devices: [],
+    })));
+    return { adapter, sm, client, ws: sockets[0], store, tmp, cleanup: () => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ } } };
+  }
+
+  it('tool_start carries headline + argsRef (when args ≥ floor), no inline args', () => {
+    const { adapter, ws, cleanup } = buildClientWithStore();
+    try {
+      ws.sent.length = 0;
+      const bigArgs = { command: 'echo ' + 'x'.repeat(400) };
+      (adapter.onToolStart as ((sid: string, e: Record<string, unknown>) => void))('sess_1', {
+        toolName: 'bash',
+        args: bigArgs,
+        toolCallId: 'tc1',
+      });
+      const start = ws.sent.map(s => JSON.parse(s)).find(m => m.type === 'tool_start');
+      expect(start).toBeDefined();
+      expect(start.payload.toolName).toBe('bash');
+      expect(start.payload.headline).toMatch(/^\$ echo/);
+      expect(start.payload.args).toBeUndefined();
+      expect(start.payload.argsRef).toBeDefined();
+      expect(start.payload.argsRef.mimeType).toBe('application/json');
+      expect(start.payload.argsRef.size).toBeGreaterThan(256);
+    } finally { cleanup(); }
+  });
+
+  it('tool_start with tiny args has headline but NO argsRef (below floor)', () => {
+    const { adapter, ws, cleanup } = buildClientWithStore();
+    try {
+      ws.sent.length = 0;
+      (adapter.onToolStart as ((sid: string, e: Record<string, unknown>) => void))('sess_1', {
+        toolName: 'view',
+        args: { path: '/foo.ts' },
+        toolCallId: 'tc1',
+      });
+      const start = ws.sent.map(s => JSON.parse(s)).find(m => m.type === 'tool_start');
+      expect(start.payload.headline).toBe('/foo.ts');
+      expect(start.payload.argsRef).toBeUndefined();
+      expect(start.payload.args).toBeUndefined();
+    } finally { cleanup(); }
+  });
+
+  it('tool_complete always ships resultRef (even tiny results) and no inline result', () => {
+    const { adapter, ws, cleanup } = buildClientWithStore();
+    try {
+      ws.sent.length = 0;
+      (adapter.onToolComplete as ((sid: string, e: Record<string, unknown>) => void))('sess_1', {
+        toolName: 'bash',
+        result: 'ok',
+        toolCallId: 'tc1',
+      });
+      const complete = ws.sent.map(s => JSON.parse(s)).find(m => m.type === 'tool_complete');
+      expect(complete.payload.toolName).toBe('bash');
+      expect(complete.payload.result).toBeUndefined();
+      expect(complete.payload.resultRef).toBeDefined();
+      expect(complete.payload.resultRef.mimeType).toBe('text/plain');
+      expect(complete.payload.resultRef.size).toBe(2);
+    } finally { cleanup(); }
+  });
+
+  it('tool_complete pushes attachment_data chunks for resultRef after the message', () => {
+    const { adapter, ws, cleanup } = buildClientWithStore();
+    try {
+      ws.sent.length = 0;
+      (adapter.onToolComplete as ((sid: string, e: Record<string, unknown>) => void))('sess_1', {
+        toolName: 'bash',
+        result: 'hello world',
+        toolCallId: 'tc1',
+      });
+      const sent = ws.sent.map(s => JSON.parse(s));
+      const completeIdx = sent.findIndex(m => m.type === 'tool_complete');
+      const chunkIdx = sent.findIndex(m => m.type === 'attachment_data');
+      expect(completeIdx).toBeGreaterThanOrEqual(0);
+      expect(chunkIdx).toBeGreaterThanOrEqual(0);
+      // Chunks ride after the tool_complete in send order
+      expect(chunkIdx).toBeGreaterThan(completeIdx);
+      const chunk = sent[chunkIdx];
+      expect(chunk.payload.mimeType).toBe('text/plain');
+      expect(Buffer.from(chunk.payload.data, 'base64').toString('utf-8')).toBe('hello world');
+    } finally { cleanup(); }
+  });
+
+  it('tool_complete with no result has no resultRef', () => {
+    const { adapter, ws, cleanup } = buildClientWithStore();
+    try {
+      ws.sent.length = 0;
+      (adapter.onToolComplete as ((sid: string, e: Record<string, unknown>) => void))('sess_1', {
+        toolName: 'noop',
+        result: '',
+        toolCallId: 'tc1',
+      });
+      const complete = ws.sent.map(s => JSON.parse(s)).find(m => m.type === 'tool_complete');
+      expect(complete.payload.resultRef).toBeUndefined();
+    } finally { cleanup(); }
   });
 });

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -737,4 +737,37 @@ describe('RelayClient tool message lazy-load shape', () => {
       expect(complete.payload.resultRef).toBeUndefined();
     } finally { cleanup(); }
   });
+
+  it('purges lastArgs* + broadcastedAttachmentIds when a session ends with in-flight tool calls', () => {
+    const { adapter, client, cleanup } = buildClientWithStore();
+    try {
+      const bigArgs = { command: 'echo ' + 'x'.repeat(400) };
+      // Two tool_starts that never get a matching tool_complete (mimics
+      // session being killed mid-tool).
+      (adapter.onToolStart as ((sid: string, e: Record<string, unknown>) => void))('sess_1', {
+        toolName: 'bash', args: bigArgs, toolCallId: 'leak-1',
+      });
+      (adapter.onToolStart as ((sid: string, e: Record<string, unknown>) => void))('sess_1', {
+        toolName: 'bash', args: bigArgs, toolCallId: 'leak-2',
+      });
+      const c = client as unknown as {
+        lastArgsByToolCallId: Map<string, unknown>;
+        lastArgsRefByToolCallId: Map<string, unknown>;
+        sessionToolCallIds: Map<string, Set<string>>;
+        broadcastedAttachmentIds: Map<string, Set<string>>;
+      };
+      expect(c.lastArgsByToolCallId.size).toBe(2);
+      expect(c.lastArgsRefByToolCallId.size).toBe(2);
+      expect(c.sessionToolCallIds.get('sess_1')?.size).toBe(2);
+      expect(c.broadcastedAttachmentIds.has('sess_1')).toBe(true);
+
+      // Session ends.
+      (adapter.onSessionEnded as ((sid: string, e: { reason: string }) => void))('sess_1', { reason: 'killed' });
+
+      expect(c.lastArgsByToolCallId.size).toBe(0);
+      expect(c.lastArgsRefByToolCallId.size).toBe(0);
+      expect(c.sessionToolCallIds.has('sess_1')).toBe(false);
+      expect(c.broadcastedAttachmentIds.has('sess_1')).toBe(false);
+    } finally { cleanup(); }
+  });
 });

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -657,7 +657,7 @@ describe('SessionManager', () => {
       expect(sm2.getMeta(sessionId)!.inlineImagesStripped).toBe(true);
     });
 
-    it('leaves AttachmentRef attachments untouched', () => {
+    it('leaves ContentRef attachments untouched', () => {
       const { sessionId } = sm.createSession('copilot');
       sm.appendMessage(sessionId, 'tool_complete', JSON.stringify({
         type: 'tool_complete',
@@ -665,7 +665,7 @@ describe('SessionManager', () => {
         payload: {
           toolName: 'kraki-show_image',
           result: 'Image displayed to user.',
-          attachments: [{ type: 'image_ref', id: 'abc', mimeType: 'image/png', size: 100 }],
+          attachments: [{ type: 'content_ref', id: 'abc', mimeType: 'image/png', size: 100 }],
         },
       }));
 
@@ -677,7 +677,7 @@ describe('SessionManager', () => {
       const after = sm2.getMessagesAfterSeq(sessionId, 0);
       const inner = JSON.parse(after[0].payload) as { payload: { attachments?: unknown[] } };
       expect(inner.payload.attachments).toEqual([
-        { type: 'image_ref', id: 'abc', mimeType: 'image/png', size: 100 },
+        { type: 'content_ref', id: 'abc', mimeType: 'image/png', size: 100 },
       ]);
     });
 

--- a/packages/tentacle/src/__tests__/tool-headline.test.ts
+++ b/packages/tentacle/src/__tests__/tool-headline.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { makeHeadline, MAX_HEADLINE } from '../tool-headline.js';
+
+describe('makeHeadline', () => {
+  it('extracts shell command with $ prefix', () => {
+    expect(makeHeadline('bash', { command: 'echo hi' })).toBe('$ echo hi');
+    expect(makeHeadline('shell', { command: 'ls -la' })).toBe('$ ls -la');
+  });
+
+  it('extracts view/read path', () => {
+    expect(makeHeadline('view', { path: '/foo.ts' })).toBe('/foo.ts');
+    expect(makeHeadline('read_file', { path: '/x.md' })).toBe('/x.md');
+  });
+
+  it('extracts edit/create/write path', () => {
+    expect(makeHeadline('edit', { path: '/a.ts', old_str: 'x', new_str: 'y' })).toBe('/a.ts');
+    expect(makeHeadline('create', { path: '/b.ts', file_text: 'huge content...' })).toBe('/b.ts');
+    expect(makeHeadline('write_file', { path: '/c.ts', content: 'huge content...' })).toBe('/c.ts');
+    expect(makeHeadline('edit_file', { file_path: '/d.ts' })).toBe('/d.ts');
+  });
+
+  it('extracts grep/search pattern wrapped in slashes', () => {
+    expect(makeHeadline('grep', { pattern: 'foo.*bar' })).toBe('/foo.*bar/');
+    expect(makeHeadline('search', { pattern: 'TODO' })).toBe('/TODO/');
+  });
+
+  it('extracts glob pattern as-is', () => {
+    expect(makeHeadline('glob', { pattern: '**/*.ts' })).toBe('**/*.ts');
+  });
+
+  it('extracts fetch_url url', () => {
+    expect(makeHeadline('fetch_url', { url: 'https://example.com' })).toBe('https://example.com');
+    expect(makeHeadline('web_fetch', { url: 'https://example.com' })).toBe('https://example.com');
+  });
+
+  it('formats mcp tool as server/tool', () => {
+    expect(makeHeadline('mcp', { server: 'kraki', tool: 'show_image' })).toBe('kraki/show_image');
+    expect(makeHeadline('mcp', { server: 'kraki' })).toBe('kraki/?');
+    expect(makeHeadline('mcp', {})).toBe('?/?');
+  });
+
+  it('falls back to first short string for unknown tools', () => {
+    expect(makeHeadline('weird_tool', { foo: 'bar', baz: 42 })).toBe('bar');
+    expect(makeHeadline('weird_tool', { huge: 'x'.repeat(1000) })).toBe('');
+    expect(makeHeadline('weird_tool', {})).toBe('');
+  });
+
+  it('returns empty for missing required field', () => {
+    expect(makeHeadline('bash', {})).toBe('');
+    expect(makeHeadline('view', {})).toBe('');
+    expect(makeHeadline('view', undefined)).toBe('');
+  });
+
+  it('truncates at MAX_HEADLINE with ellipsis', () => {
+    const longCmd = 'x'.repeat(MAX_HEADLINE + 50);
+    const result = makeHeadline('bash', { command: longCmd });
+    expect(result.length).toBe(MAX_HEADLINE);
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.startsWith('$ x')).toBe(true);
+  });
+
+  it('does not truncate exactly at MAX_HEADLINE', () => {
+    const exact = 'x'.repeat(MAX_HEADLINE);
+    expect(makeHeadline('view', { path: exact })).toBe(exact);
+  });
+
+  it('handles non-string field values gracefully', () => {
+    expect(makeHeadline('bash', { command: 42 })).toBe('');
+    expect(makeHeadline('view', { path: null })).toBe('');
+  });
+});

--- a/packages/tentacle/src/__tests__/tool-headline.test.ts
+++ b/packages/tentacle/src/__tests__/tool-headline.test.ts
@@ -39,8 +39,9 @@ describe('makeHeadline', () => {
     expect(makeHeadline('mcp', {})).toBe('?/?');
   });
 
-  it('falls back to first short string for unknown tools', () => {
-    expect(makeHeadline('weird_tool', { foo: 'bar', baz: 42 })).toBe('bar');
+  it('returns empty for unknown tools (no fallback to avoid leaking sensitive args)', () => {
+    expect(makeHeadline('weird_tool', { foo: 'bar', baz: 42 })).toBe('');
+    expect(makeHeadline('weird_tool', { token: 'sk-XXX' })).toBe('');
     expect(makeHeadline('weird_tool', { huge: 'x'.repeat(1000) })).toBe('');
     expect(makeHeadline('weird_tool', {})).toBe('');
   });

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -55,10 +55,10 @@ export interface ToolCompleteEvent {
 }
 
 /** Emitted alongside a tool_complete that carries one or more
- *  `AttachmentRef`s. Tells the runtime (RelayClient) to broadcast the bytes
+ *  `ContentRef`s. Tells the runtime (RelayClient) to broadcast the bytes
  *  to all connected devices as `attachment_data` chunks. */
 export interface AttachmentBytesEvent {
-  refs: Array<import('@kraki/protocol').AttachmentRef>;
+  refs: Array<import('@kraki/protocol').ContentRef>;
 }
 
 export interface SessionEndedEvent {

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -150,7 +150,7 @@ function isRecoverableSessionError(err: unknown): boolean {
 }
 
 /** Defensive basename — strips any leading directory components and never
- *  throws. Used to populate AttachmentRef.name from the absolute path the
+ *  throws. Used to populate ContentRef.name from the absolute path the
  *  agent passed to show_image. */
 function basenameSafe(p: string): string {
   try {
@@ -1151,7 +1151,7 @@ export class CopilotAdapter extends AgentAdapter {
           ? args.caption.trim()
           : undefined;
         const path = typeof args.path === 'string' ? args.path : undefined;
-        const refs: import('@kraki/protocol').AttachmentRef[] = [];
+        const refs: import('@kraki/protocol').ContentRef[] = [];
         if (Array.isArray(contentBlocks)) {
           for (const block of contentBlocks) {
             if (
@@ -1192,7 +1192,7 @@ export class CopilotAdapter extends AgentAdapter {
       // can stream attachment_data chunks to all connected devices.
       if (attachments && attachments.length > 0) {
         const refs = attachments.filter(
-          (a): a is import('@kraki/protocol').AttachmentRef => a.type === 'image_ref',
+          (a): a is import('@kraki/protocol').ContentRef => a.type === 'content_ref',
         );
         if (refs.length > 0) {
           this.onAttachmentBytes?.(sessionId, { refs });

--- a/packages/tentacle/src/attachment-store.ts
+++ b/packages/tentacle/src/attachment-store.ts
@@ -37,7 +37,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 
-import type { AttachmentRef } from '@kraki/protocol';
+import type { ContentRef } from '@kraki/protocol';
 
 import { createLogger } from './logger.js';
 
@@ -175,14 +175,14 @@ export class AttachmentStore {
   /**
    * Write bytes to the store (idempotent — same hash → same id, no re-write).
    *
-   * Returns an `AttachmentRef` ready to embed in a message envelope.
+   * Returns a `ContentRef` ready to embed in a message envelope.
    */
   put(
     sessionId: string,
     bytes: Buffer,
     mimeType: string,
     options?: { name?: string; caption?: string },
-  ): AttachmentRef {
+  ): ContentRef {
     const id = hashBytes(bytes);
     const ext = extForMime(mimeType);
     const dir = this.dir(sessionId);
@@ -222,7 +222,7 @@ export class AttachmentStore {
     }
 
     return {
-      type: 'image_ref',
+      type: 'content_ref',
       id,
       mimeType: meta.mimeType,
       size: meta.size,

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -24,6 +24,7 @@ import { scanLocalSessions, filterSessions } from './session-scanner.js';
 import { parseSessionHistory } from './history-parser.js';
 import { createLogger } from './logger.js';
 import { getKrakiHome } from './config.js';
+import { makeHeadline } from './tool-headline.js';
 
 const logger = createLogger('relay-client');
 
@@ -137,6 +138,68 @@ export class RelayClient {
    *  receiving devices still see the ref each time (so the chat history is
    *  correct); they just don't get a redundant byte broadcast. */
   private broadcastedAttachmentIds = new Map<string, Set<string>>();
+
+  /** Inline floor for offloading args. Below this we don't bother creating
+   *  a ContentRef + chunk push — the round-trip overhead would exceed the
+   *  bytes saved. Above it we always offload. */
+  private static readonly ARGS_INLINE_FLOOR = 256;
+
+  /** Stash args (and the matching argsRef if we created one) at tool_start
+   *  so tool_complete can recompute the headline and carry the same argsRef
+   *  forward. Keyed by toolCallId. Cleaned on complete. */
+  private lastArgsByToolCallId = new Map<string, Record<string, unknown>>();
+  private lastArgsRefByToolCallId = new Map<string, import('@kraki/protocol').ContentRef>();
+
+  /** Build a ContentRef for the args JSON if the serialized size exceeds the
+   *  inline floor. Returns undefined when args are trivially small. */
+  private offloadArgs(
+    sessionId: string,
+    toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): import('@kraki/protocol').ContentRef | undefined {
+    if (!this.attachmentStore || !args) return undefined;
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(args);
+    } catch {
+      return undefined;
+    }
+    if (serialized.length < RelayClient.ARGS_INLINE_FLOOR) return undefined;
+    try {
+      const ref = this.attachmentStore.put(
+        sessionId,
+        Buffer.from(serialized, 'utf-8'),
+        'application/json',
+        { name: `${toolName}.args.json` },
+      );
+      return ref;
+    } catch (err) {
+      logger.warn({ err, sessionId, toolName }, 'failed to offload args');
+      return undefined;
+    }
+  }
+
+  /** Build a ContentRef for the tool result body. All non-empty results are
+   *  offloaded (uniform lazy treatment — the wire shape stays predictable). */
+  private offloadResult(
+    sessionId: string,
+    toolName: string,
+    result: string | undefined,
+  ): import('@kraki/protocol').ContentRef | undefined {
+    if (!this.attachmentStore || !result) return undefined;
+    try {
+      const ref = this.attachmentStore.put(
+        sessionId,
+        Buffer.from(result, 'utf-8'),
+        'text/plain',
+        { name: `${toolName}.result.txt` },
+      );
+      return ref;
+    } catch (err) {
+      logger.warn({ err, sessionId, toolName }, 'failed to offload result');
+      return undefined;
+    }
+  }
 
   /**
    * Connect to the relay. Auto-reconnects on disconnect.
@@ -983,13 +1046,30 @@ export class RelayClient {
     };
 
     this.adapter.onToolStart = (sessionId, event) => {
+      const headline = makeHeadline(event.toolName, event.args);
+      const argsRef = this.offloadArgs(sessionId, event.toolName, event.args);
+      if (event.toolCallId) {
+        this.lastArgsByToolCallId.set(event.toolCallId, event.args ?? {});
+        if (argsRef) this.lastArgsRefByToolCallId.set(event.toolCallId, argsRef);
+      }
       this.send({
         type: 'tool_start',
         sessionId,
-        payload: { toolName: event.toolName, args: event.args, toolCallId: event.toolCallId },
+        payload: {
+          toolName: event.toolName,
+          headline,
+          ...(argsRef && { argsRef }),
+          toolCallId: event.toolCallId,
+        },
       });
+      if (argsRef) {
+        this.broadcastAttachmentBytes(sessionId, argsRef).catch((err) => {
+          logger.warn({ err, sessionId, attachmentId: argsRef.id }, 'failed to broadcast args bytes');
+        });
+      }
       // Track key files from tool usage
-      if (event.toolName === 'read_file' || event.toolName === 'write_file') {
+      if (event.toolName === 'read_file' || event.toolName === 'write_file' || event.toolName === 'view' ||
+          event.toolName === 'edit' || event.toolName === 'create') {
         const path = (event.args as Record<string, unknown>)?.path as string | undefined;
         if (path) {
           const ctx = this.sessionManager.getContext(sessionId);
@@ -1003,16 +1083,33 @@ export class RelayClient {
     };
 
     this.adapter.onToolComplete = (sessionId, event) => {
+      // Recompute headline from the args we stashed at start; falls back to
+      // toolName if args aren't available.
+      const headline = makeHeadline(event.toolName, this.lastArgsByToolCallId.get(event.toolCallId ?? '') ?? {});
+      const resultRef = this.offloadResult(sessionId, event.toolName, event.result);
+      const argsRef = this.lastArgsRefByToolCallId.get(event.toolCallId ?? '');
+      if (event.toolCallId) {
+        this.lastArgsByToolCallId.delete(event.toolCallId);
+        this.lastArgsRefByToolCallId.delete(event.toolCallId);
+      }
       this.send({
         type: 'tool_complete',
         sessionId,
         payload: {
-          toolName: event.toolName, args: {}, result: event.result,
+          toolName: event.toolName,
+          headline,
+          ...(resultRef && { resultRef }),
+          ...(argsRef && { argsRef }),
           toolCallId: event.toolCallId,
           ...(event.success === false && { success: false }),
           ...(event.attachments?.length && { attachments: event.attachments }),
         },
       });
+      if (resultRef) {
+        this.broadcastAttachmentBytes(sessionId, resultRef).catch((err) => {
+          logger.warn({ err, sessionId, attachmentId: resultRef.id }, 'failed to broadcast result bytes');
+        });
+      }
     };
 
     this.adapter.onAttachmentBytes = (sessionId, event) => {
@@ -1195,12 +1292,12 @@ export class RelayClient {
   /**
    * Stream an attachment's bytes to all connected consumers as
    * `attachment_data` chunks. Called immediately after the producer fires
-   * a `tool_complete` carrying the matching `AttachmentRef`. Skipped if
+   * a `tool_complete` carrying the matching `ContentRef`. Skipped if
    * we've already broadcast this id within the session.
    */
   private async broadcastAttachmentBytes(
     sessionId: string,
-    ref: import('@kraki/protocol').AttachmentRef,
+    ref: import('@kraki/protocol').ContentRef,
   ): Promise<void> {
     if (!this.attachmentStore) {
       logger.warn({ sessionId, attachmentId: ref.id }, 'no attachment store — skipping broadcast');

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -146,9 +146,15 @@ export class RelayClient {
 
   /** Stash args (and the matching argsRef if we created one) at tool_start
    *  so tool_complete can recompute the headline and carry the same argsRef
-   *  forward. Keyed by toolCallId. Cleaned on complete. */
+   *  forward. Keyed by toolCallId. Cleaned on complete OR on session end. */
   private lastArgsByToolCallId = new Map<string, Record<string, unknown>>();
   private lastArgsRefByToolCallId = new Map<string, import('@kraki/protocol').ContentRef>();
+  /** Reverse index of in-flight toolCallIds per session — so we can purge
+   *  the two `lastArgs*` maps when a session ends with tool calls that
+   *  never received a matching `tool_complete`. Without this, the toolCallId-
+   *  keyed maps leak entries permanently (Phase 1 had the identical issue
+   *  in the Copilot adapter; same fix here). */
+  private sessionToolCallIds = new Map<string, Set<string>>();
 
   /** Build a ContentRef for the args JSON if the serialized size exceeds the
    *  inline floor. Returns undefined when args are trivially small. */
@@ -199,6 +205,20 @@ export class RelayClient {
       logger.warn({ err, sessionId, toolName }, 'failed to offload result');
       return undefined;
     }
+  }
+
+  /** Drop any in-flight toolCallId state for a session — called when a
+   *  session ends or is deleted. Without this, the toolCallId-keyed
+   *  `lastArgs*` maps would leak entries for any tool call that didn't
+   *  receive a matching `tool_complete` before the session went away. */
+  private purgeSessionToolState(sessionId: string): void {
+    const inflight = this.sessionToolCallIds.get(sessionId);
+    if (!inflight) return;
+    for (const id of inflight) {
+      this.lastArgsByToolCallId.delete(id);
+      this.lastArgsRefByToolCallId.delete(id);
+    }
+    this.sessionToolCallIds.delete(sessionId);
   }
 
   /**
@@ -579,6 +599,8 @@ export class RelayClient {
               this.sessionManager.removeLinkByKrakiId(sessionId);
               this.sessionManager.deleteSession(sessionId);
               this.lastAgentContent.delete(sessionId);
+              this.purgeSessionToolState(sessionId);
+              this.broadcastedAttachmentIds.delete(sessionId);
               this.send({ type: 'session_deleted', sessionId, payload: {} });
             });
           break;
@@ -1051,6 +1073,12 @@ export class RelayClient {
       if (event.toolCallId) {
         this.lastArgsByToolCallId.set(event.toolCallId, event.args ?? {});
         if (argsRef) this.lastArgsRefByToolCallId.set(event.toolCallId, argsRef);
+        let inflight = this.sessionToolCallIds.get(sessionId);
+        if (!inflight) {
+          inflight = new Set();
+          this.sessionToolCallIds.set(sessionId, inflight);
+        }
+        inflight.add(event.toolCallId);
       }
       this.send({
         type: 'tool_start',
@@ -1091,6 +1119,11 @@ export class RelayClient {
       if (event.toolCallId) {
         this.lastArgsByToolCallId.delete(event.toolCallId);
         this.lastArgsRefByToolCallId.delete(event.toolCallId);
+        const inflight = this.sessionToolCallIds.get(sessionId);
+        if (inflight) {
+          inflight.delete(event.toolCallId);
+          if (inflight.size === 0) this.sessionToolCallIds.delete(sessionId);
+        }
       }
       this.send({
         type: 'tool_complete',
@@ -1149,6 +1182,8 @@ export class RelayClient {
       this.turnCounts.delete(sessionId);
       this.titleGenerationInFlight.delete(sessionId);
       this.lastAgentContent.delete(sessionId);
+      this.purgeSessionToolState(sessionId);
+      this.broadcastedAttachmentIds.delete(sessionId);
       this.send({
         type: 'session_ended',
         sessionId,

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -226,7 +226,7 @@ export class SessionManager {
       if (!Array.isArray(attachments) || attachments.length === 0) return line;
 
       // Drop any attachment that carries inline `data` (legacy shape). Refs
-      // (type === 'image_ref') are kept untouched.
+      // (type === 'content_ref') are kept untouched.
       let droppedAny = false;
       const filtered = attachments.filter((a) => {
         if (a && typeof a === 'object' && (a as Record<string, unknown>).type === 'image' && typeof (a as Record<string, unknown>).data === 'string') {

--- a/packages/tentacle/src/tool-headline.ts
+++ b/packages/tentacle/src/tool-headline.ts
@@ -63,14 +63,16 @@ function pickRaw(toolName: string, args: Record<string, unknown>): string {
     case 'report_intent':
       return strField(args, 'intent');
     default:
-      // Unknown tool: pick the first non-empty short string arg.
-      // (Long strings are likely file_text dumps — skip those so we
-      // don't accidentally inline what the ref is supposed to carry.)
-      for (const v of Object.values(args)) {
-        if (typeof v === 'string' && v.length > 0 && v.length <= MAX_HEADLINE * 2) {
-          return v;
-        }
-      }
+      // Unknown tool: return empty. Why not pick the first string arg?
+      //  - We can't tell whether an arbitrary field carries something
+      //    sensitive (a token, password, API key). The headline goes
+      //    inline in the message envelope (broadcast eagerly), unlike
+      //    the args themselves which ship as a lazy ref.
+      //  - The chip still shows the toolName, which is enough signal
+      //    for an unknown tool. Users who want details can expand to
+      //    fetch the full args.
+      //  - When a new tool is observed in real sessions, add a case
+      //    above with the right field.
       return '';
   }
 }

--- a/packages/tentacle/src/tool-headline.ts
+++ b/packages/tentacle/src/tool-headline.ts
@@ -1,0 +1,86 @@
+/**
+ * Compose a short user-facing preview ("headline") for a tool invocation.
+ *
+ * Lives on the tentacle so the per-tool display logic is in one place
+ * — every client (web, future iOS) gets the same chip header without
+ * duplicating switch statements.
+ *
+ * The headline is intentionally lossy:
+ *  - Capped at MAX_HEADLINE characters (truncated with "…" suffix).
+ *  - Shows the single most identity-defining arg (path for view/edit,
+ *    command for bash, pattern for grep, etc.).
+ *
+ * The full args are shipped as a separate `argsRef` so the web can
+ * lazily fetch and replace the headline with the full args once
+ * resolved.
+ */
+
+export const MAX_HEADLINE = 200;
+
+export function makeHeadline(toolName: string, args: Record<string, unknown> | undefined): string {
+  const a = args ?? {};
+  const raw = pickRaw(toolName, a);
+  const s = typeof raw === 'string' ? raw : '';
+  return truncate(s);
+}
+
+function pickRaw(toolName: string, args: Record<string, unknown>): string {
+  switch (toolName) {
+    case 'bash':
+    case 'shell': {
+      const cmd = strField(args, 'command');
+      return cmd ? `$ ${cmd}` : '';
+    }
+    case 'view':
+    case 'read_file':
+      return strField(args, 'path');
+    case 'edit':
+    case 'edit_file':
+    case 'create':
+    case 'create_file':
+    case 'write_file':
+    case 'write':
+      return strField(args, 'path') || strField(args, 'file_path');
+    case 'grep':
+    case 'search': {
+      const pattern = strField(args, 'pattern');
+      return pattern ? `/${pattern}/` : '';
+    }
+    case 'glob':
+      return strField(args, 'pattern');
+    case 'fetch_url':
+    case 'web_fetch':
+      return strField(args, 'url');
+    case 'mcp': {
+      const server = strField(args, 'server') || '?';
+      const tool = strField(args, 'tool') || '?';
+      return `${server}/${tool}`;
+    }
+    case 'task': {
+      const desc = strField(args, 'description') || strField(args, 'prompt');
+      return desc;
+    }
+    case 'report_intent':
+      return strField(args, 'intent');
+    default:
+      // Unknown tool: pick the first non-empty short string arg.
+      // (Long strings are likely file_text dumps — skip those so we
+      // don't accidentally inline what the ref is supposed to carry.)
+      for (const v of Object.values(args)) {
+        if (typeof v === 'string' && v.length > 0 && v.length <= MAX_HEADLINE * 2) {
+          return v;
+        }
+      }
+      return '';
+  }
+}
+
+function strField(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  return typeof v === 'string' ? v : '';
+}
+
+function truncate(s: string): string {
+  if (s.length <= MAX_HEADLINE) return s;
+  return s.slice(0, MAX_HEADLINE - 1) + '…';
+}


### PR DESCRIPTION
## Why

Tool messages were the biggest remaining byte sink after Phase 1 (kraki-show_image / image refs) landed.

Sampled 10 large local sessions, ~14,783 tool calls, ~50 MB jsonl total:

| type | share of session bytes |
|---|---|
| `tool_complete` | **56%** |50
| `tool_start` | **31%** |28
| `agent_message` | 10% |9
| user_message | 11% |1

Inside `tool_complete`, the **`result` body alone is 42% of the whole log**.  10  19 KB. A 14k-tool-call session uses ~16 MB of jsonl just for result text. Replay batches were creeping toward the relay's 10 MB `maxPayload` again on long sessions.max result 36

This PR runs tool args + result bodies through the same lazy chunked pipeline the image attachments already use.

## What changes

**Wire shape (breaking, lockstep ship):**

```ts
 'content_ref'.
type ContentRef = { id, mimeType, size, name?, caption?, width?, height? }

// Old:
tool_start.payload = ToolArgs & { toolCallId }
tool_complete.payload = ToolArgs & { result, toolCallId, success?, attachments? }

// New:
tool_start.payload = { toolName, headline, argsRef?, toolCallId }
tool_complete.payload = { toolName, headline, argsRef?, resultRef?,
                          success?, attachments?, toolCallId }
```

- `headline`: short tool-aware 200 chars, ends ` if truncated). Always inline; safe to render on cold replay.with `preview (
- `argsRef`: full args JSON, lazy. Skipped if args < 256 B (no point ref-ing trivial args).
- `resultRef`: full result text, **always** lazy when non-empty.  even tiny results are refs so the wire shape stays predictable and replays stay flat.Uniform 

Permission prompt path keeps args eager (operator needs to see them to approve). That's a different message type.

**Tentacle:**

- New `packages/tentacle/src/tool-headline. `makeHeadline(toolName, args)` composes the chip header. The per-tool switch that used to live in web/ToolActivity moves here so every client (web + future iOS) gets the same chip without duplication.ts` 
- `RelayClient.onToolStart`/`onToolComplete` compose headline + offload bytes via the existing `AttachmentStore` + `broadcastAttachmentBytes`. Live viewers warm IDB before any user clicks expand.

**Web:**

- `ToolActivity` drops the per-tool switch. Chip = `payload.headline`. On expand, the new `useAttachmentText` hook pulls argsRef/resultRef via the same IDB cache (UTF-8 decoded `blob.text()`).
- Per design discussion: when argsRef resolves, the expand body **upgrades** the headline preview to full args text (option  chip stays, body upgrades). No layout reflow.b 
- `message-router` marks new ContentRefs as awaiting-push so the spinner appears on cold replay and chunks land into cache when they arrive.
- `ThinkingBox` reads `payload.headline` directly. `useTurns` merge logic carries headline/argsRef forward.

## Tests

- **441 tentacle tests pass** (was 436, +12 headline unit + 5 relay-client wire-shape integration)
- **281 web tests pass** (rewrote 14 tool-activity tests for the new shape; same count overall)
- **biome lint clean** (96 files)

**Playwright E2E** on a fresh local stack (ports 4500/3500/3600):

1. New session with claude-sonnet-4.6, Execute mode
2. Asked agent to run `bash echo "hello from kraki lazy-tool E2E"` + `view /etc/hostname`
3. Steps modal shows:
 `bash $ echo "hello from kraki lazy-tool E2E"`   - 
 `view /etc/hostname`   - 
4. Expanded the bash chip: **Command** body shows the full args (lazy-fetched + parsed JSON); **Result** body shows the full stdout (lazy-fetched + UTF-8 decoded)
5. Verified `messages.jsonl` on disk: `tool_start`/`tool_complete` entries have `headline` + `resultRef`  **no inline `args`, no inline `result`**.only 

## Versions

 **0.13.0** (breaking)
 **0.17.0**
 **0.12.0**

Lockstep ship. No backwards-compat  pre-release, lockstep deploy. Old jsonl entries that still have inline `args`/`result` are tolerated on the read side but never re-emitted.layer 

## Rollout notes

- **No migration of existing sessions.** Old sessions stay verbose; new tool calls get the lazy treatment. Tool result bodies max out around 19  even 50 inline entries in a batch is ~1 MB, well under cap. Different from Phase 1's multi-MB images that forced a one-shot strip.KB 
- **GC scheduler still not shipped.** Same reasoning as Phase  `gc()` primitive sits on AttachmentStore for later. Per-session disk: ~300 refs per session 1501 small sizes. Session-delete already nukes the dir. 
- **No capability negotiation.** Lockstep ship; old web sees an empty chip body (no readable inline result fallback), but no crashes.

## Estimated savings

6 MB on replay** (~70% reduction). Phone reconnect batches drop from ~1 MB to ~150 KB.5
