### PR TITLE
fix(tentacle): lazy-resume state race + sendMessage self-heal (v0.21.2)

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -587,6 +587,69 @@ describe('RelayClient set_session_model', () => {
     await vi.runAllTimersAsync();
   });
 
+  it('send_input on disconnected session: ensureSessionResumed runs BEFORE markActive (regression for v0.21.1 state-race)', async () => {
+    // Before the fix, markActive was called before ensureSessionResumed.
+    // That flipped meta state from `disconnected` → `active`, defeating the
+    // lazy-resume gate, so the session was never loaded and the very next
+    // sendMessage call hit "Session not found" forever.
+    const callOrder: string[] = [];
+    const adapter = {
+      onSessionEnded: undefined,
+      sendMessage: vi.fn(() => { callOrder.push('sendMessage'); return Promise.resolve(); }),
+      respondToPermission: vi.fn(() => Promise.resolve()),
+      respondToQuestion: vi.fn(() => Promise.resolve()),
+      killSession: vi.fn(() => Promise.resolve()),
+      abortSession: vi.fn(() => Promise.resolve()),
+      resumeSession: vi.fn(() => { callOrder.push('resumeSession'); return Promise.resolve({ sessionId: 'sess_d' }); }),
+      createSession: vi.fn(() => Promise.resolve({ sessionId: 'sess_d' })),
+      forkSession: vi.fn(() => Promise.resolve({ sessionId: 'sess_d' })),
+      listSessions: vi.fn(() => Promise.resolve([])),
+      listModels: vi.fn(() => Promise.resolve([])),
+      listModelDetails: vi.fn(() => Promise.resolve([])),
+      start: vi.fn(() => Promise.resolve()),
+      stop: vi.fn(() => Promise.resolve()),
+      setSessionMode: vi.fn(),
+      setSessionUsage: vi.fn(),
+    };
+    const sm = {
+      ...createSessionManager(),
+      getMeta: vi.fn(() => ({ id: 'sess_d', state: 'disconnected' })),
+      resumeSession: vi.fn(() => ({ runId: 'run_002', context: { summary: '', keyFiles: [], lastUserMessage: '', updatedAt: '' } })),
+      markActive: vi.fn(() => { callOrder.push('markActive'); }),
+      markIdle: vi.fn(),
+      appendMessage: vi.fn(() => 1),
+    };
+    const client = new RelayClient(adapter as unknown as Parameters<typeof RelayClient>[0], sm as unknown as Parameters<typeof RelayClient>[1], {
+      relayUrl: 'ws://localhost:4000',
+      authMethod: 'open',
+      device: { name: 'Test', role: 'tentacle' },
+      reconnectDelay: 10,
+    });
+    client.connect();
+    sockets[0].emit('open');
+    sockets[0].emit('message', Buffer.from(JSON.stringify({
+      type: 'auth_ok',
+      deviceId: 'dev_1',
+      authMethod: 'open',
+      user: { id: 'u1', login: 'test', provider: 'open' },
+      devices: [],
+    })));
+
+    sockets[0].emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input',
+      sessionId: 'sess_d',
+      deviceId: 'dev_1',
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: { text: 'hi' },
+    })));
+
+    await vi.runAllTimersAsync();
+    // resumeSession MUST come before markActive, and markActive before
+    // sendMessage — otherwise the state-race bug returns.
+    expect(callOrder).toEqual(['resumeSession', 'markActive', 'sendMessage']);
+  });
+
   it('persists and broadcasts session_pinned on pin_session', () => {
     const { sm } = buildConnectedClient();
     const ws = sockets[0];

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -383,9 +383,20 @@ describe('CopilotAdapter', () => {
       await expect(adapter.createSession({})).rejects.toThrow('not started');
     });
 
-    it('sendMessage throws for unknown session', async () => {
+    it('sendMessage on unknown session attempts to resume and reports session_ended if resume fails', async () => {
+      // Previously: sendMessage threw "Session not found" as a guard.
+      // After v0.21.1+ fix: sendMessage tries to resume from disk (self-heal
+      // for state-drift cases). If the SDK has no record either, we fall
+      // through to handleUnavailableSession → arm sees session_ended.
+      const endedSpy = vi.fn();
+      const errorSpy = vi.fn();
+      adapter.onSessionEnded = endedSpy;
+      adapter.onError = errorSpy;
       await adapter.start();
-      await expect(adapter.sendMessage('nonexistent', 'hi')).rejects.toThrow('not found');
+      mockResumeSessionError = new Error('Session file is missing');
+
+      await expect(adapter.sendMessage('nonexistent', 'hi')).rejects.toThrow();
+      expect(endedSpy).toHaveBeenCalledWith('nonexistent', { reason: 'session unavailable' });
     });
 
     it('respondToPermission returns silently for unknown session', async () => {
@@ -566,6 +577,27 @@ describe('CopilotAdapter', () => {
       expect(errorSpy).toHaveBeenCalledWith(sessionId, expect.objectContaining({
         message: expect.stringContaining('GitHub credential expired'),
       }));
+    });
+
+    it('self-heals when the SDK session is not loaded (resumes from disk + retries)', async () => {
+      // Regression for v0.21.1: meta state could drift such that the relay-
+      // client did not lazy-resume before calling sendMessage. The adapter's
+      // getSession() would throw "Session not found" and escape the recovery
+      // path, leaving the user with a permanent "Failed to deliver message"
+      // until restart.
+      await adapter.start();
+      // Pretend the session exists on disk (resume will succeed) but is not
+      // tracked in the adapter's in-memory map.
+      const sessionId = 'sess-not-loaded';
+
+      await adapter.sendMessage(sessionId, 'first message after crash');
+
+      // The adapter resumed the session from disk and successfully delivered.
+      expect(capturedResumeConfigs).toEqual([
+        expect.objectContaining({ sessionId }),
+      ]);
+      // The freshly-resumed session received the prompt.
+      expect(mockSessions[mockSessions.length - 1].send).toHaveBeenCalledWith({ prompt: 'first message after crash' });
     });
   });
 

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -897,9 +897,14 @@ export class CopilotAdapter extends AgentAdapter {
   }
 
   private async sendMessageInner(sessionId: string, opts: MessageOptions): Promise<void> {
-    let entry = this.getSession(sessionId);
-
+    // getSession() is inside the try so that a "Session not found" throw —
+    // which happens when meta says active/idle but the SDK runtime never
+    // loaded the session (state-drift after a crash, or a missed
+    // ensureSessionResumed gate) — flows into the recovery path that calls
+    // resumeTrackedSession instead of escaping all the way to the arm.
+    let entry: SessionEntry;
     try {
+      entry = this.getSession(sessionId);
       await entry.session.send(opts);
       return;
     } catch (err) {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -604,12 +604,16 @@ export class RelayClient {
               ...(msg.payload.clientId && { clientId: msg.payload.clientId }),
             },
           });
-          this.sessionManager.markActive(sessionId);
           this.send({ type: 'active', sessionId, payload: {} });
-          // Lazy resume: if session is still disconnected from a prior daemon
-          // run, resume it into the runtime before sending the first message.
+          // Lazy resume must run BEFORE markActive — otherwise the meta flip
+          // from disconnected → active defeats ensureSessionResumed's state
+          // gate, sessions never get loaded, and every send fails with
+          // "Session not found". (Regression discovered post-v0.21.1.)
           this.ensureSessionResumed(sessionId)
-            .then(() => this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments))
+            .then(() => {
+              this.sessionManager.markActive(sessionId);
+              return this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
+            })
             .catch((err) => {
               logger.error({ err, sessionId }, 'sendMessage failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver message: ${(err as Error).message}` } });
@@ -1351,11 +1355,28 @@ export class RelayClient {
    * loaded into the runtime. Instead, each session is lazily resumed on first
    * user interaction via {@link ensureSessionResumed}. This avoids the O(N)
    * memory cost of loading every historical session into the runtime process.
+   *
+   * We force-normalise any sessions still in `active`/`idle` state from a
+   * previous (possibly un-graceful) daemon exit to `disconnected`, restoring
+   * the invariant "active/idle == loaded in the runtime". Without this, a
+   * leftover `active` state from a crash would make ensureSessionResumed
+   * skip resume (because state ≠ 'disconnected') even though the runtime
+   * has no handle for the session.
    */
   private async resumeDisconnectedSessions(): Promise<void> {
     const resumable = this.sessionManager.getResumableSessions();
+    let normalised = 0;
+    for (const meta of resumable) {
+      if (meta.state === 'active' || meta.state === 'idle') {
+        this.sessionManager.markDisconnected(meta.id);
+        normalised++;
+      }
+    }
     if (resumable.length > 0) {
-      logger.info({ count: resumable.length }, 'Sessions available for lazy resume on first interaction');
+      logger.info(
+        { count: resumable.length, normalised },
+        'Sessions available for lazy resume on first interaction',
+      );
     }
   }
 


### PR DESCRIPTION
Fixes two regressions surfaced after upgrading to v0.21.1 with leftover
`active`/`idle` sessions from a pre-upgrade un-graceful daemon exit.
Every send to those sessions failed with `Failed to deliver message:
Session not found: <id>` with no recovery.

## Root causes
- `send_input` handler called `sessionManager.markActive(sessionId)`
  BEFORE `ensureSessionResumed()`. The flip from `disconnected` → `active`
  defeated `ensureSessionResumed`'s state gate, so the SDK never loaded
  the session. (`relay-client.ts:602`)
- `CopilotAdapter.sendMessageInner()` called `this.getSession()` OUTSIDE
  its try block, so the `Session not found` throw escaped the recovery
  path and was forwarded straight to the arm. (`copilot.ts:900`)

## Fixes
1. **relay-client send_input**: reorder so `ensureSessionResumed()` runs
   first; `markActive()` now runs only after the resume succeeds.
2. **relay-client `resumeDisconnectedSessions`**: on startup, force-normalise
   any sessions still in `active`/`idle` (leftover from a crash) to
   `disconnected`. Restores the invariant "active/idle == loaded in the
   runtime".
3. **copilot `sendMessageInner`**: move `getSession()` inside the try block
   so a missing session triggers the existing `resumeTrackedSession`
   recovery path. Defence-in-depth.

## Tests
- New: `sendMessage` on unknown session attempts resume, ends gracefully
  if resume also fails.
- New: `sendMessage` self-heals when SDK session is not loaded.
- New: `send_input` on disconnected session calls `resumeSession` BEFORE
  `markActive` BEFORE `sendMessage` — explicit regression test for the
  ordering bug.

`pnpm validate` passes (lint + build + 493 tentacle + 312 web + 228 head
+ 31 crypto).
