### PR TITLE
feat(ios): clientId-based pending input correlation

### DIFF
--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -350,14 +350,24 @@ final class MessageRouter {
         // ── Chat messages ────────────────────────────────────────────────
 
         case "user_message":
-            let hadPending = appState.messageStore.hasPendingInput(sessionId)
-            if let seq = dict["seq"] as? Int {
-                appState.messageStore.resolvePendingInput(sessionId, seq: seq)
-            }
-            if !hadPending {
+            // Tentacle echoes user_message broadcasts for every send_input.
+            // Resolve our optimistic pending placeholder by clientId
+            // (preferred) or content match (legacy fallback). If no
+            // pending matched, append — this handles history replays,
+            // multi-device broadcasts, etc.
+            let clientId = payload?["clientId"] as? String
+            let content = payload?["content"] as? String
+            let seqValue = dict["seq"] as? Int ?? 0
+            let resolved = appState.messageStore.resolvePendingInput(
+                sessionId,
+                seq: seqValue,
+                clientId: clientId,
+                content: content
+            )
+            if !resolved {
                 appState.messageStore.appendMessage(sessionId, json: json)
             }
-            if let content = payload?["content"] as? String {
+            if let content {
                 updatePreview(sessionId, text: content, type: "user", timestamp: timestamp)
             }
 

--- a/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
@@ -150,6 +150,11 @@ struct ChatMessage: Identifiable, Codable, Equatable, Sendable {
     var model: String? { payload["model"]?.stringValue }
     var title: String? { payload["title"]?.stringValue }
     var autoTitle: String? { payload["autoTitle"]?.stringValue }
+    /// Correlation id round-tripped through tentacle for pending_input
+    /// resolution. Present on pending_input placeholders and on
+    /// user_message broadcasts that resulted from a `send_input`
+    /// carrying it. Absent on legacy/imported messages.
+    var clientId: String? { payload["clientId"]?.stringValue }
 
     var choices: [String]? {
         payload["choices"]?.arrayValue?.compactMap { $0.stringValue }

--- a/packages/arm/ios/Kraki/Core/Storage/CommandSender.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/CommandSender.swift
@@ -47,6 +47,12 @@ final class CommandSender {
     func sendInput(sessionId: String, text: String, attachments: [ImageAttachment]? = nil) {
         guard let appState else { return }
 
+        // Generate a correlation id. Tentacle echoes this back inside
+        // the resulting `user_message.payload.clientId`, letting us
+        // resolve the right pending placeholder even with multiple
+        // in-flight sends, reconnects, or multi-device scenarios.
+        let clientId = UUID().uuidString
+
         // Optimistic: insert pending_input
         let pending = ChatMessage(
             type: "pending_input",
@@ -56,11 +62,12 @@ final class CommandSender {
             timestamp: ISO8601DateFormatter().string(from: Date()),
             payload: [
                 "content": AnyCodable(text),
+                "clientId": AnyCodable(clientId),
             ]
         )
         appState.messageStore.appendMessage(sessionId, pending)
 
-        var payload: [String: Any] = ["text": text]
+        var payload: [String: Any] = ["text": text, "clientId": clientId]
         if let attachments, !attachments.isEmpty {
             let encoded = attachments.map { att -> [String: String] in
                 ["type": att.type, "mimeType": att.mimeType, "data": att.data]

--- a/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
@@ -79,7 +79,7 @@ final class MessageStore {
         let existing = messages[sessionId] ?? []
         let existingSeqs = Set(existing.map(\.seq))
         let merged = (existing + persisted.filter { !existingSeqs.contains($0.seq) })
-            .sorted { $0.seq < $1.seq }
+            .sorted { sortKey($0) < sortKey($1) }
         messages[sessionId] = merged
         return merged
     }
@@ -107,18 +107,31 @@ final class MessageStore {
         }
         hydrateFromDisk(sessionId)
         var list = messages[sessionId] ?? []
-        // Deduplicate: replace existing message with same seq, or append
-        if let idx = list.firstIndex(where: { $0.seq == message.seq }) {
+        // pending_input is identified by `clientId`, not `seq` (every
+        // pending shares seq=0). Multiple in-flight pendings coexist
+        // until each is resolved by its own ack — just append.
+        if message.type == "pending_input" {
+            list.append(message)
+        } else if let idx = list.firstIndex(where: { $0.seq == message.seq && $0.type == message.type }) {
+            // Deduplicate persistent messages by [type, seq]. Defends
+            // against relay re-broadcasts (e.g. reconnect mid-batch).
             list[idx] = message
         } else {
             list.append(message)
-            list.sort { $0.seq < $1.seq }
+            list.sort { sortKey($0) < sortKey($1) }
         }
         messages[sessionId] = list
 
         if shouldPersist(message) {
             persistentCache.appendMessage(sessionId, message)
         }
+    }
+
+    /// Sort key for chat messages. Real messages sort by seq;
+    /// `pending_input` (seq=0) sorts to the very end so optimistic
+    /// placeholders always appear after the latest server-acked turn.
+    private func sortKey(_ msg: ChatMessage) -> Int {
+        msg.type == "pending_input" ? Int.max : msg.seq
     }
 
     /// Prepend older messages (from replay), deduplicating by seq.
@@ -129,7 +142,9 @@ final class MessageStore {
         let unique = older.filter { !existingSeqs.contains($0.seq) }
         guard !unique.isEmpty else { return }
         existing.append(contentsOf: unique)
-        existing.sort { $0.seq < $1.seq }
+        // Use sortKey so pending_input (seq=0) is pinned at the tail
+        // rather than sorted before replayed history.
+        existing.sort { sortKey($0) < sortKey($1) }
         messages[sessionId] = existing
 
         let toPersist = unique.filter(shouldPersist)
@@ -192,21 +207,52 @@ final class MessageStore {
         pendingQuestions = pendingQuestions.filter { $0.value.sessionId != sessionId }
     }
 
-    /// Replace pending_input with a real user_message after server confirms.
-    func resolvePendingInput(_ sessionId: String, seq: Int, content: String) {
-        guard var list = messages[sessionId] else { return }
-        guard let idx = list.firstIndex(where: { $0.type == "pending_input" }) else { return }
+    /// Replace a pending_input with a real user_message after the
+    /// server confirms. Matching is by `clientId` when present, with
+    /// a content-match fallback for legacy clients/tentacles. Returns
+    /// `true` if a pending was resolved; the caller can then skip
+    /// appending the broadcast (which would otherwise duplicate it).
+    @discardableResult
+    func resolvePendingInput(_ sessionId: String,
+                             seq: Int,
+                             clientId: String?,
+                             content: String?) -> Bool {
+        guard var list = messages[sessionId] else { return false }
+        // Identify the right pending:
+        //   1. With clientId: exact match (new clients ↔ new tentacle).
+        //   2. Without clientId, with content: first pending whose
+        //      local text equals the server's content. Handles
+        //      "new client → old tentacle" without inappropriately
+        //      claiming user_messages broadcast by other devices.
+        //   3. Without either: no resolve. Caller will append.
+        let idx: Int?
+        if let clientId {
+            idx = list.firstIndex(where: { $0.type == "pending_input" && $0.clientId == clientId })
+        } else if let content {
+            idx = list.firstIndex(where: { $0.type == "pending_input" && $0.content == content })
+        } else {
+            idx = nil
+        }
+        guard let idx else { return false }
 
         let pending = list[idx]
+        var newPayload = pending.payload
+        if let content { newPayload["content"] = AnyCodable(content) }
+        newPayload.removeValue(forKey: "clientId")
         let resolved = ChatMessage(
             type: "user_message",
             seq: seq,
             sessionId: sessionId,
-            deviceId: "",
+            deviceId: pending.deviceId,
             timestamp: pending.timestamp,
-            payload: pending.payload
+            payload: newPayload
         )
         list[idx] = resolved
+        // Re-sort: the resolved message got its server seq and should
+        // slot into position relative to other persistent messages.
+        // Remaining pendings (still seq=0) stay at the tail thanks to
+        // `sortKey`.
+        list.sort { sortKey($0) < sortKey($1) }
         messages[sessionId] = list
 
         // Persist the resolved user_message. Without this, iOS-sent
@@ -217,6 +263,7 @@ final class MessageStore {
         if shouldPersist(resolved) {
             persistentCache.appendMessage(sessionId, resolved)
         }
+        return true
     }
 
     /// Stamp a resolution on the matching permission message in the message list.
@@ -308,13 +355,6 @@ final class MessageStore {
               let msg = ProducerMessageDecoder.decode(json) else { return }
         _ = dict // suppress unused warning
         appendMessage(sessionId, msg)
-    }
-
-    /// Resolve pending input by seq only (content comes from the existing pending message).
-    func resolvePendingInput(_ sessionId: String, seq: Int) {
-        guard let list = messages[sessionId],
-              let pending = list.first(where: { $0.type == "pending_input" }) else { return }
-        resolvePendingInput(sessionId, seq: seq, content: pending.content ?? "")
     }
 
     /// Check if a session has any pending_input messages.

--- a/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
@@ -102,7 +102,7 @@ struct MessageBubbleView: View {
 
         case "send_input":
             userBubble(
-                content: message.payload["text"]?.stringValue,
+                content: message.payload["content"]?.stringValue ?? message.payload["text"]?.stringValue,
                 attachments: message.attachments,
                 timestamp: message.timestamp
             )
@@ -201,7 +201,12 @@ struct MessageBubbleView: View {
     // MARK: - Pending Input
 
     private var pendingInputBubble: some View {
-        let text = message.payload["text"]?.stringValue
+        // CommandSender writes the text to `payload.content` (matches
+        // the eventual `user_message` shape). Earlier code wrote to
+        // `payload.text` which mismatched and caused the pending
+        // bubble to render blank. Keep a fallback to `text` for any
+        // stale-in-memory placeholders.
+        let text = message.payload["content"]?.stringValue ?? message.payload["text"]?.stringValue
         let showText = text != nil && text != "[image]"
         return HStack {
             Spacer(minLength: UIScreen.main.bounds.width * 0.10)


### PR DESCRIPTION
## Why

Aligns iOS with the web/protocol/tentacle clientId round-trip from main #117 (released as v0.19.0). Until now, iOS matched optimistic `pending_input` placeholders to their `user_message` acks by 'find first  breaks under rapid sends, reconnects, multi-device, and out-of-order acks.pending' 

## What

| File | Change |
|---|---|
| `Core/Protocol/Messages.swift` | Add `clientId` computed accessor on ChatMessage |
| `Core/Storage/CommandSender.swift` | Generate UUID per `sendInput`, stamp on pending + outbound `send_input.payload.clientId` |
| `Core/Storage/MessageStore.swift` | New `resolvePendingInput(seq, clientId?, content?) -> Bool`; match by clientId with content-match legacy fallback; `appendMessage` no longer dedups pending_input by seq (multiple coexist); persistent messages dedup by [type, seq]; new `sortKey` pins pendings at tail across all sort sites |
| `Core/Networking/MessageRouter.swift` | `user_message` case reads `payload.clientId` and `payload.content`, calls new resolve, appends on miss |
 `payload.content` typo in pending bubble (with fallback for stale placeholders) |

## Back-compat

 new tentacle**: send_input has no clientId, broadcast has no clientId. Router calls resolve with clientId=nil, content-match fallback resolves the pending. 
 old tentacle**: send_input has clientId but old tentacle strips it. Same fallback path. 
- **History replays without clientId**: no pending in store, resolve returns false, broadcast is appended normally. 

## Testing

Per-file syntax checked with `swiftc -parse`; all 5 files clean. **Full build not  the working repo has pre-existing build breaks in untracked files (`ImportSessionSheet`, `ToolStatusIcon`, etc.) from concurrent in-progress work that this PR doesn't touch. My changes are surgical and the diff is intentionally limited to the 5 files above.verified** 

Recommend testing locally on top of your current iOS WIP, since the clientId edits compose cleanly with the rest of the changes.

## Follow-up after merge

* Bump `@kraki/arm-ios` version if you track one.
* Once both iOS and web are on the new scheme, the content-match fallback in the new `resolvePendingInput` is the bridge for cross-client mixed-version  keep it.