### PR TITLE
feat(oauth): dedicated /auth/callback path + PKCE for GitHub sign-in

### DIFF
--- a/packages/arm/web/src/lib/auth.ts
+++ b/packages/arm/web/src/lib/auth.ts
@@ -15,6 +15,7 @@ export async function sendAuth(
   pairingToken: string | undefined,
   storedDeviceId: string | undefined,
   githubCode: string | undefined,
+  githubOAuthExtras?: { codeVerifier?: string; redirectUri?: string },
 ): Promise<boolean> {
   const deviceName = `Web ${navigator.userAgent.includes('Mobile') ? 'Mobile' : 'Browser'}`;
 
@@ -36,9 +37,12 @@ export async function sendAuth(
       device,
     });
   } else if (githubCode) {
+    const oauthAuth: Record<string, unknown> = { method: 'github_oauth', code: githubCode };
+    if (githubOAuthExtras?.codeVerifier) oauthAuth.codeVerifier = githubOAuthExtras.codeVerifier;
+    if (githubOAuthExtras?.redirectUri) oauthAuth.redirectUri = githubOAuthExtras.redirectUri;
     send({
       type: 'auth',
-      auth: { method: 'github_oauth', code: githubCode },
+      auth: oauthAuth,
       device,
     });
   } else if (storedDeviceId) {

--- a/packages/arm/web/src/lib/transport.test.ts
+++ b/packages/arm/web/src/lib/transport.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { KrakiTransport, OAUTH_STATE_KEY, consumeOAuthState, storeOAuthState } from './transport';
+import {
+  KrakiTransport,
+  OAUTH_STATE_KEY,
+  OAUTH_VERIFIER_KEY,
+  OAUTH_REDIRECT_KEY,
+  OAUTH_CALLBACK_PATH,
+  consumeOAuthState,
+  consumePkceMaterial,
+  storeOAuthState,
+} from './transport';
 import { useStore } from '../hooks/useStore';
 
 const callbacks = {
@@ -52,6 +61,63 @@ describe('transport oauth state handling', () => {
     expect(useStore.getState().lastError).toBe('GitHub sign-in could not be verified. Please try again.');
     expect(sessionStorage.getItem(OAUTH_STATE_KEY)).toBeNull();
     expect(localStorage.getItem(OAUTH_STATE_KEY)).toBeNull();
+  });
+
+  it('captures the PKCE verifier + redirect_uri alongside the code', () => {
+    storeOAuthState('state-123');
+    sessionStorage.setItem(OAUTH_VERIFIER_KEY, 'v-abc');
+    sessionStorage.setItem(OAUTH_REDIRECT_KEY, 'https://app.example.com/auth/callback');
+    window.history.replaceState({}, '', '/auth/callback?code=gh-code&state=state-123');
+
+    const transport = new KrakiTransport(callbacks);
+
+    expect(transport.githubCode).toBe('gh-code');
+    expect(transport.codeVerifier).toBe('v-abc');
+    expect(transport.redirectUri).toBe('https://app.example.com/auth/callback');
+    // After consuming, PKCE storage is wiped so a stale code can't be replayed.
+    expect(sessionStorage.getItem(OAUTH_VERIFIER_KEY)).toBeNull();
+    expect(localStorage.getItem(OAUTH_VERIFIER_KEY)).toBeNull();
+  });
+
+  it('redirects /auth/callback back to / after consuming the code', () => {
+    storeOAuthState('state-123');
+    window.history.replaceState({}, '', '/auth/callback?code=gh-code&state=state-123');
+
+    new KrakiTransport(callbacks);
+
+    expect(window.location.pathname).toBe('/');
+    expect(window.location.search).toBe('');
+  });
+
+  it('still accepts the OAuth code on / for back-compat with older deploys', () => {
+    storeOAuthState('state-123');
+    window.history.replaceState({}, '', '/?code=gh-code&state=state-123');
+
+    const transport = new KrakiTransport(callbacks);
+
+    expect(transport.githubCode).toBe('gh-code');
+    expect(window.location.pathname).toBe('/');
+  });
+
+  it('consumePkceMaterial returns and wipes both storages', () => {
+    sessionStorage.setItem(OAUTH_VERIFIER_KEY, 'v-from-session');
+    localStorage.setItem(OAUTH_REDIRECT_KEY, 'https://app.example.com/auth/callback');
+
+    const popped = consumePkceMaterial();
+
+    expect(popped.codeVerifier).toBe('v-from-session');
+    expect(popped.redirectUri).toBe('https://app.example.com/auth/callback');
+    expect(sessionStorage.getItem(OAUTH_VERIFIER_KEY)).toBeNull();
+    expect(localStorage.getItem(OAUTH_VERIFIER_KEY)).toBeNull();
+    expect(sessionStorage.getItem(OAUTH_REDIRECT_KEY)).toBeNull();
+    expect(localStorage.getItem(OAUTH_REDIRECT_KEY)).toBeNull();
+  });
+
+  it('exports the dedicated /auth/callback path used by the AASA file', () => {
+    // Sanity check — the path must stay in lockstep with the AASA
+    // file hosted on the web domain. If you change one, change the
+    // other.
+    expect(OAUTH_CALLBACK_PATH).toBe('/auth/callback');
   });
 });
 

--- a/packages/arm/web/src/lib/transport.test.ts
+++ b/packages/arm/web/src/lib/transport.test.ts
@@ -63,6 +63,25 @@ describe('transport oauth state handling', () => {
     expect(localStorage.getItem(OAUTH_STATE_KEY)).toBeNull();
   });
 
+  it('wipes PKCE material even when state verification fails', () => {
+    // Hygiene: a callback with a bad state shouldn't be able to leave
+    // a stale verifier in storage. Belt-and-suspenders against an
+    // attacker who manages to deliver a malformed callback.
+    storeOAuthState('expected-state');
+    sessionStorage.setItem(OAUTH_VERIFIER_KEY, 'leaked-verifier');
+    sessionStorage.setItem(OAUTH_REDIRECT_KEY, 'https://app.example.com/auth/callback');
+    localStorage.setItem(OAUTH_VERIFIER_KEY, 'leaked-verifier');
+    localStorage.setItem(OAUTH_REDIRECT_KEY, 'https://app.example.com/auth/callback');
+    window.history.replaceState({}, '', '/?code=gh-code&state=wrong-state');
+
+    new KrakiTransport(callbacks);
+
+    expect(sessionStorage.getItem(OAUTH_VERIFIER_KEY)).toBeNull();
+    expect(localStorage.getItem(OAUTH_VERIFIER_KEY)).toBeNull();
+    expect(sessionStorage.getItem(OAUTH_REDIRECT_KEY)).toBeNull();
+    expect(localStorage.getItem(OAUTH_REDIRECT_KEY)).toBeNull();
+  });
+
   it('captures the PKCE verifier + redirect_uri alongside the code', () => {
     storeOAuthState('state-123');
     sessionStorage.setItem(OAUTH_VERIFIER_KEY, 'v-abc');

--- a/packages/arm/web/src/lib/transport.ts
+++ b/packages/arm/web/src/lib/transport.ts
@@ -233,9 +233,15 @@ export class KrakiTransport {
     // (current builds) or on the homepage `/` (older builds that ran
     // before the path swap — we still accept the code there so
     // in-flight flows complete cleanly).
+    //
+    // PKCE material is popped unconditionally whenever we see a
+    // `code` parameter — even on state-mismatch — so a stale verifier
+    // can't sit in storage indefinitely if an attacker (or stale tab)
+    // delivers a malformed callback. Treat the callback as the
+    // single-use trigger that consumes the matching verifier.
     if (params.githubCode) {
+      const pkce = consumePkceMaterial();
       if (consumeOAuthState(params.oauthState)) {
-        const pkce = consumePkceMaterial();
         this.githubCode = params.githubCode;
         this.codeVerifier = pkce.codeVerifier;
         this.redirectUri = pkce.redirectUri;

--- a/packages/arm/web/src/lib/transport.ts
+++ b/packages/arm/web/src/lib/transport.ts
@@ -56,6 +56,11 @@ export interface TransportCallbacks {
 }
 
 export const OAUTH_STATE_KEY = 'kraki_oauth_state';
+export const OAUTH_VERIFIER_KEY = 'kraki_oauth_verifier';
+export const OAUTH_REDIRECT_KEY = 'kraki_oauth_redirect';
+
+/** Path the SPA uses as its GitHub OAuth redirect URI. */
+export const OAUTH_CALLBACK_PATH = '/auth/callback';
 
 function safeGetItem(storage: Storage | undefined, key: string): string | null {
   if (!storage) return null;
@@ -107,16 +112,77 @@ export function consumeOAuthState(returnedState: string | undefined): boolean {
   return !!returnedState && (returnedState === sessionState || returnedState === localState);
 }
 
-/** Generate a random OAuth state param and store it persistently for CSRF protection */
-export function startOAuthFlow(clientId: string): void {
+function storePkceMaterial(verifier: string, redirectUri: string): void {
+  for (const storage of [getSessionStorage(), getLocalStorage()]) {
+    safeSetItem(storage, OAUTH_VERIFIER_KEY, verifier);
+    safeSetItem(storage, OAUTH_REDIRECT_KEY, redirectUri);
+  }
+}
+
+/**
+ * Pop the stored PKCE verifier + redirect URI used to start this
+ * OAuth flow. Removes from both session and local storage so a stale
+ * code can't be replayed against a freshly-generated verifier.
+ */
+export function consumePkceMaterial(): { codeVerifier?: string; redirectUri?: string } {
+  const verifier = safeGetItem(getSessionStorage(), OAUTH_VERIFIER_KEY)
+    ?? safeGetItem(getLocalStorage(), OAUTH_VERIFIER_KEY) ?? undefined;
+  const redirectUri = safeGetItem(getSessionStorage(), OAUTH_REDIRECT_KEY)
+    ?? safeGetItem(getLocalStorage(), OAUTH_REDIRECT_KEY) ?? undefined;
+  for (const storage of [getSessionStorage(), getLocalStorage()]) {
+    safeRemoveItem(storage, OAUTH_VERIFIER_KEY);
+    safeRemoveItem(storage, OAUTH_REDIRECT_KEY);
+  }
+  return { codeVerifier: verifier ?? undefined, redirectUri: redirectUri ?? undefined };
+}
+
+/** Generate a high-entropy PKCE code verifier (RFC 7636 §4.1). 43–128 chars. */
+function generateCodeVerifier(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+/** SHA-256 the verifier, base64url-encode the digest. PKCE S256 challenge. */
+async function deriveCodeChallenge(verifier: string): Promise<string> {
+  const buf = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Start the GitHub OAuth flow.
+ *
+ * Builds a CSRF state + PKCE verifier/challenge, persists both, and
+ * navigates to GitHub's authorize endpoint with a fixed dedicated
+ * callback path (`/auth/callback`). The same callback path is the
+ * one that future Universal Links / App Links setups will claim, so
+ * mobile clients can intercept the same URL without changing the
+ * OAuth App config.
+ */
+export async function startOAuthFlow(clientId: string): Promise<void> {
   const state = crypto.randomUUID();
   storeOAuthState(state);
-  const redirectUri = window.location.origin + window.location.pathname;
+
+  const verifier = generateCodeVerifier();
+  const challenge = await deriveCodeChallenge(verifier);
+
+  const redirectUri = window.location.origin + OAUTH_CALLBACK_PATH;
+  storePkceMaterial(verifier, redirectUri);
+
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     scope: 'read:user',
     state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
   });
   window.location.href = `https://github.com/login/oauth/authorize?${params.toString()}`;
 }
@@ -126,6 +192,10 @@ export class KrakiTransport {
   private _url: string;
   pairingToken?: string;
   githubCode?: string;
+  /** PKCE verifier matching the challenge sent at authorize time. */
+  codeVerifier?: string;
+  /** The exact redirect_uri used at authorize time — required at exchange. */
+  redirectUri?: string;
   storedDeviceId?: string;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelay = RECONNECT_BASE;
@@ -158,19 +228,32 @@ export class KrakiTransport {
     this.storedDeviceId = stored?.deviceId;
     this.callbacks = callbacks;
 
-    // Validate and extract GitHub OAuth code from callback
+    // Validate and extract GitHub OAuth code from callback. The
+    // callback may arrive on the dedicated `/auth/callback` path
+    // (current builds) or on the homepage `/` (older builds that ran
+    // before the path swap — we still accept the code there so
+    // in-flight flows complete cleanly).
     if (params.githubCode) {
       if (consumeOAuthState(params.oauthState)) {
+        const pkce = consumePkceMaterial();
         this.githubCode = params.githubCode;
+        this.codeVerifier = pkce.codeVerifier;
+        this.redirectUri = pkce.redirectUri;
       } else {
         getStore().setLastError('GitHub sign-in could not be verified. Please try again.');
         logger.warn('OAuth state mismatch — ignoring code');
       }
     }
 
-    // Clean URL params after reading (don't leak pairing token or OAuth code in address bar)
+    // Clean URL params after reading (don't leak pairing token or
+    // OAuth code in address bar). When we landed on the dedicated
+    // OAuth callback path, also redirect back to root so a refresh
+    // doesn't restart the OAuth attempt on a stale code.
     if (params.token || params.githubCode) {
-      window.history.replaceState({}, '', window.location.pathname);
+      const cleanPath = window.location.pathname === OAUTH_CALLBACK_PATH
+        ? '/'
+        : window.location.pathname;
+      window.history.replaceState({}, '', cleanPath);
     }
   }
 

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -467,12 +467,18 @@ export class KrakiWSClient {
       this.transport.pairingToken,
       this.transport.storedDeviceId,
       this.transport.githubCode,
+      {
+        codeVerifier: this.transport.codeVerifier,
+        redirectUri: this.transport.redirectUri,
+      },
     );
     if (usedToken) {
       this.transport.pairingToken = undefined;
     }
     if (this.transport.githubCode) {
       this.transport.githubCode = undefined;
+      this.transport.codeVerifier = undefined;
+      this.transport.redirectUri = undefined;
     }
   }
 

--- a/packages/arm/web/src/pages/DashboardPage.tsx
+++ b/packages/arm/web/src/pages/DashboardPage.tsx
@@ -61,7 +61,7 @@ export function DashboardPage() {
 
         {clientId && (
           <button
-            onClick={() => startOAuthFlow(clientId)}
+            onClick={() => { void startOAuthFlow(clientId); }}
             className="mt-6 inline-flex cursor-pointer items-center gap-2 rounded-lg bg-[#24292f] px-5 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#32383f] dark:bg-[#f0f0f0] dark:text-[#24292f] dark:hover:bg-[#d0d0d0] animate-fade-up"
           >
             <GitHubMark className="h-5 w-5" />

--- a/packages/head/.env.example
+++ b/packages/head/.env.example
@@ -6,7 +6,10 @@
 
 # GitHub OAuth App credentials (required for "Sign in with GitHub" on the web app)
 # Create one at: GitHub → Settings → Developer settings → OAuth Apps → New
-# Set the callback URL to your web app URL (e.g. http://localhost:3000)
+# Set the Authorization callback URL to the root of your web app
+# (e.g. http://localhost:3000) — the SPA redirects users to its
+# /auth/callback subpath, which is automatically a valid subpath of
+# the registered root.
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
 

--- a/packages/head/src/__tests__/auth.test.ts
+++ b/packages/head/src/__tests__/auth.test.ts
@@ -73,6 +73,72 @@ describe('GitHubAuthProvider', () => {
       expect(result.message).toContain('Unexpected');
     }
   });
+
+  it('forwards code_verifier and redirect_uri to GitHub when exchanging an OAuth code', async () => {
+    // Intercept the two fetch calls (token-exchange POST, then user-info GET).
+    const seenBodies: string[] = [];
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.includes('/login/oauth/access_token')) {
+        seenBodies.push(typeof init?.body === 'string' ? init.body : '');
+        return new Response(JSON.stringify({ access_token: 'gho_xyz' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ id: 1, login: 'corelli' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const provider = new GitHubAuthProvider({
+      fetcher,
+      clientId: 'Ov_test',
+      clientSecret: 'sek',
+    });
+    const result = await provider.authenticate({
+      githubCode: 'code_xyz',
+      codeVerifier: 'verifier_42',
+      redirectUri: 'https://app.example.com/auth/callback',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(seenBodies).toHaveLength(1);
+    const body = JSON.parse(seenBodies[0]) as Record<string, string>;
+    expect(body.code).toBe('code_xyz');
+    expect(body.code_verifier).toBe('verifier_42');
+    expect(body.redirect_uri).toBe('https://app.example.com/auth/callback');
+    expect(body.client_id).toBe('Ov_test');
+    expect(body.client_secret).toBe('sek');
+  });
+
+  it('omits code_verifier and redirect_uri from the exchange body when not provided', async () => {
+    let body = '';
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.includes('/login/oauth/access_token')) {
+        body = typeof init?.body === 'string' ? init.body : '';
+        return new Response(JSON.stringify({ access_token: 'gho_xyz' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ id: 1, login: 'a' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const provider = new GitHubAuthProvider({
+      fetcher,
+      clientId: 'Ov_test',
+      clientSecret: 'sek',
+    });
+    await provider.authenticate({ githubCode: 'code_xyz' });
+
+    const parsed = JSON.parse(body) as Record<string, string>;
+    expect(parsed.code_verifier).toBeUndefined();
+    expect(parsed.redirect_uri).toBeUndefined();
+  });
 });
 
 describe('OpenAuthProvider', () => {

--- a/packages/head/src/auth.ts
+++ b/packages/head/src/auth.ts
@@ -47,6 +47,19 @@ export interface AuthCredentials {
   channelKey?: string;
   /** GitHub OAuth authorization code (exchanged for access token) */
   githubCode?: string;
+  /**
+   * PKCE code verifier matching the `code_challenge` used to obtain
+   * `githubCode`. Required by GitHub's token-exchange endpoint when
+   * the authorize request was PKCE-protected. Public clients (web,
+   * mobile) should always send this.
+   */
+  codeVerifier?: string;
+  /**
+   * Exact `redirect_uri` the client passed to GitHub's authorize
+   * endpoint. GitHub matches this at token-exchange time to defeat
+   * code substitution. Optional but recommended.
+   */
+  redirectUri?: string;
   /** IP address of the connecting device (set by the server, not the client) */
   ip?: string;
 }
@@ -83,24 +96,37 @@ export class GitHubAuthProvider implements AuthProvider {
   /**
    * Exchange a GitHub OAuth authorization code for an access token.
    * Requires clientId and clientSecret to be configured.
+   *
+   * `codeVerifier` and `redirectUri` are forwarded to GitHub when
+   * provided. GitHub requires `code_verifier` whenever the original
+   * authorize request included a `code_challenge` (PKCE), and validates
+   * `redirect_uri` against the URL used at authorize time when it was
+   * supplied. Public clients (web, mobile) should always send both.
    */
-  async exchangeCode(code: string): Promise<{ ok: true; token: string } | { ok: false; message: string }> {
+  async exchangeCode(
+    code: string,
+    opts?: { codeVerifier?: string; redirectUri?: string },
+  ): Promise<{ ok: true; token: string } | { ok: false; message: string }> {
     if (!this.clientId || !this.clientSecret) {
       return { ok: false, message: 'GitHub OAuth not configured (missing client_id/client_secret)' };
     }
 
     try {
+      const body: Record<string, string> = {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code,
+      };
+      if (opts?.codeVerifier) body.code_verifier = opts.codeVerifier;
+      if (opts?.redirectUri) body.redirect_uri = opts.redirectUri;
+
       const res = await this.fetcher('https://github.com/login/oauth/access_token', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           Accept: 'application/json',
         },
-        body: JSON.stringify({
-          client_id: this.clientId,
-          client_secret: this.clientSecret,
-          code,
-        }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) {
@@ -126,7 +152,10 @@ export class GitHubAuthProvider implements AuthProvider {
 
     // If a GitHub OAuth code is provided, exchange it for an access token first
     if (!token && credentials.githubCode) {
-      const exchange = await this.exchangeCode(credentials.githubCode);
+      const exchange = await this.exchangeCode(credentials.githubCode, {
+        codeVerifier: credentials.codeVerifier,
+        redirectUri: credentials.redirectUri,
+      });
       if (!exchange.ok) {
         return { ok: false, message: exchange.message };
       }

--- a/packages/head/src/local-auth-backend.ts
+++ b/packages/head/src/local-auth-backend.ts
@@ -488,17 +488,23 @@ export class LocalAuthBackend implements AuthBackend {
 
   private async resolveAuthUser(auth: AuthMethod): Promise<AuthUser | { ok: false; code: string; message: string }> {
     let provider: AuthProvider | undefined;
-    let credentials: { token?: string; githubCode?: string; ip?: string } = {};
+    let credentials: { token?: string; githubCode?: string; codeVerifier?: string; redirectUri?: string; ip?: string } = {};
 
     switch (auth.method) {
       case 'github_token':
         provider = this.getProviderForMode('github');
         credentials = { token: auth.token };
         break;
-      case 'github_oauth':
+      case 'github_oauth': {
         provider = this.getProviderForMode('github');
-        credentials = { githubCode: auth.code };
+        const oauthAuth = auth as { method: 'github_oauth'; code: string; codeVerifier?: string; redirectUri?: string };
+        credentials = {
+          githubCode: oauthAuth.code,
+          codeVerifier: typeof oauthAuth.codeVerifier === 'string' ? oauthAuth.codeVerifier : undefined,
+          redirectUri: typeof oauthAuth.redirectUri === 'string' ? oauthAuth.redirectUri : undefined,
+        };
         break;
+      }
       case 'apikey':
         provider = this.getProviderForMode('apikey');
         credentials = { token: auth.key };

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -826,7 +826,13 @@ export class HeadServer {
 
       case 'github_oauth': {
         const provider = this.getAuthProviderForMode('github');
-        const result = await provider.authenticate({ githubCode: auth.code, ip: state.ip });
+        const oauthAuth = auth as { method: 'github_oauth'; code: string; codeVerifier?: string; redirectUri?: string };
+        const result = await provider.authenticate({
+          githubCode: oauthAuth.code,
+          codeVerifier: typeof oauthAuth.codeVerifier === 'string' ? oauthAuth.codeVerifier : undefined,
+          redirectUri: typeof oauthAuth.redirectUri === 'string' ? oauthAuth.redirectUri : undefined,
+          ip: state.ip,
+        });
         if (!result.ok) {
           logger.warn('Auth rejected', { method: 'github_oauth', ip: state.ip, reason: result.message });
           this.sendAuthError(ws, 'auth_rejected', result.message);

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -715,6 +715,20 @@ export interface GithubTokenAuth {
 export interface GithubOAuthAuth {
   method: 'github_oauth';
   code: string;
+  /**
+   * PKCE code verifier — the random string whose SHA-256 hash was sent
+   * as `code_challenge` when this OAuth flow was started. Optional for
+   * back-compat, but required by GitHub's token-exchange endpoint when
+   * a `code_challenge` was originally provided.
+   */
+  codeVerifier?: string;
+  /**
+   * The exact `redirect_uri` the client used in the authorize URL.
+   * GitHub validates this matches at token-exchange time when the
+   * authorize request included one. Optional to preserve back-compat
+   * with older clients that never sent it.
+   */
+  redirectUri?: string;
 }
 
 export interface PairingAuth {


### PR DESCRIPTION
Foundation for multi-platform GitHub OAuth. Web behavior unchanged for users; sets up a clean target the iOS app (and any future Android client) can intercept via Universal Links / App Links without needing a separate OAuth App.

## Why

GitHub OAuth Apps register exactly one callback URL with prefix-matching for `redirect_uri`. The web was using `/` as its redirect_uri, which made any future native client have to either register a second OAuth App or use a custom URL  both inelegant.scheme 

Moving the web to a dedicated subpath (`/auth/callback`) under the already-registered root callback is a no-op for GitHub (subpaths are auto-allowed by GitHub's matching rule) but reserves a clean target that future Universal Links can claim without affecting normal SPA routing.

While here, add **PKCE (RFC 7636)** for defense in depth. The web doesn't strictly need PKCE since the relay holds `client_secret` server-side, but enabling it on web first lets the relay-side plumbing settle ahead of the iOS migration where PKCE is genuinely required (mobile clients can't safely hold a `client_secret`).

## Changes

**protocol**
- `GithubOAuthAuth` gains optional `codeVerifier` + `redirectUri` fields. Older clients without them keep  the relay only forwards them when present.working 

**head (relay)**
- `GitHubAuthProvider.exchangeCode` now takes an opts bag and forwards `code_verifier` + `redirect_uri` into the GitHub token-exchange POST body when provided.
- `AuthCredentials` carries the two extras through the abstract auth boundary.
- `server.ts` and `local-auth-backend.ts` both unpack the new fields from the `github_oauth` auth message and pass them through.

**arm/web**
- `startOAuthFlow` generates a 32-byte PKCE verifier, derives the S256 challenge via SubtleCrypto, persists verifier + the exact redirect_uri in both sessionStorage AND localStorage (same durability story as the existing `state`  survives the GitHub bounce on flaky mobile browsers).field 
- `redirect_uri` switches from `window.location.pathname` to `${origin}/auth/callback`.
- `KrakiTransport` gains `codeVerifier` + `redirectUri` fields, populated from the popped PKCE material when consuming the callback. After consumption, the path is rewritten to `/` so a refresh doesn't replay a stale code, and PKCE storage is wiped so the verifier can't be reused.
- **Back-compat**: a stray code on `/` (older deploy in-flight across the boundary) is still accepted so users mid-flow during deploy don't get stranded.
- `sendAuth` signature grows to pass the extras into the WS auth message.

**local config**
- `.env. updated guidance to reflect the new callback path convention.example` 
- `packages/head/. cleared out the confusing `Iv`-prefixed local dev client (which was actually a *GitHub App*, not an OAuth App). Local devs should populate with the prod OAuth App credentials or a personal one pointing at localhost. File is  change is local only.gitignored env` 

## Tests

- `transport.test. new cases for PKCE pop, `/auth/callback` path-rewrite, back-compat with `/?code=...`, and a sanity check that the exported callback path stays in lockstep with what the iOS AASA file will claim.ts` 
- `auth.test.ts` ( two new cases assert that `code_verifier` + `redirect_uri` arrive at GitHub's token endpoint when supplied, and that they're omitted when not (no silent garbage in the request).head) 

`pnpm validate` passes locally: 286 + 43 + 464 tests across the affected packages green.

## Rollout

1. **This  ships the dedicated callback + PKCE. Web continues to use the same OAuth App; redirect_uri auto-validates against the registered root callback URL via GitHub's prefix-match rule. No GitHub-side config change required.PR** 
2. **Infra follow- host the AASA file at `https://app.kraki.chat/.well-known/apple-app-site-association` listing `3A83X5JZ3S.chat.kraki.ios` claiming `/auth/callback*`.up** 
3. **iOS PR (separate, on `kraki-ios`  add Associated Domains entitlement + switch `ASWebAuthenticationSession` to `.https(host:path:)` callback. Same URL is intercepted by iOS for app-installed users; web users continue getting the page.repo)** 

Each step can ship independently; nothing blocks anything else and rollback at any step only affects that platform.
