### PR TITLE
fix(tentacle): graceful daemon shutdown and pending-message filter

### DIFF
--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -60,6 +60,17 @@ vi.mock('../logger.js', () => ({
   })),
 }));
 
+// Mock crypto so tests can hand-craft "encrypted" envelopes without real keys.
+// decryptFromBlob simply returns the blob string itself — tests treat the
+// blob field as the raw plaintext JSON to inject.
+vi.mock('@kraki/crypto', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@kraki/crypto');
+  return {
+    ...actual,
+    decryptFromBlob: vi.fn((payload: { blob: string }) => payload.blob),
+  };
+});
+
 import { RelayClient } from '../relay-client.js';
 import { AttachmentStore } from '../attachment-store.js';
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -539,6 +550,172 @@ describe('RelayClient set_session_model', () => {
     const sent = ws.sent.map((s: string) => JSON.parse(s));
     const deletedMsg = sent.find((m: { type: string }) => m.type === 'session_deleted');
     expect(deletedMsg).toBeDefined();
+  });
+});
+
+describe('RelayClient processPendingMessages filter', () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    vi.useFakeTimers();
+  });
+
+  function buildClientWithKeys() {
+    const adapter = {
+      ...createAdapter(),
+      sendMessage: vi.fn(() => Promise.resolve()),
+      respondToPermission: vi.fn(() => Promise.resolve()),
+      respondToQuestion: vi.fn(() => Promise.resolve()),
+      killSession: vi.fn(() => Promise.resolve()),
+      abortSession: vi.fn(() => Promise.resolve()),
+      setSessionMode: vi.fn(),
+    };
+    const sm = {
+      ...createSessionManager(),
+      deleteSession: vi.fn(),
+      removeLinkByKrakiId: vi.fn(),
+      markActive: vi.fn(),
+    };
+    const km = createKeyManager();
+    return { adapter, sm, km };
+  }
+
+  /** Connect and complete auth, then return ws and adapter/sm. */
+  function connectWithPending(
+    pendingMessages: Array<Record<string, unknown>>,
+  ): { adapter: Record<string, unknown>; sm: Record<string, unknown>; ws: typeof sockets[number] } {
+    const { adapter, sm, km } = buildClientWithKeys();
+    const client = new RelayClient(adapter, sm, {
+      relayUrl: 'ws://localhost:4000',
+      authMethod: 'open',
+      device: { name: 'Test', role: 'tentacle' },
+      reconnectDelay: 10,
+    }, km);
+    client.connect();
+    sockets[0].emit('open');
+    // The decryptFromBlob mock returns blob field as plaintext, so we put
+    // a JSON-stringified ConsumerMessage in the blob field directly.
+    const envelopes = pendingMessages.map((inner) => ({
+      type: 'unicast',
+      to: 'dev_1',
+      blob: JSON.stringify(inner),
+      keys: { dev_1: 'x' },
+    }));
+    sockets[0].emit('message', Buffer.from(JSON.stringify({
+      type: 'auth_ok',
+      deviceId: 'dev_1',
+      authMethod: 'open',
+      user: { id: 'u1', login: 'test', provider: 'open' },
+      devices: [],
+      pendingMessages: envelopes,
+    })));
+    return { adapter, sm, ws: sockets[0] };
+  }
+
+  it('processes pending delete_session', () => {
+    const { adapter, sm } = connectWithPending([
+      {
+        type: 'delete_session',
+        sessionId: 'stale_sess',
+        deviceId: 'dev_app',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: {},
+      },
+    ]);
+
+    expect(sm.deleteSession).toHaveBeenCalledWith('stale_sess');
+    expect(sm.removeLinkByKrakiId).toHaveBeenCalledWith('stale_sess');
+    expect(adapter.killSession).toHaveBeenCalledWith('stale_sess');
+  });
+
+  it('drops stale send_input without broadcasting user_message or calling adapter', () => {
+    const { adapter, ws } = connectWithPending([
+      {
+        type: 'send_input',
+        sessionId: 'sess_1',
+        deviceId: 'dev_app',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { text: 'remove the pinned icon' },
+      },
+    ]);
+
+    expect(adapter.sendMessage).not.toHaveBeenCalled();
+    const sent = ws.sent.map((s: string) => JSON.parse(s));
+    const userMsg = sent.find((m: { type: string }) => m.type === 'user_message');
+    expect(userMsg).toBeUndefined();
+  });
+
+  it('drops stale approve / deny without calling adapter.respondToPermission', () => {
+    const { adapter } = connectWithPending([
+      {
+        type: 'approve',
+        sessionId: 'sess_1',
+        deviceId: 'dev_app',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { permissionId: 'perm_1' },
+      },
+      {
+        type: 'deny',
+        sessionId: 'sess_1',
+        deviceId: 'dev_app',
+        seq: 2,
+        timestamp: new Date().toISOString(),
+        payload: { permissionId: 'perm_2' },
+      },
+    ]);
+
+    expect(adapter.respondToPermission).not.toHaveBeenCalled();
+  });
+
+  it('drops stale set_session_mode without applying it', () => {
+    const { adapter, sm } = connectWithPending([
+      {
+        type: 'set_session_mode',
+        sessionId: 'sess_1',
+        deviceId: 'dev_app',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { mode: 'execute' },
+      },
+    ]);
+
+    expect(adapter.setSessionMode).not.toHaveBeenCalled();
+    expect(sm.setMode).not.toHaveBeenCalled();
+  });
+
+  it('processes delete_session even when mixed with stale send_input', () => {
+    const { adapter, sm } = connectWithPending([
+      {
+        type: 'send_input',
+        sessionId: 'sess_1',
+        deviceId: 'dev_app',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { text: 'stale text' },
+      },
+      {
+        type: 'delete_session',
+        sessionId: 'sess_doomed',
+        deviceId: 'dev_app',
+        seq: 2,
+        timestamp: new Date().toISOString(),
+        payload: {},
+      },
+      {
+        type: 'approve',
+        sessionId: 'sess_1',
+        deviceId: 'dev_app',
+        seq: 3,
+        timestamp: new Date().toISOString(),
+        payload: { permissionId: 'perm_x' },
+      },
+    ]);
+
+    expect(sm.deleteSession).toHaveBeenCalledWith('sess_doomed');
+    expect(adapter.sendMessage).not.toHaveBeenCalled();
+    expect(adapter.respondToPermission).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -253,6 +253,46 @@ describe('CopilotAdapter', () => {
     it('stop() is safe to call without start', async () => {
       await adapter.stop(); // should not throw
     });
+
+    it('stop() aborts each active session before tearing down the client', async () => {
+      await adapter.start();
+      const a = await adapter.createSession({ model: 'gpt-5' });
+      const b = await adapter.createSession({ model: 'gpt-5' });
+
+      const sessionA = mockSessions.find(s => s.sessionId === a.sessionId)!;
+      const sessionB = mockSessions.find(s => s.sessionId === b.sessionId)!;
+
+      await adapter.stop();
+
+      expect(sessionA.abort).toHaveBeenCalledTimes(1);
+      expect(sessionB.abort).toHaveBeenCalledTimes(1);
+    });
+
+    it('stop() proceeds when one session.abort() hangs (timeout guard)', async () => {
+      await adapter.start();
+      const a = await adapter.createSession({ model: 'gpt-5' });
+      const b = await adapter.createSession({ model: 'gpt-5' });
+
+      const sessionA = mockSessions.find(s => s.sessionId === a.sessionId)!;
+      const sessionB = mockSessions.find(s => s.sessionId === b.sessionId)!;
+
+      // sessionA's abort hangs forever; sessionB resolves normally.
+      sessionA.abort.mockImplementation(() => new Promise(() => {}));
+
+      vi.useFakeTimers();
+      const stopP = adapter.stop();
+      // Let microtasks run, then exceed the abort timeout.
+      await vi.advanceTimersByTimeAsync(2_500);
+      await stopP;
+      vi.useRealTimers();
+
+      // Both sessions were attempted; the hung one was abandoned.
+      expect(sessionA.abort).toHaveBeenCalledTimes(1);
+      expect(sessionB.abort).toHaveBeenCalledTimes(1);
+      // listSessions returns [] — sessions map was cleared.
+      const sessions = await adapter.listSessions();
+      expect(sessions).toEqual([]);
+    });
   });
 
   describe('patchCopilotSdkSessionImport', () => {

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -360,6 +360,12 @@ export class CopilotAdapter extends AgentAdapter {
    */
   private static readonly IDLE_FALLBACK_MS = 500;
 
+  /** Max time to wait for a single session.abort() during adapter.stop().
+   *  If exceeded we fall through and let client.stop() kill the SDK process.
+   *  At worst we get the legacy orphaned tool_use behavior for that session;
+   *  any cleanly-aborted sessions still benefit. */
+  private static readonly STOP_ABORT_TIMEOUT_MS = 2_000;
+
   /** Set of attachment ids already broadcast for this session — prevents
    *  re-broadcasting bytes when the same image is shown twice. */
   private broadcastedAttachmentIds = new Map<string, Set<string>>();
@@ -527,6 +533,32 @@ export class CopilotAdapter extends AgentAdapter {
   async stop(): Promise<void> {
     for (const timer of this.idleTimers.values()) clearTimeout(timer);
     this.idleTimers.clear();
+
+    // Abort all active sessions first so the SDK writes a clean `abort` event
+    // to events.jsonl for any in-flight tool_use. Without this, killing the
+    // client mid-turn leaves the conversation history with an orphaned
+    // tool_use block, and Claude rejects the next resume with
+    // `messages.N: tool_use ids were found without tool_result blocks`.
+    // Each abort is guarded by a short timeout so a hung session doesn't
+    // hang shutdown — at worst we still get the legacy bad behavior for that
+    // one session, no worse than today.
+    const sessionIds = Array.from(this.sessions.keys());
+    if (sessionIds.length > 0) {
+      logger.debug({ count: sessionIds.length }, 'aborting active sessions before stop');
+      await Promise.all(sessionIds.map(async (sessionId) => {
+        try {
+          await Promise.race([
+            this.abortSession(sessionId),
+            new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error('abort timeout')), CopilotAdapter.STOP_ABORT_TIMEOUT_MS),
+            ),
+          ]);
+        } catch (err) {
+          logger.warn({ err, sessionId }, 'pre-stop abort failed');
+        }
+      }));
+    }
+
     if (this.client) {
       await this.client.stop();
       this.client = null;

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -965,13 +965,29 @@ export class RelayClient {
 
   /**
    * Process queued unicast envelopes delivered by the relay in auth_ok.
-   * These are messages sent by arms while this tentacle was offline.
-   * Must run before broadcastSessionList so deletes/mode changes take effect first.
+   * These are messages sent by arms while this tentacle was offline — they
+   * may be seconds to days old depending on how long the device was
+   * disconnected (the relay's pending_messages table has a 30-day TTL).
+   *
+   * Currently only `delete_session` is replayed: it's idempotent, time-
+   * insensitive, and the user's explicit intent to remove a session
+   * remains valid no matter how stale. Other types (send_input, approve,
+   * set_session_mode, etc.) carry interactive intent that decays quickly
+   * and could cause confusing behavior if replayed — e.g. a stale
+   * send_input would broadcast a phantom user_message and kick off an
+   * agent turn the user never asked for. Those are logged and dropped
+   * here; deciding which (if any) to replay needs further design.
+   *
+   * Must run before broadcastSessionList so delete_session takes effect
+   * before the arm receives the session list (otherwise the just-deleted
+   * session would appear in the list and then disappear).
    */
   private processPendingMessages(messages?: UnicastEnvelope[]): void {
     if (!messages || messages.length === 0 || !this.keyManager || !this.authInfo) return;
 
     logger.info(`Processing ${messages.length} pending message(s) from relay`);
+    let processed = 0;
+    let skipped = 0;
     for (const envelope of messages) {
       try {
         const decrypted = decryptFromBlob(
@@ -979,11 +995,20 @@ export class RelayClient {
           this.authInfo.deviceId,
           this.keyManager.getKeyPair().privateKey,
         );
-        const inner = JSON.parse(decrypted);
-        this.handleConsumerMessage(inner as ConsumerMessage);
+        const inner = JSON.parse(decrypted) as ConsumerMessage;
+        if (inner.type !== 'delete_session') {
+          logger.debug({ type: inner.type }, 'Skipping stale pending message');
+          skipped += 1;
+          continue;
+        }
+        this.handleConsumerMessage(inner);
+        processed += 1;
       } catch (err) {
         logger.warn({ err }, 'Failed to process pending message');
       }
+    }
+    if (skipped > 0) {
+      logger.info({ processed, skipped }, 'Pending message replay summary');
     }
   }
 

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -362,12 +362,18 @@ export async function performUpdate(currentVersion: string): Promise<void> {
   const { isDaemonRunning, stopDaemon, startDaemon, MacOSCodeSignatureError } = await import('./daemon.js');
   const daemonWasRunning = isDaemonRunning();
 
-  // On Windows, a running .exe is locked by the OS and cannot be renamed or
-  // overwritten. Stop the daemon before attempting to replace the binary.
-  if (daemonWasRunning && method === 'sea' && process.platform === 'win32') {
+  // Stop the daemon before the install. This serves two purposes:
+  //  1. On Windows, a running .exe is locked by the OS and cannot be renamed
+  //     or overwritten — without this, SEA updates fail with EBUSY and npm
+  //     -g installs fail when the running process holds the file open.
+  //  2. SIGTERM triggers the daemon's graceful shutdown path, which aborts
+  //     active SDK sessions cleanly so events.jsonl gets a proper `abort`
+  //     event. Skipping this leaves orphaned tool_use blocks in the
+  //     conversation history and the next resume hits CAPIError 400.
+  // Wait briefly for the process to release locks / finish flushing.
+  if (daemonWasRunning) {
     spinner.text = `Stopping daemon before update…`;
     stopDaemon();
-    // Wait for the process to release the file lock
     await waitForProcessExit(500, 10);
   }
 


### PR DESCRIPTION
## Problems

Three bugs surfaced together when v0.17.0 tentacle / v0.13.0 head shipped:

1. **CAPIError 400 `tool_use ids were found without tool_result  `adapter.stop()` killed the SDK client mid-turn without aborting active sessions. The SDK never wrote a closing `abort` event for in-flight tool_use, and Claude rejects the orphaned conversation on next resume.blocks`** 

2. **Windows EBUSY on `kraki  `npm install -g` fails because the running daemon holds the binary open. Pre-update stop only fired for SEA+Windows, not npm.update`** 

3. **Phantom `user_message` after  Head v0.13.0 finally started flushing the edge's `pending_messages` table (commit 61899d6 fixed a >1-month-old edge auth bug). Stale unicasts that had been stuck for days/weeks suddenly delivered as fresh user input, broadcasting a phantom bubble and kicking off an unwanted agent turn. `processPendingMessages` was replaying every queued type unconditionally.reconnect** 

## Fixes

### `packages/tentacle/src/adapters/copilot. `stop()`ts` 
Abort each active session before `client.stop()` so the SDK writes a clean `abort` event. `Promise.all` with a 2s per-session timeout so a hung session can't hang shutdown.

### `packages/tentacle/src/update. `performUpdate()`ts` 
Pre-update `stopDaemon()` now runs for **all** install methods on **all** platforms. Resolves the Windows EBUSY and ensures the graceful abort runs before macOS/Linux updates too.

### `packages/tentacle/src/relay-client. `processPendingMessages()`ts` 
Only `delete_session` is replayed (idempotent and time- the user's explicit intent to delete remains valid). Everything else is logged at debug and dropped. Which other types deserve replay is a separate design pass.insensitive 

## Tests

- `adapter.stop()` aborts each active session
- `adapter.stop()` proceeds past a hung `session.abort()` via timeout
- `processPendingMessages` runs `delete_session`
- `processPendingMessages` drops `send_input`, `approve`, `deny`, `set_session_mode`
- `processPendingMessages` runs `delete_session` mixed with stale types

`pnpm validate` passes (lint + builds + 451 tentacle tests + 281 arm-web tests + crypto/head/integration).

## Notes
- No protocol changes
- No schema changes
- No behavior change for non-update reconnects (existing pending_messages traffic was always going to  this just filters what gets acted on)deliver 
- Behavior of non-delete pending types is preserved as 'drop with a debug log'; revisit in a follow-up if/when we want time-aware replay for other types