### PR TITLE
feat(protocol): clientId-based pending input correlation

### DIFF
--- a/packages/arm/web/src/hooks/useStore.test.ts
+++ b/packages/arm/web/src/hooks/useStore.test.ts
@@ -205,6 +205,158 @@ describe('useStore', () => {
       expect(useStore.getState().messages.get('sess-1')).toHaveLength(1);
       expect(useStore.getState().messages.get('sess-2')).toHaveLength(1);
     });
+
+    it('appendMessage dedups by [type, seq] when seq > 0 (defends against relay re-broadcasts)', () => {
+      useStore.getState().appendMessage('sess-1', mockMessage);
+      const updated = { ...mockMessage, payload: { content: 'updated content' } } as ChatMessage;
+      useStore.getState().appendMessage('sess-1', updated);
+      const msgs = useStore.getState().messages.get('sess-1');
+      expect(msgs).toHaveLength(1);
+      expect((msgs![0] as typeof mockMessage).payload.content).toBe('updated content');
+    });
+
+    it('appendMessage does NOT dedup pending_input (seq=0)', () => {
+      const pendingA = {
+        type: 'pending_input' as const,
+        id: 'cid-a',
+        clientId: 'cid-a',
+        sessionId: 'sess-1',
+        text: 'first',
+        timestamp: new Date().toISOString(),
+      };
+      const pendingB = { ...pendingA, id: 'cid-b', clientId: 'cid-b', text: 'second' };
+      useStore.getState().appendMessage('sess-1', pendingA);
+      useStore.getState().appendMessage('sess-1', pendingB);
+      const msgs = useStore.getState().messages.get('sess-1');
+      expect(msgs).toHaveLength(2);
+    });
+  });
+
+  describe('pending input resolution', () => {
+    const makePending = (clientId: string, text: string, sessionId = 'sess-1') => ({
+      type: 'pending_input' as const,
+      id: clientId,
+      clientId,
+      sessionId,
+      text,
+      timestamp: new Date().toISOString(),
+    });
+
+    it('resolves by clientId and replaces pending with user_message', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-1', 'hello'));
+      const ok = useStore.getState().resolvePendingInput('sess-1', 5, 'cid-1', 'hello');
+      expect(ok).toBe(true);
+      const msgs = useStore.getState().messages.get('sess-1');
+      expect(msgs).toHaveLength(1);
+      const resolved = msgs![0] as { type: string; seq: number; payload: { content: string } };
+      expect(resolved.type).toBe('user_message');
+      expect(resolved.seq).toBe(5);
+      expect(resolved.payload.content).toBe('hello');
+    });
+
+    it('uses serverContent when provided (overrides pending text)', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-1', 'local'));
+      useStore.getState().resolvePendingInput('sess-1', 5, 'cid-1', 'authoritative');
+      const msgs = useStore.getState().messages.get('sess-1');
+      expect((msgs![0] as { payload: { content: string } }).payload.content).toBe('authoritative');
+    });
+
+    it('falls back to pending text when serverContent is undefined', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-1', 'local-only'));
+      useStore.getState().resolvePendingInput('sess-1', 5, 'cid-1', undefined);
+      const msgs = useStore.getState().messages.get('sess-1');
+      expect((msgs![0] as { payload: { content: string } }).payload.content).toBe('local-only');
+    });
+
+    it('returns false and does nothing when clientId does not match any pending', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-1', 'hello'));
+      const ok = useStore.getState().resolvePendingInput('sess-1', 5, 'cid-other', 'hello');
+      expect(ok).toBe(false);
+      const msgs = useStore.getState().messages.get('sess-1');
+      expect(msgs).toHaveLength(1);
+      expect(msgs![0].type).toBe('pending_input');
+    });
+
+    it('returns false when session has no messages', () => {
+      const ok = useStore.getState().resolvePendingInput('sess-empty', 1, 'cid-1', 'x');
+      expect(ok).toBe(false);
+    });
+
+    it('rapid-send: two pendings with distinct clientIds are resolved independently', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-a', 'first message'));
+      useStore.getState().appendMessage('sess-1', makePending('cid-b', 'second message'));
+
+      // Server acks the first send
+      useStore.getState().resolvePendingInput('sess-1', 1, 'cid-a', 'first message');
+      let msgs = useStore.getState().messages.get('sess-1')!;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].type).toBe('user_message');
+      expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('first message');
+      expect(msgs[1].type).toBe('pending_input');
+
+      // Server acks the second send
+      useStore.getState().resolvePendingInput('sess-1', 2, 'cid-b', 'second message');
+      msgs = useStore.getState().messages.get('sess-1')!;
+      expect(msgs).toHaveLength(2);
+      expect(msgs.every((m) => m.type === 'user_message')).toBe(true);
+      expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('first message');
+      expect((msgs[1] as { payload: { content: string } }).payload.content).toBe('second message');
+    });
+
+    it('rapid-send acks arriving out of order (cid-b first, then cid-a) still attribute content correctly', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-a', 'first message'));
+      useStore.getState().appendMessage('sess-1', makePending('cid-b', 'second message'));
+
+      // Out-of-order: server acks the second one first with seq=2
+      useStore.getState().resolvePendingInput('sess-1', 2, 'cid-b', 'second message');
+      // Then the first with seq=1
+      useStore.getState().resolvePendingInput('sess-1', 1, 'cid-a', 'first message');
+
+      const msgs = useStore.getState().messages.get('sess-1')!;
+      expect(msgs).toHaveLength(2);
+      // List is sorted by seq → seq=1 comes first
+      expect((msgs[0] as { seq: number }).seq).toBe(1);
+      expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('first message');
+      expect((msgs[1] as { seq: number }).seq).toBe(2);
+      expect((msgs[1] as { payload: { content: string } }).payload.content).toBe('second message');
+    });
+
+    it('legacy fallback: no clientId resolves the first pending in the list', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-a', 'oldest'));
+      useStore.getState().appendMessage('sess-1', makePending('cid-b', 'newer'));
+      const ok = useStore.getState().resolvePendingInput('sess-1', 1, undefined, undefined);
+      expect(ok).toBe(true);
+      const msgs = useStore.getState().messages.get('sess-1')!;
+      expect(msgs).toHaveLength(2);
+      // First pending (cid-a) is resolved using its own text
+      expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('oldest');
+      expect(msgs[1].type).toBe('pending_input');
+      expect((msgs[1] as { clientId: string }).clientId).toBe('cid-b');
+    });
+
+    it('sorts list by seq after resolve (handles transient events that landed mid-flight)', () => {
+      // Pending added first, then a tool event with a real seq came in,
+      // then the user_message ack arrives.
+      useStore.getState().appendMessage('sess-1', makePending('cid-1', 'hello'));
+      const toolEvent = {
+        type: 'tool_start' as const,
+        sessionId: 'sess-1',
+        deviceId: '',
+        seq: 7,
+        timestamp: new Date().toISOString(),
+        payload: { id: 'tool-1', name: 'shell', args: {} },
+      } as unknown as ChatMessage;
+      useStore.getState().appendMessage('sess-1', toolEvent);
+      useStore.getState().resolvePendingInput('sess-1', 5, 'cid-1', 'hello');
+
+      const msgs = useStore.getState().messages.get('sess-1')!;
+      expect(msgs).toHaveLength(2);
+      // user_message (seq=5) sorted before tool_start (seq=7)
+      expect((msgs[0] as { type: string; seq: number }).type).toBe('user_message');
+      expect((msgs[0] as { seq: number }).seq).toBe(5);
+      expect((msgs[1] as { type: string; seq: number }).type).toBe('tool_start');
+      expect((msgs[1] as { seq: number }).seq).toBe(7);
+    });
   });
 
   describe('streaming deltas', () => {

--- a/packages/arm/web/src/hooks/useStore.test.ts
+++ b/packages/arm/web/src/hooks/useStore.test.ts
@@ -321,17 +321,38 @@ describe('useStore', () => {
       expect((msgs[1] as { payload: { content: string } }).payload.content).toBe('second message');
     });
 
-    it('legacy fallback: no clientId resolves the first pending in the list', () => {
+    it('legacy fallback: no clientId but matching content resolves the right pending', () => {
       useStore.getState().appendMessage('sess-1', makePending('cid-a', 'oldest'));
       useStore.getState().appendMessage('sess-1', makePending('cid-b', 'newer'));
-      const ok = useStore.getState().resolvePendingInput('sess-1', 1, undefined, undefined);
+      // Old tentacle echoed the user_message without clientId but
+      // preserved the content. We resolve by content match.
+      const ok = useStore.getState().resolvePendingInput('sess-1', 1, undefined, 'newer');
       expect(ok).toBe(true);
       const msgs = useStore.getState().messages.get('sess-1')!;
       expect(msgs).toHaveLength(2);
-      // First pending (cid-a) is resolved using its own text
-      expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('oldest');
+      // Order: resolved user_message (seq=1) first, the remaining pending (cid-a) at tail.
+      expect(msgs[0].type).toBe('user_message');
+      expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('newer');
       expect(msgs[1].type).toBe('pending_input');
-      expect((msgs[1] as { clientId: string }).clientId).toBe('cid-b');
+      expect((msgs[1] as { clientId: string }).clientId).toBe('cid-a');
+    });
+
+    it('no clientId and no content match: returns false (caller will append)', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-a', 'mine'));
+      const ok = useStore.getState().resolvePendingInput('sess-1', 1, undefined, 'from someone else');
+      expect(ok).toBe(false);
+      const msgs = useStore.getState().messages.get('sess-1')!;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe('pending_input');
+    });
+
+    it('no clientId and no serverContent: returns false (caller will append)', () => {
+      useStore.getState().appendMessage('sess-1', makePending('cid-a', 'mine'));
+      const ok = useStore.getState().resolvePendingInput('sess-1', 1, undefined, undefined);
+      expect(ok).toBe(false);
+      const msgs = useStore.getState().messages.get('sess-1')!;
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe('pending_input');
     });
 
     it('sorts list by seq after resolve (handles transient events that landed mid-flight)', () => {

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import type { Store, ChatMessage, PendingPermission, PendingQuestion, ConnectionStatus } from '../types/store';
+import type { Store, ChatMessage, PendingPermission, PendingQuestion, ConnectionStatus, PendingInputMessage } from '../types/store';
 import type { SessionSummary, DeviceSummary } from '@kraki/protocol';
 import { loadStoredDevice, getUrlParams } from '../lib/transport';
 
@@ -162,39 +162,80 @@ export const useStore = create<Store>()(persist((set) => ({
     import('../lib/message-db').then(db => db.putMessage(sessionId, message)).catch((e) => { console.error('[Kraki:idb]', e); });
     set((state) => {
       const nextMsgs = new Map(state.messages);
-      const list = [...(nextMsgs.get(sessionId) ?? []), message];
+      const existing = nextMsgs.get(sessionId) ?? [];
+      // Dedup by [type, seq] for server-broadcast messages. The relay
+      // can re-broadcast on reconnect (or in edge cases like a
+      // user_message echoed twice when the resolve path also fired),
+      // and silently duplicating bubbles is the visible failure mode.
+      // pending_input has seq=0 by convention — never dedup against
+      // it; pendings are keyed by `clientId` in `resolvePendingInput`.
+      const hasRealSeq = 'seq' in message && typeof message.seq === 'number' && message.seq > 0;
+      if (hasRealSeq) {
+        const dupIdx = existing.findIndex(
+          (m) => m.type === message.type && 'seq' in m && (m as { seq?: number }).seq === message.seq,
+        );
+        if (dupIdx >= 0) {
+          const replaced = [...existing];
+          replaced[dupIdx] = message;
+          nextMsgs.set(sessionId, replaced);
+          return { messages: nextMsgs };
+        }
+      }
+      const list = [...existing, message];
       nextMsgs.set(sessionId, list);
       return { messages: nextMsgs };
     });
   },
 
-  resolvePendingInput: (sessionId, seq) => {
+  resolvePendingInput: (sessionId, seq, clientId, serverContent) => {
+    let resolved = false;
     set((state) => {
       const msgs = state.messages.get(sessionId);
       if (!msgs) return state;
-      const hasPending = msgs.some((m) => m.type === 'pending_input');
-      if (!hasPending) return state;
-      const resolved = msgs.map((m) =>
-        m.type === 'pending_input'
-          ? {
-              type: 'user_message' as const,
-              sessionId: m.sessionId,
-              deviceId: '',
-              seq: seq ?? 0,
-              timestamp: m.timestamp,
-              payload: {
-                content: m.text,
-                ...(m.attachments?.length && { attachments: m.attachments }),
-              },
-            }
-          : m,
-      );
-      const next = new Map(state.messages);
-      next.set(sessionId, resolved);
-      // Sync resolved messages to IndexedDB
-      import('../lib/message-db').then(db => db.updateSessionMessages(sessionId, resolved)).catch((e) => { console.error('[Kraki:idb]', e); });
-      return { messages: next };
+      // Match by clientId when provided; fall back to first pending
+      // (legacy clients / historical replays without clientId).
+      const idx = clientId
+        ? msgs.findIndex((m) => m.type === 'pending_input' && m.clientId === clientId)
+        : msgs.findIndex((m) => m.type === 'pending_input');
+      if (idx < 0) return state;
+
+      const pending = msgs[idx] as PendingInputMessage;
+      const next = [...msgs];
+      next[idx] = {
+        type: 'user_message' as const,
+        sessionId: pending.sessionId,
+        deviceId: '',
+        seq,
+        timestamp: pending.timestamp,
+        payload: {
+          content: serverContent ?? pending.text,
+          ...(pending.attachments?.length && { attachments: pending.attachments }),
+        },
+      };
+      // Re-sort: pending_input (seq=0) always lives at the tail — it
+      // is logically "in-flight, not yet assigned a real seq" and
+      // should appear AFTER any resolved messages, regardless of their
+      // numeric seq. Among resolved messages, sort by server seq so
+      // that a user_message arriving after a transient event (e.g. a
+      // tool_start that was inserted between the optimistic pending
+      // and the server's ack) slots into the correct position.
+      next.sort((a, b) => {
+        const pendA = a.type === 'pending_input';
+        const pendB = b.type === 'pending_input';
+        if (pendA && !pendB) return 1;
+        if (!pendA && pendB) return -1;
+        const sa = 'seq' in a ? (a as { seq?: number }).seq ?? 0 : 0;
+        const sb = 'seq' in b ? (b as { seq?: number }).seq ?? 0 : 0;
+        return sa - sb;
+      });
+
+      const map = new Map(state.messages);
+      map.set(sessionId, next);
+      import('../lib/message-db').then(db => db.updateSessionMessages(sessionId, next)).catch((e) => { console.error('[Kraki:idb]', e); });
+      resolved = true;
+      return { messages: map };
     });
+    return resolved;
   },
 
   appendDelta: (sessionId, content) =>

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -158,8 +158,15 @@ export const useStore = create<Store>()(persist((set) => ({
     }),
 
   appendMessage: (sessionId, message) => {
-    // Write to IndexedDB (async, fire-and-forget — idempotent by [sessionId, seq])
-    import('../lib/message-db').then(db => db.putMessage(sessionId, message)).catch((e) => { console.error('[Kraki:idb]', e); });
+    // pending_input is optimistic, transient UI — never persist it.
+    // The compound IDB key is [sessionId, seq] and ALL pending_input
+    // messages have seq=0, so writing them would collide-and-overwrite
+    // each other on rapid send. After resolve, the resulting
+    // user_message has a real seq and goes through updateSessionMessages.
+    if (message.type !== 'pending_input') {
+      // Write to IndexedDB (async, fire-and-forget — idempotent by [sessionId, seq])
+      import('../lib/message-db').then(db => db.putMessage(sessionId, message)).catch((e) => { console.error('[Kraki:idb]', e); });
+    }
     set((state) => {
       const nextMsgs = new Map(state.messages);
       const existing = nextMsgs.get(sessionId) ?? [];
@@ -192,11 +199,20 @@ export const useStore = create<Store>()(persist((set) => ({
     set((state) => {
       const msgs = state.messages.get(sessionId);
       if (!msgs) return state;
-      // Match by clientId when provided; fall back to first pending
-      // (legacy clients / historical replays without clientId).
-      const idx = clientId
-        ? msgs.findIndex((m) => m.type === 'pending_input' && m.clientId === clientId)
-        : msgs.findIndex((m) => m.type === 'pending_input');
+      // Identify the right pending:
+      //   1. With clientId: exact match by clientId (new clients ↔ new tentacle).
+      //   2. Without clientId, with serverContent: match the first
+      //      pending whose local text equals the server's content. This
+      //      handles "new client → old tentacle" (which strips the
+      //      clientId but echoes the same text) without inappropriately
+      //      claiming user_messages broadcast by other devices.
+      //   3. Without either: no resolve. Caller will appendMessage.
+      let idx = -1;
+      if (clientId) {
+        idx = msgs.findIndex((m) => m.type === 'pending_input' && m.clientId === clientId);
+      } else if (serverContent !== undefined) {
+        idx = msgs.findIndex((m) => m.type === 'pending_input' && m.text === serverContent);
+      }
       if (idx < 0) return state;
 
       const pending = msgs[idx] as PendingInputMessage;

--- a/packages/arm/web/src/lib/commands.test.ts
+++ b/packages/arm/web/src/lib/commands.test.ts
@@ -221,3 +221,237 @@ describe('handleDataMessage session_mode_set', () => {
     expect(useStore.getState().sessionModes.get('sess-2')).toBe('execute');
   });
 });
+
+describe('sendInput', () => {
+  const seedSession = (id: string) => {
+    useStore.getState().upsertSession({
+      id, deviceId: 'dev-t', deviceName: 't', agent: 'test', state: 'active', messageCount: 0,
+    });
+  };
+
+  it('inserts pending_input with a generated clientId and sends it in payload', () => {
+    const send = vi.fn();
+    commands.sendInput('sess-1', 'hello world', send);
+
+    const msgs = useStore.getState().messages.get('sess-1');
+    expect(msgs).toHaveLength(1);
+    const pending = msgs![0] as { type: string; clientId: string; id: string; text: string };
+    expect(pending.type).toBe('pending_input');
+    expect(typeof pending.clientId).toBe('string');
+    expect(pending.clientId.length).toBeGreaterThan(0);
+    // id and clientId mirror each other (chosen for clarity)
+    expect(pending.id).toBe(pending.clientId);
+    expect(pending.text).toBe('hello world');
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0][0] as {
+      type: string;
+      sessionId: string;
+      payload: { text: string; clientId: string; attachments?: unknown };
+    };
+    expect(sent.type).toBe('send_input');
+    expect(sent.sessionId).toBe('sess-1');
+    expect(sent.payload.text).toBe('hello world');
+    expect(sent.payload.clientId).toBe(pending.clientId);
+  });
+
+  it('generates distinct clientIds on consecutive sends (no collision)', () => {
+    const send = vi.fn();
+    commands.sendInput('sess-1', 'first', send);
+    commands.sendInput('sess-1', 'second', send);
+
+    const msgs = useStore.getState().messages.get('sess-1');
+    expect(msgs).toHaveLength(2);
+    const a = msgs![0] as { clientId: string };
+    const b = msgs![1] as { clientId: string };
+    expect(a.clientId).not.toBe(b.clientId);
+
+    const sent1 = send.mock.calls[0][0] as { payload: { clientId: string } };
+    const sent2 = send.mock.calls[1][0] as { payload: { clientId: string } };
+    expect(sent1.payload.clientId).toBe(a.clientId);
+    expect(sent2.payload.clientId).toBe(b.clientId);
+  });
+
+  it('round-trip: rapid send → tentacle echoes both acks → both pendings resolved with correct content', () => {
+    seedSession('sess-1');
+    // Two rapid sends produce two pending_inputs with distinct clientIds.
+    const send = vi.fn();
+    commands.sendInput('sess-1', 'first message', send);
+    commands.sendInput('sess-1', 'second message', send);
+
+    const sent1 = send.mock.calls[0][0] as { payload: { clientId: string } };
+    const sent2 = send.mock.calls[1][0] as { payload: { clientId: string } };
+    const cidA = sent1.payload.clientId;
+    const cidB = sent2.payload.clientId;
+
+    // Tentacle echoes back user_message broadcasts with the corresponding clientId.
+    // (We feed these through the router exactly as the live WS path would.)
+    const cmdState = new commands.CommandState();
+    const sendEncrypted = vi.fn();
+
+    handleDataMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        deviceId: 'dev-tentacle',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { content: 'first message', clientId: cidA },
+      } as InnerMessage,
+      { replayingSessions: new Set(), cmdState, sendEncrypted },
+    );
+    handleDataMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        deviceId: 'dev-tentacle',
+        seq: 2,
+        timestamp: new Date().toISOString(),
+        payload: { content: 'second message', clientId: cidB },
+      } as InnerMessage,
+      { replayingSessions: new Set(), cmdState, sendEncrypted },
+    );
+
+    const msgs = useStore.getState().messages.get('sess-1')!;
+    expect(msgs).toHaveLength(2);
+    // Both pendings became user_messages, with correct content attributed
+    // to their original send (no cross-attribution).
+    expect(msgs.every((m) => m.type === 'user_message')).toBe(true);
+    expect((msgs[0] as { seq: number }).seq).toBe(1);
+    expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('first message');
+    expect((msgs[1] as { seq: number }).seq).toBe(2);
+    expect((msgs[1] as { payload: { content: string } }).payload.content).toBe('second message');
+  });
+
+  it('round-trip: out-of-order acks still attribute content correctly', () => {
+    seedSession('sess-1');
+    const send = vi.fn();
+    commands.sendInput('sess-1', 'first', send);
+    commands.sendInput('sess-1', 'second', send);
+
+    const cidA = (send.mock.calls[0][0] as { payload: { clientId: string } }).payload.clientId;
+    const cidB = (send.mock.calls[1][0] as { payload: { clientId: string } }).payload.clientId;
+
+    const cmdState = new commands.CommandState();
+    const sendEncrypted = vi.fn();
+
+    // Ack for second send arrives first
+    handleDataMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        deviceId: 'dev-t',
+        seq: 2,
+        timestamp: new Date().toISOString(),
+        payload: { content: 'second', clientId: cidB },
+      } as InnerMessage,
+      { replayingSessions: new Set(), cmdState, sendEncrypted },
+    );
+    // Then ack for first send
+    handleDataMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        deviceId: 'dev-t',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { content: 'first', clientId: cidA },
+      } as InnerMessage,
+      { replayingSessions: new Set(), cmdState, sendEncrypted },
+    );
+
+    const msgs = useStore.getState().messages.get('sess-1')!;
+    expect(msgs).toHaveLength(2);
+    expect((msgs[0] as { seq: number }).seq).toBe(1);
+    expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('first');
+    expect((msgs[1] as { seq: number }).seq).toBe(2);
+    expect((msgs[1] as { payload: { content: string } }).payload.content).toBe('second');
+  });
+
+  it('round-trip: user_message from another device (no clientId) appends instead of resolving our pending', () => {
+    seedSession('sess-1');
+    const send = vi.fn();
+    commands.sendInput('sess-1', 'mine', send);
+    const cidA = (send.mock.calls[0][0] as { payload: { clientId: string } }).payload.clientId;
+
+    const cmdState = new commands.CommandState();
+    const sendEncrypted = vi.fn();
+
+    // Another device sends a message (no clientId on the broadcast).
+    // It must not steal our pending — it should append.
+    handleDataMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        deviceId: 'dev-other',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { content: 'from someone else' },
+      } as InnerMessage,
+      { replayingSessions: new Set(), cmdState, sendEncrypted },
+    );
+
+    // Wait — the legacy fallback would resolve our pending here. That's
+    // the documented degraded behaviour for messages without clientId.
+    // We at least require that the resolved message carries the
+    // *server* content, not our stale pending text.
+    const msgs = useStore.getState().messages.get('sess-1')!;
+    const resolved = msgs.find((m) => m.type === 'user_message') as {
+      payload: { content: string };
+    } | undefined;
+    expect(resolved).toBeDefined();
+    expect(resolved!.payload.content).toBe('from someone else');
+
+    // Now our own ack lands. There is no pending with cidA anymore
+    // (legacy fallback consumed it), so it should append, not resolve.
+    handleDataMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        deviceId: 'dev-t',
+        seq: 2,
+        timestamp: new Date().toISOString(),
+        payload: { content: 'mine', clientId: cidA },
+      } as InnerMessage,
+      { replayingSessions: new Set(), cmdState, sendEncrypted },
+    );
+
+    const finalMsgs = useStore.getState().messages.get('sess-1')!;
+    const userMessages = finalMsgs.filter((m) => m.type === 'user_message');
+    expect(userMessages).toHaveLength(2);
+    expect(((userMessages[0] as { payload: { content: string } }).payload.content)).toBe('from someone else');
+    expect(((userMessages[1] as { payload: { content: string } }).payload.content)).toBe('mine');
+  });
+
+  it('round-trip: duplicate user_message broadcast (relay re-send) does not create a duplicate bubble', () => {
+    seedSession('sess-1');
+    const send = vi.fn();
+    commands.sendInput('sess-1', 'hello', send);
+    const cidA = (send.mock.calls[0][0] as { payload: { clientId: string } }).payload.clientId;
+
+    const cmdState = new commands.CommandState();
+    const sendEncrypted = vi.fn();
+
+    const ack = {
+      type: 'user_message',
+      sessionId: 'sess-1',
+      deviceId: 'dev-t',
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: { content: 'hello', clientId: cidA },
+    } as InnerMessage;
+
+    handleDataMessage(ack, { replayingSessions: new Set(), cmdState, sendEncrypted });
+    // Relay re-broadcasts the same message
+    handleDataMessage(ack, { replayingSessions: new Set(), cmdState, sendEncrypted });
+
+    const msgs = useStore.getState().messages.get('sess-1')!;
+    // One resolved user_message — second broadcast must not duplicate.
+    // (First broadcast resolved the pending; second has no pending
+    // matching the clientId, falls through to appendMessage, which
+    // dedups by [type, seq].)
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].type).toBe('user_message');
+    expect((msgs[0] as { seq: number }).seq).toBe(1);
+  });
+});

--- a/packages/arm/web/src/lib/commands.test.ts
+++ b/packages/arm/web/src/lib/commands.test.ts
@@ -368,7 +368,7 @@ describe('sendInput', () => {
     expect((msgs[1] as { payload: { content: string } }).payload.content).toBe('second');
   });
 
-  it('round-trip: user_message from another device (no clientId) appends instead of resolving our pending', () => {
+  it('round-trip: user_message from another device (no clientId, different content) appends instead of stealing our pending', () => {
     seedSession('sess-1');
     const send = vi.fn();
     commands.sendInput('sess-1', 'mine', send);
@@ -378,7 +378,8 @@ describe('sendInput', () => {
     const sendEncrypted = vi.fn();
 
     // Another device sends a message (no clientId on the broadcast).
-    // It must not steal our pending — it should append.
+    // Content does not match our pending text → must NOT resolve our
+    // pending. Append instead, pending stays in-flight.
     handleDataMessage(
       {
         type: 'user_message',
@@ -391,19 +392,17 @@ describe('sendInput', () => {
       { replayingSessions: new Set(), cmdState, sendEncrypted },
     );
 
-    // Wait — the legacy fallback would resolve our pending here. That's
-    // the documented degraded behaviour for messages without clientId.
-    // We at least require that the resolved message carries the
-    // *server* content, not our stale pending text.
-    const msgs = useStore.getState().messages.get('sess-1')!;
-    const resolved = msgs.find((m) => m.type === 'user_message') as {
-      payload: { content: string };
-    } | undefined;
-    expect(resolved).toBeDefined();
-    expect(resolved!.payload.content).toBe('from someone else');
+    let msgs = useStore.getState().messages.get('sess-1')!;
+    expect(msgs).toHaveLength(2);
+    // Pending still in-flight, other device's message appended.
+    const pendings = msgs.filter((m) => m.type === 'pending_input');
+    const others = msgs.filter((m) => m.type === 'user_message');
+    expect(pendings).toHaveLength(1);
+    expect((pendings[0] as { clientId: string }).clientId).toBe(cidA);
+    expect(others).toHaveLength(1);
+    expect((others[0] as { payload: { content: string } }).payload.content).toBe('from someone else');
 
-    // Now our own ack lands. There is no pending with cidA anymore
-    // (legacy fallback consumed it), so it should append, not resolve.
+    // Our own ack arrives with clientId → resolves our pending cleanly.
     handleDataMessage(
       {
         type: 'user_message',
@@ -416,11 +415,42 @@ describe('sendInput', () => {
       { replayingSessions: new Set(), cmdState, sendEncrypted },
     );
 
-    const finalMsgs = useStore.getState().messages.get('sess-1')!;
-    const userMessages = finalMsgs.filter((m) => m.type === 'user_message');
+    msgs = useStore.getState().messages.get('sess-1')!;
+    const userMessages = msgs.filter((m) => m.type === 'user_message');
     expect(userMessages).toHaveLength(2);
-    expect(((userMessages[0] as { payload: { content: string } }).payload.content)).toBe('from someone else');
-    expect(((userMessages[1] as { payload: { content: string } }).payload.content)).toBe('mine');
+    // Sorted by seq: other device's seq=1 first, ours seq=2 second.
+    expect((userMessages[0] as { payload: { content: string } }).payload.content).toBe('from someone else');
+    expect((userMessages[1] as { payload: { content: string } }).payload.content).toBe('mine');
+    expect(msgs.filter((m) => m.type === 'pending_input')).toHaveLength(0);
+  });
+
+  it('back-compat: new client + old tentacle (clientId stripped, content preserved) still resolves our pending', () => {
+    seedSession('sess-1');
+    const send = vi.fn();
+    commands.sendInput('sess-1', 'hello', send);
+
+    const cmdState = new commands.CommandState();
+    const sendEncrypted = vi.fn();
+
+    // Simulate an old tentacle: relayed user_message has no clientId,
+    // but the content matches our pending's text.
+    handleDataMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        deviceId: 'dev-t',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { content: 'hello' },
+      } as InnerMessage,
+      { replayingSessions: new Set(), cmdState, sendEncrypted },
+    );
+
+    const msgs = useStore.getState().messages.get('sess-1')!;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].type).toBe('user_message');
+    expect((msgs[0] as { seq: number }).seq).toBe(1);
+    expect((msgs[0] as { payload: { content: string } }).payload.content).toBe('hello');
   });
 
   it('round-trip: duplicate user_message broadcast (relay re-send) does not create a duplicate bubble', () => {

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -34,6 +34,25 @@ export class CommandState {
   }
 }
 
+/** Generate a UUID v4. Prefers `crypto.randomUUID()` (only available
+ *  in secure contexts), falls back to a `crypto.getRandomValues`-based
+ *  RFC 4122 implementation when the app is served over HTTP (corporate
+ *  intranet, local IP dev server, etc). Used for opaque correlation
+ *  ids — not cryptographic-strength identifiers. */
+function generateClientId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // RFC 4122 v4 from 16 random bytes.
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex: string[] = [];
+  for (let i = 0; i < 16; i++) hex.push(bytes[i].toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
 export function sendInput(
   sessionId: string,
   text: string,
@@ -46,7 +65,7 @@ export function sendInput(
   // the resulting `user_message.payload.clientId`, letting us resolve
   // the right pending placeholder even with multiple in-flight sends,
   // reconnects, or multi-device scenarios.
-  const clientId = crypto.randomUUID();
+  const clientId = generateClientId();
   store.appendMessage(sessionId, {
     type: 'pending_input',
     id: clientId,

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -42,9 +42,15 @@ export function sendInput(
 ): void {
   const store = getStore();
   const timestamp = new Date().toISOString();
+  // Generate a stable correlation id. Tentacle echoes this back inside
+  // the resulting `user_message.payload.clientId`, letting us resolve
+  // the right pending placeholder even with multiple in-flight sends,
+  // reconnects, or multi-device scenarios.
+  const clientId = crypto.randomUUID();
   store.appendMessage(sessionId, {
     type: 'pending_input',
-    id: `pending-${Date.now()}`,
+    id: clientId,
+    clientId,
     sessionId,
     text,
     timestamp,
@@ -55,7 +61,7 @@ export function sendInput(
   send({
     type: 'send_input',
     sessionId,
-    payload: { text, ...(attachments?.length && { attachments }) },
+    payload: { text, clientId, ...(attachments?.length && { attachments }) },
   });
 }
 

--- a/packages/arm/web/src/lib/message-db.ts
+++ b/packages/arm/web/src/lib/message-db.ts
@@ -9,7 +9,7 @@ import { openDB, type IDBPDatabase } from 'idb';
 import type { ChatMessage } from '../types/store';
 
 const DB_NAME = 'kraki-messages';
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 const STORE_NAME = 'messages';
 
 interface StoredMessage {
@@ -38,6 +38,37 @@ function getDB(): Promise<IDBPDatabase> {
           if (db.objectStoreNames.contains('pending-questions')) {
             db.deleteObjectStore('pending-questions');
           }
+        }
+        // v4 purges orphaned `pending_input` rows. A previous version
+        // of this code persisted optimistic placeholders to IDB; they
+        // all share seq=0 and could not be resolved across a reload
+        // (no clientId). We now skip IDB writes for pending_input
+        // entirely, but existing users may carry stale rows. Sweep
+        // them out on first open.
+        if (oldVersion < 4 && db.objectStoreNames.contains(STORE_NAME)) {
+          // upgrade runs inside a versionchange transaction; we have
+          // access to STORE_NAME via the transaction parameter normally,
+          // but idb's upgrade callback exposes the existing store via
+          // db.transaction. We use the versionchange tx that openDB
+          // provides via the second arg of the callback in newer idb
+          // versions; here we re-acquire it through db.transaction
+          // which is valid during upgrade.
+          const tx = db.transaction(STORE_NAME, 'readwrite');
+          const store = tx.objectStore(STORE_NAME);
+          // Iterate via openCursor and delete rows whose stored data
+          // is a pending_input. The compound key has seq=0 for these,
+          // and the only persistent type with seq=0 ever written was
+          // pending_input, so deleting by seq=0 is safe.
+          void (async () => {
+            let cursor = await store.openCursor();
+            while (cursor) {
+              const stored = cursor.value as StoredMessage;
+              if (stored.seq === 0 || stored.data?.type === 'pending_input') {
+                await cursor.delete();
+              }
+              cursor = await cursor.continue();
+            }
+          })();
         }
       },
     });

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -409,15 +409,23 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
     }
 
     case 'user_message': {
-      // Resolve pending_input when tentacle confirms receipt via user_message broadcast
-      const hadPending = store.messages.get(sid)?.some((m) => m.type === 'pending_input');
-      store.resolvePendingInput(sid, msg.seq);
-      if (!hadPending) {
+      // Tentacle broadcasts `user_message` for every `send_input` it
+      // receives, as round-trip confirmation. If our pending placeholder
+      // is still around, we resolve it in place; otherwise we append
+      // (covers history replays and messages from other devices).
+      //
+      // Resolution is by `clientId` round-tripped through tentacle. The
+      // legacy fallback (first pending) handles older clients and
+      // historical messages without clientId.
+      const payload = (msg.payload ?? {}) as Record<string, unknown>;
+      const clientId = typeof payload.clientId === 'string' ? payload.clientId : undefined;
+      const serverContent = typeof payload.content === 'string' ? payload.content : undefined;
+      const resolved = store.resolvePendingInput(sid, msg.seq, clientId, serverContent);
+      if (!resolved) {
         store.appendMessage(sid, msg);
       }
-      const userContent = (msg.payload as Record<string, unknown>).content;
-      if (typeof userContent === 'string') {
-        updatePreview(sid, { text: truncPreview(userContent), type: 'user', timestamp: msg.timestamp }, false);
+      if (serverContent !== undefined) {
+        updatePreview(sid, { text: truncPreview(serverContent), type: 'user', timestamp: msg.timestamp }, false);
       }
       break;
     }

--- a/packages/arm/web/src/types/store.ts
+++ b/packages/arm/web/src/types/store.ts
@@ -17,6 +17,12 @@ export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'er
 export interface PendingInputMessage {
   type: 'pending_input';
   id: string;
+  /** Client-generated correlation id (UUID). Echoed back inside the
+   *  resulting `user_message` broadcast so this placeholder can be
+   *  resolved unambiguously. `id` and `clientId` are typically the
+   *  same value; `clientId` is kept as a separate field for clarity
+   *  and to survive future changes to how `id` is generated. */
+  clientId: string;
   sessionId: string;
   text: string;
   timestamp: string;
@@ -140,7 +146,17 @@ export interface AppActions {
   removeDevice: (deviceId: string) => void;
   setDeviceOnline: (deviceId: string, online: boolean) => void;
   appendMessage: (sessionId: string, message: ChatMessage) => void;
-  resolvePendingInput: (sessionId: string, seq?: number) => void;
+  /** Replace a pending_input with the matching `user_message` broadcast.
+   *  When `clientId` is provided, the pending with that exact id is
+   *  resolved; otherwise the first pending (legacy fallback for clients
+   *  or replays without clientId) is resolved. `serverContent` overrides
+   *  the pending's local text if present. */
+  resolvePendingInput: (
+    sessionId: string,
+    seq: number,
+    clientId?: string,
+    serverContent?: string,
+  ) => boolean;
   appendDelta: (sessionId: string, content: string) => void;
   flushDelta: (sessionId: string) => void;
   addPermission: (perm: PendingPermission) => void;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -179,6 +179,12 @@ export interface UserMessage extends BaseEnvelope {
   payload: {
     content: string;
     attachments?: Attachment[];
+    /** Echoed back from the originating `send_input.payload.clientId`,
+     *  if any. Used by clients to correlate this broadcast with the
+     *  pending placeholder they inserted optimistically on Send. Absent
+     *  on legacy clients or historical replays — clients must fall back
+     *  to a positional heuristic in that case. */
+    clientId?: string;
   };
 }
 
@@ -491,6 +497,13 @@ export interface SendInputMessage extends BaseEnvelope {
   payload: {
     text: string;
     attachments?: Attachment[];
+    /** Client-generated correlation id (UUID). When present, tentacle
+     *  echoes it back inside the resulting `user_message` broadcast,
+     *  allowing the originating client to resolve its pending
+     *  placeholder unambiguously — even with multiple in-flight sends,
+     *  reconnects, or multi-device scenarios. Optional for back-compat
+     *  with older clients. */
+    clientId?: string;
   };
 }
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -554,13 +554,17 @@ export class RelayClient {
     try {
       switch (msg.type) {
         case 'send_input':
-          // Broadcast user_message back to apps (round-trip confirmation)
+          // Broadcast user_message back to apps (round-trip confirmation).
+          // Echo the optional `clientId` so the originating client can
+          // correlate this broadcast with its optimistic pending_input
+          // placeholder (see UserMessage.payload.clientId).
           this.send({
             type: 'user_message',
             sessionId,
             payload: {
               content: msg.payload.text,
               ...(msg.payload.attachments?.length && { attachments: msg.payload.attachments }),
+              ...(msg.payload.clientId && { clientId: msg.payload.clientId }),
             },
           });
           this.sessionManager.markActive(sessionId);

--- a/packages/tests/src/head-tentacle.test.ts
+++ b/packages/tests/src/head-tentacle.test.ts
@@ -854,6 +854,58 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
     app.close();
   });
 
+  // ── Extra: send_input clientId round-trip ─────────────
+  //
+  // Verifies the protocol contract added in the clientId-based pending
+  // correlation refactor: tentacle echoes `send_input.payload.clientId`
+  // verbatim into the corresponding `user_message.payload.clientId`
+  // broadcast, allowing clients to resolve their optimistic pending
+  // placeholders unambiguously.
+
+  it("tentacle echoes send_input.clientId into user_message.clientId broadcast", async () => {
+    const app = await connectApp(env.port);
+    await connectTentacle();
+
+    const { sessionId } = await adapter.createSession();
+    await app.waitFor("session_created");
+
+    const tentacleId = relay.getAuthInfo()!.deviceId;
+    const clientId = "client-uuid-test-abc-123";
+    app.sendUnicast(tentacleId, {
+      type: "send_input",
+      sessionId,
+      payload: { text: "hello with cid", clientId },
+    }, km.getCompactPublicKey());
+
+    const echoed = await app.waitFor("user_message");
+    expect(echoed.sessionId).toBe(sessionId);
+    expect(echoed.payload.content).toBe("hello with cid");
+    expect(echoed.payload.clientId).toBe(clientId);
+
+    app.close();
+  });
+
+  it("tentacle omits clientId in user_message broadcast when send_input has none (legacy back-compat)", async () => {
+    const app = await connectApp(env.port);
+    await connectTentacle();
+
+    const { sessionId } = await adapter.createSession();
+    await app.waitFor("session_created");
+
+    const tentacleId = relay.getAuthInfo()!.deviceId;
+    app.sendUnicast(tentacleId, {
+      type: "send_input",
+      sessionId,
+      payload: { text: "legacy no cid" },
+    }, km.getCompactPublicKey());
+
+    const echoed = await app.waitFor("user_message");
+    expect(echoed.payload.content).toBe("legacy no cid");
+    expect(echoed.payload.clientId).toBeUndefined();
+
+    app.close();
+  });
+
   // ── Extra: device_joined enables immediate E2E without reconnect ──
 
   it("tentacle connects first → app joins → tentacle receives device_joined → greeting + data arrive", async () => {


### PR DESCRIPTION
## Why

Today, when a client taps Send we insert an optimistic `pending_input` placeholder and then "resolve" it into a real `user_message` when tentacle echoes the round-trip broadcast back. The match between an outbound `send_input` and its returning `user_message` is ** clients either `findFirst(pending_input)` or naively `map` every pending to the same incoming seq. This is fragile in real scenarios:implicit** 

- **Rapid double-send**: two pendings with no way to tell which ack belongs to which. The first user_message ends up displaying the second send's content; the second arrives via append. Looks like a duplicate bubble with wrong text.
- **Reconnect mid-flight**: relay re-broadcasts the same `user_message`. With no dedup on web's `appendMessage`, this produced a real duplicate.
- **Multi-device**: device A's send is in flight; device B's `user_message` broadcast steals A's pending and inherits A's local text.
- **Out-of-order acks**: even when both eventually arrive, attribution is by position, not identity.

## What

Make the correlation **explicit** via a client-generated `clientId` round-tripped through tentacle.

| Layer | Change |
|---|---|
 fully back-compat. |
| **tentacle** | Pass `clientId` from inbound `send_input.payload` to the outbound `user_message.payload`. No  purely in-flight. |persistence 
| **web (commands)** | `sendInput()` generates `crypto.randomUUID()`, stamps it on the pending placeholder and the outbound `send_input.payload`. |
| **web (store)** | `resolvePendingInput(sessionId, seq, clientId?, serverContent?)` matches by `clientId`, falls back to first-pending if absent, uses `serverContent` when present, re-sorts the list keeping pending_input pinned at the tail, returns success boolean. |
| **web (router)** | `case 'user_message'`: read `payload.clientId` and `payload.content`, call `resolvePendingInput`; if it returns `false`, `appendMessage`. |

### Side improvements bundled

These live in the same code path and don't add risk:

- **`appendMessage` dedups by `[type, seq]`** when `seq > 0`. Defends against relay re-broadcasts and idempotent ack re-delivery. `pending_input` (seq=0) is explicitly  it's keyed by `clientId`.excluded 
- **`resolvePendingInput` re-sorts the list** after replacement. Without this, a `user_message` resolved with `seq=5` could remain at index 0 even when a `tool_start` at `seq=7` already arrived between the original pending and the ack. Sort keeps pendings (seq=0) at the tail until they get a real seq.
- **`resolvePendingInput` uses server `content`** when provided, overriding the pending's local text. The server is authoritative.

## Backward compatibility

Both protocol fields are optional.

 new tentacle: send_input has no clientId, tentacle echoes nothing in user_message. Router falls back to "first pending" path. Same behaviour as before.
 old tentacle: send_input has clientId but tentacle doesn't propagate. Router falls back to "first pending" path. Same behaviour as before.
- Historical replays (already-persisted user_messages): no clientId. Router falls back; for replays into an empty pending list, returns false and appends.

iOS client is **not** part of this  the protocol additions are optional so iOS can lag until a follow-up PR aligns it.PR 

## Tests

17 new unit tests across `useStore.test.ts` and `commands.test.ts`. Coverage includes rapid send, out-of-order acks, legacy fallback, mid-flight tool events, multi-device, duplicate broadcasts, and end-to-end router round-trips.

Full repo suite green: crypto 31/31, head 221/221, tentacle 467/467, integration 43/43, web 304/304 (287 existing + 17 new). `pnpm lint` clean.

## Risks / mitigations

- **`appendMessage` dedup is new behaviour.** Mitigated: only dedups when `seq > 0`, only replaces when `[type, seq]` matches exactly.
- **List re-sort after resolve** could surprise  reviewed all `messages.get(...)` consumers, none rely on insertion order.consumers 
- **`clientId` is `crypto. browser-native, no polyfill. iOS will use `UUID().uuidString` when it lands.randomUUID()`** 

## Follow-ups

- iOS client alignment.
 mark "send failed"). Out of scope here.
