### PR TITLE
feat(tentacle): add request_session_messages_range endpoint

### DIFF
--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -380,12 +380,6 @@ export interface SessionMessagesBatchMessage extends BaseEnvelope {
 
 // ── Range-based message fetch ───────────────────────
 
-/** Server-side hard cap on the number of messages returned by a single
- *  `request_session_messages_range` reply. Defensive backstop — clients
- *  should chunk their own requests well below this. When the server
- *  truncates, the response's `truncated` flag is set. */
-export const SESSION_MESSAGES_RANGE_MAX_COUNT = 500;
-
 /**
  * Sent by app to tentacle to fetch an EXACT seq range from a session.
  *
@@ -395,10 +389,9 @@ export const SESSION_MESSAGES_RANGE_MAX_COUNT = 500;
  * push delivers a seq jump, or web's IndexedDB cache filling holes.
  *
  * Pagination is caller-driven: chunk `[fromSeq..toSeq]` yourself before
- * sending. The server has a hard cap (`SESSION_MESSAGES_RANGE_MAX_COUNT`)
- * as a defensive backstop — if the request exceeds it, the server keeps
- * the newer end and sets `truncated: true` so the caller can iterate to
- * fill the older remainder.
+ * sending. The server applies a defensive backstop on very large ranges
+ * — if it triggers, the reply keeps the newer end and sets
+ * `truncated: true` so the caller can iterate to fill the older remainder.
  */
 export interface RequestSessionMessagesRangeMessage extends BaseEnvelope {
   type: 'request_session_messages_range';
@@ -416,24 +409,28 @@ export interface RequestSessionMessagesRangeMessage extends BaseEnvelope {
  * Sent by tentacle in response to `request_session_messages_range`.
  *
  * Per-session seqs are strictly monotonic and only assigned to
- * persistent message types, so `messages` is contiguous within
- * `[firstSeq..lastSeq]` — no holes possible. Empty `messages`
- * means the requested range had no overlap with `[1..headSeq]`
- * (or the session doesn't exist).
+ * persistent message types. `messages` is normally contiguous within
+ * `[firstSeq..lastSeq]`; older session logs may defensively contain
+ * non-persistent stragglers which the server filters out, in which
+ * case the returned set is a subset of `[firstSeq..lastSeq]`.
+ *
+ * Empty `messages` occurs when the session is unknown, the requested
+ * range falls entirely outside `[1..headSeq]`, or `fromSeq > toSeq`
+ * after server-side clamping. In that case `firstSeq` and `lastSeq`
+ * are both `0` and `truncated` is `false`.
  */
 export interface SessionMessagesRangeBatchMessage extends BaseEnvelope {
   type: 'session_messages_range_batch';
   payload: {
     /** The session these messages belong to. */
     sessionId: string;
-    /** Messages in ascending seq order. Contiguous: every seq in
-     *  `[firstSeq..lastSeq]` is present. */
+    /** Messages in ascending seq order. */
     messages: ProducerMessage[];
     /** `messages[0].seq`, or `0` if `messages` is empty. */
     firstSeq: number;
     /** `messages.at(-1).seq`, or `0` if `messages` is empty. */
     lastSeq: number;
-    /** True iff the server's hard cap reduced the range from the
+    /** True iff the server's defensive cap reduced the range from the
      *  older end. Caller may iterate by requesting another page
      *  ending at `firstSeq - 1`. */
     truncated: boolean;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -378,6 +378,68 @@ export interface SessionMessagesBatchMessage extends BaseEnvelope {
   };
 }
 
+// ── Range-based message fetch ───────────────────────
+
+/** Server-side hard cap on the number of messages returned by a single
+ *  `request_session_messages_range` reply. Defensive backstop — clients
+ *  should chunk their own requests well below this. When the server
+ *  truncates, the response's `truncated` flag is set. */
+export const SESSION_MESSAGES_RANGE_MAX_COUNT = 500;
+
+/**
+ * Sent by app to tentacle to fetch an EXACT seq range from a session.
+ *
+ * Distinct from `request_session_messages` which is turn-aligned and
+ * always anchored at the upper end. This endpoint exists for clients
+ * that know precisely which seqs they want — e.g. gap recovery when a
+ * push delivers a seq jump, or web's IndexedDB cache filling holes.
+ *
+ * Pagination is caller-driven: chunk `[fromSeq..toSeq]` yourself before
+ * sending. The server has a hard cap (`SESSION_MESSAGES_RANGE_MAX_COUNT`)
+ * as a defensive backstop — if the request exceeds it, the server keeps
+ * the newer end and sets `truncated: true` so the caller can iterate to
+ * fill the older remainder.
+ */
+export interface RequestSessionMessagesRangeMessage extends BaseEnvelope {
+  type: 'request_session_messages_range';
+  payload: {
+    /** Session to fetch from. */
+    sessionId: string;
+    /** Inclusive lower bound. Server clamps to ≥ 1. */
+    fromSeq: number;
+    /** Inclusive upper bound. Server clamps to ≤ session head seq. */
+    toSeq: number;
+  };
+}
+
+/**
+ * Sent by tentacle in response to `request_session_messages_range`.
+ *
+ * Per-session seqs are strictly monotonic and only assigned to
+ * persistent message types, so `messages` is contiguous within
+ * `[firstSeq..lastSeq]` — no holes possible. Empty `messages`
+ * means the requested range had no overlap with `[1..headSeq]`
+ * (or the session doesn't exist).
+ */
+export interface SessionMessagesRangeBatchMessage extends BaseEnvelope {
+  type: 'session_messages_range_batch';
+  payload: {
+    /** The session these messages belong to. */
+    sessionId: string;
+    /** Messages in ascending seq order. Contiguous: every seq in
+     *  `[firstSeq..lastSeq]` is present. */
+    messages: ProducerMessage[];
+    /** `messages[0].seq`, or `0` if `messages` is empty. */
+    firstSeq: number;
+    /** `messages.at(-1).seq`, or `0` if `messages` is empty. */
+    lastSeq: number;
+    /** True iff the server's hard cap reduced the range from the
+     *  older end. Caller may iterate by requesting another page
+     *  ending at `firstSeq - 1`. */
+    truncated: boolean;
+  };
+}
+
 /** Sent by tentacle to app with metadata for all active sessions. */
 export interface SessionListMessage extends BaseEnvelope {
   type: 'session_list';
@@ -482,6 +544,7 @@ export type ProducerMessage =
   | DeviceGreetingMessage
   | SessionReplayBatchMessage
   | SessionMessagesBatchMessage
+  | SessionMessagesRangeBatchMessage
   | SessionListMessage
   | PermissionResolvedMessage
   | QuestionResolvedMessage
@@ -710,6 +773,7 @@ export type ConsumerMessage =
   | MarkUnreadMessage
   | RequestSessionReplayMessage
   | RequestSessionMessagesMessage
+  | RequestSessionMessagesRangeMessage
   | RenameSessionMessage
   | PinSessionMessage
   | RequestLocalSessionsMessage

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -62,12 +62,15 @@ vi.mock('../logger.js', () => ({
 
 // Mock crypto so tests can hand-craft "encrypted" envelopes without real keys.
 // decryptFromBlob simply returns the blob string itself — tests treat the
-// blob field as the raw plaintext JSON to inject.
+// blob field as the raw plaintext JSON to inject. encryptToBlob mirrors it
+// so outbound unicasts can be JSON.parsed straight out of `envelope.blob`.
 vi.mock('@kraki/crypto', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@kraki/crypto');
   return {
     ...actual,
     decryptFromBlob: vi.fn((payload: { blob: string }) => payload.blob),
+    encryptToBlob: vi.fn((plaintext: string) => ({ blob: plaintext, keys: {} })),
+    importPublicKey: vi.fn(() => ({})),
   };
 });
 
@@ -1323,5 +1326,303 @@ describe('RelayClient delta debounce', () => {
       .map(s => JSON.parse(s))
       .filter(m => m.type === 'agent_message_delta');
     expect(deltasAfter).toHaveLength(0);
+  });
+});
+
+describe('RelayClient handleSessionMessagesRange', () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    vi.useFakeTimers();
+  });
+
+  type RangeBatch = {
+    type: 'session_messages_range_batch';
+    payload: {
+      sessionId: string;
+      messages: Array<Record<string, unknown>>;
+      firstSeq: number;
+      lastSeq: number;
+      truncated: boolean;
+    };
+  };
+
+  /** Build a `LoggedMessage`-shaped entry from a partial. */
+  function entry(seq: number, type = 'agent_message', payload: Record<string, unknown> = {}): {
+    seq: number;
+    type: string;
+    payload: string;
+    ts: string;
+  } {
+    return {
+      seq,
+      type,
+      payload: JSON.stringify({ type, payload, ...payload }),
+      ts: '2026-01-01T00:00:00Z',
+    };
+  }
+
+  /**
+   * Stand up a connected RelayClient with the consumer device already
+   * registered (so `consumerKeys` is populated and outbound unicasts succeed).
+   * Returns helpers to inject a range request and read back the resulting batch.
+   */
+  function connectWithConsumer() {
+    const adapter = createAdapter();
+    const sm = createSessionManager();
+    const keyManager = {
+      getCompactPublicKey: vi.fn(() => 'tentacle-pub'),
+      getKeyPair: vi.fn(() => ({ privateKey: 'tentacle-priv', publicKey: 'tentacle-pub' })),
+    };
+    const client = new RelayClient(
+      adapter,
+      sm,
+      {
+        relayUrl: 'ws://localhost:4000',
+        authMethod: 'open',
+        device: { name: 'Test', role: 'tentacle', deviceId: 'tentacle-dev' },
+        reconnectDelay: 10,
+      },
+      keyManager,
+    );
+    client.connect();
+    const ws = sockets[0];
+    ws.emit('open');
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'auth_ok',
+      deviceId: 'tentacle-dev',
+      authMethod: 'open',
+      user: { id: 'u1', login: 'test', provider: 'local' },
+      devices: [],
+    })));
+    // Register a consumer device — this is what populates `consumerKeys`.
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'device_joined',
+      device: { id: 'consumer-dev', role: 'app', encryptionKey: 'consumer-pub' },
+    })));
+
+    /** Inject a `request_session_messages_range` from the consumer. */
+    function sendRangeRequest(sessionId: string, fromSeq: number, toSeq: number): void {
+      ws.sent.length = 0;
+      const inner = JSON.stringify({
+        type: 'request_session_messages_range',
+        deviceId: 'consumer-dev',
+        seq: 1,
+        timestamp: new Date().toISOString(),
+        payload: { sessionId, fromSeq, toSeq },
+      });
+      ws.emit('message', Buffer.from(JSON.stringify({
+        type: 'unicast',
+        to: 'tentacle-dev',
+        blob: inner,
+        keys: {},
+      })));
+    }
+
+    /** Find the single range-batch reply produced by the last request. */
+    function lastRangeBatch(): RangeBatch | undefined {
+      for (const raw of ws.sent) {
+        const env = JSON.parse(raw);
+        if (env.type !== 'unicast' || env.to !== 'consumer-dev') continue;
+        const inner = JSON.parse(env.blob as string);
+        if (inner.type === 'session_messages_range_batch') return inner as RangeBatch;
+      }
+      return undefined;
+    }
+
+    return { adapter, sm, client, ws, sendRangeRequest, lastRangeBatch };
+  }
+
+  it('returns the requested inclusive seq range', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 100 });
+    // getMessagesAfterSeq is called with `lo - 1`; return seqs 5..10 so the
+    // hi-side filter `e.seq <= 10` keeps all of them.
+    smMock.getMessagesAfterSeq.mockReturnValue([
+      entry(5), entry(6), entry(7), entry(8), entry(9), entry(10),
+    ]);
+
+    sendRangeRequest('s1', 5, 10);
+    const batch = lastRangeBatch();
+
+    expect(smMock.getMessagesAfterSeq).toHaveBeenCalledWith('s1', 4);
+    expect(batch).toBeDefined();
+    expect(batch!.payload.sessionId).toBe('s1');
+    expect(batch!.payload.messages.map(m => m.seq)).toEqual([5, 6, 7, 8, 9, 10]);
+    expect(batch!.payload.firstSeq).toBe(5);
+    expect(batch!.payload.lastSeq).toBe(10);
+    expect(batch!.payload.truncated).toBe(false);
+  });
+
+  it('drops entries past the requested toSeq', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 100 });
+    smMock.getMessagesAfterSeq.mockReturnValue([
+      entry(5), entry(6), entry(7), entry(8), entry(9), entry(10),
+    ]);
+
+    sendRangeRequest('s1', 5, 7);
+    const batch = lastRangeBatch()!;
+
+    expect(batch.payload.messages.map(m => m.seq)).toEqual([5, 6, 7]);
+    expect(batch.payload.lastSeq).toBe(7);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('clamps fromSeq below 1 up to 1', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 100 });
+    smMock.getMessagesAfterSeq.mockReturnValue([entry(1), entry(2), entry(3)]);
+
+    sendRangeRequest('s1', -5, 3);
+
+    expect(smMock.getMessagesAfterSeq).toHaveBeenCalledWith('s1', 0);
+    const batch = lastRangeBatch()!;
+    expect(batch.payload.firstSeq).toBe(1);
+    expect(batch.payload.lastSeq).toBe(3);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('clamps toSeq above headSeq down to headSeq', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 7 });
+    smMock.getMessagesAfterSeq.mockReturnValue([
+      entry(5), entry(6), entry(7),
+    ]);
+
+    sendRangeRequest('s1', 5, 9999);
+    const batch = lastRangeBatch()!;
+
+    expect(batch.payload.messages.map(m => m.seq)).toEqual([5, 6, 7]);
+    expect(batch.payload.lastSeq).toBe(7);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('returns empty batch when session is unknown', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue(null);
+
+    sendRangeRequest('missing', 1, 10);
+    const batch = lastRangeBatch()!;
+
+    expect(smMock.getMessagesAfterSeq).not.toHaveBeenCalled();
+    expect(batch.payload.messages).toHaveLength(0);
+    expect(batch.payload.firstSeq).toBe(0);
+    expect(batch.payload.lastSeq).toBe(0);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('returns empty batch when fromSeq exceeds headSeq', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 10 });
+
+    sendRangeRequest('s1', 50, 100);
+    const batch = lastRangeBatch()!;
+
+    expect(batch.payload.messages).toHaveLength(0);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('returns empty batch when fromSeq > toSeq after clamping', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 100 });
+
+    sendRangeRequest('s1', 30, 20);
+    const batch = lastRangeBatch()!;
+
+    expect(batch.payload.messages).toHaveLength(0);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('returns empty batch for NaN / non-finite inputs', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 100 });
+
+    sendRangeRequest('s1', Number.NaN, 10);
+    const batch = lastRangeBatch()!;
+
+    expect(batch.payload.messages).toHaveLength(0);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('truncates at the cap, keeping the newer end', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 5000 });
+
+    // Request 1..1000 (range = 1000 > cap 500). Handler should bump lo to
+    // hi - 500 + 1 = 501. We assert getMessagesAfterSeq was called with 500.
+    // Provide returned entries to span the kept range so the batch shape is
+    // verifiable: 501..1000 (500 entries).
+    const kept = Array.from({ length: 500 }, (_, i) => entry(501 + i));
+    smMock.getMessagesAfterSeq.mockReturnValue(kept);
+
+    sendRangeRequest('s1', 1, 1000);
+
+    expect(smMock.getMessagesAfterSeq).toHaveBeenCalledWith('s1', 500);
+    const batch = lastRangeBatch()!;
+    expect(batch.payload.firstSeq).toBe(501);
+    expect(batch.payload.lastSeq).toBe(1000);
+    expect(batch.payload.messages).toHaveLength(500);
+    expect(batch.payload.truncated).toBe(true);
+  });
+
+  it('does not truncate when range exactly equals the cap', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 5000 });
+
+    // Range = 500 exactly (1..500) — boundary case.
+    const kept = Array.from({ length: 500 }, (_, i) => entry(1 + i));
+    smMock.getMessagesAfterSeq.mockReturnValue(kept);
+
+    sendRangeRequest('s1', 1, 500);
+
+    expect(smMock.getMessagesAfterSeq).toHaveBeenCalledWith('s1', 0);
+    const batch = lastRangeBatch()!;
+    expect(batch.payload.messages).toHaveLength(500);
+    expect(batch.payload.truncated).toBe(false);
+  });
+
+  it('filters out non-persistent types defensively', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 100 });
+    // Pretend an older log accidentally has a transient type with a seq —
+    // the handler should skip it (parity with handleSessionMessages).
+    smMock.getMessagesAfterSeq.mockReturnValue([
+      entry(5, 'agent_message'),
+      entry(6, 'agent_message_delta'), // transient — should be dropped
+      entry(7, 'agent_message'),
+    ]);
+
+    sendRangeRequest('s1', 5, 7);
+    const batch = lastRangeBatch()!;
+
+    expect(batch.payload.messages.map(m => m.seq)).toEqual([5, 7]);
+    // firstSeq / lastSeq reflect what's actually returned post-filter.
+    expect(batch.payload.firstSeq).toBe(5);
+    expect(batch.payload.lastSeq).toBe(7);
+  });
+
+  it('floors fractional seq inputs', () => {
+    const { sm, sendRangeRequest, lastRangeBatch } = connectWithConsumer();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 's1', lastSeq: 100 });
+    smMock.getMessagesAfterSeq.mockReturnValue([entry(5), entry(6), entry(7)]);
+
+    sendRangeRequest('s1', 5.9, 7.9);
+
+    // 5.9 → 5 (lo - 1 = 4), 7.9 → 7
+    expect(smMock.getMessagesAfterSeq).toHaveBeenCalledWith('s1', 4);
+    const batch = lastRangeBatch()!;
+    expect(batch.payload.messages.map(m => m.seq)).toEqual([5, 6, 7]);
   });
 });

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -15,6 +15,7 @@ import type {
   DeviceInfo, AuthOkMessage, AuthErrorMessage, DeviceSummary, AuthMethod,
   BroadcastEnvelope, UnicastEnvelope,
 } from '@kraki/protocol';
+import { SESSION_MESSAGES_RANGE_MAX_COUNT } from '@kraki/protocol';
 import { importPublicKey, encryptToBlob, decryptFromBlob, signChallenge } from '@kraki/crypto';
 import type { RecipientKey } from '@kraki/crypto';
 import type { AgentAdapter } from './adapters/base.js';
@@ -546,6 +547,12 @@ export class RelayClient {
     // request_session_messages — turn-aware paginated replay
     if (msg.type === 'request_session_messages') {
       this.handleSessionMessages(msg.deviceId, msg.payload.sessionId, msg.payload.beforeSeq);
+      return;
+    }
+
+    // request_session_messages_range — exact seq-range fetch (gap recovery, range queries)
+    if (msg.type === 'request_session_messages_range') {
+      this.handleSessionMessagesRange(msg.deviceId, msg.payload.sessionId, msg.payload.fromSeq, msg.payload.toSeq);
       return;
     }
 
@@ -1586,6 +1593,109 @@ export class RelayClient {
     logger.info(
       { requesterDeviceId, sessionId, beforeSeq, startSeq, endSeqInclusive, count: parsed.length },
       'Replied to turn-aware session messages request',
+    );
+    this.sendUnicastTo(requesterDeviceId, requesterKey, batchMsg);
+  }
+
+  /**
+   * Handle an exact seq-range messages request.
+   *
+   * Used for gap recovery (push delivered a seq jump and the arm wants
+   * to fill the missing seqs) and for range queries (web's IndexedDB
+   * cache filling holes). Distinct from `handleSessionMessages` —
+   * range queries are NOT turn-aligned and return exactly the seqs
+   * requested, subject to defensive clamping.
+   *
+   * Robustness contract:
+   *  - `fromSeq < 1`     → clamped to 1
+   *  - `toSeq > headSeq` → clamped to headSeq (informational, not lossy)
+   *  - `fromSeq > toSeq` (post-clamp) → empty batch, truncated=false
+   *  - range > SESSION_MESSAGES_RANGE_MAX_COUNT → keep newer end,
+   *    `truncated: true` so caller can iterate for older seqs
+   *  - session not found → empty batch, truncated=false
+   */
+  private handleSessionMessagesRange(
+    requesterDeviceId: string,
+    sessionId: string,
+    fromSeq: number,
+    toSeq: number,
+  ): void {
+    const requesterKey = this.consumerKeys.get(requesterDeviceId);
+    if (!requesterKey) {
+      logger.warn({ requesterDeviceId }, 'Session messages range requested but no encryption key for requester');
+      return;
+    }
+
+    const sendEmpty = (): void => {
+      this.sendUnicastTo(requesterDeviceId, requesterKey, {
+        type: 'session_messages_range_batch',
+        deviceId: this.authInfo?.deviceId ?? '',
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: { sessionId, messages: [], firstSeq: 0, lastSeq: 0, truncated: false },
+      });
+    };
+
+    const meta = this.sessionManager.getMeta(sessionId);
+    if (!meta) {
+      logger.info({ requesterDeviceId, sessionId, fromSeq, toSeq }, 'Range request for unknown session — empty reply');
+      sendEmpty();
+      return;
+    }
+
+    const headSeq = meta.lastSeq ?? 0;
+
+    // Sanitize bounds — never trust client input.
+    let lo = Math.max(1, Math.floor(fromSeq));
+    let hi = Math.min(headSeq, Math.floor(toSeq));
+
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo > hi) {
+      logger.info({ requesterDeviceId, sessionId, fromSeq, toSeq, lo, hi, headSeq }, 'Range request empty after clamping');
+      sendEmpty();
+      return;
+    }
+
+    // Server-side hard cap — keep newer end so client can iterate older.
+    let truncated = false;
+    if (hi - lo + 1 > SESSION_MESSAGES_RANGE_MAX_COUNT) {
+      lo = hi - SESSION_MESSAGES_RANGE_MAX_COUNT + 1;
+      truncated = true;
+    }
+
+    const logged = this.sessionManager
+      .getMessagesAfterSeq(sessionId, lo - 1)
+      .filter(e => e.seq <= hi);
+
+    const parsed: Array<Record<string, unknown>> = [];
+    for (const entry of logged) {
+      // Defensive: only PERSISTENT_TYPES ever get a seq, but older logs
+      // may contain stragglers. Keep parity with handleSessionMessages.
+      if (!RelayClient.PERSISTENT_TYPES.has(entry.type)) continue;
+      try {
+        const m = JSON.parse(entry.payload);
+        m.seq = entry.seq;
+        parsed.push(m);
+      } catch {
+        logger.warn({ seq: entry.seq, sessionId }, 'Failed to parse session message for range batch');
+      }
+    }
+
+    const batchMsg = {
+      type: 'session_messages_range_batch',
+      deviceId: this.authInfo?.deviceId ?? '',
+      seq: ++this.seqCounter,
+      timestamp: new Date().toISOString(),
+      payload: {
+        sessionId,
+        messages: parsed,
+        firstSeq: parsed.length > 0 ? (parsed[0].seq as number) : 0,
+        lastSeq: parsed.length > 0 ? ((parsed.at(-1) as Record<string, unknown>).seq as number) : 0,
+        truncated,
+      },
+    };
+    logger.info(
+      { requesterDeviceId, sessionId, fromSeq, toSeq, lo, hi, headSeq, count: parsed.length, truncated },
+      'Replied to range session messages request',
     );
     this.sendUnicastTo(requesterDeviceId, requesterKey, batchMsg);
   }

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -15,7 +15,6 @@ import type {
   DeviceInfo, AuthOkMessage, AuthErrorMessage, DeviceSummary, AuthMethod,
   BroadcastEnvelope, UnicastEnvelope,
 } from '@kraki/protocol';
-import { SESSION_MESSAGES_RANGE_MAX_COUNT } from '@kraki/protocol';
 import { importPublicKey, encryptToBlob, decryptFromBlob, signChallenge } from '@kraki/crypto';
 import type { RecipientKey } from '@kraki/crypto';
 import type { AgentAdapter } from './adapters/base.js';
@@ -1598,6 +1597,14 @@ export class RelayClient {
   }
 
   /**
+   * Server-side hard cap on messages returned by a single
+   * `request_session_messages_range` reply. Defensive backstop —
+   * clients should chunk their own requests well below this. When
+   * the cap triggers, the reply's `truncated` flag is set.
+   */
+  private static readonly RANGE_MAX_COUNT = 500;
+
+  /**
    * Handle an exact seq-range messages request.
    *
    * Used for gap recovery (push delivered a seq jump and the arm wants
@@ -1610,8 +1617,8 @@ export class RelayClient {
    *  - `fromSeq < 1`     → clamped to 1
    *  - `toSeq > headSeq` → clamped to headSeq (informational, not lossy)
    *  - `fromSeq > toSeq` (post-clamp) → empty batch, truncated=false
-   *  - range > SESSION_MESSAGES_RANGE_MAX_COUNT → keep newer end,
-   *    `truncated: true` so caller can iterate for older seqs
+   *  - range > `RANGE_MAX_COUNT` → keep newer end, `truncated: true`
+   *    so caller can iterate for older seqs
    *  - session not found → empty batch, truncated=false
    */
   private handleSessionMessagesRange(
@@ -1657,8 +1664,8 @@ export class RelayClient {
 
     // Server-side hard cap — keep newer end so client can iterate older.
     let truncated = false;
-    if (hi - lo + 1 > SESSION_MESSAGES_RANGE_MAX_COUNT) {
-      lo = hi - SESSION_MESSAGES_RANGE_MAX_COUNT + 1;
+    if (hi - lo + 1 > RelayClient.RANGE_MAX_COUNT) {
+      lo = hi - RelayClient.RANGE_MAX_COUNT + 1;
       truncated = true;
     }
 


### PR DESCRIPTION
## What

Adds a third session-message fetch endpoint to tentacle:
- existing **`request_session_ turn-aligned, pagination by `beforeSeq`, current iOS history fetchmessages`** 
- existing **`request_session_ deprecated but still used by web's `MessageProvider.fetchRange` for range queries (keeping for now)replay`** 
- new **`request_session_messages_ exact `(fromSeq, toSeq)` inclusive interval fetch (this PR)range`** 

## Why

Two consumers need exact-range fetches that neither existing endpoint serves cleanly:

1. **iOS gap recovery (motivating case).** When a push arrives with `seq > store.lastSeq + 1`, we today have no compensating  we either request the latest turn (loses older missing seqs) or refuse to insert (creates a hole). The new endpoint lets the arm fetch exactly the missing `(store.lastSeq + 1, push.seq - 1)` interval, no turn realignment, no over-fetch.fetch 
2. **Web range-query migration target.** `MessageProvider.fetchRange` currently leans on `request_session_replay`. Once this lands, web can migrate to a non-deprecated, well-defined endpoint and we can finally retire `request_session_replay`. (Migration happens in a follow-up PR.)

## Protocol

```ts
// @kraki/protocol
export const SESSION_MESSAGES_RANGE_MAX_COUNT = 500;

interface RequestSessionMessagesRangeMessage {
  type: 'request_session_messages_range';
  payload: { sessionId; fromSeq; toSeq }; // both inclusive
}

interface SessionMessagesRangeBatchMessage {
  type: 'session_messages_range_batch';
  payload: {
    sessionId;
    messages;     // PERSISTENT_TYPES only, each with .seq
    firstSeq;     // 0 when messages empty
    lastSeq;      // 0 when messages empty
    truncated;    // true iff server hit the 500-row cap
  };
}
```

Design decisions worth flagging (all settled in discussion):
- **Interval-based** `(fromSeq, toSeq)` not `(afterSeq,  matches the gap-recovery use case where the caller already knows both endpoints.limit)` 
- **Client-driven pagination.** No `pageSize` request parameter. The 500-row cap is a defensive backstop; iOS will hard-code a page size of 200 client-side and iterate.
- **`truncated` semantics.** When the requested range exceeds the cap, the handler keeps the **newer** end and sets `truncated: true`, so the caller's next page request shifts toward older seqs naturally.
- **No `coveredFromSeq` ambiguity.** Per-session seqs are strictly contiguous (`appendMessage` does `meta.lastSeq + 1`) and only `PERSISTENT_TYPES` ever get a seq (gated at `relay-client.ts:1780`). So `firstSeq`/`lastSeq` of the returned messages always exactly describe what was  "truncated && empty" is impossible.scanned 

## Robustness contract

The handler is defensive about  never trust the consumer:input 

| Input | Behavior |
|---|---|
| `fromSeq < 1` | clamp to 1 |
| `toSeq > headSeq` | clamp to `headSeq` |
| `fromSeq > toSeq` (post-clamp) | empty batch, `truncated: false` |
| `hi - lo + 1 > 500` | keep newer end, `truncated: true` |
| unknown sessionId | empty batch |
| NaN / non-finite | empty batch |
| transient type with a seq (older logs) | filtered out |
| fractional seq | `Math.floor` |
| per-line JSON parse error | logged, skipped |

## Tests

12 new unit tests in `relay-client.test.ts` cover every row above plus the boundary case `range == 500`. All 515 tentacle tests pass (was 503).

## Out of scope (follow-up PRs)

- **iOS gap-recovery integration** in `MessageProvider. uses `RANGE_PAGE = 200`, threshold to decide range-fetch vs `requestLatest`.observeLiveMessageSeq` 
 `request_session_messages_range`.
- **Retiring `request_session_replay`** once both arms have cut over.
