### PR TITLE
fix(tentacle): reclaim stale connection before relay times out + tick-drift instrumentation

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -114,10 +114,16 @@ export class RelayClient {
   // Stale connection detection — tracks last incoming message to detect sleep/network changes
   private lastActivityAt = 0;
   private staleCheckTimer: ReturnType<typeof setInterval> | null = null;
-  /** How long without any activity before we consider the connection stale (ms) */
-  private static readonly STALE_THRESHOLD = 60_000;
+  /** Tick instrumentation: last time the staleCheck callback ran (ms epoch).
+   *  Used to detect timer drift / event-loop block. 0 = first tick. */
+  private staleCheckLastTickAt = 0;
+  /** How long without any activity before we consider the connection stale (ms).
+   *  Must be < relay's PING_INTERVAL * 2 (60s) so we reconnect first, instead
+   *  of being killed by the relay's slower stale-detection. Tentacle-initiated
+   *  reconnects take ~3s vs ~10s for relay-kill→close-frame→reconnect. */
+  private static readonly STALE_THRESHOLD = 45_000;
   /** How often to check for stale connection (ms) */
-  private static readonly STALE_CHECK_INTERVAL = 10_000;
+  private static readonly STALE_CHECK_INTERVAL = 5_000;
 
   // ── Delivery assurance state (per-connection) ──────────────
   /** Highest relaySeq received from head on this connection. Echoed back as
@@ -2037,9 +2043,23 @@ export class RelayClient {
 
   private startStaleCheck(): void {
     this.stopStaleCheck();
+    this.staleCheckLastTickAt = 0;
     this.staleCheckTimer = setInterval(() => {
+      const now = Date.now();
+      // Tick instrumentation: detect timer drift / event-loop block
+      if (this.staleCheckLastTickAt > 0) {
+        const tickDrift = now - this.staleCheckLastTickAt - RelayClient.STALE_CHECK_INTERVAL;
+        if (tickDrift > 2_000) {
+          logger.warn(
+            { tickDriftMs: tickDrift, intervalMs: RelayClient.STALE_CHECK_INTERVAL },
+            'staleCheck tick was late (event-loop block or timer drift)',
+          );
+        }
+      }
+      this.staleCheckLastTickAt = now;
+
       if (this.state !== 'connected' && this.state !== 'authenticating') return;
-      const elapsed = Date.now() - this.lastActivityAt;
+      const elapsed = now - this.lastActivityAt;
       // Warn before kill so we capture context for slow-but-not-yet-stale connections
       if (elapsed > RelayClient.STALE_THRESHOLD / 2 && elapsed <= RelayClient.STALE_THRESHOLD) {
         logger.info(


### PR DESCRIPTION
Lowers `STALE_THRESHOLD` 60s → 45s and `STALE_CHECK_INTERVAL` 10s → 5s, so the tentacle reclaims its own stale connection before the relay times out and disconnects it.

**Why now:** Investigating the 2026-05-31 15:36 disconnect showed:
- Relay logged: `Terminating stale connection (no pong) {msSincePingSent: 30002, msSinceLastPong: 59991}` — server-side decision
- Tentacle logged: `WS closed {code: 1005, intentional: false}` — got the close frame ~700ms later
- Cause: Mac had a ~27s network glitch (Copilot SDK simultaneously logged transient API error at the same instant)

The relay times out at exactly 60s without pong (`PING_INTERVAL=30s × 2`). Tentacle's own stale-detection threshold was also 60s — a tied race the tentacle was always going to lose, because the relay's close frame still has to travel back to the Mac.

With 45s/5s the tentacle reconnects at most 50s after a stalled ping (well before the 60s server cutoff), and tentacle-initiated reconnect is ~3s vs ~10s for the relay-driven path. **Net: every glitch is ~7s shorter and recovery is initiated by the side that knows its own connection best.**

**Also adds tick-drift instrumentation.** During the same investigation, the existing "Activity gap approaching stale threshold" log never fired even though setInterval should have ticked at 5 separate moments in the 60s window. Cause unknown. The new `staleCheck tick was late` warn (logged when `tickDrift > 2s`) will reveal whether setInterval is dropping ticks under load.

**Validation:**
- 471/471 tentacle tests pass
- pnpm lint clean
- Bundle verified to contain `STALE_THRESHOLD = 45_000` and `STALE_CHECK_INTERVAL = 5_000`

Bumps tentacle 0.19.2 → 0.19.3. No protocol change.
