### PR TITLE
feat(head): broadcast `device_pending` during ping/pong uncertainty window

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",

--- a/packages/head/src/__tests__/device-pending.test.ts
+++ b/packages/head/src/__tests__/device-pending.test.ts
@@ -1,0 +1,159 @@
+/**
+ * device_pending liveness broadcast tests.
+ *
+ * Verifies:
+ *  - Pong arrives before grace expires → no device_pending emitted.
+ *  - Pong arrives after grace expires → device_pending then device_joined re-promotion.
+ *  - No pong at all → device_pending then device_left on next ping pass.
+ *
+ * Uses simulatePingSent() to avoid ws library auto-pong on protocol-level ping,
+ * which would make it impossible to test overdue scenarios.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createTestEnv, connectDevice, type TestEnv } from './integration-helpers.js';
+
+describe('device_pending liveness broadcast', () => {
+  let env: TestEnv;
+
+  afterEach(async () => { await env.cleanup(); });
+
+  function messagesOfType(messages: Record<string, unknown>[], type: string): Record<string, unknown>[] {
+    return messages.filter(m => m.type === type);
+  }
+
+  // App connects first so it receives device_joined when tentacle connects.
+  async function setupPair() {
+    const app = await connectDevice(env.port, 'Phone', 'app');
+    const tentacle = await connectDevice(env.port, 'Laptop', 'tentacle');
+    await app.waitFor('device_joined', 2000);
+    return { app, tentacle };
+  }
+
+  it('pong before grace → no device_pending emitted', async () => {
+    env = await createTestEnv();
+    const { app, tentacle } = await setupPair();
+
+    // Simulate ping sent to tentacle (sets isAlive=false, starts grace timer)
+    env.server.simulatePingSent(tentacle.deviceId);
+
+    // Tentacle responds with JSON pong before grace expires
+    tentacle.send({ type: 'pong' });
+    await new Promise(r => setTimeout(r, 50));
+
+    // Run retry pass (includes pending check) — pong arrived, so no pending
+    env.server.forceRetryPass();
+    await new Promise(r => setTimeout(r, 100));
+
+    expect(messagesOfType(app.messages, 'device_pending')).toHaveLength(0);
+
+    tentacle.close();
+    app.close();
+  });
+
+  it('pong after grace → device_pending then device_joined re-promotion', async () => {
+    env = await createTestEnv();
+    const { app, tentacle } = await setupPair();
+
+    // Simulate ping sent to tentacle
+    env.server.simulatePingSent(tentacle.deviceId);
+
+    // Expire the grace timer (simulates 8s passing without pong)
+    env.server.expirePongGrace(tentacle.deviceId);
+
+    // Retry pass detects overdue → broadcasts device_pending
+    env.server.forceRetryPass();
+
+    const pending = await app.waitFor('device_pending', 2000);
+    expect(pending.deviceId).toBe(tentacle.deviceId);
+
+    // Late pong arrives → re-promotes via device_joined
+    tentacle.send({ type: 'pong' });
+
+    const rejoin = await app.waitFor('device_joined', 2000);
+    expect((rejoin.device as { id: string }).id).toBe(tentacle.deviceId);
+
+    tentacle.close();
+    app.close();
+  });
+
+  it('no pong → device_pending then device_left on next ping pass', async () => {
+    env = await createTestEnv();
+    const { app, tentacle } = await setupPair();
+
+    // Simulate ping sent to tentacle
+    env.server.simulatePingSent(tentacle.deviceId);
+
+    // Grace expires
+    env.server.expirePongGrace(tentacle.deviceId);
+    env.server.forceRetryPass();
+
+    const pending = await app.waitFor('device_pending', 2000);
+    expect(pending.deviceId).toBe(tentacle.deviceId);
+
+    // No pong sent. forcePingPass sees isAlive=false → terminates connection.
+    env.server.forcePingPass();
+
+    const left = await app.waitFor('device_left', 2000);
+    expect(left.deviceId).toBe(tentacle.deviceId);
+
+    app.close();
+  });
+
+  it('device_pending is not sent to the pending device itself', async () => {
+    env = await createTestEnv();
+    const { app, tentacle } = await setupPair();
+
+    env.server.simulatePingSent(tentacle.deviceId);
+    env.server.expirePongGrace(tentacle.deviceId);
+    env.server.forceRetryPass();
+
+    await app.waitFor('device_pending', 2000);
+    await new Promise(r => setTimeout(r, 100));
+
+    // Tentacle should NOT have received device_pending about itself
+    expect(messagesOfType(tentacle.messages, 'device_pending')).toHaveLength(0);
+
+    // Recover so cleanup doesn't hang
+    tentacle.send({ type: 'pong' });
+    await new Promise(r => setTimeout(r, 50));
+
+    tentacle.close();
+    app.close();
+  });
+
+  it('multiple healthy cycles then one overdue → exactly one device_pending', async () => {
+    env = await createTestEnv();
+    const { app, tentacle } = await setupPair();
+
+    // Cycle 1: ping → pong promptly → no pending
+    env.server.simulatePingSent(tentacle.deviceId);
+    tentacle.send({ type: 'pong' });
+    await new Promise(r => setTimeout(r, 50));
+    env.server.forceRetryPass();
+
+    // Cycle 2: same
+    env.server.simulatePingSent(tentacle.deviceId);
+    tentacle.send({ type: 'pong' });
+    await new Promise(r => setTimeout(r, 50));
+    env.server.forceRetryPass();
+
+    // Cycle 3: grace expires → pending
+    env.server.simulatePingSent(tentacle.deviceId);
+    env.server.expirePongGrace(tentacle.deviceId);
+    env.server.forceRetryPass();
+
+    await app.waitFor('device_pending', 2000);
+    await new Promise(r => setTimeout(r, 100));
+
+    // Exactly one device_pending across all cycles
+    expect(messagesOfType(app.messages, 'device_pending')).toHaveLength(1);
+
+    // Recover
+    tentacle.send({ type: 'pong' });
+    await new Promise(r => setTimeout(r, 50));
+
+    tentacle.close();
+    app.close();
+  });
+});

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -52,6 +52,12 @@ interface ClientState {
   pendingDeviceInfo?: { encryptionKey?: string };
   pendingAuthMethod?: string;
 
+  // ── Liveness uncertainty (device_pending broadcast) ──
+  /** Timestamp when pong grace period expires (null = no pending ping). */
+  pongOverdueAt: number | null;
+  /** Whether we already broadcast device_pending for this ping cycle. */
+  pendingLivenessBroadcast: boolean;
+
   // ── Delivery assurance (per-connection, head→peer direction) ──
   /** Monotonic counter for relaySeq head stamps on outbound tracked sends. */
   relaySeqCounter: number;
@@ -105,6 +111,9 @@ const MAX_RETRIES = 3;
  *  so detection latency tracks the recipient's ping cadence (~10s), not the
  *  liveness check cadence. */
 const RETRY_CHECK_INTERVAL_MS = 2_500;
+/** Grace period after ping before broadcasting device_pending (ms).
+ *  Overridable via PONG_GRACE_MS environment variable. */
+const PONG_GRACE_MS = Math.max(1_000, parseInt(process.env.PONG_GRACE_MS ?? '8000', 10) || 8_000);
 
 function isValidMessage(msg: unknown): msg is { type: string; [key: string]: unknown } {
   if (typeof msg !== 'object' || msg === null) return false;
@@ -187,6 +196,11 @@ export class HeadServer {
               pingMsg.ack = state.lastReceivedRelaySeq;
             }
             ws.send(JSON.stringify(pingMsg));
+            // Start the grace timer for device_pending broadcast
+            if (state) {
+              state.pongOverdueAt = Date.now() + PONG_GRACE_MS;
+              state.pendingLivenessBroadcast = false;
+            }
           }
         } catch {
           this.removeConnection(deviceId);
@@ -375,6 +389,19 @@ export class HeadServer {
         this.removeConnection(deviceId);
       }
     }
+
+    // ── Liveness uncertainty: broadcast device_pending when pong is overdue ──
+    for (const [deviceId, ws] of this.connections) {
+      const state = this.clients.get(ws);
+      if (!state?.authenticated || !state.userId) continue;
+      if (state.pongOverdueAt === null) continue;
+      if (state.pendingLivenessBroadcast) continue;
+      if (now <= state.pongOverdueAt) continue;
+
+      state.pendingLivenessBroadcast = true;
+      getLogger().debug('Broadcasting device_pending (pong overdue)', { deviceId });
+      this.broadcastDevicePending(state.userId, deviceId);
+    }
   }
 
   // ── End delivery assurance ──────────────────────────────
@@ -435,6 +462,8 @@ export class HeadServer {
       authenticated: false,
       isAlive: true,
       ip,
+      pongOverdueAt: null,
+      pendingLivenessBroadcast: false,
       relaySeqCounter: 0,
       inFlight: [],
       lastAckedSeq: 0,
@@ -447,7 +476,7 @@ export class HeadServer {
     this.clients.set(ws, state);
     logger.debug('WebSocket connected', { ip });
 
-    ws.on('pong', () => { state.isAlive = true; });
+    ws.on('pong', () => { this.onPongReceived(state); });
 
     ws.on('message', (data) => {
       try {
@@ -631,7 +660,7 @@ export class HeadServer {
     }
 
     if (msg.type === 'pong') {
-      state.isAlive = true;
+      this.onPongReceived(state);
       return;
     }
 
@@ -1333,6 +1362,42 @@ export class HeadServer {
     }
   }
 
+  private broadcastDevicePending(userId: string, pendingDeviceId: string): void {
+    let userDevices;
+    try {
+      userDevices = this.storage.getDevicesByUser(userId);
+    } catch { return; }
+    for (const d of userDevices) {
+      if (d.id === pendingDeviceId) continue;
+      const ws = this.connections.get(d.id);
+      if (!ws || ws.readyState !== WebSocket.OPEN) continue;
+      const targetState = this.clients.get(ws);
+      if (!targetState) continue;
+      this.trackedSend(ws, targetState, { type: 'device_pending', deviceId: pendingDeviceId });
+    }
+  }
+
+  /** Handle pong from either protocol-level or JSON pong.
+   *  Re-promotes to device_joined if we already broadcast device_pending.
+   *  Guards against stale pongs from replaced connections (reconnect race). */
+  private onPongReceived(state: ClientState): void {
+    state.isAlive = true;
+    const wasPending = state.pendingLivenessBroadcast;
+    state.pongOverdueAt = null;
+    state.pendingLivenessBroadcast = false;
+
+    if (wasPending && state.userId && state.deviceId) {
+      // Only re-promote if this state still belongs to the active connection.
+      // A reconnecting device may have replaced us in the connections map;
+      // broadcasting from a stale socket would emit a duplicate device_joined.
+      const activeWs = this.connections.get(state.deviceId);
+      const activeState = activeWs ? this.clients.get(activeWs) : null;
+      if (activeState === state) {
+        this.broadcastDeviceJoined(state.userId, state.deviceId);
+      }
+    }
+  }
+
   // --- Helpers ---
 
   private getDeviceSummaries(userId: string): DeviceSummary[] {
@@ -1496,6 +1561,61 @@ export class HeadServer {
   /** Test hook: force a retry pass without waiting for the timer. */
   forceRetryPass(): void {
     this.runRetryPass();
+  }
+
+  /** Test hook: run the ping pass (set isAlive=false, send ping, start grace timer). */
+  forcePingPass(): void {
+    for (const [deviceId, ws] of this.connections) {
+      const state = this.clients.get(ws);
+      if (state && !state.isAlive) {
+        getLogger().info('Terminating stale connection (no pong)', { deviceId });
+        this.removeConnection(deviceId);
+        continue;
+      }
+      if (state) state.isAlive = false;
+      try {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.ping();
+          const pingMsg: Record<string, unknown> = { type: 'ping' };
+          if (state && state.lastReceivedRelaySeq > 0) {
+            pingMsg.ack = state.lastReceivedRelaySeq;
+          }
+          ws.send(JSON.stringify(pingMsg));
+          if (state) {
+            state.pongOverdueAt = Date.now() + PONG_GRACE_MS;
+            state.pendingLivenessBroadcast = false;
+          }
+        }
+      } catch {
+        this.removeConnection(deviceId);
+      }
+    }
+  }
+
+  /** Test hook: simulate the effect of a ping pass on a single device without
+   *  actually sending a protocol-level ws.ping() (which triggers an auto-pong
+   *  from the ws library client, making it impossible to test overdue scenarios).
+   *  Sets isAlive=false and starts the grace timer. */
+  simulatePingSent(deviceId: string): void {
+    const ws = this.connections.get(deviceId);
+    if (!ws) return;
+    const state = this.clients.get(ws);
+    if (!state) return;
+    state.isAlive = false;
+    state.pongOverdueAt = Date.now() + PONG_GRACE_MS;
+    state.pendingLivenessBroadcast = false;
+  }
+
+  /** Test hook: expire the pong grace timer for a specific device so the next
+   *  retry pass will broadcast device_pending immediately. */
+  expirePongGrace(deviceId: string): void {
+    const ws = this.connections.get(deviceId);
+    if (!ws) return;
+    const state = this.clients.get(ws);
+    if (!state) return;
+    if (state.pongOverdueAt !== null) {
+      state.pongOverdueAt = Date.now() - 1;
+    }
   }
 
   close(): void {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -804,6 +804,15 @@ export interface DeviceLeftMessage {
   deviceId: string;
 }
 
+/** Sent to all connected devices when a device's liveness is uncertain
+ *  (ping sent but pong not yet received within the grace period).
+ *  Transient: will be followed by either device_joined (recovered)
+ *  or device_left (terminated). */
+export interface DevicePendingMessage {
+  type: 'device_pending';
+  deviceId: string;
+}
+
 /** Request to remove an offline device from the user's account. */
 export interface RemoveDeviceMessage {
   type: 'remove_device';
@@ -875,6 +884,7 @@ export type ControlMessage =
   | AuthInfoResponse
   | DeviceJoinedMessage
   | DeviceLeftMessage
+  | DevicePendingMessage
   | RemoveDeviceMessage
   | DeviceRemovedMessage
   | UpdatePreferencesMessage


### PR DESCRIPTION
## Motivation

Today the head broadcasts only `device_joined` / `device_left`. The transient window when the head has sent a ping but not yet received a pong (up to 30s) is hidden from arm  peers see the device as fully online right up until termination.clients 

## Changes

### Protocol (`@kraki/protocol`)
- New `DevicePendingMessage` type: `{ type: 'device_pending'; deviceId: string }`
- Added to `ControlMessage`  backwards compatible (older arms silently ignore it)union 

### Head (`@kraki/head`)

**State:** Two new fields on `ClientState`:
- `pongOverdueAt: number |  when pong grace expiresnull` 
- `pendingLivenessBroadcast:  whether we already announced pendingboolean` 

**Lifecycle:**
 `pongOverdueAt = now + PONG_GRACE_MS`, `pendingLivenessBroadcast = false`
 broadcast `device_pending` to peers, set flag
 `onPongReceived()` clears timer; if pending was broadcast, re-promotes via `device_joined`
 `device_left` (unchanged)

**Safety:**
- `PONG_GRACE_MS` configurable via env var (default 8s, floor 1s)
- `onPongReceived` guards against stale pongs from replaced connections (reconnect race)
- Pending check only runs for authenticated connections
- `device_pending` is never sent to the pending device itself

### Tests
5 integration tests in `device-pending.test.ts`:
 no `device_pending` emitted
 `device_pending` then `device_joined` re-promotion
 `device_pending` then `device_left`
-  `device_pending` not sent to the pending device itself
 exactly one pending

All 205 head tests pass (200 existing + 5 new).

### Version
 0.13.0 (protocol-additive)

## Follow-up (out of scope)
- Web arm: handle `device_pending` in ws-client, add `pendingDevices` store, shared `deviceState()` helper, refactor device dot components
- iOS arm: analogous `pending: Bool` flag on DeviceStore