### PR TITLE
fix: retry copilot CLI resolution on boot, auto-restart on crash

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -597,7 +597,17 @@ export class CopilotAdapter extends AgentAdapter {
 
     let cliPath = this.cliPath ?? resolveCopilotCliPath();
     if (!cliPath && isSea()) {
-      throw new Error('Copilot CLI not found on PATH. Install GitHub Copilot CLI so `copilot` is available.');
+      // At boot, PATH tools (nvm, copilot) may not be ready yet.
+      // Retry for up to 30s before giving up.
+      const deadline = Date.now() + 30_000;
+      while (!cliPath && Date.now() < deadline) {
+        logger.debug('Copilot CLI not found yet, retrying...');
+        await new Promise(r => setTimeout(r, 2_000));
+        cliPath = resolveCopilotCliPath();
+      }
+      if (!cliPath) {
+        throw new Error('Copilot CLI not found on PATH. Install GitHub Copilot CLI so `copilot` is available.');
+      }
     }
 
     // On Windows, resolve the actual .js entry point from the .cmd wrapper.

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -296,7 +296,10 @@ async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
-    <false/>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
     <key>EnvironmentVariables</key>
     <dict>
 ${envXml}


### PR DESCRIPTION
Boot autostart fix: retry CLI resolution 30s, KeepAlive SuccessfulExit=false, bump v0.22.3