### PR TITLE
fix(tentacle): skip eviction tests on Windows + v0.22.1

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -1888,7 +1888,11 @@ describe('CopilotAdapter', () => {
 
   // ── Idle-session eviction ─────────────────────────────────────
 
-  describe('idle-session eviction', () => {
+  // Eviction is intentionally a no-op on Windows (no pgrep for descendant
+  // RSS walk). Skip the test suite there — semantics are platform-aware.
+  const describeEviction = process.platform === 'win32' ? describe.skip : describe;
+
+  describeEviction('idle-session eviction', () => {
     type AdapterInternals = {
       sessions: Map<string, { pendingPermissions: Map<string, unknown>; pendingQuestions: Map<string, unknown>; session: { disconnect: Mock } }>;
       lastActivityAt: Map<string, number>;


### PR DESCRIPTION
The eviction sweep introduced in v0.22.0 is intentionally a no-op on
Windows (no `pgrep` for descendant RSS walk), so the 5 new eviction tests
can't pass there. Skip the suite on `win32`. Behavior unchanged everywhere
else.

This also unblocks the v0.22.0 release pipeline, which failed on
"Build Binary (Windows x64)" due to these tests. npm
`@kraki/tentacle@0.22.0` already published successfully; this 0.22.1
bump primarily exists to also produce the GitHub Release binaries.
