### PR TITLE
fix(observability): instrument WS ping/pong + close events on both sides

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kraki/head",
-  "version": "0.14.2",
-  "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
+  "version": "0.14.3",
+  "description": "Kraki relay server \u2014 the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",
     "url": "https://github.com/corelli18512/kraki",

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -57,6 +57,10 @@ interface ClientState {
   pongOverdueAt: number | null;
   /** Whether we already broadcast device_pending for this ping cycle. */
   pendingLivenessBroadcast: boolean;
+  /** Diagnostic: last time we sent a ping to this client (ms epoch). */
+  lastPingSentAt?: number;
+  /** Diagnostic: last time we received a pong from this client (ms epoch). */
+  lastPongRecvAt?: number;
 
   // ── Delivery assurance (per-connection, head→peer direction) ──
   /** Monotonic counter for relaySeq head stamps on outbound tracked sends. */
@@ -177,11 +181,18 @@ export class HeadServer {
 
   private startPingInterval(): void {
     this.pingTimer = setInterval(() => {
+      const now = Date.now();
       for (const [deviceId, ws] of this.connections) {
         const state = this.clients.get(ws);
         if (state && !state.isAlive) {
-          // Missed last pong — connection is dead
-          getLogger().info('Terminating stale connection (no pong)', { deviceId });
+          // Missed last pong — connection is dead. Log diagnostic timing so
+          // post-mortems can tell network drop from event-loop block.
+          getLogger().info('Terminating stale connection (no pong)', {
+            deviceId,
+            msSincePingSent: state.lastPingSentAt ? now - state.lastPingSentAt : null,
+            msSinceLastPong: state.lastPongRecvAt ? now - state.lastPongRecvAt : null,
+            wsReadyState: ws.readyState,
+          });
           this.removeConnection(deviceId);
           continue;
         }
@@ -196,19 +207,26 @@ export class HeadServer {
               pingMsg.ack = state.lastReceivedRelaySeq;
             }
             ws.send(JSON.stringify(pingMsg));
-            // Start the grace timer for device_pending broadcast
             if (state) {
-              state.pongOverdueAt = Date.now() + PONG_GRACE_MS;
+              state.pongOverdueAt = now + PONG_GRACE_MS;
               state.pendingLivenessBroadcast = false;
+              state.lastPingSentAt = now;
             }
+            getLogger().debug('Sent ping', {
+              deviceId,
+              msSinceLastPong: state?.lastPongRecvAt ? now - state.lastPongRecvAt : null,
+            });
           }
-        } catch {
+        } catch (err) {
+          getLogger().warn('Ping send failed', {
+            deviceId,
+            error: (err as Error)?.message,
+          });
           this.removeConnection(deviceId);
         }
       }
 
       // Sweep expired pairing tokens
-      const now = Date.now();
       for (const [token, data] of this.pairingTokens) {
         if (now > data.expiresAt) this.pairingTokens.delete(token);
       }
@@ -494,7 +512,8 @@ export class HeadServer {
       }
     });
 
-    ws.on('close', () => {
+    ws.on('close', (code: number, reason: Buffer) => {
+      const reasonStr = reason?.toString?.() || '';
       if (state.deviceId) {
         const disconnectedDeviceId = state.deviceId;
         const disconnectedUserId = state.userId;
@@ -505,19 +524,35 @@ export class HeadServer {
           try { this.storage.touchDeviceLastSeen(disconnectedDeviceId); } catch { /* storage may be closed */ }
           this.connections.delete(disconnectedDeviceId);
           this.userByDevice.delete(disconnectedDeviceId);
-          logger.info('Device disconnected', { deviceId: disconnectedDeviceId });
+          logger.info('Device disconnected', {
+            deviceId: disconnectedDeviceId,
+            closeCode: code,
+            closeReason: reasonStr,
+          });
 
           if (disconnectedUserId) {
             this.broadcastDeviceLeft(disconnectedUserId, disconnectedDeviceId);
           }
         } else {
-          logger.debug('Stale socket closed (already replaced by reconnect)', { deviceId: disconnectedDeviceId });
+          logger.debug('Stale socket closed (already replaced by reconnect)', {
+            deviceId: disconnectedDeviceId,
+            closeCode: code,
+            closeReason: reasonStr,
+          });
         }
+      } else {
+        logger.debug('WebSocket closed before auth', { ip: state.ip, closeCode: code, closeReason: reasonStr });
       }
       this.clients.delete(ws);
     });
 
-    ws.on('error', () => {
+    ws.on('error', (err: Error) => {
+      logger.warn('WebSocket error', {
+        deviceId: state.deviceId,
+        ip: state.ip,
+        error: err?.message,
+        code: (err as NodeJS.ErrnoException)?.code,
+      });
       ws.close();
     });
   }
@@ -1466,10 +1501,16 @@ export class HeadServer {
    *  Re-promotes to device_joined if we already broadcast device_pending.
    *  Guards against stale pongs from replaced connections (reconnect race). */
   private onPongReceived(state: ClientState): void {
+    const now = Date.now();
+    const rttMs = state.lastPingSentAt ? now - state.lastPingSentAt : null;
     state.isAlive = true;
     const wasPending = state.pendingLivenessBroadcast;
     state.pongOverdueAt = null;
     state.pendingLivenessBroadcast = false;
+    state.lastPongRecvAt = now;
+    if (state.deviceId) {
+      getLogger().debug('Received pong', { deviceId: state.deviceId, rttMs });
+    }
 
     if (wasPending && state.userId && state.deviceId) {
       // Only re-promote if this state still belongs to the active connection.

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.19.0",
-  "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
+  "version": "0.19.1",
+  "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",
     "url": "https://github.com/corelli18512/kraki",

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -271,22 +271,30 @@ export class RelayClient {
       }
     });
 
-    ws.on('close', () => {
+    ws.on('close', (code: number, reason: Buffer) => {
+      const reasonStr = reason?.toString?.() || '';
       this.stopStaleCheck();
       this.ws = null;
+      logger.info({ code, reason: reasonStr, intentional: this.intentionalDisconnect }, 'WS closed');
       this.setState('disconnected');
       if (!this.intentionalDisconnect) {
         this.scheduleReconnect();
       }
     });
 
-    ws.on('error', () => {
+    ws.on('error', (err: Error) => {
+      logger.warn({ err: err?.message, code: (err as NodeJS.ErrnoException)?.code }, 'WS error');
       // Error triggers close, which handles reconnect
     });
 
     // Track any incoming frames as activity for stale detection
     ws.on('ping', () => {
       this.lastActivityAt = Date.now();
+      logger.debug('Received WS ping from relay');
+    });
+
+    ws.on('pong', () => {
+      logger.debug('Received WS pong from relay');
     });
   }
 
@@ -385,14 +393,19 @@ export class RelayClient {
     }
 
     if (msg.type === 'pong') {
+      logger.debug('Received JSON pong from relay');
       return;
     }
 
     if (msg.type === 'ping') {
+      logger.debug('Received JSON ping from relay');
       if (this.ws?.readyState === WebSocket.OPEN) {
         const pong: Record<string, unknown> = { type: 'pong' };
         if (this.lastReceivedRelaySeq > 0) pong.ack = this.lastReceivedRelaySeq;
         this.ws.send(JSON.stringify(pong));
+        logger.debug('Sent JSON pong to relay');
+      } else {
+        logger.warn({ readyState: this.ws?.readyState }, 'Could not pong — WS not open');
       }
       return;
     }
@@ -1951,6 +1964,13 @@ export class RelayClient {
     this.staleCheckTimer = setInterval(() => {
       if (this.state !== 'connected' && this.state !== 'authenticating') return;
       const elapsed = Date.now() - this.lastActivityAt;
+      // Warn before kill so we capture context for slow-but-not-yet-stale connections
+      if (elapsed > RelayClient.STALE_THRESHOLD / 2 && elapsed <= RelayClient.STALE_THRESHOLD) {
+        logger.info(
+          { elapsedSec: Math.round(elapsed / 1000), thresholdSec: RelayClient.STALE_THRESHOLD / 1000 },
+          'Activity gap approaching stale threshold',
+        );
+      }
       if (elapsed > RelayClient.STALE_THRESHOLD) {
         logger.warn(`No activity for ${Math.round(elapsed / 1000)}s — connection stale, reconnecting`);
         this.ws?.close();


### PR DESCRIPTION
Adds diagnostic logging so the next time a ping/pong watchdog disconnects a client, the cause is obvious from logs alone.

**Why:** Today, the relay only logs `Terminating stale connection (no pong)` when it closes a connection. No close code, no RTT, no signal of why the pong didn't arrive. Tentacle was even worse: `ws.on('close')` and `ws.on('error')` were both completely silent. Investigating a real recurrence this morning revealed we couldn't distinguish network drop, event-loop block, or pong-send failure.

**What's added** (no behavior changes, only logs):

Head (`server.ts`):
- Track `lastPingSentAt` + `lastPongRecvAt` per client
- Log `rttMs` on pong receipt
- Enrich the stale-termination log with `msSincePingSent`, `msSinceLastPong`, `wsReadyState`
- Capture WS close `code` + `reason` (was missing)
- Capture WS `error` (was silently swallowed)

Tentacle (`relay-client.ts`):
- Log WS + JSON ping/pong frame receipt and pong send
- Capture WS close `code` + `reason`
- Capture WS `error` (was silently swallowed)
- Warn when activity gap reaches half the stale threshold (early signal)
- Warn when pong can't be sent

**Validation:**
- pnpm lint clean, 228/228 head tests pass, 467/467 tentacle tests pass

Bumps head 0.14.2 → 0.14.3 and tentacle 0.19.0 → 0.19.1.
