### PR TITLE
fix(head): retry APNs push on stale connection (ECONNRESET)

### DIFF
--- a/packages/head/src/__tests__/push.test.ts
+++ b/packages/head/src/__tests__/push.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { Storage } from '../storage.js';
 import { PushManager } from '../push/index.js';
 import type { PushProvider, PushPayload, PushResult } from '../push/index.js';
@@ -280,5 +280,46 @@ describe('Storage.touchDeviceLastSeen', () => {
     const after = storage.getDevice('dev-1')!;
 
     expect(new Date(after.lastSeen).getTime()).toBeGreaterThan(new Date(before.lastSeen).getTime());
+  });
+});
+
+// ── APNs retry on stale connection ──────────────────────
+
+describe('isConnectionError', () => {
+  // Inline import to test the exported helper
+  let isConnectionError: (error: string | undefined) => boolean;
+
+  beforeAll(async () => {
+    const mod = await import('../push/apns.js');
+    isConnectionError = mod.isConnectionError;
+  });
+
+  it('matches ECONNRESET', () => {
+    expect(isConnectionError('read ECONNRESET')).toBe(true);
+  });
+
+  it('matches ETIMEDOUT', () => {
+    expect(isConnectionError('connect ETIMEDOUT 17.188.166.17:443')).toBe(true);
+  });
+
+  it('matches GOAWAY', () => {
+    expect(isConnectionError('GOAWAY')).toBe(true);
+  });
+
+  it('matches socket hang up', () => {
+    expect(isConnectionError('socket hang up')).toBe(true);
+  });
+
+  it('matches EPIPE', () => {
+    expect(isConnectionError('write EPIPE')).toBe(true);
+  });
+
+  it('does not match HTTP errors', () => {
+    expect(isConnectionError('HTTP 403')).toBe(false);
+    expect(isConnectionError('BadDeviceToken')).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isConnectionError(undefined)).toBe(false);
   });
 });

--- a/packages/head/src/push/apns.ts
+++ b/packages/head/src/push/apns.ts
@@ -13,6 +13,12 @@ const APNS_HOST_SANDBOX = 'api.sandbox.push.apple.com';
 const JWT_ALGORITHM = 'ES256';
 const JWT_TTL_MS = 50 * 60 * 1000; // Refresh JWT every 50 minutes (APNs requires < 1 hour)
 
+/** Errors that indicate a dead/stale TCP connection — worth retrying with a fresh session. */
+export function isConnectionError(error: string | undefined): boolean {
+  if (!error) return false;
+  return /ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|GOAWAY|socket hang up/i.test(error);
+}
+
 export interface ApnsConfig {
   /** Path to the .p8 private key file */
   keyPath: string;
@@ -83,6 +89,24 @@ export class ApnsProvider implements PushProvider {
 
   private async sendRaw(host: string, token: string, bundleId: string, body: string): Promise<PushResult> {
     const logger = getLogger();
+    const sessionBefore = this.sessions.get(host);
+    const result = await this.attemptSend(host, token, bundleId, body);
+
+    // Retry once on connection-level errors (stale session after idle).
+    // Only destroy if the session hasn't already been replaced by a concurrent retry.
+    if (!result.success && isConnectionError(result.error)) {
+      logger.info('APNs connection error, retrying with fresh session', { error: result.error, tokenSuffix: token.slice(-8) });
+      if (this.sessions.get(host) === sessionBefore) {
+        this.destroySession(host);
+      }
+      return this.attemptSend(host, token, bundleId, body);
+    }
+
+    return result;
+  }
+
+  private attemptSend(host: string, token: string, bundleId: string, body: string): Promise<PushResult> {
+    const logger = getLogger();
     const jwt = this.getJwt();
     const session = this.getSession(host);
 
@@ -134,6 +158,14 @@ export class ApnsProvider implements PushProvider {
     });
   }
 
+  private destroySession(host: string): void {
+    const session = this.sessions.get(host);
+    if (session) {
+      try { session.destroy(); } catch { /* best effort */ }
+      this.sessions.delete(host);
+    }
+  }
+
   private getSession(host: string): http2.ClientHttp2Session {
     let session = this.sessions.get(host);
     if (session && !session.destroyed && !session.closed) return session;
@@ -169,9 +201,8 @@ export class ApnsProvider implements PushProvider {
   }
 
   close(): void {
-    for (const session of this.sessions.values()) {
-      try { session.close(); } catch { /* best effort */ }
+    for (const host of this.sessions.keys()) {
+      this.destroySession(host);
     }
-    this.sessions.clear();
   }
 }


### PR DESCRIPTION
The HTTP/2 session to `api.push.apple.com` goes stale after idle  the remote drops the TCP socket silently. Next push gets `ECONNRESET` and the notification is lost.periods 

**Fix:** On connection-level errors (`ECONNRESET`, `ETIMEDOUT`, `GOAWAY`, etc.), destroy the stale session and retry once with a fresh connection.

**Evidence from Tencent Cloud relay logs:**
```
 APNs request error {"error":"read ECONNRESET","tokenSuffix":"ff1d4c97"}
```

**Changes:** `packages/head/src/push/apns. split `sendRaw` into `sendRaw` (retry wrapper) + `attemptSend` (single attempt). Added `destroySession` helper and `isConnectionError` check.ts` 

All 221 head tests pass.