### PR TITLE
chore(deploy): pin npm registry in deploy script to avoid mirror lag

### DIFF
--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -98,6 +98,8 @@ sudo /usr/local/sbin/deploy-edge-relay.sh 0.12.0
 
 (or invoke `scripts/deploy-edge-relay.sh` directly from a checkout — the script doesn't depend on the repo).
 
+The script pins `npm install` to `https://registry.npmjs.org` so it doesn't see stale versions from mirrors (e.g. `registry.npmmirror.com`, common on Chinese edge hosts, can lag the upstream registry by hours). Override via `NPM_REGISTRY=...` if you need to install from a different source.
+
 ### Daily database backups
 
 `scripts/backup-relay-db.sh` performs a WAL-safe `sqlite3 .backup` of the live DB and prunes copies older than 14 days. Install it once on the relay host:

--- a/scripts/deploy-edge-relay.sh
+++ b/scripts/deploy-edge-relay.sh
@@ -86,8 +86,13 @@ find "$BACKUP_ROOT" -maxdepth 1 -type d -name 'pre-*' -mtime +30 -exec rm -rf {}
 
 # ---- install ----
 
-echo "==> npm install -g @kraki/head@$VERSION"
-npm install -g "@kraki/head@$VERSION"
+# Pin to the upstream registry. Edge nodes in China often have npm configured
+# for registry.npmmirror.com, which lags behind on new versions by hours.
+# We want the freshly-published @kraki/head@$VERSION right now, not whenever
+# the mirror syncs.
+NPM_REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
+echo "==> npm install -g --registry=$NPM_REGISTRY @kraki/head@$VERSION"
+npm install -g --registry="$NPM_REGISTRY" "@kraki/head@$VERSION"
 
 INSTALLED_VERSION="$(current_version || true)"
 if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
@@ -103,7 +108,7 @@ rollback() {
   local reason="$1"
   echo "==> ROLLBACK ($reason)"
   if [ -n "${CURRENT_VERSION:-}" ] && [ "$CURRENT_VERSION" != "$VERSION" ]; then
-    npm install -g "@kraki/head@$CURRENT_VERSION" || true
+    npm install -g --registry="$NPM_REGISTRY" "@kraki/head@$CURRENT_VERSION" || true
   fi
   cp -p "$SNAP/kraki-relay.service" "$UNIT"
   if [ -f "$SNAP/relay.env" ]; then


### PR DESCRIPTION
Pins `npm install` in `scripts/deploy-edge-relay.sh` to `https://registry.npmjs.org` (overridable via `NPM_REGISTRY`).

Today's 0.12.1 deploy hit `npm error code ETARGET` because the China edge relay had `registry.npmmirror.com` configured as its default npm registry, and the mirror hadn't synced 0.12.1 yet. Worked around by passing `--registry=https://registry.npmjs.org` manually. This bakes the workaround into the script so it doesn't bite again.

Also updates `SELF-HOSTING.md` to document the override.

Trivial 11-line change. No code change, no protocol change, no relay impact.
