### PR TITLE
refactor(head): unify auth completion across all auth paths (0.13.0)

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",

--- a/packages/head/src/__tests__/auth-backend-integration.test.ts
+++ b/packages/head/src/__tests__/auth-backend-integration.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the edge-mode auth path (authBackend configured).
+ *
+ * These specifically guard against bugs that were silently active for ~a
+ * month after the multi-region migration:
+ *
+ *  1. The edge head's local `pending_messages` table was never flushed on
+ *     reconnect, because `handleBackendAuthResult` only used the auth
+ *     backend's `pendingMessages` (which is always empty in delegated mode).
+ *     Any unicasts the edge had queued for an offline device were silently
+ *     dropped on reconnect.
+ *
+ *  2. The edge path also did not merge local user preferences into the
+ *     auth_ok user response — it returned the backend's user object verbatim.
+ *     A user updating preferences via an edge would have their local prefs
+ *     overwritten by the backend's stale view on next reconnect.
+ *
+ * Both are now fixed by routing all three auth paths through a single
+ * `completeAuthHandshake` helper.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import { WebSocket } from 'ws';
+import type { AuthMethod, DeviceInfo, UnicastEnvelope } from '@kraki/protocol';
+import { Storage } from '../storage.js';
+import { HeadServer } from '../server.js';
+import type {
+  AuthBackend, AuthOutcome, ChallengeOutcome, AuthInfoConfig,
+} from '../auth-backend.js';
+
+// ── Minimal mock auth backend ───────────────────────────────
+
+/**
+ * Mock auth backend that always succeeds for `open` and `pairing` and reports
+ * an empty pendingMessages list (simulating a real edge where the remote
+ * backend has no view into the edge's local pending queue).
+ */
+class MockAuthBackend implements AuthBackend {
+  private static seq = 0;
+  /** Override per call if needed (default: empty). */
+  backendPendingMessages: UnicastEnvelope[] = [];
+  /** User identity returned to the head. */
+  user = {
+    id: 'u_remote',
+    login: 'remote-user',
+    provider: 'open',
+    email: 'remote@example.com',
+  };
+
+  async authenticate(_auth: AuthMethod, device: DeviceInfo): Promise<AuthOutcome> {
+    const deviceId = device.deviceId ?? `dev_remote_${++MockAuthBackend.seq}`;
+    return {
+      ok: true,
+      userId: this.user.id,
+      deviceId,
+      authMethod: 'open',
+      user: { ...this.user },
+      devices: [{
+        id: deviceId,
+        name: device.name,
+        role: device.role,
+        kind: device.kind,
+        publicKey: device.publicKey,
+        encryptionKey: device.encryptionKey,
+        online: false,
+      }],
+      pendingMessages: this.backendPendingMessages,
+    };
+  }
+
+  async startChallenge(_deviceId: string): Promise<ChallengeOutcome> {
+    throw new Error('not implemented for these tests');
+  }
+
+  async verifyChallenge(): Promise<AuthOutcome> {
+    throw new Error('not implemented for these tests');
+  }
+
+  createPairingToken(): { token: string; expiresIn: number } {
+    return { token: 'mock-token', expiresIn: 900 };
+  }
+
+  async requestPairingToken() {
+    return { ok: true as const, userId: this.user.id, pairingToken: 'mock', expiresIn: 900 };
+  }
+
+  getAuthInfo(): AuthInfoConfig {
+    return { methods: ['open'] };
+  }
+}
+
+// ── Test rig ────────────────────────────────────────────────
+
+interface EdgeTestEnv {
+  port: number;
+  storage: Storage;
+  server: HeadServer;
+  httpServer: Server;
+  backend: MockAuthBackend;
+  cleanup: () => Promise<void>;
+}
+
+async function createEdgeTestEnv(): Promise<EdgeTestEnv> {
+  const storage = new Storage(':memory:');
+  const backend = new MockAuthBackend();
+  const server = new HeadServer(storage, { authBackend: backend });
+
+  const httpServer = createServer();
+  server.attach(httpServer);
+  await new Promise<void>(resolve => httpServer.listen(0, resolve));
+  const port = (httpServer.address() as AddressInfo).port;
+
+  const cleanup = async () => {
+    server.close();
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    storage.close();
+  };
+
+  return { port, storage, server, httpServer, backend, cleanup };
+}
+
+interface Connected {
+  ws: WebSocket;
+  authOk: Record<string, unknown>;
+  deviceId: string;
+  raw: Record<string, unknown>[];
+}
+
+async function connectEdge(port: number, deviceId: string, role: 'tentacle' | 'app' = 'tentacle'): Promise<Connected> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  const raw: Record<string, unknown>[] = [];
+  await new Promise<void>((resolve, reject) => {
+    ws.on('open', resolve);
+    ws.on('error', reject);
+  });
+  ws.on('message', (data) => {
+    raw.push(JSON.parse(data.toString()));
+  });
+
+  ws.send(JSON.stringify({
+    type: 'auth',
+    auth: { method: 'open' },
+    device: { name: `dev-${deviceId}`, role, deviceId, publicKey: 'pub-' + deviceId },
+  }));
+
+  // Wait for auth_ok (~100ms is plenty).
+  const start = Date.now();
+  while (Date.now() - start < 2000) {
+    const ok = raw.find(m => m.type === 'auth_ok');
+    if (ok) return { ws, authOk: ok, deviceId, raw };
+    await new Promise(r => setTimeout(r, 10));
+  }
+  throw new Error(`auth_ok timeout for ${deviceId}`);
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('Edge-mode auth: local pending_messages flush on reconnect', () => {
+  let env: EdgeTestEnv;
+  beforeEach(async () => { env = await createEdgeTestEnv(); });
+  afterEach(async () => { await env.cleanup(); });
+
+  it('delivers locally-queued pending messages alongside auth_ok', async () => {
+    // Pre-condition: head has 3 pending unicasts queued locally for dev_t1.
+    // (This is what happens when an arm sends a unicast to a tentacle that
+    // happens to be offline. handleUnicast → storage.insertPending.)
+    env.storage.insertPending('dev_t1', 'u_remote', JSON.stringify({
+      type: 'unicast', to: 'dev_t1', blob: 'envelope_1', keys: { 'dev_t1': 'k' },
+    }));
+    env.storage.insertPending('dev_t1', 'u_remote', JSON.stringify({
+      type: 'unicast', to: 'dev_t1', blob: 'envelope_2', keys: { 'dev_t1': 'k' },
+    }));
+    env.storage.insertPending('dev_t1', 'u_remote', JSON.stringify({
+      type: 'unicast', to: 'dev_t1', blob: 'envelope_3', keys: { 'dev_t1': 'k' },
+    }));
+
+    const { authOk } = await connectEdge(env.port, 'dev_t1');
+
+    expect(authOk.pendingMessages).toBeDefined();
+    const pending = authOk.pendingMessages as UnicastEnvelope[];
+    expect(pending).toHaveLength(3);
+    expect(pending.map(p => p.blob)).toEqual(['envelope_1', 'envelope_2', 'envelope_3']);
+
+    // Queue is now empty (flushPendingEnvelopes both reads AND deletes).
+    expect(env.storage.flushPending('dev_t1')).toHaveLength(0);
+  });
+
+  it('merges backend-supplied and locally-queued pending messages', async () => {
+    // Backend hands us one pending message…
+    env.backend.backendPendingMessages = [{
+      type: 'unicast', to: 'dev_t2', blob: 'from_backend', keys: { 'dev_t2': 'k' },
+    }];
+    // …and head has two queued locally.
+    env.storage.insertPending('dev_t2', 'u_remote', JSON.stringify({
+      type: 'unicast', to: 'dev_t2', blob: 'local_1', keys: { 'dev_t2': 'k' },
+    }));
+    env.storage.insertPending('dev_t2', 'u_remote', JSON.stringify({
+      type: 'unicast', to: 'dev_t2', blob: 'local_2', keys: { 'dev_t2': 'k' },
+    }));
+
+    const { authOk } = await connectEdge(env.port, 'dev_t2');
+
+    const pending = authOk.pendingMessages as UnicastEnvelope[];
+    expect(pending).toHaveLength(3);
+    // Backend's contribution comes first (preserving prior behavior),
+    // then local entries.
+    expect(pending[0].blob).toBe('from_backend');
+    expect(pending.slice(1).map(p => p.blob).sort()).toEqual(['local_1', 'local_2']);
+  });
+
+  it('omits pendingMessages from auth_ok when both queues are empty', async () => {
+    const { authOk } = await connectEdge(env.port, 'dev_t3');
+    expect(authOk.pendingMessages).toBeUndefined();
+  });
+});
+
+describe('Edge-mode auth: local preferences merged into user response', () => {
+  let env: EdgeTestEnv;
+  beforeEach(async () => { env = await createEdgeTestEnv(); });
+  afterEach(async () => { await env.cleanup(); });
+
+  it('returns local preferences even when backend returns user without them', async () => {
+    // User exists in local storage with preferences set (the edge mirrored
+    // the user during a previous auth, and the user updated prefs since).
+    env.storage.upsertUser('u_remote', 'remote-user', 'open');
+    env.storage.updatePreferences('u_remote', { theme: 'dark', autoMode: true });
+
+    // Backend's user object doesn't include the preferences.
+    env.backend.user = {
+      id: 'u_remote', login: 'remote-user', provider: 'open', email: 'remote@example.com',
+    };
+
+    const { authOk } = await connectEdge(env.port, 'dev_t4');
+
+    const user = authOk.user as Record<string, unknown>;
+    expect(user.preferences).toEqual({ theme: 'dark', autoMode: true });
+  });
+
+  it('handles missing local user record gracefully (preferences undefined)', async () => {
+    // No upsertUser before connect — head will upsert during mirror, but
+    // with no preferences set.
+    const { authOk } = await connectEdge(env.port, 'dev_t5');
+    const user = authOk.user as Record<string, unknown>;
+    // preferences should be omitted/undefined, not crash.
+    expect(user.preferences).toBeUndefined();
+  });
+});
+
+describe('Edge-mode auth: response shape regression', () => {
+  let env: EdgeTestEnv;
+  beforeEach(async () => { env = await createEdgeTestEnv(); });
+  afterEach(async () => { await env.cleanup(); });
+
+  it('auth_ok contains all expected fields', async () => {
+    const { authOk } = await connectEdge(env.port, 'dev_t6');
+    expect(authOk.type).toBe('auth_ok');
+    expect(authOk.deviceId).toBe('dev_t6');
+    expect(authOk.authMethod).toBe('open');
+    expect(authOk.user).toMatchObject({ id: 'u_remote', login: 'remote-user' });
+    expect(Array.isArray(authOk.devices)).toBe(true);
+  });
+
+  it('device_joined is broadcast to existing peers on new auth', async () => {
+    // First device — no peers to notify.
+    const first = await connectEdge(env.port, 'dev_first');
+    expect(first.raw.find(m => m.type === 'device_joined')).toBeUndefined();
+
+    // Second device connects — first should receive device_joined.
+    await connectEdge(env.port, 'dev_second');
+    // Allow time for the broadcast.
+    await new Promise(r => setTimeout(r, 50));
+
+    const joined = first.raw.find(m => m.type === 'device_joined');
+    expect(joined).toBeDefined();
+    expect((joined!.device as Record<string, unknown>).id).toBe('dev_second');
+  });
+});

--- a/packages/head/src/__tests__/auth-backend-integration.test.ts
+++ b/packages/head/src/__tests__/auth-backend-integration.test.ts
@@ -42,7 +42,14 @@ class MockAuthBackend implements AuthBackend {
   /** Override per call if needed (default: empty). */
   backendPendingMessages: UnicastEnvelope[] = [];
   /** User identity returned to the head. */
-  user = {
+  user: {
+    id: string;
+    login: string;
+    provider: string;
+    email?: string;
+    preferences?: Record<string, unknown>;
+    region?: string;
+  } = {
     id: 'u_remote',
     login: 'remote-user',
     provider: 'open',
@@ -240,11 +247,50 @@ describe('Edge-mode auth: local preferences merged into user response', () => {
 
   it('handles missing local user record gracefully (preferences undefined)', async () => {
     // No upsertUser before connect — head will upsert during mirror, but
-    // with no preferences set.
+    // with no preferences set. Backend also returns no preferences.
     const { authOk } = await connectEdge(env.port, 'dev_t5');
     const user = authOk.user as Record<string, unknown>;
     // preferences should be omitted/undefined, not crash.
     expect(user.preferences).toBeUndefined();
+  });
+
+  it('falls back to backend preferences when local has none (first-time auth)', async () => {
+    // User authenticating for the first time on this edge — no local record yet.
+    // Backend is canonical and supplies preferences.
+    env.backend.user = {
+      id: 'u_remote',
+      login: 'remote-user',
+      provider: 'open',
+      email: 'remote@example.com',
+      preferences: { theme: 'light', autoMode: false, fromBackend: true },
+    };
+
+    const { authOk } = await connectEdge(env.port, 'dev_t_first_auth');
+
+    const user = authOk.user as Record<string, unknown>;
+    // Backend preferences must reach the client. Without the fallback, they
+    // would be silently dropped because storage.upsertUser doesn't persist
+    // preferences and the subsequent getUser returns preferences=undefined.
+    expect(user.preferences).toEqual({ theme: 'light', autoMode: false, fromBackend: true });
+  });
+
+  it('local preferences override backend preferences when both exist', async () => {
+    // Local already has prefs (set by user via update_preferences on this edge).
+    env.storage.upsertUser('u_remote', 'remote-user', 'open');
+    env.storage.updatePreferences('u_remote', { theme: 'dark', source: 'local' });
+
+    // Backend also reports preferences, but stale ones.
+    env.backend.user = {
+      id: 'u_remote',
+      login: 'remote-user',
+      provider: 'open',
+      preferences: { theme: 'light', source: 'backend' },
+    };
+
+    const { authOk } = await connectEdge(env.port, 'dev_t_pref_conflict');
+
+    const user = authOk.user as Record<string, unknown>;
+    expect(user.preferences).toEqual({ theme: 'dark', source: 'local' });
   });
 });
 

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -1037,12 +1037,17 @@ export class HeadServer {
       deviceId: string;
       /** The authenticated user's ID. */
       userId: string;
-      /** Identity fields from the auth source (local DB or remote backend). */
+      /** Identity fields from the auth source (local DB or remote backend).
+       *  `preferences` and `region` are optional and only meaningful from the
+       *  delegated-backend path — local paths leave them undefined and the
+       *  helper reads preferences from local storage instead. */
       user: {
         id: string;
         login: string;
         provider: string;
         email?: string;
+        preferences?: Record<string, unknown>;
+        region?: string;
       };
       /** Auth method, echoed back in auth_ok. */
       authMethod: string;
@@ -1059,14 +1064,20 @@ export class HeadServer {
       vapidPublicKey?: string;
     },
   ): void {
-    // Local preferences win. Some auth paths receive a `user` object from a
-    // remote backend that doesn't know about per-edge preference overrides.
-    // Reading from local storage (which both edge and non-edge maintain via
-    // upsertUser) guarantees a consistent view regardless of auth path.
+    // Merge preferences. Local storage takes precedence (it captures per-edge
+    // overrides the backend might not know about), but fall back to the
+    // backend-supplied preferences if local has none — e.g. on a user's very
+    // first auth to this edge, before upsertUser has been called or when the
+    // backend is the canonical source of truth.
+    //
+    // Why this matters: storage.upsertUser only writes username/provider/email,
+    // NOT preferences. So a brand-new user record reads back with
+    // preferences=undefined. Without this fallback, backend preferences would
+    // be silently dropped at every first auth.
     const fullUser = this.storage.getUser(params.userId);
     const userResponse = {
       ...params.user,
-      preferences: fullUser?.preferences,
+      preferences: fullUser?.preferences ?? params.user.preferences,
     };
 
     // Flush locally-queued pending messages — every auth path that lands here

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -937,22 +937,17 @@ export class HeadServer {
 
     logger.info('Device authenticated via challenge-response', { deviceId, ip: state.ip });
 
-    const fullUser = this.storage.getUser(user.userId);
-    const pendingMessages = this.flushPendingEnvelopes(deviceId);
-    ws.send(JSON.stringify({
-      type: 'auth_ok',
+    this.completeAuthHandshake(ws, {
       deviceId,
+      userId: user.userId,
+      user: {
+        id: user.userId,
+        login: user.username,
+        provider: user.provider,
+        email: user.email,
+      },
       authMethod: 'challenge',
-      user: { id: user.userId, login: user.username, provider: user.provider, preferences: fullUser?.preferences },
-      devices: this.getDeviceSummaries(user.userId),
-      githubClientId: this.getGitHubClientId(),
-      vapidPublicKey: this.getVapidPublicKey(),
-      relayVersion: this.options.version,
-      ...(pendingMessages.length > 0 && { pendingMessages }),
-    }));
-
-    // Notify other connected devices about the reconnected device
-    this.broadcastDeviceJoined(user.userId, deviceId);
+    });
   }
 
   /**
@@ -1005,26 +1000,104 @@ export class HeadServer {
       logger.warn('Failed to mirror user locally', { userId: result.userId, error: (err as Error).message });
     }
 
-    // Set correct online status on device summaries
-    const devices = result.devices.map(d => ({
-      ...d,
-      online: this.connections.has(d.id),
-    }));
+    this.completeAuthHandshake(ws, {
+      deviceId: result.deviceId,
+      userId: result.userId,
+      user: result.user,
+      authMethod: result.authMethod,
+      devices: result.devices,
+      backendPendingMessages: result.pendingMessages,
+      githubClientId: result.githubClientId,
+      vapidPublicKey: result.vapidPublicKey,
+    });
+  }
+
+  /**
+   * Common post-auth completion logic, used by every auth path.
+   *
+   * Responsibilities:
+   *  - Read user preferences from local storage and merge into the user object.
+   *  - Flush any locally-queued pending messages for this device (offline-queue).
+   *  - Build and send the `auth_ok` response.
+   *  - Broadcast `device_joined` to the user's other connected devices.
+   *
+   * Each caller is responsible for path-specific work BEFORE calling this:
+   * validating credentials, persisting user/device records, setting up
+   * ClientState, populating `connections` / `userByDevice` maps, and logging
+   * the path-specific "authenticated via X" line.
+   *
+   * Centralising the tail eliminates a class of bugs where new auth paths
+   * (notably the multi-region delegated-backend path) silently diverge from
+   * the established post-auth flow.
+   */
+  private completeAuthHandshake(
+    ws: WebSocket,
+    params: {
+      /** The authenticated device's ID. */
+      deviceId: string;
+      /** The authenticated user's ID. */
+      userId: string;
+      /** Identity fields from the auth source (local DB or remote backend). */
+      user: {
+        id: string;
+        login: string;
+        provider: string;
+        email?: string;
+      };
+      /** Auth method, echoed back in auth_ok. */
+      authMethod: string;
+      /** Devices list to include in auth_ok. If omitted, derived from local storage.
+       *  Edge mode supplies this from the remote backend's view. */
+      devices?: DeviceSummary[];
+      /** Pending messages forwarded by a remote auth backend, if any. Merged with
+       *  the local edge's own pending_messages table (which the head queued when
+       *  unicasts arrived for this device while it was offline). */
+      backendPendingMessages?: UnicastEnvelope[];
+      /** Override of `getGitHubClientId()` (used when delegated). */
+      githubClientId?: string;
+      /** Override of `getVapidPublicKey()` (used when delegated). */
+      vapidPublicKey?: string;
+    },
+  ): void {
+    // Local preferences win. Some auth paths receive a `user` object from a
+    // remote backend that doesn't know about per-edge preference overrides.
+    // Reading from local storage (which both edge and non-edge maintain via
+    // upsertUser) guarantees a consistent view regardless of auth path.
+    const fullUser = this.storage.getUser(params.userId);
+    const userResponse = {
+      ...params.user,
+      preferences: fullUser?.preferences,
+    };
+
+    // Flush locally-queued pending messages — every auth path that lands here
+    // means a device is reconnecting, and any unicasts queued for it locally
+    // (via handleUnicast → storage.insertPending) should be delivered now.
+    // Combined with whatever the remote backend forwarded, if applicable.
+    const localPending = this.flushPendingEnvelopes(params.deviceId);
+    const pendingMessages = [
+      ...(params.backendPendingMessages ?? []),
+      ...localPending,
+    ];
+
+    // Devices list. If the caller provided one (edge mode), recompute online
+    // status against our current connections map. Otherwise derive locally.
+    const devices = params.devices
+      ? params.devices.map(d => ({ ...d, online: this.connections.has(d.id) }))
+      : this.getDeviceSummaries(params.userId);
 
     ws.send(JSON.stringify({
       type: 'auth_ok',
-      deviceId: result.deviceId,
-      authMethod: result.authMethod,
-      user: result.user,
+      deviceId: params.deviceId,
+      authMethod: params.authMethod,
+      user: userResponse,
       devices,
-      githubClientId: result.githubClientId,
-      vapidPublicKey: result.vapidPublicKey ?? this.getVapidPublicKey(),
+      githubClientId: params.githubClientId ?? this.getGitHubClientId(),
+      vapidPublicKey: params.vapidPublicKey ?? this.getVapidPublicKey(),
       relayVersion: this.options.version,
-      ...(result.pendingMessages.length > 0 && { pendingMessages: result.pendingMessages }),
+      ...(pendingMessages.length > 0 && { pendingMessages }),
     }));
 
-    // Notify other connected devices
-    this.broadcastDeviceJoined(result.userId, result.deviceId);
+    this.broadcastDeviceJoined(params.userId, params.deviceId);
   }
 
   private completeAuth(
@@ -1067,22 +1140,17 @@ export class HeadServer {
       ip: state.ip,
     });
 
-    const fullUser = this.storage.getUser(user.id);
-    const pendingMessages = this.flushPendingEnvelopes(deviceId);
-    ws.send(JSON.stringify({
-      type: 'auth_ok',
+    this.completeAuthHandshake(ws, {
       deviceId,
+      userId: user.id,
+      user: {
+        id: user.id,
+        login: user.login,
+        provider: user.provider,
+        email: user.email,
+      },
       authMethod,
-      user: { id: user.id, login: user.login, provider: user.provider, preferences: fullUser?.preferences },
-      devices: this.getDeviceSummaries(user.id),
-      githubClientId: this.getGitHubClientId(),
-      vapidPublicKey: this.getVapidPublicKey(),
-      relayVersion: this.options.version,
-      ...(pendingMessages.length > 0 && { pendingMessages }),
-    }));
-
-    // Notify other connected devices about the new device
-    this.broadcastDeviceJoined(user.id, deviceId);
+    });
   }
 
   // --- Pairing tokens (in-memory) ---

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -371,6 +371,7 @@ describe('RelayClient set_session_model', () => {
       markActive: vi.fn(),
       markRead: vi.fn(),
       deleteSession: vi.fn(),
+      removeLinkByKrakiId: vi.fn(),
       appendMessage: vi.fn(() => 1),
       getSessionList: vi.fn(() => []),
       getMessagesAfterSeq: vi.fn(() => []),
@@ -478,6 +479,66 @@ describe('RelayClient set_session_model', () => {
     expect(readMsg).toBeDefined();
     expect(readMsg.payload.seq).toBe(42);
     expect(readMsg.sessionId).toBe('sess_1');
+  });
+
+  it('delete_session removes from sessionManager SYNCHRONOUSLY before any awaits', () => {
+    // Regression for: pre-fix, session removal happened in adapter.killSession()'s
+    // .finally(), so a broadcastSessionList fired immediately after (e.g. on
+    // auth_ok during reconnect after processPendingMessages) would still see
+    // the session and broadcast it back to arms. After the fix, deletion is
+    // synchronous; the async killSession runs in the background.
+    const { adapter, sm } = buildConnectedClient();
+    const ws = sockets[0];
+    ws.sent.length = 0;
+
+    // Adapter's killSession returns a Promise that NEVER resolves — to prove
+    // we don't depend on it.
+    adapter.killSession = vi.fn(() => new Promise<void>(() => {}));
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'delete_session',
+      sessionId: 'sess_1',
+      deviceId: 'dev_app',
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: {},
+    })));
+
+    // SYNCHRONOUSLY: sessionManager state was cleaned up.
+    expect(sm.deleteSession).toHaveBeenCalledWith('sess_1');
+    expect(sm.removeLinkByKrakiId).toHaveBeenCalledWith('sess_1');
+
+    // SYNCHRONOUSLY: session_deleted broadcast was sent.
+    const sent = ws.sent.map((s: string) => JSON.parse(s));
+    const deletedMsg = sent.find((m: { type: string }) => m.type === 'session_deleted');
+    expect(deletedMsg).toBeDefined();
+    expect(deletedMsg.sessionId).toBe('sess_1');
+
+    // killSession was kicked off but we didn't wait for it.
+    expect(adapter.killSession).toHaveBeenCalledWith('sess_1');
+  });
+
+  it('delete_session is robust to adapter.killSession failure', () => {
+    const { adapter, sm } = buildConnectedClient();
+    const ws = sockets[0];
+
+    // Adapter rejects — but our local cleanup already ran, so this should
+    // not affect the observable side effects.
+    adapter.killSession = vi.fn(() => Promise.reject(new Error('adapter exploded')));
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'delete_session',
+      sessionId: 'sess_doomed',
+      deviceId: 'dev_app',
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: {},
+    })));
+
+    expect(sm.deleteSession).toHaveBeenCalledWith('sess_doomed');
+    const sent = ws.sent.map((s: string) => JSON.parse(s));
+    const deletedMsg = sent.find((m: { type: string }) => m.type === 'session_deleted');
+    expect(deletedMsg).toBeDefined();
   });
 });
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -593,16 +593,19 @@ export class RelayClient {
             });
           break;
         case 'delete_session':
+          // Remove from local session state SYNCHRONOUSLY. The adapter's
+          // killSession runs async and may take a while to talk to the
+          // Copilot SDK; we don't want broadcastSessionList (which fires
+          // immediately after processPendingMessages on auth_ok) to see
+          // the still-tracked session and broadcast it back to arms.
+          this.sessionManager.removeLinkByKrakiId(sessionId);
+          this.sessionManager.deleteSession(sessionId);
+          this.lastAgentContent.delete(sessionId);
+          this.purgeSessionToolState(sessionId);
+          this.broadcastedAttachmentIds.delete(sessionId);
+          this.send({ type: 'session_deleted', sessionId, payload: {} });
           this.adapter.killSession(sessionId)
-            .catch((err) => logger.error({ err, sessionId }, 'killSession on delete failed'))
-            .finally(() => {
-              this.sessionManager.removeLinkByKrakiId(sessionId);
-              this.sessionManager.deleteSession(sessionId);
-              this.lastAgentContent.delete(sessionId);
-              this.purgeSessionToolState(sessionId);
-              this.broadcastedAttachmentIds.delete(sessionId);
-              this.send({ type: 'session_deleted', sessionId, payload: {} });
-            });
+            .catch((err) => logger.error({ err, sessionId }, 'killSession on delete failed'));
           break;
         case 'mark_read':
           this.sessionManager.markRead(sessionId, msg.payload.seq);


### PR DESCRIPTION
## Summary

The relay had three auth_ok completion paths that each independently built the post-auth response — `handleChallengeResponse`, `completeAuth`, and `handleBackendAuthResult`. When the multi-region/edge mode was added (the third one), two correctness regressions slipped in silently and have been live in production for ~1 month.

This PR refactors all three paths to share a single `completeAuthHandshake()` helper, eliminating the divergence and fixing both bugs in one structural change.

## The bugs (silent in production since the multi-region migration)

### Bug #1 — Edge head never flushed its local `pending_messages` queue on reconnect

`handleBackendAuthResult` only used the auth backend's `pendingMessages` (empty in delegated mode), so any unicasts the edge had queued locally for an offline device (via `handleUnicast → storage.insertPending`) were silently dropped on every reconnect.

**Confirmed in production**: the local tentacle's `relay-client.log` shows the line "Processing N pending message(s) from relay" exactly twice — both on **2026-04-18**. Nothing after that despite hundreds of reconnects via the China edge. Meanwhile the edge's `pending_messages` table had grown to 229 stuck rows.

**Primary user-visible impact**: `delete_session` issued to a tentacle while the tentacle was offline silently failed to take effect.

### Bug #2 (bonus) — Edge path discarded local user preferences

The edge path used `result.user` from the backend verbatim, skipping the local-storage preference merge that the other two paths do. A user updating preferences via an edge-connected device could have them overwritten by the backend's stale view on next reconnect.

### Bug #3 (bonus, tentacle-side) — `delete_session` removal was async

Tentacle's `handleConsumerMessage` for `delete_session` removed the session from `sessionManager` inside `.finally()` of an async `adapter.killSession()` promise. The `broadcastSessionList` call fires immediately after `processPendingMessages` on auth_ok, so the deleted session was still visible in `sessionManager` and got re-broadcast to arms. (This race only manifests when pending deletes actually arrive at the tentacle — which doesn't happen at all without Bug #1 fixed. They're a matched pair.)

## The refactor

All three paths now delegate to `completeAuthHandshake(ws, params)`. The helper handles:

- Reading user preferences from local storage, merging into the user object
- Flushing locally-queued `pending_messages` for the reconnecting device
- Building and sending the `auth_ok` response
- Broadcasting `device_joined` to the user's other connected devices

Each call site keeps its own path-specific work (credential validation, user/device persistence, ClientState setup, path-specific log line) and then hands off the common tail. ~40 lines of duplication removed; the class of divergence-bugs becomes structurally hard to reintroduce.

## Test coverage added

| File | New tests | Verifies |
|------|----------:|----------|
| `head/src/__tests__/auth-backend-integration.test.ts` (new) | 7 | Edge auth flushes local pending; merges local prefs; combines backend + local pending; auth_ok shape; device_joined broadcast |
| `tentacle/src/__tests__/relay-client.test.ts` | 2 | `delete_session` is synchronous; robust to adapter rejection |

Test summary (full workspace):
- crypto: 31/31
- head: 207/207 (+7 new)
- tentacle: 444/444 (+2 new)
- tests (integration): 43/43
- arm/web: 281/281

## Versioning and rollout

- Bumps `@kraki/head` 0.12.1 → 0.13.0 (behavior change in auth path; patch bump would be misleading even though it's all additive)
- **Tentacle changes are included in code but not version-bumped here.** The tentacle's `delete_session` fix only matters once Bug #1 is fixed (otherwise deletes don't arrive at all). It'll ship with the next normal tentacle release, no urgency.

## Deploy plan

After merge:
1. Tag `head-v0.13.0`
2. `release.yml` publishes `@kraki/head@0.13.0` to npm
3. SSH to `kraki-cn.corelli.cloud` and run `scripts/deploy-edge-relay.sh 0.13.0` (the deploy script picks up the npm registry override from PR #107)

Rollback target: `@kraki/head@0.11.2` (skip 0.12.0 which had the retry-kill bug from #105).

## Pre-existing observation worth flagging (not addressed here)

`completeAuth` and `handleBackendAuthResult` log slightly different lines ("Device authenticated" vs "Device authenticated (via backend)"). The helper currently leaves this responsibility to the callers. Could be unified into a single log via a `logMessage` param if desired in a follow-up.
