### PR TITLE
fix(tentacle): heal corrupt Copilot events on resume + accurate stale-detection + non-destructive resume failure

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/adapters/__tests__/sanitize-copilot-events.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/sanitize-copilot-events.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for sanitizeCopilotEventsFile.
+ *
+ * This is the function that pre-scans `~/.copilot/session-state/<id>/events.jsonl`
+ * before resume and repairs known Copilot CLI writer-side schema violations
+ * (currently: negative `tokensRemoved` on `session.compaction_complete`).
+ *
+ * The tests use a real tmp directory and real fs so they exercise the
+ * atomic write-back path and verify byte-level file shape.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { sanitizeCopilotEventsFile } from '../copilot.js';
+
+describe('sanitizeCopilotEventsFile', () => {
+  let dir: string;
+  let eventsPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kraki-sanitize-test-'));
+    eventsPath = join(dir, 'events.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns 0 and does not create a file when path does not exist', () => {
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+    expect(fixed).toBe(0);
+    expect(existsSync(eventsPath)).toBe(false);
+  });
+
+  it('returns 0 and leaves a clean file byte-identical', () => {
+    const original = [
+      '{"type":"user.message","data":{"content":"hi"}}',
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":1234}}',
+      '{"type":"assistant.message","data":{"content":"hello"}}',
+      '',
+    ].join('\n');
+    writeFileSync(eventsPath, original, 'utf8');
+
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+
+    expect(fixed).toBe(0);
+    expect(readFileSync(eventsPath, 'utf8')).toBe(original);
+  });
+
+  it('clamps negative tokensRemoved to 0 and reports the count', () => {
+    const original = [
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":-2098}}',
+      '{"type":"assistant.message","data":{"content":"ok"}}',
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":-442}}',
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":7}}',
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":-1638}}',
+      '',
+    ].join('\n');
+    writeFileSync(eventsPath, original, 'utf8');
+
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+
+    expect(fixed).toBe(3);
+    const after = readFileSync(eventsPath, 'utf8');
+    expect(after).not.toContain('-2098');
+    expect(after).not.toContain('-442');
+    expect(after).not.toContain('-1638');
+
+    // Re-parse line-by-line to confirm structural correctness
+    const lines = after.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(5);
+    for (const line of lines) {
+      const ev = JSON.parse(line) as Record<string, unknown>;
+      const data = ev.data as Record<string, unknown> | undefined;
+      if (typeof data?.tokensRemoved === 'number') {
+        expect(data.tokensRemoved).toBeGreaterThanOrEqual(0);
+      }
+    }
+    // The previously-clean entry must be untouched at value level
+    const clean = JSON.parse(lines[3]) as { data: { tokensRemoved: number } };
+    expect(clean.data.tokensRemoved).toBe(7);
+  });
+
+  it('preserves malformed lines verbatim (does not crash, does not rewrite line)', () => {
+    const original = [
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":-1}}',
+      '{this is not valid json',
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":-2}}',
+      '',
+    ].join('\n');
+    writeFileSync(eventsPath, original, 'utf8');
+
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+
+    expect(fixed).toBe(2);
+    const after = readFileSync(eventsPath, 'utf8');
+    expect(after).toContain('{this is not valid json');
+    // Both fixable lines must be repaired
+    expect(after).not.toContain('-1');
+    expect(after).not.toContain('-2');
+  });
+
+  it('ignores positive zero and rounding edge cases', () => {
+    const original = [
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":0}}',
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":0.0}}',
+      '{"type":"session.compaction_complete","data":{"tokensRemoved":-0}}',
+      '',
+    ].join('\n');
+    writeFileSync(eventsPath, original, 'utf8');
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+    // -0 < 0 is false in JS so it should not count as a fix
+    expect(fixed).toBe(0);
+  });
+
+  it('does not modify other negative numeric fields under data', () => {
+    const original = [
+      '{"type":"x","data":{"someOtherCounter":-5}}',
+      '{"type":"y","data":{"unrelated":-100,"tokensRemoved":3}}',
+      '',
+    ].join('\n');
+    writeFileSync(eventsPath, original, 'utf8');
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+    expect(fixed).toBe(0);
+    // File unchanged
+    expect(readFileSync(eventsPath, 'utf8')).toBe(original);
+  });
+
+  it('handles events without a data field', () => {
+    const original = [
+      '{"type":"session.compaction_complete"}',
+      '{"type":"x","data":null}',
+      '{"type":"y","data":"a string"}',
+      '{"type":"z","data":42}',
+      '',
+    ].join('\n');
+    writeFileSync(eventsPath, original, 'utf8');
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+    expect(fixed).toBe(0);
+  });
+
+  it('atomic write: does not leave .tmp file behind on success', () => {
+    writeFileSync(eventsPath, '{"data":{"tokensRemoved":-1}}\n', 'utf8');
+    sanitizeCopilotEventsFile(eventsPath);
+    expect(existsSync(`${eventsPath}.kraki-sanitize.tmp`)).toBe(false);
+  });
+});

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -25,7 +25,7 @@ import type {
   MCPServerConfig,
 } from '@github/copilot-sdk';
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync, cpSync, mkdtempSync, mkdirSync, unlinkSync, readdirSync, symlinkSync, lstatSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, cpSync, mkdtempSync, mkdirSync, unlinkSync, readdirSync, symlinkSync, lstatSync, statSync, renameSync } from 'node:fs';
 import * as moduleApi from 'node:module';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join, basename } from 'node:path';
@@ -147,6 +147,75 @@ export function resolveCopilotCliPath(): string | undefined {
 function isRecoverableSessionError(err: unknown): boolean {
   const message = getErrorMessage(err);
   return message.includes('Session not found:') || message.includes('Connection is disposed');
+}
+
+/**
+ * Repair known Copilot CLI writer-side schema violations in an events.jsonl
+ * file so the SDK's loader-side validator accepts it on `session.resume()`.
+ *
+ * Returns the number of lines fixed. 0 means the file was already valid
+ * (or did not exist) and was not rewritten.
+ *
+ * Known fixups:
+ *   - `data.tokensRemoved` on `session.compaction_complete`: the schema
+ *     requires `>= 0` but the writer sometimes produces negatives like -2098.
+ *     We clamp to 0. This is metadata accounting only — does not affect
+ *     conversation history or agent behaviour.
+ *
+ * Atomic file replace via tmp+rename. On any I/O error the original file is
+ * left untouched and 0 is returned.
+ *
+ * Add new fixups here as more writer-side bugs are identified upstream
+ * (github/copilot-cli has a recurring pattern of these: #3454, #3432, #3520).
+ *
+ * Exported for unit testing — production code should call the wrapper on
+ * CopilotAdapter so the log line is attached to a sessionId.
+ */
+export function sanitizeCopilotEventsFile(eventsPath: string): number {
+  if (!existsSync(eventsPath)) return 0;
+
+  let raw: string;
+  try {
+    raw = readFileSync(eventsPath, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  const lines = raw.split('\n');
+  let fixed = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    try {
+      const ev = JSON.parse(line) as Record<string, unknown>;
+      const data = ev?.data as Record<string, unknown> | undefined;
+      if (data && typeof data === 'object') {
+        // github/copilot-cli: negative `tokensRemoved` on
+        // session.compaction_complete violates the schema's `>= 0`
+        // constraint. Clamp to 0.
+        if (typeof data.tokensRemoved === 'number' && data.tokensRemoved < 0) {
+          data.tokensRemoved = 0;
+          lines[i] = JSON.stringify(ev);
+          fixed++;
+        }
+      }
+    } catch {
+      // Malformed line — leave verbatim. The SDK will report its own error
+      // with the original line number, which we want to preserve.
+    }
+  }
+
+  if (fixed === 0) return 0;
+
+  const tmpPath = `${eventsPath}.kraki-sanitize.tmp`;
+  try {
+    writeFileSync(tmpPath, lines.join('\n'), 'utf8');
+    renameSync(tmpPath, eventsPath);
+    return fixed;
+  } catch {
+    try { unlinkSync(tmpPath); } catch { /* ignore */ }
+    return 0;
+  }
 }
 
 /** Defensive basename — strips any leading directory components and never
@@ -1128,6 +1197,8 @@ export class CopilotAdapter extends AgentAdapter {
   private async resumeTrackedSession(sessionId: string): Promise<SessionEntry> {
     this.ensureClient();
 
+    this.sanitizeEventsBeforeResume(sessionId);
+
     const pendingPermissions = new Map<string, PendingPermission>();
     const pendingQuestions = new Map<string, PendingQuestion>();
     const session = await this.client!.resumeSession(
@@ -1141,6 +1212,29 @@ export class CopilotAdapter extends AgentAdapter {
     logger.debug({ sessionId }, 'session resumed');
 
     return entry;
+  }
+
+  /**
+   * Pre-scan events.jsonl for known Copilot CLI writer-side bugs that cause
+   * the SDK's loader-side Zod validation to throw "Session file is corrupted"
+   * on resume.
+   *
+   * The CLI has a recurring pattern: its writer produces values that fail
+   * its own bundled schema (github/copilot-cli #3454 exitCode<0,
+   * #3432 totalPremiumRequests as float, #3520 ephemeral missing). When this
+   * happens, `session.resume()` rejects the whole file and every conversation
+   * turn is lost.
+   *
+   * We clamp known-bad values to schema-valid equivalents before resume so
+   * the SDK accepts the file. Atomic file replace; no-op (fast read-only
+   * scan) when nothing is wrong.
+   */
+  private sanitizeEventsBeforeResume(sessionId: string): void {
+    const eventsPath = join(homedir(), '.copilot', 'session-state', sessionId, 'events.jsonl');
+    const fixed = sanitizeCopilotEventsFile(eventsPath);
+    if (fixed > 0) {
+      logger.info({ sessionId, fixed }, 'sanitized Copilot events.jsonl before resume');
+    }
   }
 
   private handleUnavailableSession(sessionId: string, err: unknown): void {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1354,13 +1354,13 @@ export class RelayClient {
             this.sessionManager.markIdle(meta.id);
           }
         } catch (err) {
-          logger.warn({ err, sessionId: meta.id }, 'Session resume failed after restart');
-          this.sessionManager.endSession(meta.id, 'resume_failed');
-          this.send({
-            type: 'session_ended',
-            sessionId: meta.id,
-            payload: { reason: 'resume_failed' },
-          });
+          // Leave state as 'disconnected' so the next daemon restart will
+          // retry the resume. Flipping to 'ended' here turns a transient
+          // resume failure (e.g. corrupted events.jsonl from a known Copilot
+          // CLI writer-side bug, a rogue colliding daemon, a temporary SDK
+          // issue) into permanent session loss with no automatic recovery.
+          logger.warn({ err, sessionId: meta.id }, 'Session resume failed; leaving as disconnected for retry on next restart');
+          this.sessionManager.markDisconnected(meta.id);
         }
       }
     }
@@ -1688,8 +1688,13 @@ export class RelayClient {
       this.flushDelta(msg.sessionId);
     }
 
-    // Outbound messages also prove connectivity
-    this.lastActivityAt = Date.now();
+    // NOTE: do NOT update lastActivityAt here. Outbound send() writes to a
+    // local TCP buffer (or to a proxy on 127.0.0.1) and always succeeds
+    // synchronously — it does not prove the bytes reached the relay. During
+    // an outbound-only network blip (e.g. proxy reconnecting upstream),
+    // counting our own sends as activity makes the stale-detector think the
+    // link is healthy while the relay times us out. Track inbound traffic
+    // only — those frames are proof of bidirectional connectivity.
 
     // Tentacle assigns seq and timestamp before encryption
     const enriched = msg as Record<string, unknown>;


### PR DESCRIPTION
Three independent fixes for failure modes observed in production this week. All in `packages/tentacle/`.

## (1) Auto-heal Copilot session events on resume

The Copilot CLI's own SDK writes invalid data into `~/.copilot/session-state/<id>/events.jsonl` and then refuses to load those same files via its bundled Zod validator. Observed pattern: `session.compaction_complete` events carry negative `tokensRemoved` (e.g. `-2098`), schema requires `>= 0`, `session.resume()` rejects the whole file → "Session file is corrupted" → kraki marks the session permanently ended.

Hit production twice today (3 sessions in the morning, 7 in the afternoon) plus an unknown count over the past week of long-running sessions. One session accumulated 44 negative-tokensRemoved events in 3 hours of normal use.

New free function `sanitizeCopilotEventsFile(eventsPath)` pre-scans the file and clamps negatives to 0 before resume. No-op fast path when clean. Atomic write-back via tmp+rename. 8 new unit tests cover happy path, no-op, malformed lines preserved, edge cases.

GitHub Copilot CLI has a recurring pattern of writer/validator mismatches — they've shipped fixes for several variants (#3454 `exitCode<0`, #3432 `totalPremiumRequests` as float, #3520 `ephemeral` missing) but `tokensRemoved` is not yet reported upstream. New fixups can be added as one-liners in the same function as more bugs surface.

## (2) Don't count outbound sends as activity for stale-detection

`relay-client.ts:1692` had `lastActivityAt = Date.now()` on every outbound send with the comment "Outbound messages also prove connectivity". They don't: `send()` writes to a local TCP buffer (or, in setups with a local proxy on `127.0.0.1`, to the proxy's buffer) and always returns synchronously regardless of whether the bytes ever leave the host.

During a real outbound-only network blip today (local proxy reconnecting upstream), this defeated stale-detection entirely. The tentacle kept broadcasting permission resolutions, marked itself "active for 26s" while the relay had already timed it out for 60s of no pong. The relay always wins the race in that scenario → user sees ~10s recovery (close-frame round-trip) instead of ~3s (tentacle-initiated reconnect).

Now `lastActivityAt` updates only on inbound frames. The "Activity gap approaching" log will now report accurate elapsed times.

## (3) Resume failure no longer permanently ends the session

`relay-client.ts:1339` called `endSession(meta.id, 'resume_failed')` whenever `adapter.resumeSession()` threw. Any transient resume failure — corrupted events file (Fix #1), rogue colliding daemon, brief I/O issue — would permanently flip the session to `ended` with no automatic retry path.

Now we call `markDisconnected()` instead. State stays `disconnected`, the next daemon restart retries the resume. Combined with Fix #1 this means Copilot-corruption failures heal silently on the very next daemon startup.

## Validation

- `pnpm lint` clean
- 479/479 tentacle tests pass (8 new tests for the sanitizer, real fs + tmp dirs)
- `pnpm --filter @kraki/tentacle build` clean

Bumps tentacle 0.19.3 → 0.19.4. No protocol changes, no head changes.
