### PR TITLE
refactor: remove TCC warmup, require FDA only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ packages/toolbar/src-tauri/gen/
 packages/toolbar/src-tauri/icons/tray-*.png
 packages/toolbar/src-tauri/sidecar/
 packages/arm/web/e2e-*.png
+
+# Xcode / iOS build artifacts
+packages/arm/ios/build/
+packages/arm/ios/DerivedData/
+*.xcuserdata
+xcuserdata/

--- a/packages/tentacle/src/__tests__/checks.test.ts
+++ b/packages/tentacle/src/__tests__/checks.test.ts
@@ -67,7 +67,7 @@ import { input } from '@inquirer/prompts';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, promises as fsp } from 'node:fs';
 import { createConnection } from 'node:net';
 import { platform, homedir } from 'node:os';
-import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, ensureWindowsSystemPath, needsTccWarmup, getWarmupLabels, markTccWarmed, clearTccWarmedMarker } from '../checks.js';
+import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, ensureWindowsSystemPath, needsTccWarmup, getWarmupLabels, markTccWarmed, clearTccWarmedMarker, probeFda, pollFda } from '../checks.js';
 
 const mockExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
 const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
@@ -611,5 +611,72 @@ describe('clearTccWarmedMarker()', () => {
   it('does not throw if file does not exist', () => {
     mockUnlinkSync.mockImplementation(() => { throw Object.assign(new Error('enoent'), { code: 'ENOENT' }); });
     expect(() => clearTccWarmedMarker()).not.toThrow();
+  });
+});
+
+// ── probeFda() ──────────────────────────────────────────
+
+describe('probeFda()', () => {
+  it('returns granted when TCC.db is readable', async () => {
+    mockAccess.mockResolvedValue(undefined);
+    expect(await probeFda()).toBe('granted');
+  });
+
+  it('returns denied when TCC.db returns EPERM', async () => {
+    mockAccess.mockRejectedValue(Object.assign(new Error('perm'), { code: 'EPERM' }));
+    expect(await probeFda()).toBe('denied');
+  });
+
+  it('returns missing when TCC.db does not exist', async () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (typeof p === 'string' && p.includes('TCC.db')) return false;
+      return true;
+    });
+    expect(await probeFda()).toBe('missing');
+  });
+});
+
+// ── pollFda() ───────────────────────────────────────────
+
+describe('pollFda()', () => {
+  it('returns granted immediately if FDA is already granted', async () => {
+    mockAccess.mockResolvedValue(undefined);
+    const result = await pollFda(100);
+    expect(result).toBe('granted');
+  });
+
+  it('polls until FDA becomes granted', async () => {
+    let callCount = 0;
+    mockAccess.mockImplementation(() => {
+      callCount++;
+      if (callCount >= 3) return Promise.resolve(undefined);
+      return Promise.reject(Object.assign(new Error('perm'), { code: 'EPERM' }));
+    });
+    const result = await pollFda(50);
+    expect(result).toBe('granted');
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('stops polling when signal is aborted', async () => {
+    mockAccess.mockRejectedValue(Object.assign(new Error('perm'), { code: 'EPERM' }));
+    const ac = new AbortController();
+    // Abort after a short delay
+    setTimeout(() => ac.abort(), 120);
+    const result = await pollFda(50, ac.signal);
+    expect(result).toBe('denied');
+  });
+
+  it('returns granted on final check after abort if FDA was granted', async () => {
+    let callCount = 0;
+    mockAccess.mockImplementation(() => {
+      callCount++;
+      // Grant on the final check (after abort)
+      if (callCount >= 4) return Promise.resolve(undefined);
+      return Promise.reject(Object.assign(new Error('perm'), { code: 'EPERM' }));
+    });
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 150);
+    const result = await pollFda(50, ac.signal);
+    expect(result).toBe('granted');
   });
 });

--- a/packages/tentacle/src/__tests__/checks.test.ts
+++ b/packages/tentacle/src/__tests__/checks.test.ts
@@ -10,16 +10,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
-  execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
-    // Default: simulate successful find (App Data granted)
-    setTimeout(() => cb(null), 0);
-    const { EventEmitter } = require('node:events');
-    return new EventEmitter();
-  }),
-}));
-
-vi.mock('../config.js', () => ({
-  getConfigDir: () => '/tmp/fake-kraki',
 }));
 
 vi.mock('@inquirer/prompts', () => ({
@@ -40,47 +30,25 @@ vi.mock('node:fs', async (importActual) => {
   return {
     ...actual,
     existsSync: vi.fn(() => true),
-    readFileSync: vi.fn(),
-    writeFileSync: vi.fn(),
-    unlinkSync: vi.fn(),
     promises: {
       ...actual.promises,
-      readdir: vi.fn(),
       access: vi.fn(), // FDA probe — default: resolves (granted)
     },
   };
 });
 
-vi.mock('node:net', () => ({
-  createConnection: vi.fn(() => {
-    const { EventEmitter } = require('node:events');
-    const socket = new EventEmitter();
-    socket.destroy = vi.fn();
-    // Simulate successful connection attempt (ECONNREFUSED = network allowed)
-    setTimeout(() => socket.emit('error', Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })), 0);
-    return socket;
-  }),
-}));
-
-import { execSync, execFile } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { input } from '@inquirer/prompts';
-import { existsSync, readFileSync, writeFileSync, unlinkSync, promises as fsp } from 'node:fs';
-import { createConnection } from 'node:net';
+import { existsSync, promises as fsp } from 'node:fs';
 import { platform, homedir } from 'node:os';
-import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, ensureWindowsSystemPath, needsTccWarmup, getWarmupLabels, markTccWarmed, clearTccWarmedMarker, probeFda, pollFda } from '../checks.js';
+import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, ensureWindowsSystemPath, probeFda, pollFda } from '../checks.js';
 
 const mockExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
-const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
 const mockInput = input as unknown as ReturnType<typeof vi.fn>;
 const mockExistsSync = existsSync as unknown as ReturnType<typeof vi.fn>;
-const mockReadFileSync = readFileSync as unknown as ReturnType<typeof vi.fn>;
-const mockWriteFileSync = writeFileSync as unknown as ReturnType<typeof vi.fn>;
-const mockUnlinkSync = unlinkSync as unknown as ReturnType<typeof vi.fn>;
-const mockReaddir = fsp.readdir as unknown as ReturnType<typeof vi.fn>;
 const mockAccess = fsp.access as unknown as ReturnType<typeof vi.fn>;
 const mockPlatform = platform as unknown as ReturnType<typeof vi.fn>;
 const mockHomedir = homedir as unknown as ReturnType<typeof vi.fn>;
-const mockCreateConnection = createConnection as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -360,260 +328,6 @@ describe('ensureWindowsSystemPath()', () => {
   });
 });
 
-// ── warmupTccPermissions ────────────────────────────────
-
-describe('warmupTccPermissions()', () => {
-  it('returns [] on non-darwin platforms', async () => {
-    mockPlatform.mockReturnValue('linux');
-    const result = await warmupTccPermissions();
-    expect(result).toEqual([]);
-    expect(mockReaddir).not.toHaveBeenCalled();
-  });
-
-  it('returns [] on win32', async () => {
-    mockPlatform.mockReturnValue('win32');
-    const result = await warmupTccPermissions();
-    expect(result).toEqual([]);
-  });
-
-  it('probes all 7 protected folders plus App Data, Local Network, and Full Disk Access on darwin', async () => {
-    mockReaddir.mockResolvedValue([]);
-    const result = await warmupTccPermissions();
-    expect(result).toHaveLength(10);
-    // 7 folder probes + App Data + Local Network + FDA
-    expect(result.slice(0, 7).every(r => r.status === 'granted')).toBe(true);
-    expect(result[7]).toMatchObject({ label: 'App Data', path: '(file provider)', status: 'granted' });
-    expect(result[8]).toMatchObject({ label: 'Local Network', path: '(network)', status: 'granted' });
-    expect(result[9]).toMatchObject({ label: 'Full Disk Access', path: '(system)', status: 'granted' });
-    expect(mockReaddir).toHaveBeenCalledTimes(7);
-  });
-
-  it('maps EPERM to denied', async () => {
-    const eperm = Object.assign(new Error('eperm'), { code: 'EPERM' });
-    mockReaddir.mockRejectedValue(eperm);
-    const result = await warmupTccPermissions();
-    expect(result.slice(0, 7).every(r => r.status === 'denied')).toBe(true);
-  });
-
-  it('maps EACCES to denied', async () => {
-    const eacces = Object.assign(new Error('eacces'), { code: 'EACCES' });
-    mockReaddir.mockRejectedValue(eacces);
-    const result = await warmupTccPermissions();
-    expect(result.slice(0, 7).every(r => r.status === 'denied')).toBe(true);
-  });
-
-  it('reports missing when folder does not exist', async () => {
-    mockExistsSync.mockReturnValue(false);
-    const result = await warmupTccPermissions();
-    expect(result.slice(0, 7).every(r => r.status === 'missing')).toBe(true);
-    expect(mockReaddir).not.toHaveBeenCalled();
-  });
-
-  it('treats unknown errno as denied (defensive)', async () => {
-    const eio = Object.assign(new Error('io'), { code: 'EIO' });
-    mockReaddir.mockRejectedValue(eio);
-    const result = await warmupTccPermissions();
-    expect(result.slice(0, 7).every(r => r.status === 'denied')).toBe(true);
-  });
-
-  it('invokes onStart before each probe and onResult after', async () => {
-    mockReaddir.mockResolvedValue([]);
-    const starts: string[] = [];
-    const results: string[] = [];
-    await warmupTccPermissions(
-      (label) => { starts.push(label); },
-      (r) => { results.push(`${r.label}:${r.status}`); },
-    );
-    expect(starts).toHaveLength(10);
-    expect(results).toHaveLength(10);
-    expect(starts[0]).toBe('~/Documents');
-    expect(results[0]).toBe('~/Documents:granted');
-    expect(starts[7]).toBe('App Data');
-    expect(results[7]).toBe('App Data:granted');
-    expect(starts[8]).toBe('Local Network');
-    expect(results[8]).toBe('Local Network:granted');
-    expect(starts[9]).toBe('Full Disk Access');
-    expect(results[9]).toBe('Full Disk Access:granted');
-  });
-
-  it('uses absolute paths under homedir', async () => {
-    mockReaddir.mockResolvedValue([]);
-    const result = await warmupTccPermissions();
-    expect(result[0].path).toBe('/home/test/Documents');
-    // iCloud Drive uses the long Library path
-    const icloud = result.find(r => r.label === '~/iCloud Drive');
-    expect(icloud?.path).toBe('/home/test/Library/Mobile Documents/com~apple~CloudDocs');
-  });
-
-  it('continues probing remaining folders even if one denies', async () => {
-    let callCount = 0;
-    mockReaddir.mockImplementation(async () => {
-      callCount++;
-      if (callCount === 2) {
-        throw Object.assign(new Error('eperm'), { code: 'EPERM' });
-      }
-      return [];
-    });
-    const result = await warmupTccPermissions();
-    expect(result).toHaveLength(10);
-    expect(result[1].status).toBe('denied');
-    expect(result[0].status).toBe('granted');
-    expect(result[2].status).toBe('granted');
-  });
-
-  it('reports Local Network denied when socket returns EPERM', async () => {
-    const { EventEmitter } = require('node:events');
-    mockCreateConnection.mockImplementation(() => {
-      const socket = new EventEmitter();
-      socket.destroy = vi.fn();
-      setTimeout(() => socket.emit('error', Object.assign(new Error('perm'), { code: 'EPERM' })), 0);
-      return socket;
-    });
-    mockReaddir.mockResolvedValue([]);
-    const result = await warmupTccPermissions();
-    const net = result.find(r => r.label === 'Local Network');
-    expect(net).toMatchObject({ label: 'Local Network', status: 'denied' });
-  });
-
-  it('reports Local Network granted on ECONNREFUSED (network allowed, host unreachable)', async () => {
-    const { EventEmitter } = require('node:events');
-    mockCreateConnection.mockImplementation(() => {
-      const socket = new EventEmitter();
-      socket.destroy = vi.fn();
-      setTimeout(() => socket.emit('error', Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })), 0);
-      return socket;
-    });
-    mockReaddir.mockResolvedValue([]);
-    const result = await warmupTccPermissions();
-    const net = result.find(r => r.label === 'Local Network');
-    expect(net).toMatchObject({ label: 'Local Network', status: 'granted' });
-  });
-
-  it('reports App Data granted when find succeeds', async () => {
-    mockReaddir.mockResolvedValue([]);
-    // Default execFile mock already succeeds
-    const result = await warmupTccPermissions();
-    const appData = result.find(r => r.label === 'App Data');
-    expect(appData).toMatchObject({ label: 'App Data', path: '(file provider)', status: 'granted' });
-  });
-
-  it('reports App Data denied when find returns EPERM', async () => {
-    mockReaddir.mockResolvedValue([]);
-    const { EventEmitter } = require('node:events');
-    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
-      setTimeout(() => cb(Object.assign(new Error('perm'), { code: 'EPERM' })), 0);
-      return new EventEmitter();
-    });
-    const result = await warmupTccPermissions();
-    const appData = result.find(r => r.label === 'App Data');
-    expect(appData).toMatchObject({ label: 'App Data', status: 'denied' });
-  });
-
-  it('reports App Data missing when iCloud Drive folder does not exist', async () => {
-    mockReaddir.mockResolvedValue([]);
-    // existsSync returns false only for the iCloud Drive path
-    mockExistsSync.mockImplementation((p: string) => {
-      if (typeof p === 'string' && p.includes('Mobile Documents')) return false;
-      return true;
-    });
-    const result = await warmupTccPermissions();
-    const appData = result.find(r => r.label === 'App Data');
-    expect(appData).toMatchObject({ label: 'App Data', status: 'missing' });
-  });
-
-  it('reports Full Disk Access granted when TCC.db is readable', async () => {
-    mockReaddir.mockResolvedValue([]);
-    // Default mockAccess resolves → granted
-    const result = await warmupTccPermissions();
-    const fda = result.find(r => r.label === 'Full Disk Access');
-    expect(fda).toMatchObject({ label: 'Full Disk Access', path: '(system)', status: 'granted' });
-  });
-
-  it('reports Full Disk Access denied when TCC.db returns EPERM', async () => {
-    mockReaddir.mockResolvedValue([]);
-    mockAccess.mockRejectedValue(Object.assign(new Error('perm'), { code: 'EPERM' }));
-    const result = await warmupTccPermissions();
-    const fda = result.find(r => r.label === 'Full Disk Access');
-    expect(fda).toMatchObject({ label: 'Full Disk Access', status: 'denied' });
-  });
-
-  it('reports Full Disk Access missing when TCC.db does not exist', async () => {
-    mockReaddir.mockResolvedValue([]);
-    mockExistsSync.mockImplementation((p: string) => {
-      if (typeof p === 'string' && p.includes('TCC.db')) return false;
-      return true;
-    });
-    const result = await warmupTccPermissions();
-    const fda = result.find(r => r.label === 'Full Disk Access');
-    expect(fda).toMatchObject({ label: 'Full Disk Access', status: 'missing' });
-  });
-});
-
-// ── TCC marker functions ────────────────────────────────
-
-describe('needsTccWarmup()', () => {
-  it('returns false on non-darwin', () => {
-    mockPlatform.mockReturnValue('linux');
-    expect(needsTccWarmup()).toBe(false);
-  });
-
-  it('returns true when marker file does not exist', () => {
-    mockExistsSync.mockReturnValue(false);
-    expect(needsTccWarmup()).toBe(true);
-  });
-
-  it('returns false when all labels are in the marker', () => {
-    mockExistsSync.mockReturnValue(true);
-    mockReadFileSync.mockReturnValue(getWarmupLabels().join('\n') + '\n');
-    expect(needsTccWarmup()).toBe(false);
-  });
-
-  it('returns true when a new label is missing from the marker', () => {
-    mockExistsSync.mockReturnValue(true);
-    // Simulate old marker missing Full Disk Access
-    const oldLabels = getWarmupLabels().filter(l => l !== 'Full Disk Access');
-    mockReadFileSync.mockReturnValue(oldLabels.join('\n') + '\n');
-    expect(needsTccWarmup()).toBe(true);
-  });
-});
-
-describe('getWarmupLabels()', () => {
-  it('includes Full Disk Access', () => {
-    expect(getWarmupLabels()).toContain('Full Disk Access');
-  });
-
-  it('has 10 labels matching warmupTccPermissions probe count', () => {
-    expect(getWarmupLabels()).toHaveLength(10);
-  });
-});
-
-describe('markTccWarmed()', () => {
-  it('writes labels to marker file', () => {
-    const results = [
-      { label: '~/Documents', path: '/home/test/Documents', status: 'granted' as const },
-      { label: 'Full Disk Access', path: '(system)', status: 'denied' as const },
-    ];
-    markTccWarmed(results);
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('.tcc-warmed'),
-      '~/Documents\nFull Disk Access\n',
-      'utf8',
-    );
-  });
-});
-
-describe('clearTccWarmedMarker()', () => {
-  it('removes the marker file', () => {
-    clearTccWarmedMarker();
-    expect(mockUnlinkSync).toHaveBeenCalledWith(expect.stringContaining('.tcc-warmed'));
-  });
-
-  it('does not throw if file does not exist', () => {
-    mockUnlinkSync.mockImplementation(() => { throw Object.assign(new Error('enoent'), { code: 'ENOENT' }); });
-    expect(() => clearTccWarmedMarker()).not.toThrow();
-  });
-});
-
 // ── probeFda() ──────────────────────────────────────────
 
 describe('probeFda()', () => {
@@ -633,6 +347,21 @@ describe('probeFda()', () => {
       return true;
     });
     expect(await probeFda()).toBe('missing');
+  });
+
+  it('returns granted on non-darwin platforms', async () => {
+    mockPlatform.mockReturnValue('linux');
+    expect(await probeFda()).toBe('granted');
+  });
+
+  it('returns granted on win32', async () => {
+    mockPlatform.mockReturnValue('win32');
+    expect(await probeFda()).toBe('granted');
+  });
+
+  it('returns denied when TCC.db returns EACCES', async () => {
+    mockAccess.mockRejectedValue(Object.assign(new Error('eacces'), { code: 'EACCES' }));
+    expect(await probeFda()).toBe('denied');
   });
 });
 

--- a/packages/tentacle/src/__tests__/checks.test.ts
+++ b/packages/tentacle/src/__tests__/checks.test.ts
@@ -18,6 +18,10 @@ vi.mock('node:child_process', () => ({
   }),
 }));
 
+vi.mock('../config.js', () => ({
+  getConfigDir: () => '/tmp/fake-kraki',
+}));
+
 vi.mock('@inquirer/prompts', () => ({
   input: vi.fn(),
 }));
@@ -36,9 +40,13 @@ vi.mock('node:fs', async (importActual) => {
   return {
     ...actual,
     existsSync: vi.fn(() => true),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
     promises: {
       ...actual.promises,
       readdir: vi.fn(),
+      access: vi.fn(), // FDA probe — default: resolves (granted)
     },
   };
 });
@@ -56,16 +64,20 @@ vi.mock('node:net', () => ({
 
 import { execSync, execFile } from 'node:child_process';
 import { input } from '@inquirer/prompts';
-import { existsSync, promises as fsp } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, promises as fsp } from 'node:fs';
 import { createConnection } from 'node:net';
 import { platform, homedir } from 'node:os';
-import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, ensureWindowsSystemPath } from '../checks.js';
+import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, ensureWindowsSystemPath, needsTccWarmup, getWarmupLabels, markTccWarmed, clearTccWarmedMarker } from '../checks.js';
 
 const mockExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
 const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
 const mockInput = input as unknown as ReturnType<typeof vi.fn>;
 const mockExistsSync = existsSync as unknown as ReturnType<typeof vi.fn>;
+const mockReadFileSync = readFileSync as unknown as ReturnType<typeof vi.fn>;
+const mockWriteFileSync = writeFileSync as unknown as ReturnType<typeof vi.fn>;
+const mockUnlinkSync = unlinkSync as unknown as ReturnType<typeof vi.fn>;
 const mockReaddir = fsp.readdir as unknown as ReturnType<typeof vi.fn>;
+const mockAccess = fsp.access as unknown as ReturnType<typeof vi.fn>;
 const mockPlatform = platform as unknown as ReturnType<typeof vi.fn>;
 const mockHomedir = homedir as unknown as ReturnType<typeof vi.fn>;
 const mockCreateConnection = createConnection as unknown as ReturnType<typeof vi.fn>;
@@ -364,14 +376,15 @@ describe('warmupTccPermissions()', () => {
     expect(result).toEqual([]);
   });
 
-  it('probes all 7 protected folders plus App Data and Local Network on darwin', async () => {
+  it('probes all 7 protected folders plus App Data, Local Network, and Full Disk Access on darwin', async () => {
     mockReaddir.mockResolvedValue([]);
     const result = await warmupTccPermissions();
-    expect(result).toHaveLength(9);
-    // 7 folder probes + 1 App Data + 1 network probe
+    expect(result).toHaveLength(10);
+    // 7 folder probes + App Data + Local Network + FDA
     expect(result.slice(0, 7).every(r => r.status === 'granted')).toBe(true);
     expect(result[7]).toMatchObject({ label: 'App Data', path: '(file provider)', status: 'granted' });
     expect(result[8]).toMatchObject({ label: 'Local Network', path: '(network)', status: 'granted' });
+    expect(result[9]).toMatchObject({ label: 'Full Disk Access', path: '(system)', status: 'granted' });
     expect(mockReaddir).toHaveBeenCalledTimes(7);
   });
 
@@ -411,14 +424,16 @@ describe('warmupTccPermissions()', () => {
       (label) => { starts.push(label); },
       (r) => { results.push(`${r.label}:${r.status}`); },
     );
-    expect(starts).toHaveLength(9);
-    expect(results).toHaveLength(9);
+    expect(starts).toHaveLength(10);
+    expect(results).toHaveLength(10);
     expect(starts[0]).toBe('~/Documents');
     expect(results[0]).toBe('~/Documents:granted');
     expect(starts[7]).toBe('App Data');
     expect(results[7]).toBe('App Data:granted');
     expect(starts[8]).toBe('Local Network');
     expect(results[8]).toBe('Local Network:granted');
+    expect(starts[9]).toBe('Full Disk Access');
+    expect(results[9]).toBe('Full Disk Access:granted');
   });
 
   it('uses absolute paths under homedir', async () => {
@@ -440,7 +455,7 @@ describe('warmupTccPermissions()', () => {
       return [];
     });
     const result = await warmupTccPermissions();
-    expect(result).toHaveLength(9);
+    expect(result).toHaveLength(10);
     expect(result[1].status).toBe('denied');
     expect(result[0].status).toBe('granted');
     expect(result[2].status).toBe('granted');
@@ -504,5 +519,97 @@ describe('warmupTccPermissions()', () => {
     const result = await warmupTccPermissions();
     const appData = result.find(r => r.label === 'App Data');
     expect(appData).toMatchObject({ label: 'App Data', status: 'missing' });
+  });
+
+  it('reports Full Disk Access granted when TCC.db is readable', async () => {
+    mockReaddir.mockResolvedValue([]);
+    // Default mockAccess resolves → granted
+    const result = await warmupTccPermissions();
+    const fda = result.find(r => r.label === 'Full Disk Access');
+    expect(fda).toMatchObject({ label: 'Full Disk Access', path: '(system)', status: 'granted' });
+  });
+
+  it('reports Full Disk Access denied when TCC.db returns EPERM', async () => {
+    mockReaddir.mockResolvedValue([]);
+    mockAccess.mockRejectedValue(Object.assign(new Error('perm'), { code: 'EPERM' }));
+    const result = await warmupTccPermissions();
+    const fda = result.find(r => r.label === 'Full Disk Access');
+    expect(fda).toMatchObject({ label: 'Full Disk Access', status: 'denied' });
+  });
+
+  it('reports Full Disk Access missing when TCC.db does not exist', async () => {
+    mockReaddir.mockResolvedValue([]);
+    mockExistsSync.mockImplementation((p: string) => {
+      if (typeof p === 'string' && p.includes('TCC.db')) return false;
+      return true;
+    });
+    const result = await warmupTccPermissions();
+    const fda = result.find(r => r.label === 'Full Disk Access');
+    expect(fda).toMatchObject({ label: 'Full Disk Access', status: 'missing' });
+  });
+});
+
+// ── TCC marker functions ────────────────────────────────
+
+describe('needsTccWarmup()', () => {
+  it('returns false on non-darwin', () => {
+    mockPlatform.mockReturnValue('linux');
+    expect(needsTccWarmup()).toBe(false);
+  });
+
+  it('returns true when marker file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(needsTccWarmup()).toBe(true);
+  });
+
+  it('returns false when all labels are in the marker', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(getWarmupLabels().join('\n') + '\n');
+    expect(needsTccWarmup()).toBe(false);
+  });
+
+  it('returns true when a new label is missing from the marker', () => {
+    mockExistsSync.mockReturnValue(true);
+    // Simulate old marker missing Full Disk Access
+    const oldLabels = getWarmupLabels().filter(l => l !== 'Full Disk Access');
+    mockReadFileSync.mockReturnValue(oldLabels.join('\n') + '\n');
+    expect(needsTccWarmup()).toBe(true);
+  });
+});
+
+describe('getWarmupLabels()', () => {
+  it('includes Full Disk Access', () => {
+    expect(getWarmupLabels()).toContain('Full Disk Access');
+  });
+
+  it('has 10 labels matching warmupTccPermissions probe count', () => {
+    expect(getWarmupLabels()).toHaveLength(10);
+  });
+});
+
+describe('markTccWarmed()', () => {
+  it('writes labels to marker file', () => {
+    const results = [
+      { label: '~/Documents', path: '/home/test/Documents', status: 'granted' as const },
+      { label: 'Full Disk Access', path: '(system)', status: 'denied' as const },
+    ];
+    markTccWarmed(results);
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('.tcc-warmed'),
+      '~/Documents\nFull Disk Access\n',
+      'utf8',
+    );
+  });
+});
+
+describe('clearTccWarmedMarker()', () => {
+  it('removes the marker file', () => {
+    clearTccWarmedMarker();
+    expect(mockUnlinkSync).toHaveBeenCalledWith(expect.stringContaining('.tcc-warmed'));
+  });
+
+  it('does not throw if file does not exist', () => {
+    mockUnlinkSync.mockImplementation(() => { throw Object.assign(new Error('enoent'), { code: 'ENOENT' }); });
+    expect(() => clearTccWarmedMarker()).not.toThrow();
   });
 });

--- a/packages/tentacle/src/__tests__/daemon-worker.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-worker.test.ts
@@ -121,6 +121,18 @@ vi.mock('node:child_process', () => ({
     if (mockExecSyncThrow) throw new Error('gh not found');
     return mockExecSyncReturn;
   }),
+  execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
+    setTimeout(() => cb(null), 0);
+    const { EventEmitter } = require('node:events');
+    return new EventEmitter();
+  }),
+}));
+
+vi.mock('../checks.js', () => ({
+  ensureWindowsSystemPath: vi.fn().mockReturnValue([]),
+  needsTccWarmup: vi.fn().mockReturnValue(false),
+  warmupTccPermissions: vi.fn().mockResolvedValue([]),
+  markTccWarmed: vi.fn(),
 }));
 
 // Prevent process.exit from killing the test runner

--- a/packages/tentacle/src/__tests__/daemon-worker.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-worker.test.ts
@@ -130,11 +130,7 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('../checks.js', () => ({
   ensureWindowsSystemPath: vi.fn().mockReturnValue([]),
-  needsTccWarmup: vi.fn().mockReturnValue(false),
-  warmupTccPermissions: vi.fn().mockResolvedValue([]),
-  markTccWarmed: vi.fn(),
   probeFda: vi.fn().mockResolvedValue('granted'),
-  pollFda: vi.fn().mockResolvedValue('granted'),
 }));
 
 // Prevent process.exit from killing the test runner

--- a/packages/tentacle/src/__tests__/daemon-worker.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-worker.test.ts
@@ -133,6 +133,8 @@ vi.mock('../checks.js', () => ({
   needsTccWarmup: vi.fn().mockReturnValue(false),
   warmupTccPermissions: vi.fn().mockResolvedValue([]),
   markTccWarmed: vi.fn(),
+  probeFda: vi.fn().mockResolvedValue('granted'),
+  pollFda: vi.fn().mockResolvedValue('granted'),
 }));
 
 // Prevent process.exit from killing the test runner

--- a/packages/tentacle/src/__tests__/setup.test.ts
+++ b/packages/tentacle/src/__tests__/setup.test.ts
@@ -77,9 +77,6 @@ vi.mock("../checks.js", () => ({
   checkGhAuth: (...args: unknown[]) => mockCheckGhAuth(...args),
   checkCopilotCli: vi.fn(),
   withRetry: (...args: unknown[]) => mockWithRetry(...args),
-  warmupTccPermissions: vi.fn().mockResolvedValue([]),
-  needsTccWarmup: vi.fn().mockReturnValue(false),
-  markTccWarmed: vi.fn(),
   probeFda: vi.fn().mockResolvedValue('granted'),
   pollFda: vi.fn().mockResolvedValue('granted'),
 }));

--- a/packages/tentacle/src/__tests__/setup.test.ts
+++ b/packages/tentacle/src/__tests__/setup.test.ts
@@ -78,6 +78,8 @@ vi.mock("../checks.js", () => ({
   checkCopilotCli: vi.fn(),
   withRetry: (...args: unknown[]) => mockWithRetry(...args),
   warmupTccPermissions: vi.fn().mockResolvedValue([]),
+  needsTccWarmup: vi.fn().mockReturnValue(false),
+  markTccWarmed: vi.fn(),
 }));
 
 // Mock pair module to avoid real WebSocket connection

--- a/packages/tentacle/src/__tests__/setup.test.ts
+++ b/packages/tentacle/src/__tests__/setup.test.ts
@@ -80,6 +80,8 @@ vi.mock("../checks.js", () => ({
   warmupTccPermissions: vi.fn().mockResolvedValue([]),
   needsTccWarmup: vi.fn().mockReturnValue(false),
   markTccWarmed: vi.fn(),
+  probeFda: vi.fn().mockResolvedValue('granted'),
+  pollFda: vi.fn().mockResolvedValue('granted'),
 }));
 
 // Mock pair module to avoid real WebSocket connection

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -6,12 +6,13 @@
  */
 
 import { execSync, execFile } from 'node:child_process';
-import { existsSync, promises as fsp, appendFileSync, mkdirSync } from 'node:fs';
+import { existsSync, constants as fsConstants, promises as fsp, appendFileSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import { createConnection } from 'node:net';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { input } from '@inquirer/prompts';
 import chalk from 'chalk';
+import { getConfigDir } from './config.js';
 
 /**
  * On Windows, ensure essential system directories are present in
@@ -188,6 +189,60 @@ export interface TccProbeResult {
   status: TccProbeStatus;
 }
 
+// ── macOS TCC marker ────────────────────────────────────
+
+const TCC_WARMED_MARKER = '.tcc-warmed';
+
+/**
+ * True when this is a macOS install whose TCC warm-up is incomplete.
+ * Reads the stored set of probed labels from the marker file and
+ * compares against the current probe list.  Returns true if any
+ * current probe label is missing — this way newly-added probes
+ * (e.g. Full Disk Access) are automatically detected without version numbers.
+ */
+export function needsTccWarmup(): boolean {
+  if (platform() !== 'darwin') return false;
+  const markerPath = join(getConfigDir(), TCC_WARMED_MARKER);
+  if (!existsSync(markerPath)) return true;
+  try {
+    const stored = readFileSync(markerPath, 'utf8').trim().split('\n').filter(Boolean);
+    const currentLabels = getWarmupLabels();
+    return currentLabels.some(label => !stored.includes(label));
+  } catch {
+    return true;
+  }
+}
+
+/** Return the full set of labels that warmupTccPermissions() will probe. */
+export function getWarmupLabels(): string[] {
+  // Must stay in sync with the labels used in warmupTccPermissions() below.
+  return [
+    '~/Documents', '~/Desktop', '~/Downloads', '~/iCloud Drive',
+    '~/Pictures', '~/Movies', '~/Music',
+    'App Data', 'Local Network', 'Full Disk Access',
+  ];
+}
+
+export function markTccWarmed(results: TccProbeResult[]): void {
+  try {
+    const labels = results.map(r => r.label);
+    writeFileSync(join(getConfigDir(), TCC_WARMED_MARKER),
+      labels.join('\n') + '\n', 'utf8');
+  } catch {
+    // Best-effort — if we can't write the marker, the worst case is that
+    // the warm-up runs again next time.
+  }
+}
+
+/** Remove the TCC warmup marker so the next startup re-probes permissions. */
+export function clearTccWarmedMarker(): void {
+  try {
+    unlinkSync(join(getConfigDir(), TCC_WARMED_MARKER));
+  } catch {
+    // File may not exist — that's fine
+  }
+}
+
 /**
  * Folders that macOS protects via TCC (Transparency, Consent, Control).
  * Touching any of these for the first time triggers a system permission
@@ -307,11 +362,35 @@ async function probeLocalNetwork(): Promise<TccProbeStatus> {
 }
 
 /**
+ * Probe macOS Full Disk Access (kTCCServiceSystemPolicyAllFiles) by
+ * attempting to read the user-level TCC database. This file is only
+ * readable when Full Disk Access has been granted.
+ *
+ * Unlike other probes, this does NOT trigger any system dialog — it only
+ * checks the current permission state. FDA bypasses the AppData TCC
+ * category entirely, so granting it eliminates the recurring "data from
+ * other apps" dialog.
+ */
+async function probeFda(): Promise<TccProbeStatus> {
+  const target = join(homedir(), 'Library', 'Application Support', 'com.apple.TCC', 'TCC.db');
+  if (!existsSync(target)) return 'missing';
+  try {
+    await fsp.access(target, fsConstants.R_OK);
+    return 'granted';
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EPERM' || code === 'EACCES') return 'denied';
+    if (code === 'ENOENT') return 'missing';
+    return 'denied';
+  }
+}
+
+/**
  * Probe each macOS TCC-protected resource in turn, triggering the system
  * permission prompt on first run. Probes folders first, then Local
- * Network. Calls `onStart` before each probe so a UI can render the
- * status line before the modal blocks, then `onResult` after the probe
- * resolves so the UI can show the outcome.
+ * Network, then checks Full Disk Access status. Calls `onStart` before
+ * each probe so a UI can render the status line before the modal blocks,
+ * then `onResult` after the probe resolves so the UI can show the outcome.
  *
  * Returns one result per resource. On non-macOS platforms returns [].
  */
@@ -351,6 +430,16 @@ export async function warmupTccPermissions(
   const netResult: TccProbeResult = { label: netLabel, path: '(network)', status: netStatus };
   results.push(netResult);
   onResult?.(netResult);
+
+  // Full Disk Access — informational check only, never triggers a dialog.
+  // FDA (kTCCServiceSystemPolicyAllFiles) bypasses AppData TCC, so if
+  // granted, the "data from other apps" dialog will never appear.
+  const fdaLabel = 'Full Disk Access';
+  onStart?.(fdaLabel);
+  const fdaStatus = await probeFda();
+  const fdaResult: TccProbeResult = { label: fdaLabel, path: '(system)', status: fdaStatus };
+  results.push(fdaResult);
+  onResult?.(fdaResult);
 
   return results;
 }

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -5,14 +5,12 @@
  * Provides a retry mechanism for interactive setup flows.
  */
 
-import { execSync, execFile } from 'node:child_process';
-import { existsSync, constants as fsConstants, promises as fsp, appendFileSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
-import { createConnection } from 'node:net';
+import { execSync } from 'node:child_process';
+import { existsSync, constants as fsConstants, promises as fsp, appendFileSync, mkdirSync } from 'node:fs';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { input } from '@inquirer/prompts';
 import chalk from 'chalk';
-import { getConfigDir } from './config.js';
 
 /**
  * On Windows, ensure essential system directories are present in
@@ -177,201 +175,23 @@ export async function withRetry<T extends { found?: boolean; authenticated?: boo
   }
 }
 
-// ── macOS TCC warm-up ───────────────────────────────────
+// ── macOS Full Disk Access ───────────────────────────────
+//
+// FDA (kTCCServiceSystemPolicyAllFiles) is a superset of all per-folder
+// and AppData TCC categories. Granting it eliminates every recurring
+// macOS permission dialog that the Copilot agent would otherwise trigger.
+// Instead of probing individual folders, we simply require FDA.
 
-export type TccProbeStatus = 'granted' | 'denied' | 'missing';
-
-export interface TccProbeResult {
-  /** Short label suitable for display, e.g. "~/Documents". */
-  label: string;
-  /** Absolute path that was probed. */
-  path: string;
-  status: TccProbeStatus;
-}
-
-// ── macOS TCC marker ────────────────────────────────────
-
-const TCC_WARMED_MARKER = '.tcc-warmed';
+export type FdaStatus = 'granted' | 'denied' | 'missing';
 
 /**
- * True when this is a macOS install whose TCC warm-up is incomplete.
- * Reads the stored set of probed labels from the marker file and
- * compares against the current probe list.  Returns true if any
- * current probe label is missing — this way newly-added probes
- * (e.g. Full Disk Access) are automatically detected without version numbers.
- */
-export function needsTccWarmup(): boolean {
-  if (platform() !== 'darwin') return false;
-  const markerPath = join(getConfigDir(), TCC_WARMED_MARKER);
-  if (!existsSync(markerPath)) return true;
-  try {
-    const stored = readFileSync(markerPath, 'utf8').trim().split('\n').filter(Boolean);
-    const currentLabels = getWarmupLabels();
-    return currentLabels.some(label => !stored.includes(label));
-  } catch {
-    return true;
-  }
-}
-
-/** Return the full set of labels that warmupTccPermissions() will probe. */
-export function getWarmupLabels(): string[] {
-  // Must stay in sync with the labels used in warmupTccPermissions() below.
-  return [
-    '~/Documents', '~/Desktop', '~/Downloads', '~/iCloud Drive',
-    '~/Pictures', '~/Movies', '~/Music',
-    'App Data', 'Local Network', 'Full Disk Access',
-  ];
-}
-
-export function markTccWarmed(results: TccProbeResult[]): void {
-  try {
-    const labels = results.map(r => r.label);
-    writeFileSync(join(getConfigDir(), TCC_WARMED_MARKER),
-      labels.join('\n') + '\n', 'utf8');
-  } catch {
-    // Best-effort — if we can't write the marker, the worst case is that
-    // the warm-up runs again next time.
-  }
-}
-
-/** Remove the TCC warmup marker so the next startup re-probes permissions. */
-export function clearTccWarmedMarker(): void {
-  try {
-    unlinkSync(join(getConfigDir(), TCC_WARMED_MARKER));
-  } catch {
-    // File may not exist — that's fine
-  }
-}
-
-/**
- * Folders that macOS protects via TCC (Transparency, Consent, Control).
- * Touching any of these for the first time triggers a system permission
- * prompt attributed to the calling binary.
+ * Probe macOS Full Disk Access by attempting to read the user-level TCC
+ * database. This file is only readable when FDA has been granted.
  *
- * Order matters — prompts appear in this order during setup.
+ * Never triggers a system dialog — it only checks the current state.
  */
-const TCC_PROTECTED_FOLDERS: Array<{ label: string; relPath: string }> = [
-  { label: '~/Documents', relPath: 'Documents' },
-  { label: '~/Desktop', relPath: 'Desktop' },
-  { label: '~/Downloads', relPath: 'Downloads' },
-  { label: '~/iCloud Drive', relPath: 'Library/Mobile Documents/com~apple~CloudDocs' },
-  { label: '~/Pictures', relPath: 'Pictures' },
-  { label: '~/Movies', relPath: 'Movies' },
-  { label: '~/Music', relPath: 'Music' },
-];
-
-/**
- * Probe a single TCC-protected folder by attempting a tiny readdir.
- * Resolves with the access status. Never throws.
- */
-async function probeFolder(absPath: string): Promise<TccProbeStatus> {
-  if (!existsSync(absPath)) return 'missing';
-  try {
-    // Reading the directory is enough to trigger TCC. We don't need the
-    // entries themselves — the system call is what flips the permission bit.
-    await fsp.readdir(absPath);
-    return 'granted';
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    // EPERM / EACCES → user denied (or hasn't decided yet and dismissed).
-    if (code === 'EPERM' || code === 'EACCES') return 'denied';
-    // ENOENT shouldn't happen since we existsSync'd, but treat as missing.
-    if (code === 'ENOENT') return 'missing';
-    // Anything else — treat as denied so we don't lie about access.
-    return 'denied';
-  }
-}
-
-/**
- * Probe macOS "App Data" TCC (kTCCServiceSystemPolicyAppData) by spawning
- * /usr/bin/find against the iCloud Drive FileProvider path.
- *
- * A Node readdir from the parent process triggers per-folder TCC, but the
- * separate AppData category is only triggered when a *child process*
- * accesses a FileProvider-managed path. The Copilot agent regularly runs
- * `find` / `glob` which hits this code path — so we pre-trigger it here
- * during setup to avoid a surprise prompt mid-session.
- *
- * We use `-maxdepth 0` so find only stats the root directory without
- * actually traversing it.
- */
-async function probeAppData(): Promise<TccProbeStatus> {
-  const target = join(homedir(), 'Library/Mobile Documents/com~apple~CloudDocs');
-  if (!existsSync(target)) return 'missing';
-
-  return new Promise((resolve) => {
-    const child = execFile(
-      '/usr/bin/find',
-      [target, '-maxdepth', '0'],
-      { timeout: 30_000 },
-      (err) => {
-        if (!err) { resolve('granted'); return; }
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code === 'EPERM' || code === 'EACCES') { resolve('denied'); return; }
-        // Exit code 1 from find usually means permission denied on the path
-        if (err.code === null && (err as { status?: number }).status === 1) { resolve('denied'); return; }
-        resolve('denied');
-      },
-    );
-    // Safety: if the child somehow hangs beyond the timeout, kill it
-    child.on('error', () => resolve('denied'));
-  });
-}
-
-/**
- * Probe macOS Local Network TCC by making a brief TCP connection to a
- * LAN-routable address. macOS surfaces the "Local Network" permission
- * prompt when a signed binary first attempts a local-network operation.
- *
- * We connect to 224.0.0.1:0 (the all-hosts multicast group) which is
- * guaranteed to be unroutable but still triggers the TCC check in the
- * kernel's network stack before the connection attempt fails. The
- * socket is destroyed immediately after the TCC decision.
- */
-async function probeLocalNetwork(): Promise<TccProbeStatus> {
-  return new Promise((resolve) => {
-    const timeout = setTimeout(() => {
-      socket.destroy();
-      // Timed out waiting for the TCC dialog — treat as granted (the
-      // dialog blocks the kernel call, so a timeout means it wasn't shown).
-      resolve('granted');
-    }, 10_000);
-
-    const socket = createConnection({ host: '224.0.0.1', port: 9 });
-
-    socket.on('connect', () => {
-      clearTimeout(timeout);
-      socket.destroy();
-      resolve('granted');
-    });
-
-    socket.on('error', (err) => {
-      clearTimeout(timeout);
-      socket.destroy();
-      const code = (err as NodeJS.ErrnoException).code;
-      // ENETUNREACH / ECONNREFUSED / EHOSTUNREACH are normal — they mean
-      // macOS allowed the network call but the destination is unreachable.
-      // EPERM means the user denied the Local Network prompt.
-      if (code === 'EPERM' || code === 'EACCES') {
-        resolve('denied');
-      } else {
-        resolve('granted');
-      }
-    });
-  });
-}
-
-/**
- * Probe macOS Full Disk Access (kTCCServiceSystemPolicyAllFiles) by
- * attempting to read the user-level TCC database. This file is only
- * readable when Full Disk Access has been granted.
- *
- * Unlike other probes, this does NOT trigger any system dialog — it only
- * checks the current permission state. FDA bypasses the AppData TCC
- * category entirely, so granting it eliminates the recurring "data from
- * other apps" dialog.
- */
-export async function probeFda(): Promise<TccProbeStatus> {
+export async function probeFda(): Promise<FdaStatus> {
+  if (platform() !== 'darwin') return 'granted'; // non-macOS: not applicable
   const target = join(homedir(), 'Library', 'Application Support', 'com.apple.TCC', 'TCC.db');
   if (!existsSync(target)) return 'missing';
   try {
@@ -386,65 +206,6 @@ export async function probeFda(): Promise<TccProbeStatus> {
 }
 
 /**
- * Probe each macOS TCC-protected resource in turn, triggering the system
- * permission prompt on first run. Probes folders first, then Local
- * Network, then checks Full Disk Access status. Calls `onStart` before
- * each probe so a UI can render the status line before the modal blocks,
- * then `onResult` after the probe resolves so the UI can show the outcome.
- *
- * Returns one result per resource. On non-macOS platforms returns [].
- */
-export async function warmupTccPermissions(
-  onStart?: (label: string) => void,
-  onResult?: (result: TccProbeResult) => void,
-): Promise<TccProbeResult[]> {
-  if (platform() !== 'darwin') return [];
-
-  const home = homedir();
-  const results: TccProbeResult[] = [];
-
-  for (const { label, relPath } of TCC_PROTECTED_FOLDERS) {
-    const absPath = join(home, relPath);
-    onStart?.(label);
-    const status = await probeFolder(absPath);
-    const result: TccProbeResult = { label, path: absPath, status };
-    results.push(result);
-    onResult?.(result);
-  }
-
-  // App Data (FileProvider) — child-process access to iCloud Drive triggers
-  // kTCCServiceSystemPolicyAppData, a separate TCC category from folder access.
-  // Probe after folders since it's file-related but uses a different mechanism.
-  const appDataLabel = 'App Data';
-  onStart?.(appDataLabel);
-  const appDataStatus = await probeAppData();
-  const appDataResult: TccProbeResult = { label: appDataLabel, path: '(file provider)', status: appDataStatus };
-  results.push(appDataResult);
-  onResult?.(appDataResult);
-
-  // Local Network — probe after folders so the network dialog doesn't
-  // interleave with folder dialogs.
-  const netLabel = 'Local Network';
-  onStart?.(netLabel);
-  const netStatus = await probeLocalNetwork();
-  const netResult: TccProbeResult = { label: netLabel, path: '(network)', status: netStatus };
-  results.push(netResult);
-  onResult?.(netResult);
-
-  // Full Disk Access — informational check only, never triggers a dialog.
-  // FDA (kTCCServiceSystemPolicyAllFiles) bypasses AppData TCC, so if
-  // granted, the "data from other apps" dialog will never appear.
-  const fdaLabel = 'Full Disk Access';
-  onStart?.(fdaLabel);
-  const fdaStatus = await probeFda();
-  const fdaResult: TccProbeResult = { label: fdaLabel, path: '(system)', status: fdaStatus };
-  results.push(fdaResult);
-  onResult?.(fdaResult);
-
-  return results;
-}
-
-/**
  * Poll Full Disk Access at regular intervals until granted or the signal
  * is aborted. Never triggers a system dialog — uses the same read-only
  * TCC.db probe as `probeFda()`.
@@ -455,8 +216,7 @@ export async function warmupTccPermissions(
 export async function pollFda(
   intervalMs = 2000,
   signal?: AbortSignal,
-): Promise<TccProbeStatus> {
-  // Immediate check before entering the loop
+): Promise<FdaStatus> {
   const initial = await probeFda();
   if (initial === 'granted') return 'granted';
 

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -371,7 +371,7 @@ async function probeLocalNetwork(): Promise<TccProbeStatus> {
  * category entirely, so granting it eliminates the recurring "data from
  * other apps" dialog.
  */
-async function probeFda(): Promise<TccProbeStatus> {
+export async function probeFda(): Promise<TccProbeStatus> {
   const target = join(homedir(), 'Library', 'Application Support', 'com.apple.TCC', 'TCC.db');
   if (!existsSync(target)) return 'missing';
   try {
@@ -442,4 +442,37 @@ export async function warmupTccPermissions(
   onResult?.(fdaResult);
 
   return results;
+}
+
+/**
+ * Poll Full Disk Access at regular intervals until granted or the signal
+ * is aborted. Never triggers a system dialog — uses the same read-only
+ * TCC.db probe as `probeFda()`.
+ *
+ * Returns the final observed status ('granted' once the user toggles FDA
+ * in System Settings, or the last polled status if aborted early).
+ */
+export async function pollFda(
+  intervalMs = 2000,
+  signal?: AbortSignal,
+): Promise<TccProbeStatus> {
+  // Immediate check before entering the loop
+  const initial = await probeFda();
+  if (initial === 'granted') return 'granted';
+
+  while (!signal?.aborted) {
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, intervalMs);
+      if (signal) {
+        const onAbort = () => { clearTimeout(timer); resolve(); };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    });
+    if (signal?.aborted) break;
+    const status = await probeFda();
+    if (status === 'granted') return 'granted';
+  }
+
+  // Final check after abort — the user may have granted just before skip
+  return probeFda();
 }

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -12,7 +12,7 @@
 
 import { execSync } from 'node:child_process';
 import { loadConfig, loadChannelKey, getOrCreateDeviceId, getConfigPath, getChannelKeyPath, getVersion, saveDaemonPid } from './config.js';
-import { ensureWindowsSystemPath } from './checks.js';
+import { ensureWindowsSystemPath, needsTccWarmup, warmupTccPermissions, markTccWarmed } from './checks.js';
 import { CopilotAdapter } from './adapters/copilot.js';
 
 // Self-heal PATH on Windows BEFORE any child process is spawned. The
@@ -74,6 +74,26 @@ export async function startWorker(): Promise<WorkerResult> {
       'Self-healed PATH on Windows (System32 and friends were missing)',
     );
   }
+
+  // macOS: silently run TCC warmup on daemon start so folder-access and
+  // network permission dialogs are front-loaded rather than appearing
+  // mid-session when the Copilot agent triggers them.
+  if (needsTccWarmup()) {
+    logger.info('Running TCC permission warmup…');
+    const tccResults = await warmupTccPermissions();
+    markTccWarmed(tccResults);
+    const denied = tccResults.filter(r => r.status === 'denied');
+    if (denied.length > 0) {
+      logger.warn({ denied: denied.map(r => r.label) }, 'Some TCC permissions not granted');
+    }
+    const fda = tccResults.find(r => r.label === 'Full Disk Access');
+    if (fda?.status === 'denied') {
+      logger.warn(
+        'Full Disk Access not granted — grant in System Settings → Privacy & Security → Full Disk Access to prevent recurring permission dialogs',
+      );
+    }
+  }
+
   const configPath = getConfigPath();
   const channelKeyPath = getChannelKeyPath();
 

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -11,8 +11,9 @@
  */
 
 import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
 import { loadConfig, loadChannelKey, getOrCreateDeviceId, getConfigPath, getChannelKeyPath, getVersion, saveDaemonPid } from './config.js';
-import { ensureWindowsSystemPath, needsTccWarmup, warmupTccPermissions, markTccWarmed } from './checks.js';
+import { ensureWindowsSystemPath, probeFda } from './checks.js';
 import { CopilotAdapter } from './adapters/copilot.js';
 
 // Self-heal PATH on Windows BEFORE any child process is spawned. The
@@ -75,19 +76,11 @@ export async function startWorker(): Promise<WorkerResult> {
     );
   }
 
-  // macOS: silently run TCC warmup on daemon start so folder-access and
-  // network permission dialogs are front-loaded rather than appearing
-  // mid-session when the Copilot agent triggers them.
-  if (needsTccWarmup()) {
-    logger.info('Running TCC permission warmup…');
-    const tccResults = await warmupTccPermissions();
-    markTccWarmed(tccResults);
-    const denied = tccResults.filter(r => r.status === 'denied');
-    if (denied.length > 0) {
-      logger.warn({ denied: denied.map(r => r.label) }, 'Some TCC permissions not granted');
-    }
-    const fda = tccResults.find(r => r.label === 'Full Disk Access');
-    if (fda?.status === 'denied') {
+  // macOS: check Full Disk Access status. FDA is required to prevent
+  // recurring TCC permission dialogs during agent sessions.
+  if (platform() === 'darwin') {
+    const fdaStatus = await probeFda();
+    if (fdaStatus !== 'granted') {
       logger.warn(
         'Full Disk Access not granted — grant in System Settings → Privacy & Security → Full Disk Access to prevent recurring permission dialogs',
       );

--- a/packages/tentacle/src/setup.ts
+++ b/packages/tentacle/src/setup.ts
@@ -21,7 +21,7 @@ import {
   getOrCreateDeviceId,
   getConfigPath,
 } from './config.js';
-import { checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, needsTccWarmup, markTccWarmed, type TccProbeResult } from './checks.js';
+import { checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, needsTccWarmup, markTccWarmed, pollFda, type TccProbeResult } from './checks.js';
 import { printAnimatedBanner } from './banner.js';
 import { isSea } from 'node:sea';
 
@@ -127,9 +127,34 @@ async function runTccWarmupStep(stepNum: number, total: number): Promise<void> {
   const fda = results.find(r => r.label === 'Full Disk Access');
   if (fda?.status === 'denied') {
     console.log('');
-    console.log(chalk.dim('    💡 Tip: Grant Full Disk Access to eliminate the "data from'));
-    console.log(chalk.dim('    other apps" dialog. System Settings → Privacy & Security →'));
-    console.log(chalk.dim('    Full Disk Access → add kraki.'));
+    console.log(chalk.dim('    💡 Grant Full Disk Access to eliminate the recurring'));
+    console.log(chalk.dim('    "data from other apps" dialog during agent sessions.'));
+    console.log('');
+    console.log(chalk.dim('    Open: System Settings → Privacy & Security → Full Disk Access → add kraki'));
+    console.log('');
+
+    const ac = new AbortController();
+    const spinner = ora({
+      indent: 4,
+      text: `Waiting for Full Disk Access…  ${chalk.dim('(press Enter to skip)')}`,
+    }).start();
+
+    // Race: poll FDA every 2 s vs. user pressing Enter to skip
+    const granted = await Promise.race([
+      pollFda(2000, ac.signal).then((s) => { ac.abort(); return s === 'granted'; }),
+      input(
+        { message: '' },
+        { signal: ac.signal },
+      ).then(() => { ac.abort(); return false; })
+       .catch(() => false), // AbortError when poll wins
+    ]);
+
+    if (granted) {
+      spinner.succeed('Full Disk Access granted');
+      fda.status = 'granted';
+    } else {
+      spinner.warn('Skipped — grant Full Disk Access later to avoid the "data from other apps" dialog');
+    }
   }
 
   markTccWarmed(results);

--- a/packages/tentacle/src/setup.ts
+++ b/packages/tentacle/src/setup.ts
@@ -21,7 +21,7 @@ import {
   getOrCreateDeviceId,
   getConfigPath,
 } from './config.js';
-import { checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, needsTccWarmup, markTccWarmed, pollFda, type TccProbeResult } from './checks.js';
+import { checkGhAuth, checkCopilotCli, withRetry, probeFda, pollFda } from './checks.js';
 import { printAnimatedBanner } from './banner.js';
 import { isSea } from 'node:sea';
 
@@ -88,76 +88,44 @@ function step(n: number, total: number) { return chalk.dim(`[${n}/${total}]`); }
 function divider() { console.log(chalk.dim('  ─────────────────────────────────')); }
 
 /**
- * Render the TCC warm-up step. Probes each protected folder one at a
- * time, printing a status line as we go. macOS surfaces the permission
- * modal during each probe; the modal blocks until the user clicks.
+ * Check and guide the user through granting Full Disk Access.
+ * FDA is a superset of all per-folder and AppData TCC categories —
+ * granting it eliminates every recurring macOS permission dialog.
  */
-async function runTccWarmupStep(stepNum: number, total: number): Promise<void> {
+async function runFdaStep(stepNum: number, total: number): Promise<void> {
   console.log(`  ${icon} ${step(stepNum, total)} ${chalk.bold('macOS Privacy')}`);
-  console.log(chalk.dim('    macOS will ask kraki for permission to access folders where'));
-  console.log(chalk.dim('    your code lives and your local network. Click "Allow" on'));
-  console.log(chalk.dim('    each prompt — this only happens once.\n'));
 
-  const formatStatus = (r: TccProbeResult): string => {
-    switch (r.status) {
-      case 'granted': return chalk.green('✓ allowed');
-      case 'denied':  return chalk.yellow('⚠ denied');
-      case 'missing': return chalk.dim('— not present');
-    }
-  };
-
-  const results = await warmupTccPermissions(
-    (label) => {
-      // Print label + ellipsis on the same line; status overwrites it.
-      process.stdout.write(`    ${label.padEnd(22)} ${chalk.dim('checking…')}`);
-    },
-    (result) => {
-      // Carriage return + clear-line (ANSI EL), then re-print with status.
-      process.stdout.write(`\r\u001b[2K    ${result.label.padEnd(22)} ${formatStatus(result)}\n`);
-    },
-  );
-
-  const denied = results.filter(r => r.status === 'denied');
-  if (denied.length > 0) {
-    console.log('');
-    console.log(chalk.dim('    You can grant access later in System Settings →'));
-    console.log(chalk.dim('    Privacy & Security → Files and Folders / Local Network → kraki.'));
+  const fdaStatus = await probeFda();
+  if (fdaStatus === 'granted') {
+    console.log(chalk.green('    ✓ Full Disk Access granted'));
+    return;
   }
 
-  const fda = results.find(r => r.label === 'Full Disk Access');
-  if (fda?.status === 'denied') {
-    console.log('');
-    console.log(chalk.dim('    💡 Grant Full Disk Access to eliminate the recurring'));
-    console.log(chalk.dim('    "data from other apps" dialog during agent sessions.'));
-    console.log('');
-    console.log(chalk.dim('    Open: System Settings → Privacy & Security → Full Disk Access → add kraki'));
-    console.log('');
+  console.log(chalk.dim('    Grant Full Disk Access to prevent recurring permission dialogs'));
+  console.log(chalk.dim('    during agent sessions.\n'));
+  console.log(chalk.dim('    Open: System Settings → Privacy & Security → Full Disk Access → add kraki'));
+  console.log('');
 
-    const ac = new AbortController();
-    const spinner = ora({
-      indent: 4,
-      text: `Waiting for Full Disk Access…  ${chalk.dim('(press Enter to skip)')}`,
-    }).start();
+  const ac = new AbortController();
+  const spinner = ora({
+    indent: 4,
+    text: `Waiting for Full Disk Access…  ${chalk.dim('(press Enter to skip)')}`,
+  }).start();
 
-    // Race: poll FDA every 2 s vs. user pressing Enter to skip
-    const granted = await Promise.race([
-      pollFda(2000, ac.signal).then((s) => { ac.abort(); return s === 'granted'; }),
-      input(
-        { message: '' },
-        { signal: ac.signal },
-      ).then(() => { ac.abort(); return false; })
-       .catch(() => false), // AbortError when poll wins
-    ]);
+  const granted = await Promise.race([
+    pollFda(2000, ac.signal).then((s) => { ac.abort(); return s === 'granted'; }),
+    input(
+      { message: '' },
+      { signal: ac.signal },
+    ).then(() => { ac.abort(); return false; })
+     .catch(() => false), // AbortError when poll wins
+  ]);
 
-    if (granted) {
-      spinner.succeed('Full Disk Access granted');
-      fda.status = 'granted';
-    } else {
-      spinner.warn('Skipped — grant Full Disk Access later to avoid the "data from other apps" dialog');
-    }
+  if (granted) {
+    spinner.succeed('Full Disk Access granted');
+  } else {
+    spinner.warn('Skipped — grant Full Disk Access later in System Settings');
   }
-
-  markTccWarmed(results);
 }
 
 // Align inquirer prefix (✔/?) with ora spinners (4-space indent)
@@ -354,8 +322,8 @@ export async function runSetup(): Promise<KrakiConfig> {
     return runSetupDirect(customRelay);
   }
 
-  const tccSteps = needsTccWarmup() ? 1 : 0;
-  const total = 4 + tccSteps;
+  const fdaSteps = platform() === 'darwin' ? 1 : 0;
+  const total = 4 + fdaSteps;
   const apiBase = process.env.KRAKI_API_URL ?? OFFICIAL_API;
 
   // 1. Authentication
@@ -478,10 +446,10 @@ export async function runSetup(): Promise<KrakiConfig> {
     default: defaultName,
   });
 
-  // 5. macOS Privacy (TCC warm-up) — fresh installs only
-  if (tccSteps > 0) {
+  // 5. macOS Privacy (Full Disk Access)
+  if (fdaSteps > 0) {
     console.log('');
-    await runTccWarmupStep(5, total);
+    await runFdaStep(5, total);
   }
 
   // Build config
@@ -521,8 +489,8 @@ export async function runSetup(): Promise<KrakiConfig> {
  * Connects to the relay, queries capabilities, does inline auth.
  */
 async function runSetupDirect(defaultRelay: string): Promise<KrakiConfig> {
-  const tccSteps = needsTccWarmup() ? 1 : 0;
-  const total = 4 + tccSteps;
+  const fdaSteps = platform() === 'darwin' ? 1 : 0;
+  const total = 4 + fdaSteps;
 
   // 1. Relay URL (with retry loop)
   let relay: string = defaultRelay;
@@ -643,10 +611,10 @@ async function runSetupDirect(defaultRelay: string): Promise<KrakiConfig> {
     default: defaultName,
   });
 
-  // 5. macOS Privacy (TCC warm-up) — fresh installs only
-  if (tccSteps > 0) {
+  // 5. macOS Privacy (Full Disk Access)
+  if (fdaSteps > 0) {
     console.log('');
-    await runTccWarmupStep(5, total);
+    await runFdaStep(5, total);
   }
 
   // Build config

--- a/packages/tentacle/src/setup.ts
+++ b/packages/tentacle/src/setup.ts
@@ -9,7 +9,7 @@ import { select, input } from '@inquirer/prompts';
 import chalk from 'chalk';
 import ora from 'ora';
 import { hostname, platform } from 'node:os';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { WebSocket } from 'ws';
 
@@ -20,9 +20,8 @@ import {
   saveChannelKey,
   getOrCreateDeviceId,
   getConfigPath,
-  getConfigDir,
 } from './config.js';
-import { checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, type TccProbeResult } from './checks.js';
+import { checkGhAuth, checkCopilotCli, withRetry, warmupTccPermissions, needsTccWarmup, markTccWarmed, type TccProbeResult } from './checks.js';
 import { printAnimatedBanner } from './banner.js';
 import { isSea } from 'node:sea';
 
@@ -88,58 +87,6 @@ const icon = '◈';
 function step(n: number, total: number) { return chalk.dim(`[${n}/${total}]`); }
 function divider() { console.log(chalk.dim('  ─────────────────────────────────')); }
 
-// ── macOS TCC warm-up ────────────────────────────────────
-
-const TCC_WARMED_MARKER = '.tcc-warmed';
-
-/**
- * True when this is a macOS install whose TCC warm-up is incomplete.
- * Reads the stored set of probed labels from the marker file and
- * compares against the current probe list.  Returns true if any
- * current probe label is missing — this way newly-added probes
- * (e.g. App Data) are automatically detected without version numbers.
- */
-function needsTccWarmup(): boolean {
-  if (platform() !== 'darwin') return false;
-  const markerPath = join(getConfigDir(), TCC_WARMED_MARKER);
-  if (!existsSync(markerPath)) return true;
-  try {
-    const stored = readFileSync(markerPath, 'utf8').trim().split('\n').filter(Boolean);
-    // Run a synchronous warmup probe to get the current list of labels.
-    // This is cheap: we only need the labels, not actual probing.
-    const currentLabels = getWarmupLabels();
-    return currentLabels.some(label => !stored.includes(label));
-  } catch {
-    return true;
-  }
-}
-
-/** Return the full set of labels that warmupTccPermissions() will probe. */
-function getWarmupLabels(): string[] {
-  // Must stay in sync with the labels in checks.ts warmupTccPermissions().
-  // We import and run it with a dry callback to collect labels, but since
-  // warmupTccPermissions is async and actually probes, we hardcode the
-  // list here.  This is intentionally a simple string array so adding a
-  // new probe in checks.ts requires a matching entry here — the test
-  // suite enforces they stay in sync.
-  return [
-    '~/Documents', '~/Desktop', '~/Downloads', '~/iCloud Drive',
-    '~/Pictures', '~/Movies', '~/Music',
-    'App Data', 'Local Network',
-  ];
-}
-
-function markTccWarmed(results: TccProbeResult[]): void {
-  try {
-    const labels = results.map(r => r.label);
-    writeFileSync(join(getConfigDir(), TCC_WARMED_MARKER),
-      labels.join('\n') + '\n', 'utf8');
-  } catch {
-    // Best-effort — if we can't write the marker, the worst case is that
-    // the warm-up runs again next time the wizard is invoked.
-  }
-}
-
 /**
  * Render the TCC warm-up step. Probes each protected folder one at a
  * time, printing a status line as we go. macOS surfaces the permission
@@ -175,6 +122,14 @@ async function runTccWarmupStep(stepNum: number, total: number): Promise<void> {
     console.log('');
     console.log(chalk.dim('    You can grant access later in System Settings →'));
     console.log(chalk.dim('    Privacy & Security → Files and Folders / Local Network → kraki.'));
+  }
+
+  const fda = results.find(r => r.label === 'Full Disk Access');
+  if (fda?.status === 'denied') {
+    console.log('');
+    console.log(chalk.dim('    💡 Tip: Grant Full Disk Access to eliminate the "data from'));
+    console.log(chalk.dim('    other apps" dialog. System Settings → Privacy & Security →'));
+    console.log(chalk.dim('    Full Disk Access → add kraki.'));
   }
 
   markTccWarmed(results);

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -20,6 +20,7 @@ import { isSea } from 'node:sea';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getKrakiHome } from './config.js';
+import { clearTccWarmedMarker } from './checks.js';
 
 const GITHUB_REPO = 'corelli18512/kraki';
 const NPM_PACKAGE = '@kraki/tentacle';
@@ -399,6 +400,10 @@ export async function performUpdate(currentVersion: string): Promise<void> {
 
     spinner.succeed(`Updated ${chalk.dim(currentVersion)} → ${chalk.green(latest)}`);
     writeCache(latest);
+
+    // Clear TCC warmup marker so the daemon re-probes permissions after
+    // the binary is replaced (code signature may differ).
+    clearTccWarmedMarker();
 
     // Restart daemon if it was running before the update
     if (daemonWasRunning) {

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -11,7 +11,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, createWriteStream, unlinkSync, chmodSync, renameSync, copyFileSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, platform } from 'node:os';
 import { request as httpRequest, type IncomingMessage, type RequestOptions as HttpRequestOptions } from 'node:http';
 import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from 'node:https';
 import { pipeline } from 'node:stream/promises';
@@ -20,7 +20,7 @@ import { isSea } from 'node:sea';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getKrakiHome } from './config.js';
-import { clearTccWarmedMarker } from './checks.js';
+import { clearTccWarmedMarker, probeFda, pollFda } from './checks.js';
 
 const GITHUB_REPO = 'corelli18512/kraki';
 const NPM_PACKAGE = '@kraki/tentacle';
@@ -404,6 +404,39 @@ export async function performUpdate(currentVersion: string): Promise<void> {
     // Clear TCC warmup marker so the daemon re-probes permissions after
     // the binary is replaced (code signature may differ).
     clearTccWarmedMarker();
+
+    // On macOS, check FDA status and guide the user if not yet granted.
+    // FDA eliminates the recurring "data from other apps" TCC dialog.
+    if (platform() === 'darwin') {
+      const fdaStatus = await probeFda();
+      if (fdaStatus === 'denied') {
+        console.log('');
+        console.log(chalk.dim('  💡 Grant Full Disk Access to eliminate the "data from other apps" dialog.'));
+        console.log(chalk.dim('  Open: System Settings → Privacy & Security → Full Disk Access → add kraki'));
+        console.log('');
+
+        const fdaSpinner = ora({
+          indent: 2,
+          text: `Waiting for Full Disk Access…  ${chalk.dim('(press Enter to skip)')}`,
+        }).start();
+
+        const ac = new AbortController();
+        const { input } = await import('@inquirer/prompts');
+
+        const granted = await Promise.race([
+          pollFda(2000, ac.signal).then((s) => { ac.abort(); return s === 'granted'; }),
+          input({ message: '' }, { signal: ac.signal })
+            .then(() => { ac.abort(); return false; })
+            .catch(() => false),
+        ]);
+
+        if (granted) {
+          fdaSpinner.succeed('Full Disk Access granted');
+        } else {
+          fdaSpinner.warn('Skipped — grant Full Disk Access later in System Settings');
+        }
+      }
+    }
 
     // Restart daemon if it was running before the update
     if (daemonWasRunning) {

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -20,7 +20,7 @@ import { isSea } from 'node:sea';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getKrakiHome } from './config.js';
-import { clearTccWarmedMarker, probeFda, pollFda } from './checks.js';
+import { probeFda, pollFda } from './checks.js';
 
 const GITHUB_REPO = 'corelli18512/kraki';
 const NPM_PACKAGE = '@kraki/tentacle';
@@ -400,10 +400,6 @@ export async function performUpdate(currentVersion: string): Promise<void> {
 
     spinner.succeed(`Updated ${chalk.dim(currentVersion)} → ${chalk.green(latest)}`);
     writeCache(latest);
-
-    // Clear TCC warmup marker so the daemon re-probes permissions after
-    // the binary is replaced (code signature may differ).
-    clearTccWarmedMarker();
 
     // On macOS, check FDA status and guide the user if not yet granted.
     // FDA eliminates the recurring "data from other apps" TCC dialog.


### PR DESCRIPTION
## Summary

Simplifies macOS permission handling by removing all TCC warmup code and requiring only Full Disk Access (FDA).

**Why:** FDA is a superset  once granted, the terminal can access all TCC-protected directories without individual prompts. The previous TCC probing caused unnecessary popup dialogs.permission 

## Changes
- **checks.ts**: Removed ~250 lines of TCC functions. Kept probeFda() and pollFda().
 FDA check.
- **daemon-worker.ts**: Only does non-blocking probeFda() check with warning log.
- **update.ts**: Removed clearTccWarmedMarker() call.
- **Tests**: Removed ~200 lines of TCC tests, added FDA edge cases.
- **.gitignore**: Added Xcode/iOS build artifact patterns.

All 481 tests pass.