### PR TITLE
feat(update): show download progress during kraki update

### DIFF
--- a/packages/tentacle/src/__tests__/update.test.ts
+++ b/packages/tentacle/src/__tests__/update.test.ts
@@ -20,7 +20,7 @@ vi.mock('node:https', async () => {
   };
 });
 
-import { fetchLatestVersion, getProxyForUrl, shouldBypassProxy } from '../update.js';
+import { fetchLatestVersion, formatBytes, getProxyForUrl, shouldBypassProxy } from '../update.js';
 
 function createMockResponse(statusCode: number, body: string, headers: Record<string, string> = {}) {
   const res = new PassThrough() as PassThrough & {
@@ -122,5 +122,25 @@ describe('update proxy support', () => {
     await expect(fetchLatestVersion()).resolves.toBe('0.12.0');
     expect(mockHttpRequest).toHaveBeenCalledOnce();
     expect(mockHttpsRequest).toHaveBeenCalledOnce();
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats < 1 KB as bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('formats KB without decimal', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1536)).toBe('2 KB');
+    expect(formatBytes(1024 * 1023)).toBe('1023 KB');
+  });
+
+  it('formats MB with 1 decimal', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.5 MB');
+    expect(formatBytes(121462912)).toBe('115.8 MB');
   });
 });

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -383,7 +383,14 @@ export async function performUpdate(currentVersion: string): Promise<void> {
         await updateViaNpm(latest);
         break;
       case 'sea':
-        await updateViaBinary(latest);
+        await updateViaBinary(latest, (received, total) => {
+          if (total > 0) {
+            const pct = Math.floor((received / total) * 100);
+            spinner.text = `Downloading ${pct}% (${formatBytes(received)} / ${formatBytes(total)})…`;
+          } else {
+            spinner.text = `Downloading ${formatBytes(received)}…`;
+          }
+        });
         break;
       default:
         spinner.fail('Cannot determine install method. Update manually.');
@@ -463,7 +470,10 @@ function getPlatformAssetName(): string {
   return `kraki-cli-${platform}-${arch}${ext}`;
 }
 
-async function updateViaBinary(version: string): Promise<void> {
+async function updateViaBinary(
+  version: string,
+  onProgress?: (received: number, total: number) => void,
+): Promise<void> {
   const assetName = getPlatformAssetName();
   // Try v* tag first, fall back to tentacle-v*
   let release: GitHubRelease;
@@ -485,7 +495,7 @@ async function updateViaBinary(version: string): Promise<void> {
   const tmpPath = join(tmpdir(), assetName + '.update');
 
   // Download binary
-  await downloadFile(downloadUrl, tmpPath);
+  await downloadFile(downloadUrl, tmpPath, onProgress);
 
   // Verify checksum if SHA256SUMS is available
   const checksumAsset = release.assets?.find((a) => a.name === 'SHA256SUMS.txt');
@@ -610,17 +620,46 @@ function fetchText(url: string): Promise<string> {
   });
 }
 
-async function downloadFile(url: string, dest: string): Promise<void> {
+async function downloadFile(
+  url: string,
+  dest: string,
+  onProgress?: (received: number, total: number) => void,
+): Promise<void> {
   const res = await sendRequest(url);
   if (res.statusCode !== 200) {
     throw new Error(`Download failed: HTTP ${res.statusCode}`);
   }
 
+  const contentLength = Number.parseInt(res.headers['content-length'] ?? '', 10);
+  const total = Number.isFinite(contentLength) && contentLength > 0 ? contentLength : 0;
+  let received = 0;
+  let lastTick = 0;
+
+  if (onProgress) {
+    res.on('data', (chunk: Buffer) => {
+      received += chunk.length;
+      // Throttle to ~10 updates/sec so the spinner doesn't churn.
+      const now = Date.now();
+      if (now - lastTick >= 100) {
+        lastTick = now;
+        onProgress(received, total);
+      }
+    });
+  }
+
   const file = createWriteStream(dest);
   try {
     await pipeline(res, file);
+    if (onProgress) onProgress(received, total); // final update
   } catch (err) {
     try { unlinkSync(dest); } catch { /* ignore */ }
     throw err;
   }
+}
+
+/** Format bytes as `12.3 MB` / `456 KB` / `78 B`. */
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }


### PR DESCRIPTION
## Why

 ` while downloading ~120 MB. Last night on a flaky network this looked indistinguishable from a  no feedback for several minutes while ~120 MB came down. (Spinner kept spinning, partial file was growing in `$TMPDIR/kraki-cli-*.update` but the user can't see that.)hang Y

## What changes

`downloadFile()` now takes an optional `onProgress(received, total)` callback. The SEA update path passes a callback that rewrites the existing ora spinner:

```
 Downloading 75% (90.5 MB / 121.0 MB)
```

When the `Content-Length` header is missing it falls back to a byte-count-only message:

```
 Downloading 12.4 MB
```

Updates are throttled to ~10/sec so the terminal doesn't churn, and a final update fires on pipeline completion so the last `100%` is always shown.

No behavioural change for npm updates (no download to  npm prints its own progress) and no throughput change for SEA (just observing the response stream).track 

## Tests

- 3 new `formatBytes` unit tests covering B / KB / MB
- Full tentacle suite: **454 pass** (was 451)
- `biome lint`: clean
