### PR TITLE
feat(tentacle): adaptive idle-session eviction (v0.22.0)

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -1885,4 +1885,128 @@ describe('CopilotAdapter', () => {
       expect(mockSessions[mockSessions.length - 1].send).toHaveBeenCalledWith({ prompt: 'wedged probe' });
     });
   });
+
+  // ── Idle-session eviction ─────────────────────────────────────
+
+  describe('idle-session eviction', () => {
+    type AdapterInternals = {
+      sessions: Map<string, { pendingPermissions: Map<string, unknown>; pendingQuestions: Map<string, unknown>; session: { disconnect: Mock } }>;
+      lastActivityAt: Map<string, number>;
+      turnHasOutput: Map<string, boolean>;
+      evictIdleSessions: () => Promise<void>;
+    };
+
+    // Helper: configure execSync to report the given total RSS (MB).
+    function mockRuntimeRssMB(mb: number, sessionCount: number) {
+      // pgrep returns child pids; ps returns rss in KB. Simulate `sessionCount`
+      // child processes each contributing equally so the sum hits `mb`.
+      const pids = Array.from({ length: sessionCount }, (_, i) => 90000 + i);
+      const rssKb = Math.round((mb * 1024) / Math.max(sessionCount, 1));
+      mockedExecSync.mockImplementation((command: string) => {
+        if (command.includes('gh auth token')) return 'fake-gh-token\n';
+        if (command.includes('command -v copilot') || command.includes('where.exe copilot')) return `${fakeCopilotPath}\n`;
+        if (command.startsWith('pgrep -P ')) {
+          // Single hop: report `sessionCount` direct children, no grandchildren.
+          if (command.includes(`-P ${process.pid}`)) return pids.join('\n');
+          return '';
+        }
+        if (command.startsWith('ps -o rss=')) {
+          return pids.map(() => String(rssKb)).join('\n');
+        }
+        return '';
+      });
+    }
+
+    it('does NOT evict when total runtime RSS is below the 2GB threshold', async () => {
+      await adapter.start();
+      const a = await adapter.createSession({});
+      const b = await adapter.createSession({});
+
+      // Force "ancient" activity so the only thing protecting these sessions
+      // is the RSS threshold.
+      const internals = adapter as unknown as AdapterInternals;
+      internals.lastActivityAt.set(a.sessionId, 0);
+      internals.lastActivityAt.set(b.sessionId, 0);
+
+      // Report RSS = 500 MB — well under threshold.
+      mockRuntimeRssMB(500, 2);
+
+      await internals.evictIdleSessions();
+
+      expect(internals.sessions.size).toBe(2);
+      expect(mockSessions[0].disconnect).not.toHaveBeenCalled();
+      expect(mockSessions[1].disconnect).not.toHaveBeenCalled();
+    });
+
+    it('evicts only sessions idle longer than 30min when RSS is over threshold', async () => {
+      await adapter.start();
+      const stale = await adapter.createSession({});
+      const recent = await adapter.createSession({});
+
+      const internals = adapter as unknown as AdapterInternals;
+      // stale: idle 1 hour ago → eligible
+      internals.lastActivityAt.set(stale.sessionId, Date.now() - 60 * 60_000);
+      // recent: idle 1 minute ago → safe
+      internals.lastActivityAt.set(recent.sessionId, Date.now() - 60_000);
+
+      mockRuntimeRssMB(3000, 2); // 3 GB > 2 GB threshold
+
+      await internals.evictIdleSessions();
+
+      expect(mockSessions[0].disconnect).toHaveBeenCalled();
+      expect(mockSessions[1].disconnect).not.toHaveBeenCalled();
+      expect(internals.sessions.has(stale.sessionId)).toBe(false);
+      expect(internals.sessions.has(recent.sessionId)).toBe(true);
+    });
+
+    it('does NOT evict a session with a pending permission, even if idle and over threshold', async () => {
+      await adapter.start();
+      const blocked = await adapter.createSession({});
+
+      const internals = adapter as unknown as AdapterInternals;
+      internals.lastActivityAt.set(blocked.sessionId, 0); // ancient
+      // Simulate a pending permission so the session is mid-prompt
+      internals.sessions.get(blocked.sessionId)!.pendingPermissions.set('perm-1', { resolve: () => {} });
+
+      mockRuntimeRssMB(3000, 1);
+
+      await internals.evictIdleSessions();
+
+      expect(mockSessions[0].disconnect).not.toHaveBeenCalled();
+      expect(internals.sessions.has(blocked.sessionId)).toBe(true);
+    });
+
+    it('does NOT evict a session currently mid-turn (turnHasOutput=true)', async () => {
+      await adapter.start();
+      const turning = await adapter.createSession({});
+
+      const internals = adapter as unknown as AdapterInternals;
+      internals.lastActivityAt.set(turning.sessionId, 0);
+      internals.turnHasOutput.set(turning.sessionId, true);
+
+      mockRuntimeRssMB(3000, 1);
+
+      await internals.evictIdleSessions();
+
+      expect(mockSessions[0].disconnect).not.toHaveBeenCalled();
+      expect(internals.sessions.has(turning.sessionId)).toBe(true);
+    });
+
+    it('fires onSessionEvicted so relay-client can mark the session disconnected', async () => {
+      const evictedSpy = vi.fn();
+      adapter.onSessionEvicted = evictedSpy;
+
+      await adapter.start();
+      const s = await adapter.createSession({});
+
+      const internals = adapter as unknown as AdapterInternals;
+      internals.lastActivityAt.set(s.sessionId, 0);
+
+      mockRuntimeRssMB(3000, 1);
+
+      await internals.evictIdleSessions();
+
+      expect(evictedSpy).toHaveBeenCalledWith(s.sessionId);
+    });
+  });
 });

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -120,6 +120,12 @@ export abstract class AgentAdapter {
   onFlushComplete: ((sessionId: string) => void) | null = null;
   onError: ((sessionId: string, event: ErrorEvent) => void) | null = null;
   onSessionEnded: ((sessionId: string, event: SessionEndedEvent) => void) | null = null;
+  /** Called when a session is evicted from the in-memory adapter map to free
+   *  runtime memory. The session is NOT ended — its on-disk state is intact
+   *  and the next interaction will lazy-resume it. The relay-client uses
+   *  this to mark the session `disconnected` in SessionManager so the meta
+   *  state matches reality. No arm broadcast: load-state is internal. */
+  onSessionEvicted: ((sessionId: string) => void) | null = null;
   /** Called when the agent produces a title for a session (e.g. via SDK event). */
   onTitleChanged: ((sessionId: string, title: string) => void) | null = null;
   /** Called with updated cumulative token usage for a session */

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -443,6 +443,26 @@ export class CopilotAdapter extends AgentAdapter {
    *  but a hung runtime doesn't stall every recovery attempt. */
   private static readonly PROBE_RUNTIME_TIMEOUT_MS = 5_000;
 
+  // ── Idle-session eviction ────────────────────────────
+  // Long-lived daemon → working set grows over time as more sessions get
+  // lazy-resumed and then sit idle. To bound runtime memory we periodically
+  // sweep the loaded set:
+  //   - skip if total runtime RSS is below the threshold (do nothing when
+  //     memory is fine — eviction is adaptive, not eager)
+  //   - skip any session that's mid-turn or has a pending permission/question
+  //     (would be rude to drop while the user is waiting)
+  //   - evict sessions that have been quiet longer than IDLE_TTL_MS
+  // The evicted session's on-disk state is intact; next user interaction
+  // triggers the existing lazy-resume path (relay-client ensureSessionResumed).
+  private static readonly EVICTION_SCAN_INTERVAL_MS = 5 * 60_000;
+  private static readonly EVICTION_RSS_THRESHOLD_MB = 2048;
+  private static readonly EVICTION_IDLE_TTL_MS = 30 * 60_000;
+  /** Per-session "last time anything happened" timestamp (ms epoch). Used
+   *  by the eviction sweep to identify candidates. Updated by sendMessage,
+   *  every SDK event handler, and permission/question responses. */
+  private lastActivityAt = new Map<string, number>();
+  private evictionTimer: ReturnType<typeof setInterval> | null = null;
+
   private static readonly CONTEXT_WINDOWS: Record<string, number> = {
     'claude-sonnet-4.6': 200_000,
     'claude-sonnet-4.5': 200_000,
@@ -626,10 +646,12 @@ export class CopilotAdapter extends AgentAdapter {
     this.client = new CopilotClient(opts);
     await this.client.start();
     if (restoreExecPath) restoreExecPath();
+    this.startEvictionSweep();
     logger.debug('started');
   }
 
   async stop(): Promise<void> {
+    this.stopEvictionSweep();
     for (const timer of this.idleTimers.values()) clearTimeout(timer);
     this.idleTimers.clear();
 
@@ -663,6 +685,7 @@ export class CopilotAdapter extends AgentAdapter {
       this.client = null;
     }
     this.sessions.clear();
+    this.lastActivityAt.clear();
     logger.debug('stopped');
   }
 
@@ -694,6 +717,7 @@ export class CopilotAdapter extends AgentAdapter {
         }
         // All SDK session handles are now invalid
         this.sessions.clear();
+        this.lastActivityAt.clear();
         await this.start();
         logger.info('CopilotClient rebuilt successfully');
       } finally {
@@ -701,6 +725,133 @@ export class CopilotAdapter extends AgentAdapter {
       }
     })();
     return this.rebuildingClient;
+  }
+
+  // ── Idle-session eviction ────────────────────────────
+
+  /**
+   * Sum RSS (MB) of this process plus every descendant. The real memory
+   * consumer is the native `copilot-darwin-arm64` grandchild, not the
+   * daemon's Node heap — so we walk the whole tree and report the total.
+   *
+   * Returns null on Windows (no pgrep) or when the descendant walk fails;
+   * callers treat null as "skip eviction this cycle" (fail-safe).
+   */
+  private getRuntimeRssMB(): number | null {
+    if (process.platform === 'win32') return null;
+    const descendants: number[] = [];
+    const queue: number[] = [process.pid];
+    while (queue.length) {
+      const pid = queue.shift()!;
+      try {
+        const out = execSync(`pgrep -P ${pid}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+        if (!out) continue;
+        for (const line of out.split('\n')) {
+          const child = parseInt(line, 10);
+          if (!isNaN(child)) {
+            descendants.push(child);
+            queue.push(child);
+          }
+        }
+      } catch { /* pgrep exits non-zero when no children — normal */ }
+    }
+    if (descendants.length === 0) return 0;
+    try {
+      const out = execSync(`ps -o rss= -p ${descendants.join(',')}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      const kb = out.split('\n')
+        .map((s) => parseInt(s.trim(), 10))
+        .reduce((acc, v) => acc + (isNaN(v) ? 0 : v), 0);
+      return Math.round(kb / 1024);
+    } catch {
+      return null;
+    }
+  }
+
+  private startEvictionSweep(): void {
+    if (this.evictionTimer) return;
+    this.evictionTimer = setInterval(() => {
+      this.evictIdleSessions().catch((err) => {
+        logger.warn({ err }, 'eviction sweep threw');
+      });
+    }, CopilotAdapter.EVICTION_SCAN_INTERVAL_MS);
+    // Don't block process exit on the timer
+    this.evictionTimer.unref?.();
+  }
+
+  private stopEvictionSweep(): void {
+    if (this.evictionTimer) {
+      clearInterval(this.evictionTimer);
+      this.evictionTimer = null;
+    }
+  }
+
+  /**
+   * Periodic sweep: if total runtime RSS is over threshold, evict any
+   * loaded session that has been quiet > IDLE_TTL_MS and is safe to drop
+   * (not mid-turn, no pending permission/question).
+   *
+   * Eviction is purely a memory hygiene operation; the user-visible session
+   * is unaffected because the next interaction triggers lazy resume.
+   */
+  private async evictIdleSessions(): Promise<void> {
+    if (this.sessions.size === 0) return;
+    const rssMB = this.getRuntimeRssMB();
+    if (rssMB === null || rssMB < CopilotAdapter.EVICTION_RSS_THRESHOLD_MB) {
+      // Under the threshold (or measurement unavailable) — do nothing.
+      // This is deliberately adaptive: when memory is fine, never evict.
+      return;
+    }
+
+    const now = Date.now();
+    const ttl = CopilotAdapter.EVICTION_IDLE_TTL_MS;
+    const candidates: string[] = [];
+    for (const [sessionId, entry] of this.sessions) {
+      if (entry.pendingPermissions.size > 0 || entry.pendingQuestions.size > 0) continue;
+      // turnHasOutput.get(sessionId) === true => a turn is currently in flight
+      if (this.turnHasOutput.get(sessionId)) continue;
+      const lastAt = this.lastActivityAt.get(sessionId) ?? 0;
+      if (now - lastAt < ttl) continue;
+      candidates.push(sessionId);
+    }
+    if (candidates.length === 0) {
+      logger.info({ rssMB, loaded: this.sessions.size }, 'eviction: over threshold but no eligible candidates');
+      return;
+    }
+    logger.info(
+      { rssMB, threshold: CopilotAdapter.EVICTION_RSS_THRESHOLD_MB, candidates: candidates.length, loaded: this.sessions.size },
+      'eviction: sweeping idle sessions',
+    );
+    for (const sessionId of candidates) {
+      await this.evictSession(sessionId);
+    }
+  }
+
+  /**
+   * Release an idle SDK session handle so the runtime can reclaim its
+   * memory. The on-disk session is intact; lazy resume picks it up on
+   * next interaction. Fires {@link onSessionEvicted} so the relay-client
+   * can mark the meta state `disconnected` for invariant consistency.
+   */
+  private async evictSession(sessionId: string): Promise<void> {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    try {
+      await entry.session.disconnect();
+    } catch (err) {
+      logger.warn({ err, sessionId }, 'evictSession: disconnect failed, removing entry anyway');
+    }
+    this.sessions.delete(sessionId);
+    this.lastActivityAt.delete(sessionId);
+    this.clearIdleTimer(sessionId);
+    // Note: we intentionally do NOT clear sessionModes / sessionUsage /
+    // expectedModels — those represent persistent per-session preferences
+    // that should survive the unload/reload cycle.
+    logger.info({ sessionId }, 'session evicted from runtime (idle, over RSS threshold)');
+    this.onSessionEvicted?.(sessionId);
+  }
+
+  private touchSession(sessionId: string): void {
+    this.lastActivityAt.set(sessionId, Date.now());
   }
 
   // ── Session management ──────────────────────────────
@@ -789,6 +940,7 @@ export class CopilotAdapter extends AgentAdapter {
     const sid = session.sessionId;
 
     this.sessions.set(sid, { session, pendingPermissions, pendingQuestions });
+    this.touchSession(sid);
     this.wireEvents(sid, session);
 
     logger.info(`session created: ${sid} (model: ${config.model ?? 'default'})`);
@@ -855,6 +1007,7 @@ export class CopilotAdapter extends AgentAdapter {
     this.cycleHasOutput.set(sessionId, false);
     this.turnErrorReported.set(sessionId, false);
     this.cycleUserAborted.delete(sessionId);
+    this.touchSession(sessionId);
 
     // Prepend mode-switch signal if mode changed since last message
     const pendingMode = this.pendingModeSignals.get(sessionId);
@@ -998,6 +1151,7 @@ export class CopilotAdapter extends AgentAdapter {
 
     pending.resolve(kindMap[decision] ?? { kind: 'reject' });
     entry.pendingPermissions.delete(permissionId);
+    this.touchSession(sessionId);
     logger.debug({ permissionId, sessionId, decision }, 'permission resolved');
   }
 
@@ -1020,6 +1174,7 @@ export class CopilotAdapter extends AgentAdapter {
 
     pending.resolve({ answer, wasFreeform });
     entry.pendingQuestions.delete(questionId);
+    this.touchSession(sessionId);
   }
 
   async killSession(sessionId: string): Promise<void> {
@@ -1270,6 +1425,7 @@ export class CopilotAdapter extends AgentAdapter {
     const entry = { session, pendingPermissions, pendingQuestions };
 
     this.sessions.set(sessionId, entry);
+    this.touchSession(sessionId);
     this.wireEvents(sessionId, session);
     logger.debug({ sessionId }, 'session resumed');
 
@@ -1376,6 +1532,7 @@ export class CopilotAdapter extends AgentAdapter {
       if (event.data.content) {
         this.turnHasOutput.set(sessionId, true);
         this.cycleHasOutput.set(sessionId, true);
+        this.touchSession(sessionId);
         this.onMessage?.(sessionId, { content: event.data.content });
       }
     });
@@ -1386,6 +1543,7 @@ export class CopilotAdapter extends AgentAdapter {
       if (data.toolName === 'report_intent') return;
       this.turnHasOutput.set(sessionId, true);
       this.cycleHasOutput.set(sessionId, true);
+      this.touchSession(sessionId);
       if (data.mcpServerName) {
         logger.info({ mcpServer: data.mcpServerName, mcpTool: data.mcpToolName }, `[MCP tool] ${data.mcpServerName}/${data.mcpToolName}`);
       }

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1334,6 +1334,14 @@ export class RelayClient {
       });
     };
 
+    // Idle-session eviction: keep meta state consistent with runtime load-
+    // state by marking the session `disconnected` on eviction. No arm
+    // broadcast — load-state is internal; the next user interaction goes
+    // through ensureSessionResumed and lazy-loads transparently.
+    this.adapter.onSessionEvicted = (sessionId) => {
+      this.sessionManager.markDisconnected(sessionId);
+    };
+
     // SDK title fallback — use as fast placeholder while LLM generation runs
     this.adapter.onTitleChanged = (sessionId, title) => {
       const meta = this.sessionManager.getMeta(sessionId);


### PR DESCRIPTION
Lazy resume bounded the **startup** spike but did not bound **long-term**
growth: a daemon left running for days will keep every session the user
has interacted with loaded in the SDK runtime forever. On a 24 GB machine
with 30–50 large sessions touched over a week, runtime RSS would grow into
the multiple-GB range and recreate the OOM pressure 0.21.x fixed.

## Design — adaptive, pressure-triggered eviction
```
every 5 min:
  if runtime RSS > 2 GB:
    for each loaded session:
      skip if pendingPermissions/pendingQuestions non-empty
      skip if turnHasOutput (mid-turn)
      skip if last activity < 30 min ago
      otherwise: session.disconnect(), remove from this.sessions,
                 fire onSessionEvicted → markDisconnected
```

Key properties:
- **Adaptive**: when memory is fine, nothing happens. Eviction is purely
  pressure-relief, not eager cleanup.
- **Safe**: never drops a session the user is actively engaged with.
- **Transparent**: evicted → state goes `disconnected` → next user
  interaction triggers existing lazy-resume path. Arm sees nothing.

## RSS measurement
Walks `process.pid` descendants via `pgrep`, sums `ps -o rss=`. The heavy
consumer is the native `copilot-darwin-arm64` grandchild (not the daemon's
Node heap), so the descendant walk captures it.

Windows: returns `null` (no pgrep). Eviction is a no-op on Windows in
v0.22.0; can revisit with `tasklist` later if needed.

## Tunables (constants on `CopilotAdapter`)
| | value | rationale |
|---|---|---|
| `EVICTION_SCAN_INTERVAL_MS` | 5 min | catches fast spikes from compaction; one `ps` call, near-zero overhead |
| `EVICTION_RSS_THRESHOLD_MB` | 2 GB | below typical OOM warning (~1.8 GB baseline observed pre-fix); above natural working-set for moderate use |
| `EVICTION_IDLE_TTL_MS` | 30 min | matches "step away from desk" UX boundary |

Will graduate to config when real-world data informs the defaults.

## Tests
5 new in `copilot.test.ts`:
- Under-threshold RSS → no eviction (the adaptive property)
- Over-threshold + idle → evict, but only the stale one (not the recent)
- Skip when pending permission exists
- Skip when mid-turn (`turnHasOutput=true`)
- Fires `onSessionEvicted` callback so relay-client can mark disconnected

`pnpm validate` passes (lint + build + 498 tentacle + 312 web + 228 head +
31 crypto).
