### PR TITLE
feat: turn-aware message pagination + context window telemetry

### DIFF
--- a/packages/protocol/src/devices.ts
+++ b/packages/protocol/src/devices.ts
@@ -70,4 +70,6 @@ export interface ModelDetail {
   supportsReasoningEffort: boolean;
   supportedReasoningEfforts?: ReasoningEffort[];
   defaultReasoningEffort?: ReasoningEffort;
+  /** Total token ceiling for the model (e.g. 200000). */
+  contextWindow?: number;
 }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -324,7 +324,10 @@ export interface DeviceGreetingMessage extends BaseEnvelope {
   };
 }
 
-/** Sent by tentacle to a device after replaying all buffered messages for a session. */
+/**
+ * Sent by tentacle to a device after replaying all buffered messages for a session.
+ * @deprecated Use `request_session_messages` / `session_messages_batch` instead.
+ */
 export interface SessionReplayBatchMessage extends BaseEnvelope {
   type: 'session_replay_batch';
   payload: {
@@ -336,6 +339,36 @@ export interface SessionReplayBatchMessage extends BaseEnvelope {
     lastSeq: number;
     /** The total highest seq in the session (for detecting if more messages are available). */
     totalLastSeq: number;
+  };
+}
+
+// ── Turn-aware message pagination ───────────────────
+
+/** Sent by app to tentacle to request turn-aligned messages for a session. */
+export interface RequestSessionMessagesMessage extends BaseEnvelope {
+  type: 'request_session_messages';
+  payload: {
+    /** Session to load messages for. */
+    sessionId: string;
+    /** Load messages strictly before this seq. Omit to load from head. */
+    beforeSeq?: number;
+  };
+}
+
+/** Sent by tentacle to a device with turn-aligned messages for a session. */
+export interface SessionMessagesBatchMessage extends BaseEnvelope {
+  type: 'session_messages_batch';
+  payload: {
+    /** The session these messages belong to. */
+    sessionId: string;
+    /** Messages in ascending seq order. Always composed of complete turns. */
+    messages: ProducerMessage[];
+    /** Lowest seq in messages. If 1, no older messages exist. */
+    firstSeq: number;
+    /** Highest seq in messages. */
+    lastSeq: number;
+    /** True if this batch covers the session head. */
+    containsHead: boolean;
   };
 }
 
@@ -442,6 +475,7 @@ export type ProducerMessage =
   | SessionReadMessage
   | DeviceGreetingMessage
   | SessionReplayBatchMessage
+  | SessionMessagesBatchMessage
   | SessionListMessage
   | PermissionResolvedMessage
   | QuestionResolvedMessage
@@ -557,7 +591,10 @@ export interface MarkReadMessage extends BaseEnvelope {
   };
 }
 
-/** Sent by app to tentacle to request replay for a specific session. */
+/**
+ * Sent by app to tentacle to request replay for a specific session.
+ * @deprecated Use `request_session_messages` / `session_messages_batch` instead.
+ */
 export interface RequestSessionReplayMessage extends BaseEnvelope {
   type: 'request_session_replay';
   payload: {
@@ -659,6 +696,7 @@ export type ConsumerMessage =
   | MarkReadMessage
   | MarkUnreadMessage
   | RequestSessionReplayMessage
+  | RequestSessionMessagesMessage
   | RenameSessionMessage
   | PinSessionMessage
   | RequestLocalSessionsMessage

--- a/packages/protocol/src/sessions.ts
+++ b/packages/protocol/src/sessions.ts
@@ -15,6 +15,8 @@ export interface SessionUsage {
   cacheWriteTokens: number;
   totalCost: number;
   totalDurationMs: number;
+  /** Prompt tokens used by the last turn — per-turn snapshot, NOT cumulative. */
+  contextTokens?: number;
 }
 
 export interface SessionSummary {

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -705,4 +705,172 @@ describe('SessionManager', () => {
       expect(inner.payload.attachments).toHaveLength(1);
     });
   });
+
+  // ── idleSeqs tracking ──────────────────────────────────
+
+  describe('idleSeqs tracking', () => {
+    it('maintains idleSeqs on appendMessage', () => {
+      const { sessionId } = sm.createSession('copilot');
+
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'hello' },
+      }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({
+        type: 'agent_message', sessionId, payload: { content: 'hi' },
+      }));
+      const idleSeq1 = sm.appendMessage(sessionId, 'idle', JSON.stringify({
+        type: 'idle', sessionId, payload: {},
+      }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({
+        type: 'agent_message', sessionId, payload: { content: 'more' },
+      }));
+      const idleSeq2 = sm.appendMessage(sessionId, 'idle', JSON.stringify({
+        type: 'idle', sessionId, payload: {},
+      }));
+
+      const meta = sm.getMeta(sessionId)!;
+      expect(meta.idleSeqs).toEqual([idleSeq1, idleSeq2]);
+    });
+
+    it('maintains idleSeqs on appendMessagesBatch', () => {
+      const { sessionId } = sm.createSession('copilot');
+
+      const messages = [
+        { type: 'user_message', payload: JSON.stringify({ type: 'user_message', payload: {} }) },
+        { type: 'agent_message', payload: JSON.stringify({ type: 'agent_message', payload: {} }) },
+        { type: 'idle', payload: JSON.stringify({ type: 'idle', payload: {} }) },
+        { type: 'user_message', payload: JSON.stringify({ type: 'user_message', payload: {} }) },
+        { type: 'agent_message', payload: JSON.stringify({ type: 'agent_message', payload: {} }) },
+        { type: 'idle', payload: JSON.stringify({ type: 'idle', payload: {} }) },
+      ];
+      sm.appendMessagesBatch(sessionId, messages);
+
+      const meta = sm.getMeta(sessionId)!;
+      expect(meta.idleSeqs).toEqual([3, 6]);
+    });
+
+    it('backfills idleSeqs from existing log', () => {
+      const { sessionId } = sm.createSession('copilot');
+
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', payload: {},
+      }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({
+        type: 'agent_message', payload: {},
+      }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({
+        type: 'idle', payload: {},
+      }));
+
+      // Manually remove idleSeqs from meta to simulate pre-existing session
+      const meta = sm.getMeta(sessionId)!;
+      delete meta.idleSeqs;
+      sm['writeMeta'](sessionId, meta);
+
+      // Verify it was removed
+      expect(sm.getMeta(sessionId)!.idleSeqs).toBeUndefined();
+
+      // findTurnAlignedStart triggers backfill
+      sm.findTurnAlignedStart(sessionId, 4);
+
+      const backfilled = sm.getMeta(sessionId)!;
+      expect(backfilled.idleSeqs).toEqual([3]);
+    });
+  });
+
+  // ── findTurnAlignedStart ────────────────────────────────
+
+  describe('findTurnAlignedStart', () => {
+    function buildSession(sm: SessionManager, turns: Array<{ msgCount: number }>): string {
+      const { sessionId } = sm.createSession('copilot');
+      for (const turn of turns) {
+        for (let i = 0; i < turn.msgCount - 1; i++) {
+          sm.appendMessage(sessionId, 'agent_message', JSON.stringify({
+            type: 'agent_message', payload: { content: `msg ${i}` },
+          }));
+        }
+        sm.appendMessage(sessionId, 'idle', JSON.stringify({
+          type: 'idle', payload: {},
+        }));
+      }
+      return sessionId;
+    }
+
+    it('anchors at latest idle before endSeqExclusive', () => {
+      // Turn 1: msgs 1-5, idle@5. Turn 2: msgs 6-10, idle@10. Turn 3: msgs 11-50, idle@50.
+      const { sessionId } = sm.createSession('copilot');
+      for (let i = 0; i < 4; i++) sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ type: 'idle', payload: {} })); // seq 5
+      for (let i = 0; i < 4; i++) sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ type: 'idle', payload: {} })); // seq 10
+      for (let i = 0; i < 39; i++) sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ type: 'idle', payload: {} })); // seq 50
+
+      // endSeqExclusive=60 → latest idle before 60 is @50 → candidateStart = 51
+      // 60 - 51 = 9, which is < 100, so extend backwards
+      // cursor goes to idle@10 → candidateStart = 11, 60 - 11 = 49, still < 100
+      // cursor goes to idle@5 → candidateStart = 6, 60 - 6 = 54, still < 100
+      // cursor goes to -1 → candidateStart = 1
+      const start = sm.findTurnAlignedStart(sessionId, 60);
+      // With only 50 messages total and soft cap 100, it should return 1
+      expect(start).toBe(1);
+    });
+
+    it('extends backwards to fill soft cap', () => {
+      // Create a session with enough messages that soft cap matters
+      // 20 turns of 10 messages each = 200 messages, idle at 10,20,...,200
+      const { sessionId } = sm.createSession('copilot');
+      for (let t = 0; t < 20; t++) {
+        for (let i = 0; i < 9; i++) sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+        sm.appendMessage(sessionId, 'idle', JSON.stringify({ type: 'idle', payload: {} }));
+      }
+      // idles at 10,20,...,200
+
+      // findTurnAlignedStart(sessionId, 201) → anchor at idle@200 → candidateStart=201
+      // Wait, 201 > 200, so latest idle < 201 is @200. candidateStart = 201.
+      // But 201-201 = 0 < 100, extend back: idle@190 → candidateStart=191, 201-191=10 < 100
+      // Continue extending... until we reach candidateStart where 201-candidateStart >= 100
+      // idle@100 → candidateStart=101, 201-101=100 >= 100 → stop
+      const start = sm.findTurnAlignedStart(sessionId, 201);
+      expect(start).toBe(101);
+    });
+
+    it('respects soft cap with many small turns', () => {
+      // 200 turns of 2 messages each (400 messages total), idle at every even seq
+      const { sessionId } = sm.createSession('copilot');
+      for (let t = 0; t < 200; t++) {
+        sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+        sm.appendMessage(sessionId, 'idle', JSON.stringify({ type: 'idle', payload: {} }));
+      }
+      // idles at 2,4,6,...,400
+
+      // findTurnAlignedStart(sessionId, 401)
+      // anchor at idle@400 → candidateStart=401, 401-401=0 < 100
+      // extend back: idle@398 → candidateStart=399, 401-399=2 < 100
+      // ... keep going until 401-candidateStart >= 100
+      // idle@300 → candidateStart=301, 401-301=100 >= 100 → stop
+      const start = sm.findTurnAlignedStart(sessionId, 401);
+      expect(start).toBe(301);
+    });
+
+    it('returns whole oversized turn when no earlier idle', () => {
+      // Single turn of 200 messages (no idle)
+      const { sessionId } = sm.createSession('copilot');
+      for (let i = 0; i < 200; i++) {
+        sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+      }
+
+      const start = sm.findTurnAlignedStart(sessionId, 201);
+      expect(start).toBe(1);
+    });
+
+    it('returns 1 for session with no idles', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+
+      const start = sm.findTurnAlignedStart(sessionId, 3);
+      expect(start).toBe(1);
+    });
+  });
 });

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -370,6 +370,24 @@ export class CopilotAdapter extends AgentAdapter {
    *  any cleanly-aborted sessions still benefit. */
   private static readonly STOP_ABORT_TIMEOUT_MS = 2_000;
 
+  private static readonly CONTEXT_WINDOWS: Record<string, number> = {
+    'claude-sonnet-4.6': 200_000,
+    'claude-sonnet-4.5': 200_000,
+    'claude-haiku-4.5': 200_000,
+    'claude-opus-4.7': 200_000,
+    'claude-opus-4.7-1m-internal': 1_000_000,
+    'claude-opus-4.6': 200_000,
+    'claude-opus-4.5': 200_000,
+    'gpt-5.5': 400_000,
+    'gpt-5.4': 400_000,
+    'gpt-5.3-codex': 400_000,
+    'gpt-5.2': 400_000,
+    'gpt-5.2-codex': 400_000,
+    'gpt-5.4-mini': 128_000,
+    'gpt-5-mini': 128_000,
+    'gpt-4.1': 1_000_000,
+  };
+
   /** Set of attachment ids already broadcast for this session — prevents
    *  re-broadcasting bytes when the same image is shown twice. */
   private broadcastedAttachmentIds = new Map<string, Set<string>>();
@@ -941,6 +959,7 @@ export class CopilotAdapter extends AgentAdapter {
         supportsReasoningEffort: m.capabilities?.supports?.reasoningEffort ?? false,
         ...(m.supportedReasoningEfforts && { supportedReasoningEfforts: m.supportedReasoningEfforts }),
         ...(m.defaultReasoningEffort && { defaultReasoningEffort: m.defaultReasoningEffort }),
+        ...(CopilotAdapter.CONTEXT_WINDOWS[m.id] && { contextWindow: CopilotAdapter.CONTEXT_WINDOWS[m.id] }),
       }));
     } catch (err) {
       logger.warn({ err: (err as Error).message }, 'listModelDetails failed');
@@ -1433,6 +1452,7 @@ export class CopilotAdapter extends AgentAdapter {
         cacheWriteTokens: prev.cacheWriteTokens + ((data.cacheWriteTokens as number) ?? 0),
         totalCost: prev.totalCost + ((data.cost as number) ?? 0),
         totalDurationMs: prev.totalDurationMs + ((data.duration as number) ?? 0),
+        contextTokens: (data.inputTokens as number) ?? prev.contextTokens,
       };
       this.sessionUsage.set(sessionId, updated);
       this.onUsageUpdate?.(sessionId, updated);

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -82,10 +82,10 @@ export class RelayClient {
     'error',
     'session_ended',
     'idle',
-    'session_replay_batch',
   ]);
   /** Global seq counter for envelope ordering (not used for replay — per-session seq handles that). */
   private seqCounter = 0;
+  private legacyReplayWarned = new Set<string>();
   /** Prefer challenge auth when the relay already knows this device */
   private preferChallengeAuth = true;
 
@@ -506,9 +506,19 @@ export class RelayClient {
       return;
     }
 
+    // request_session_messages — turn-aware paginated replay
+    if (msg.type === 'request_session_messages') {
+      this.handleSessionMessages(msg.deviceId, msg.payload.sessionId, msg.payload.beforeSeq);
+      return;
+    }
+
     // request_replay — replay buffered messages to the requesting device
     // request_session_replay — replay buffered messages for a specific session
     if (msg.type === 'request_session_replay') {
+      if (!this.legacyReplayWarned.has(msg.deviceId)) {
+        this.legacyReplayWarned.add(msg.deviceId);
+        logger.warn({ deviceId: msg.deviceId, sessionId: msg.payload.sessionId }, 'Arm using deprecated request_session_replay — should migrate to request_session_messages');
+      }
       this.handleSessionReplay(msg.deviceId, msg.payload.sessionId, msg.payload.afterSeq, msg.payload.limit);
       return;
     }
@@ -1397,6 +1407,86 @@ export class RelayClient {
     this.sendUnicastTo(requesterDeviceId, requesterKey, batchMsg);
   }
 
+  /**
+   * Handle a turn-aware session messages request.
+   */
+  private handleSessionMessages(requesterDeviceId: string, sessionId: string, beforeSeq: number | undefined): void {
+    const requesterKey = this.consumerKeys.get(requesterDeviceId);
+    if (!requesterKey) {
+      logger.warn({ requesterDeviceId }, 'Session messages requested but no encryption key for requester');
+      return;
+    }
+
+    const meta = this.sessionManager.getMeta(sessionId);
+    if (!meta) {
+      this.sendUnicastTo(requesterDeviceId, requesterKey, {
+        type: 'session_messages_batch',
+        deviceId: this.authInfo?.deviceId ?? '',
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: { sessionId, messages: [], firstSeq: 0, lastSeq: 0, containsHead: true },
+      });
+      return;
+    }
+
+    const headSeq = meta.lastSeq ?? 0;
+    const endSeqExclusive = beforeSeq ?? headSeq + 1;
+
+    if (endSeqExclusive <= 1) {
+      this.sendUnicastTo(requesterDeviceId, requesterKey, {
+        type: 'session_messages_batch',
+        deviceId: this.authInfo?.deviceId ?? '',
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: { sessionId, messages: [], firstSeq: 1, lastSeq: 0, containsHead: endSeqExclusive > headSeq },
+      });
+      return;
+    }
+
+    let startSeq = this.sessionManager.findTurnAlignedStart(sessionId, endSeqExclusive);
+
+    const HARD_CAP = 500;
+    if (endSeqExclusive - startSeq > HARD_CAP) {
+      startSeq = endSeqExclusive - HARD_CAP;
+    }
+
+    const endSeqInclusive = endSeqExclusive - 1;
+    const logged = this.sessionManager
+      .getMessagesAfterSeq(sessionId, startSeq - 1)
+      .filter(e => e.seq <= endSeqInclusive);
+
+    const parsed: Array<Record<string, unknown>> = [];
+    for (const entry of logged) {
+      if (!RelayClient.PERSISTENT_TYPES.has(entry.type)) continue;
+      try {
+        const msg = JSON.parse(entry.payload);
+        msg.seq = entry.seq;
+        parsed.push(msg);
+      } catch {
+        logger.warn({ seq: entry.seq, sessionId }, 'Failed to parse session message for turn-aware batch');
+      }
+    }
+
+    const batchMsg = {
+      type: 'session_messages_batch',
+      deviceId: this.authInfo?.deviceId ?? '',
+      seq: ++this.seqCounter,
+      timestamp: new Date().toISOString(),
+      payload: {
+        sessionId,
+        messages: parsed,
+        firstSeq: parsed.length > 0 ? parsed[0].seq as number : startSeq,
+        lastSeq: parsed.length > 0 ? (parsed.at(-1) as Record<string, unknown>).seq as number : startSeq - 1,
+        containsHead: endSeqInclusive >= headSeq,
+      },
+    };
+    logger.info(
+      { requesterDeviceId, sessionId, beforeSeq, startSeq, endSeqInclusive, count: parsed.length },
+      'Replied to turn-aware session messages request',
+    );
+    this.sendUnicastTo(requesterDeviceId, requesterKey, batchMsg);
+  }
+
   // ── Attachment bytes ────────────────────────────────
 
   /** Plaintext chunk budget for `attachment_data` envelopes.
@@ -1761,6 +1851,7 @@ export class RelayClient {
   private updateConsumerKeys(devices: DeviceSummary[]): void {
     this.consumerKeys.clear();
     this.onlineConsumers.clear();
+    this.legacyReplayWarned.clear();
     for (const d of devices) {
       if (d.role === 'app') {
         const key = d.encryptionKey ?? d.publicKey;

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -82,6 +82,8 @@ export interface SessionMeta {
    *  in place (the bytes weren't recoverable via the new ref path anyway,
    *  since they came from `view`-on-an-image, not show_image). */
   inlineImagesStripped?: boolean;
+  /** Seq numbers of idle messages — used for turn-aligned pagination. */
+  idleSeqs?: number[];
 }
 
 export interface RunRecord {
@@ -629,6 +631,11 @@ export class SessionManager {
     const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
     appendFileSync(logPath, line, 'utf8');
 
+    if (type === 'idle') {
+      if (!meta.idleSeqs) meta.idleSeqs = [];
+      meta.idleSeqs.push(seq);
+    }
+
     meta.lastSeq = seq;
     meta.updatedAt = new Date().toISOString();
     this.writeMeta(sessionId, meta);
@@ -657,6 +664,13 @@ export class SessionManager {
 
     const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
     appendFileSync(logPath, lines.join('\n') + '\n', 'utf8');
+
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i].type === 'idle') {
+        if (!meta.idleSeqs) meta.idleSeqs = [];
+        meta.idleSeqs.push(seq - messages.length + i + 1);
+      }
+    }
 
     meta.lastSeq = seq;
     meta.updatedAt = now;
@@ -850,6 +864,66 @@ export class SessionManager {
       }
     }
     return undefined;
+  }
+
+  // ── Turn-aligned pagination ──────────────────────────
+
+  private backfillIdleSeqs(sessionId: string): void {
+    const meta = this.readMeta(sessionId);
+    if (!meta || meta.idleSeqs) return;
+
+    const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
+    if (!existsSync(logPath)) {
+      meta.idleSeqs = [];
+      this.writeMeta(sessionId, meta);
+      return;
+    }
+
+    const idles: number[] = [];
+    const content = readFileSync(logPath, 'utf8');
+    for (const line of content.split('\n')) {
+      if (!line) continue;
+      try {
+        const entry = JSON.parse(line) as LoggedMessage;
+        if (entry.type === 'idle') idles.push(entry.seq);
+      } catch { /* skip corrupt lines */ }
+    }
+    meta.idleSeqs = idles;
+    this.writeMeta(sessionId, meta);
+  }
+
+  findTurnAlignedStart(sessionId: string, endSeqExclusive: number): number {
+    if (endSeqExclusive <= 1) return 1;
+
+    let meta = this.readMeta(sessionId);
+    if (!meta) return 1;
+    if (!meta.idleSeqs) {
+      this.backfillIdleSeqs(sessionId);
+      meta = this.readMeta(sessionId)!;
+    }
+    const idles = meta.idleSeqs ?? [];
+
+    // Binary search: find count of idles with seq < endSeqExclusive
+    let lo = 0, hi = idles.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (idles[mid] < endSeqExclusive) lo = mid + 1;
+      else hi = mid;
+    }
+    let cursor = lo - 1;
+
+    // Step A: anchor at latest idle before endSeqExclusive
+    let candidateStart = cursor >= 0 ? idles[cursor] + 1 : 1;
+
+    // Step B: extend backwards through whole turns until soft cap
+    const TURN_SOFT_CAP = 100;
+    while ((endSeqExclusive - candidateStart) < TURN_SOFT_CAP && candidateStart > 1) {
+      cursor--;
+      if (cursor < 0) { candidateStart = 1; break; }
+      candidateStart = idles[cursor] + 1;
+    }
+
+    return candidateStart;
   }
 
   private readMeta(sessionId: string): SessionMeta | null {


### PR DESCRIPTION
## Turn-aware message pagination

New `request_session_messages` / `session_messages_batch` protocol pair that paginates by **turn boundary** (idle-anchored) instead of message count. Clients ask "give me messages before seq X" and tentacle returns one or more complete turns.

- `SessionMeta.idleSeqs` tracks idle boundaries; backfills lazily for pre-existing sessions
- `findTurnAlignedStart` uses binary search + soft cap (100 messages) to return complete turns
- Hard cap at 500 messages per batch
- Deprecates `request_session_replay` / `session_replay_batch` with `@deprecated` JSDoc + one-time-per-device warning log
- Old path still  no client breakageworks 

## Context window telemetry

- `ModelDetail. static token ceiling per modelcontextWindow` 
- `SessionUsage. per-turn prompt token snapshot (not cumulative)contextTokens` 
- Copilot adapter: `CONTEXT_WINDOWS` lookup table + wired into `listModelDetails()` and `assistant.usage` handler

## Tests

10 new tests covering `idleSeqs` tracking, backfill, and `findTurnAlignedStart` edge cases. All 464 tentacle tests pass. Web build verified (backward compatible).

## Follow-up

After merge:
- iOS: swap to `request_session_messages`, remove message-content turn scanning
- Web: same swap in `MessageProvider`, simplify scroll controller