### PR TITLE
fix: clamp readSeq to lastSeq (cross-arm mark_read corruption) (v0.22.2)

### DIFF
--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -188,8 +188,16 @@ export class KrakiWSClient {
 
   markRead(sessionId: string, seq?: number): void {
     markSessionRead(sessionId);
-    // Send to tentacle so it persists readSeq and broadcasts to other arms
-    const resolvedSeq = seq ?? this.getLastSeq(sessionId);
+    // Send to tentacle so it persists readSeq and broadcasts to other arms.
+    // When no explicit seq is supplied, fall back to the authoritative
+    // `lastSeq` carried on the session digest from session_list. The
+    // previous fallback walked `store.messages.get(sessionId)` and picked
+    // the last element's `seq`, which could be polluted by transient
+    // entries (envelope-level seq, replay residue, etc.) and produced
+    // wildly inflated values (~35 % of sessions on disk ended up with
+    // readSeq > lastSeq, one sample 57× overshoot).
+    const session = getStore().sessions.get(sessionId);
+    const resolvedSeq = seq ?? session?.lastSeq ?? 0;
     if (resolvedSeq > 0) {
       this.sendEncrypted({
         type: 'mark_read',
@@ -211,17 +219,6 @@ export class KrakiWSClient {
   /** Send a preferences update to the relay (unencrypted control message). */
   updatePreferences(prefs: Record<string, unknown>): void {
     this.transport.send({ type: 'update_preferences', preferences: prefs });
-  }
-
-  private getLastSeq(sessionId: string): number {
-    const msgs = getStore().messages.get(sessionId);
-    if (!msgs || msgs.length === 0) return 0;
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      const m = msgs[i];
-      const seq = 'seq' in m ? (m as { seq?: number }).seq : undefined;
-      if (typeof seq === 'number' && seq > 0) return seq;
-    }
-    return 0;
   }
 
   /**

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.22.1",
-  "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
+  "version": "0.22.2",
+  "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",
     "url": "https://github.com/corelli18512/kraki",

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SessionManager } from '../session-manager.js';
-import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -871,6 +871,75 @@ describe('SessionManager', () => {
 
       const start = sm.findTurnAlignedStart(sessionId, 3);
       expect(start).toBe(1);
+    });
+  });
+
+  // ── markRead clamp + migration ─────────────────────────
+
+  describe('markRead', () => {
+    it('clamps incoming seq to lastSeq', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      // lastSeq is now 2; arm sends a runaway seq from a stale store
+      sm.markRead(sessionId, 999_999);
+      const meta = sm.getMeta(sessionId)!;
+      expect(meta.lastSeq).toBe(2);
+      expect(meta.readSeq).toBe(2);
+    });
+
+    it('still advances readSeq when seq is within range', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.markRead(sessionId, 2);
+      expect(sm.getMeta(sessionId)!.readSeq).toBe(2);
+      sm.markRead(sessionId, 3);
+      expect(sm.getMeta(sessionId)!.readSeq).toBe(3);
+    });
+
+    it('does not roll readSeq backwards', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.markRead(sessionId, 3);
+      sm.markRead(sessionId, 1);
+      expect(sm.getMeta(sessionId)!.readSeq).toBe(3);
+    });
+  });
+
+  describe('clampOverflowReadSeq migration', () => {
+    it('repairs sessions where readSeq exceeds lastSeq on startup', () => {
+      // Hand-write a meta.json that simulates the legacy corruption
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      const metaPath = join(dir, sessionId, 'meta.json');
+      const meta = JSON.parse(readFileSync(metaPath, 'utf8'));
+      meta.readSeq = 99_999;
+      writeFileSync(metaPath, JSON.stringify(meta), 'utf8');
+
+      // Re-construct triggers the migration
+      const sm2 = new SessionManager(dir);
+      expect(sm2.getMeta(sessionId)!.readSeq).toBe(2);
+      expect(sm2.getMeta(sessionId)!.lastSeq).toBe(2);
+    });
+
+    it('leaves healthy meta untouched (idempotent)', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.markRead(sessionId, 1);
+      const before = readFileSync(join(dir, sessionId, 'meta.json'), 'utf8');
+
+      // Second construct over the same dir should be a no-op
+      const _sm2 = new SessionManager(dir);
+      const after = readFileSync(join(dir, sessionId, 'meta.json'), 'utf8');
+      expect(JSON.parse(after).readSeq).toBe(1);
+      // updatedAt is the only field we may bump, and we don't bump it
+      // when readSeq doesn't need clamping
+      expect(JSON.parse(before).updatedAt).toBe(JSON.parse(after).updatedAt);
     });
   });
 });

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -103,6 +103,46 @@ export class SessionManager {
     mkdirSync(this.sessionsDir, { recursive: true });
     this.migrateGlobalLog();
     this.stripAllLegacyInlineImages();
+    this.clampOverflowReadSeq();
+  }
+
+  /**
+   * One-shot migration: clamp every session's `readSeq` to at most
+   * its `lastSeq`. Pre-fix, arms could send `mark_read` with an
+   * arbitrary seq (web's `getLastSeq` fallback walked the in-memory
+   * message store and sometimes returned a value that wasn't really
+   * a session-message seq) — and `markRead` here trusted it
+   * blindly. This left ~35 % of sessions with readSeq > lastSeq (one
+   * sample: lastSeq=472, readSeq=27,265 — 57× overshoot), which
+   * broke unread badges and triggered noisy `session_read` echoes
+   * across all peer arms.
+   *
+   * Idempotent: only rewrites meta files where readSeq actually
+   * exceeds lastSeq.
+   */
+  private clampOverflowReadSeq(): void {
+    if (!existsSync(this.sessionsDir)) return;
+    let dirs: string[];
+    try {
+      dirs = readdirSync(this.sessionsDir);
+    } catch {
+      return;
+    }
+    for (const dir of dirs) {
+      const meta = this.readMeta(dir);
+      if (!meta) continue;
+      const ls = meta.lastSeq ?? 0;
+      const rs = meta.readSeq ?? 0;
+      if (rs > ls) {
+        meta.readSeq = ls;
+        meta.updatedAt = new Date().toISOString();
+        try {
+          this.writeMeta(dir, meta);
+        } catch {
+          // Best-effort — failures never crash startup
+        }
+      }
+    }
   }
 
   /**
@@ -721,8 +761,13 @@ export class SessionManager {
   markRead(sessionId: string, seq: number): void {
     const meta = this.readMeta(sessionId);
     if (!meta) return;
-    if (seq > (meta.readSeq ?? 0)) {
-      meta.readSeq = seq;
+    // Clamp to lastSeq — readSeq must never exceed it. Pre-fix, arms
+    // sometimes sent garbage seq values (web's stale `getLastSeq`
+    // fallback), and a stuck readSeq > lastSeq broke unread badges
+    // and triggered noisy session_read echoes across all peers.
+    const clamped = Math.min(seq, meta.lastSeq ?? 0);
+    if (clamped > (meta.readSeq ?? 0)) {
+      meta.readSeq = clamped;
       meta.updatedAt = new Date().toISOString();
       this.writeMeta(sessionId, meta);
     }


### PR DESCRIPTION
## Problem

On a real device (Macbook, 94 sessions), **33 / 94 (35 %)** session metas had `readSeq > lastSeq` on disk. Worst case: `lastSeq=472`, `readSeq=27265` — a 57.8× overshoot.

Symptoms:
- Unread badges stuck "forever" (we count unread as `lastSeq - readSeq`, but the comparison was lying).
- Noisy `session_read` echoes broadcast to every paired arm whenever a session was opened, because the tentacle kept re-persisting a `readSeq` that no one would ever actually advance past.

## Root cause (two-sided)

### Web arm — origin of the garbage seq

`packages/arm/web/src/lib/ws-client.ts` had:

```ts
markRead(sessionId, seq?) {
  const resolvedSeq = seq ?? this.getLastSeq(sessionId); // ← bug
  ...
}

private getLastSeq(sessionId) {
  const msgs = getStore().messages.get(sessionId);
  return msgs?.[msgs.length - 1]?.seq ?? 0;
}
```

`store.messages.get(sessionId)` is a `ChatMessage[]` that gets polluted with transient entries whose `seq` is from a different scope (envelope-level counters / replay residue). When a caller invoked `markRead` without an explicit seq, we'd send the polluted value to the tentacle.

### Tentacle — trusted the garbage and persisted it

`packages/tentacle/src/session-manager.ts` `markRead` only checked `seq > readSeq`, never clamped to `lastSeq`. So whatever the arm sent went straight to disk and back out via `session_read`.

## Fix

### Tentacle (defense-in-depth + cleanup)

1. `markRead(sessionId, seq)` now does `Math.min(seq, meta.lastSeq ?? 0)` before the `> readSeq` check. No arm — present or future — can push `readSeq` past `lastSeq`.
2. New startup migration `clampOverflowReadSeq()` walks every session meta once and clamps `readSeq` down to `lastSeq`. Idempotent — leaves clean metas alone, safe to keep in the boot path forever.

### Web (root cause)

`markRead` fallback now reads `getStore().sessions.get(sessionId)?.lastSeq`, which is the authoritative value carried on the `session_list` digest. The private `getLastSeq` helper is deleted — nothing else used it.

## Tests

- 5 new tentacle tests covering: clamp on overshoot, forward advancement still works, no backward rolls, migration repairs corrupted metas on startup, migration is a no-op on clean metas.
- All existing tests still pass: tentacle 503/503, web arm 312/312, biome lint clean.

## Verified on real data

Ran the equivalent of `clampOverflowReadSeq` against my own `~/.kraki/sessions/`:

```
before:  scanned=94  broken=33  (max 57.8x overshoot)
after:   scanned=94  broken=0
```

## What this does NOT touch

iOS arm — already safe. All `commandSender.markRead(sessionId:seq:)` callers (`SessionDetailView`, `SessionTable`, `MessageRouter`) pass `session.lastSeq` from the digest. `CommandSender.markRead` has no fallback. No change needed.
