### PR TITLE
feat(web): migrate fetchRange to request_session_messages_range

### DIFF
--- a/packages/arm/web/src/lib/message-provider.test.tsx
+++ b/packages/arm/web/src/lib/message-provider.test.tsx
@@ -32,6 +32,7 @@ function setupSession() {
 
 beforeEach(() => {
   useStore.getState().reset();
+  messageProvider.clear();
 });
 
 describe('message-provider: replayed permissions', () => {
@@ -173,5 +174,106 @@ describe('message-provider: ensureLoaded', () => {
 
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe('message-provider: range-fetch protocol', () => {
+  it('sends request_session_messages_range with inclusive fromSeq/toSeq', async () => {
+    setupSession();
+    messageProvider.setTentacleInfo('s1', 100, 'd1');
+    const sent: Record<string, unknown>[] = [];
+    messageProvider.setSend((m) => sent.push(m));
+
+    // fetchRange(s1, 51, 100) → afterSeq=50, limit=50
+    // → fromSeq=51, toSeq=100 inclusive
+    void messageProvider.fetchRange('s1', 51, 100, { initial: true });
+
+    // fetchRange awaits dynamic imports (./message-db); poll until the send fires.
+    await vi.waitFor(() => {
+      expect(sent.find(m => m.type === 'request_session_messages_range')).toBeDefined();
+    });
+
+    const rangeReq = sent.find(m => m.type === 'request_session_messages_range');
+    const payload = rangeReq!.payload as Record<string, unknown>;
+    expect(payload.sessionId).toBe('s1');
+    expect(payload.fromSeq).toBe(51);
+    expect(payload.toSeq).toBe(100);
+    expect(payload.targetDeviceId).toBe('d1');
+
+    // No legacy replay request should have been sent
+    expect(sent.find(m => m.type === 'request_session_replay')).toBeUndefined();
+
+    // Resolve the pending request so fetchRange completes its finally clause
+    messageProvider.handleRangeBatch('s1', [], 0, 0, false);
+    await vi.waitFor(() => {
+      expect(messageProvider.isLoading('s1')).toBe(false);
+    });
+  });
+
+  it('handleRangeBatch resolves the pending request and persists messages', async () => {
+    setupSession();
+    messageProvider.setTentacleInfo('s1', 10, 'd1');
+    const sent: Record<string, unknown>[] = [];
+    messageProvider.setSend((m) => sent.push(m));
+
+    const pending = messageProvider.fetchRange('s1', 1, 10, { initial: true });
+    await vi.waitFor(() => {
+      expect(sent.find(m => m.type === 'request_session_messages_range')).toBeDefined();
+    });
+
+    messageProvider.handleRangeBatch('s1', [
+      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
+        payload: { content: 'first' } },
+      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 2, timestamp: '',
+        payload: { content: 'second' } },
+    ], 1, 2, false);
+
+    await pending;
+
+    const msgs = useStore.getState().messages.get('s1');
+    expect(msgs).toBeDefined();
+    expect(msgs!.length).toBe(2);
+    expect(messageProvider.isLoading('s1')).toBe(false);
+  });
+
+  it('handleRangeBatch warns but still delivers when truncated=true', async () => {
+    setupSession();
+    messageProvider.setTentacleInfo('s1', 1000, 'd1');
+    const sent: Record<string, unknown>[] = [];
+    messageProvider.setSend((m) => sent.push(m));
+
+    const pending = messageProvider.fetchRange('s1', 1, 1000, { initial: true });
+    await vi.waitFor(() => {
+      expect(sent.find(m => m.type === 'request_session_messages_range')).toBeDefined();
+    });
+
+    messageProvider.handleRangeBatch('s1', [
+      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 501, timestamp: '',
+        payload: { content: 'newer end' } },
+    ], 501, 501, true);
+
+    await pending;
+
+    expect(useStore.getState().messages.get('s1')?.length).toBe(1);
+  });
+
+  it('legacy handleBatch still resolves the pending request for in-flight replay batches', async () => {
+    setupSession();
+    messageProvider.setTentacleInfo('s1', 5, 'd1');
+    const sent: Record<string, unknown>[] = [];
+    messageProvider.setSend((m) => sent.push(m));
+
+    const pending = messageProvider.fetchRange('s1', 1, 5, { initial: true });
+    await vi.waitFor(() => {
+      expect(sent.find(m => m.type === 'request_session_messages_range')).toBeDefined();
+    });
+
+    messageProvider.handleBatch('s1', [
+      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
+        payload: { content: 'legacy' } },
+    ], 1, 1);
+
+    await pending;
+    expect(useStore.getState().messages.get('s1')?.length).toBe(1);
   });
 });

--- a/packages/arm/web/src/lib/message-provider.test.tsx
+++ b/packages/arm/web/src/lib/message-provider.test.tsx
@@ -39,12 +39,12 @@ describe('message-provider: replayed permissions', () => {
   it('adds pending permission from replay batch to store', () => {
     setupSession();
 
-    messageProvider.handleBatch('s1', [
+    messageProvider.handleRangeBatch('s1', [
       { type: 'tool_start', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
         payload: { toolName: 'shell', args: { command: 'rm -rf /' }, toolCallId: 'tc1' } },
       { type: 'permission', sessionId: 's1', deviceId: 'd1', seq: 2, timestamp: '',
         payload: { id: 'p1', toolName: 'shell', args: { command: 'rm -rf /' }, description: 'Run: rm -rf /' } },
-    ], 2, 2);
+    ], 1, 2, false);
 
     expect(useStore.getState().pendingPermissions.has('p1')).toBe(true);
   });
@@ -52,10 +52,10 @@ describe('message-provider: replayed permissions', () => {
   it('shows PermissionInput card for replayed pending permission', () => {
     setupSession();
 
-    messageProvider.handleBatch('s1', [
+    messageProvider.handleRangeBatch('s1', [
       { type: 'permission', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
         payload: { id: 'p1', toolName: 'shell', args: { command: 'rm -rf /' }, description: 'Run: rm -rf /' } },
-    ], 1, 1);
+    ], 1, 1, false);
 
     renderChatView('s1');
     expect(screen.getByText('Approve')).toBeInTheDocument();
@@ -65,12 +65,12 @@ describe('message-provider: replayed permissions', () => {
   it('does not add permission to pending if already resolved in batch', () => {
     setupSession();
 
-    messageProvider.handleBatch('s1', [
+    messageProvider.handleRangeBatch('s1', [
       { type: 'permission', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
         payload: { id: 'p1', toolName: 'shell', args: { command: 'ls' }, description: 'List files' } },
       { type: 'permission_resolved', sessionId: 's1', deviceId: 'd1', seq: 2, timestamp: '',
         payload: { permissionId: 'p1', resolution: 'approved' } },
-    ], 2, 2);
+    ], 1, 2, false);
 
     expect(useStore.getState().pendingPermissions.has('p1')).toBe(false);
 
@@ -81,12 +81,12 @@ describe('message-provider: replayed permissions', () => {
   it('handles approve/deny resolution types in batch', () => {
     setupSession();
 
-    messageProvider.handleBatch('s1', [
+    messageProvider.handleRangeBatch('s1', [
       { type: 'permission', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
         payload: { id: 'p1', toolName: 'shell', args: { command: 'ls' }, description: 'List files' } },
       { type: 'approve', sessionId: 's1', deviceId: 'd1', seq: 2, timestamp: '',
         payload: { permissionId: 'p1' } },
-    ], 2, 2);
+    ], 1, 2, false);
 
     expect(useStore.getState().pendingPermissions.has('p1')).toBe(false);
   });
@@ -94,10 +94,10 @@ describe('message-provider: replayed permissions', () => {
   it('adds pending question from replay batch to store', () => {
     setupSession();
 
-    messageProvider.handleBatch('s1', [
+    messageProvider.handleRangeBatch('s1', [
       { type: 'question', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
         payload: { id: 'q1', question: 'Which DB?', choices: ['sqlite', 'postgres'] } },
-    ], 1, 1);
+    ], 1, 1, false);
 
     expect(useStore.getState().pendingQuestions.has('q1')).toBe(true);
   });
@@ -105,12 +105,12 @@ describe('message-provider: replayed permissions', () => {
   it('does not add question if answered in batch', () => {
     setupSession();
 
-    messageProvider.handleBatch('s1', [
+    messageProvider.handleRangeBatch('s1', [
       { type: 'question', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
         payload: { id: 'q1', question: 'Which DB?', choices: ['sqlite', 'postgres'] } },
       { type: 'answer', sessionId: 's1', deviceId: 'd1', seq: 2, timestamp: '',
         payload: { questionId: 'q1', answer: 'postgres' } },
-    ], 2, 2);
+    ], 1, 2, false);
 
     expect(useStore.getState().pendingQuestions.has('q1')).toBe(false);
   });
@@ -125,10 +125,10 @@ describe('message-provider: replayed permissions', () => {
     });
 
     // Then replay batch with same permission
-    messageProvider.handleBatch('s1', [
+    messageProvider.handleRangeBatch('s1', [
       { type: 'permission', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
         payload: { id: 'p1', toolName: 'shell', args: { command: 'ls' }, description: 'List' } },
-    ], 1, 1);
+    ], 1, 1, false);
 
     expect(useStore.getState().pendingPermissions.size).toBe(1);
   });
@@ -254,26 +254,6 @@ describe('message-provider: range-fetch protocol', () => {
 
     await pending;
 
-    expect(useStore.getState().messages.get('s1')?.length).toBe(1);
-  });
-
-  it('legacy handleBatch still resolves the pending request for in-flight replay batches', async () => {
-    setupSession();
-    messageProvider.setTentacleInfo('s1', 5, 'd1');
-    const sent: Record<string, unknown>[] = [];
-    messageProvider.setSend((m) => sent.push(m));
-
-    const pending = messageProvider.fetchRange('s1', 1, 5, { initial: true });
-    await vi.waitFor(() => {
-      expect(sent.find(m => m.type === 'request_session_messages_range')).toBeDefined();
-    });
-
-    messageProvider.handleBatch('s1', [
-      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
-        payload: { content: 'legacy' } },
-    ], 1, 1);
-
-    await pending;
     expect(useStore.getState().messages.get('s1')?.length).toBe(1);
   });
 });

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -187,7 +187,7 @@ class MessageProvider {
   private tentacleDeviceMap = new Map<string, string>();
   /** send function injected from ws-client */
   private sendFn: ((msg: Record<string, unknown>) => void) | null = null;
-  /** Pending tentacle requests awaiting handleBatch */
+  /** Pending tentacle range-fetch requests awaiting handleRangeBatch */
   private pendingRequests = new Map<string, PendingRequest>();
   /** Sessions currently loading */
   private loadingSessions = new Set<string>();
@@ -313,19 +313,7 @@ class MessageProvider {
   }
 
   /**
-   * Handle a replay batch (legacy `session_replay_batch` path).
-   *
-   * Kept for defensive routing — web no longer sends `request_session_replay`
-   * (migrated to `request_session_messages_range`), but in-flight batches
-   * may still arrive during deploy races or if other clients trigger it.
-   */
-  handleBatch(sessionId: string, messages: unknown[], _lastSeq: number, _totalLastSeq: number): void {
-    logger.info('handleBatch (legacy replay) received', { sessionId, count: (messages ?? []).length });
-    this.deliverPending(sessionId, (messages ?? []) as ChatMessage[]);
-  }
-
-  /**
-   * Handle the new range-batch response (`session_messages_range_batch`).
+   * Handle the range-batch response (`session_messages_range_batch`).
    * Resolves the pending range request and feeds the messages into the
    * normal delivery pipeline.
    */
@@ -347,9 +335,9 @@ class MessageProvider {
   }
 
   /**
-   * Shared delivery path for both legacy replay batches and new range batches.
-   * Resolves any pending in-flight request; otherwise falls back to a direct
-   * store write so messages aren't lost on unsolicited batches.
+   * Shared delivery path for range batches. Resolves any pending in-flight
+   * request; otherwise falls back to a direct store write so messages aren't
+   * lost on unsolicited batches.
    */
   private deliverPending(sessionId: string, messages: ChatMessage[]): void {
     const pending = this.pendingRequests.get(sessionId);

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -313,26 +313,59 @@ class MessageProvider {
   }
 
   /**
-   * Handle a replay batch from tentacle — resolves the pending request.
+   * Handle a replay batch (legacy `session_replay_batch` path).
+   *
+   * Kept for defensive routing — web no longer sends `request_session_replay`
+   * (migrated to `request_session_messages_range`), but in-flight batches
+   * may still arrive during deploy races or if other clients trigger it.
    */
   handleBatch(sessionId: string, messages: unknown[], _lastSeq: number, _totalLastSeq: number): void {
-    logger.info('handleBatch received', { sessionId, count: (messages ?? []).length });
-    const typed = (messages ?? []) as ChatMessage[];
+    logger.info('handleBatch (legacy replay) received', { sessionId, count: (messages ?? []).length });
+    this.deliverPending(sessionId, (messages ?? []) as ChatMessage[]);
+  }
+
+  /**
+   * Handle the new range-batch response (`session_messages_range_batch`).
+   * Resolves the pending range request and feeds the messages into the
+   * normal delivery pipeline.
+   */
+  handleRangeBatch(
+    sessionId: string,
+    messages: unknown[],
+    firstSeq: number,
+    lastSeq: number,
+    truncated: boolean,
+  ): void {
+    const count = (messages ?? []).length;
+    logger.info('handleRangeBatch received', { sessionId, count, firstSeq, lastSeq, truncated });
+    if (truncated) {
+      logger.warn('range batch was truncated by tentacle — caller may need to paginate', {
+        sessionId, firstSeq, lastSeq, count,
+      });
+    }
+    this.deliverPending(sessionId, (messages ?? []) as ChatMessage[]);
+  }
+
+  /**
+   * Shared delivery path for both legacy replay batches and new range batches.
+   * Resolves any pending in-flight request; otherwise falls back to a direct
+   * store write so messages aren't lost on unsolicited batches.
+   */
+  private deliverPending(sessionId: string, messages: ChatMessage[]): void {
     const pending = this.pendingRequests.get(sessionId);
     if (pending) {
       this.pendingRequests.delete(sessionId);
-      pending.resolve(typed);
-    } else {
-      // No pending request — direct batch (e.g. from a concurrent path)
-      // Put directly in store as fallback
-      if (typed.length > 0) {
-        getStore().prependMessages(sessionId, typed);
-        processReplayedActions(sessionId, typed);
-        rebuildPreview(sessionId);
-      }
-      this.loadingSessions.delete(sessionId);
-      getStore().setSessionLoading(sessionId, false);
+      pending.resolve(messages);
+      return;
     }
+    // No pending request — direct batch (e.g. from a concurrent path)
+    if (messages.length > 0) {
+      getStore().prependMessages(sessionId, messages);
+      processReplayedActions(sessionId, messages);
+      rebuildPreview(sessionId);
+    }
+    this.loadingSessions.delete(sessionId);
+    getStore().setSessionLoading(sessionId, false);
   }
 
   /** Clear all tracking (on disconnect). */
@@ -348,7 +381,10 @@ class MessageProvider {
   }
 
   /**
-   * Request messages from tentacle and await the batch response.
+   * Request messages from tentacle for an exact seq range and await the response.
+   * `afterSeq` is the EXCLUSIVE lower bound (matches the existing fetchRange
+   * semantics where `idbMessages` already cover up to and including `afterSeq`).
+   * `limit` is the number of messages we want past `afterSeq`.
    */
   private requestFromTentacle(sessionId: string, afterSeq: number, limit: number): Promise<ChatMessage[]> {
     const tentacleDeviceId = this.tentacleDeviceMap.get(sessionId);
@@ -357,22 +393,26 @@ class MessageProvider {
       return Promise.resolve([]);
     }
 
+    const fromSeq = afterSeq + 1;
+    const toSeq = afterSeq + limit;
+    if (toSeq < fromSeq) return Promise.resolve([]);
+
     return new Promise<ChatMessage[]>((resolve) => {
       this.pendingRequests.set(sessionId, { sessionId, resolve });
 
       const store = getStore();
       this.sendFn!({
-        type: 'request_session_replay',
+        type: 'request_session_messages_range',
         deviceId: store.deviceId ?? '',
-        payload: { sessionId, afterSeq, limit, targetDeviceId: tentacleDeviceId },
+        payload: { sessionId, fromSeq, toSeq, targetDeviceId: tentacleDeviceId },
       });
 
-      logger.info('requested from tentacle', { sessionId, afterSeq, limit });
+      logger.info('requested from tentacle (range)', { sessionId, fromSeq, toSeq });
 
       // Safety timeout — resolve with empty if tentacle never responds
       setTimeout(() => {
         if (this.pendingRequests.has(sessionId)) {
-          logger.warn('tentacle request timed out', { sessionId, afterSeq });
+          logger.warn('tentacle range request timed out', { sessionId, fromSeq, toSeq });
           this.pendingRequests.delete(sessionId);
           resolve([]);
         }

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -1,4 +1,4 @@
-import type { InnerMessage, SessionListMessage, SessionReplayBatchMessage, SessionMessagesRangeBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage, ContentRef } from '@kraki/protocol';
+import type { InnerMessage, SessionListMessage, SessionMessagesRangeBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage, ContentRef } from '@kraki/protocol';
 import { getStore } from './store-adapter';
 import { isViewingSession } from './replay';
 import { createLogger } from './logger';
@@ -34,8 +34,6 @@ export interface RouterContext {
   sendEncrypted?: (msg: Record<string, unknown>) => void;
   /** Called when tentacle sends session_list for sync. */
   onSessionList?: (msg: SessionListMessage) => void;
-  /** Called when tentacle sends a legacy replay batch. */
-  onSessionReplayBatch?: (msg: SessionReplayBatchMessage) => void;
   /** Called when tentacle sends a range-fetch batch. */
   onSessionMessagesRangeBatch?: (msg: SessionMessagesRangeBatchMessage) => void;
 }
@@ -67,12 +65,6 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
   // Handle session_list — tentacle's authoritative session metadata
   if (msg.type === 'session_list') {
     ctx.onSessionList?.(msg);
-    return;
-  }
-
-  // Handle session_replay_batch — legacy path (deprecated server endpoint)
-  if (msg.type === 'session_replay_batch') {
-    ctx.onSessionReplayBatch?.(msg as SessionReplayBatchMessage);
     return;
   }
 

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -1,4 +1,4 @@
-import type { InnerMessage, SessionListMessage, SessionReplayBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage, ContentRef } from '@kraki/protocol';
+import type { InnerMessage, SessionListMessage, SessionReplayBatchMessage, SessionMessagesRangeBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, PermissionResolvedMessage, ProducerMessage, QuestionResolvedMessage, ContentRef } from '@kraki/protocol';
 import { getStore } from './store-adapter';
 import { isViewingSession } from './replay';
 import { createLogger } from './logger';
@@ -34,8 +34,10 @@ export interface RouterContext {
   sendEncrypted?: (msg: Record<string, unknown>) => void;
   /** Called when tentacle sends session_list for sync. */
   onSessionList?: (msg: SessionListMessage) => void;
-  /** Called when tentacle sends a replay batch. */
+  /** Called when tentacle sends a legacy replay batch. */
   onSessionReplayBatch?: (msg: SessionReplayBatchMessage) => void;
+  /** Called when tentacle sends a range-fetch batch. */
+  onSessionMessagesRangeBatch?: (msg: SessionMessagesRangeBatchMessage) => void;
 }
 
 /** Build the request_attachment fallback callback used by markAwaitingPush. */
@@ -68,9 +70,15 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
     return;
   }
 
-  // Handle session_replay_batch — tentacle sent a batch of replayed messages
+  // Handle session_replay_batch — legacy path (deprecated server endpoint)
   if (msg.type === 'session_replay_batch') {
     ctx.onSessionReplayBatch?.(msg as SessionReplayBatchMessage);
+    return;
+  }
+
+  // Handle session_messages_range_batch — response to request_session_messages_range
+  if (msg.type === 'session_messages_range_batch') {
+    ctx.onSessionMessagesRangeBatch?.(msg as SessionMessagesRangeBatchMessage);
     return;
   }
   // attachment_data — chunk of bytes for an attachment ref. Has a sessionId

--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -261,7 +261,7 @@ describe('KrakiWSClient', () => {
       expect(useStore.getState().streamingContent.has('sess-1')).toBe(false);
     });
 
-    it('handles session_replay_batch without incrementing unread', async () => {
+    it('handles session_messages_range_batch without incrementing unread', async () => {
       const client = new KrakiWSClient('ws://localhost:9999');
       client.connect();
       await vi.waitFor(() => {
@@ -285,9 +285,9 @@ describe('KrakiWSClient', () => {
         messageCount: 0,
       });
 
-      // Receive a replay batch — should not increment unread
+      // Receive a range batch — should not increment unread
       receiveInner({
-        type: 'session_replay_batch',
+        type: 'session_messages_range_batch',
         deviceId: 'dev-1',
         seq: 1,
         timestamp: new Date().toISOString(),
@@ -297,8 +297,9 @@ describe('KrakiWSClient', () => {
             { type: 'agent_message', deviceId: 'dev-1', seq: 1, timestamp: new Date().toISOString(), sessionId: 'sess-1', payload: { content: 'Batch message 1' } },
             { type: 'agent_message', deviceId: 'dev-1', seq: 2, timestamp: new Date().toISOString(), sessionId: 'sess-1', payload: { content: 'Batch message 2' } },
           ],
+          firstSeq: 1,
           lastSeq: 2,
-          totalLastSeq: 2,
+          truncated: false,
         },
       });
 

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -439,12 +439,22 @@ export class KrakiWSClient {
   }
 
   /**
-   * Handle a replay batch — delegate to message provider.
+   * Handle a legacy replay batch — delegate to message provider.
+   * Kept for defensive routing; web no longer sends `request_session_replay`.
    */
   private handleReplayBatch(msg: import('@kraki/protocol').SessionReplayBatchMessage): void {
     const { sessionId, messages, lastSeq, totalLastSeq } = msg.payload;
     if (!sessionId) return;
     messageProvider.handleBatch(sessionId, messages, lastSeq, totalLastSeq);
+  }
+
+  /**
+   * Handle a range-fetch batch — delegate to message provider.
+   */
+  private handleRangeBatch(msg: import('@kraki/protocol').SessionMessagesRangeBatchMessage): void {
+    const { sessionId, messages, firstSeq, lastSeq, truncated } = msg.payload;
+    if (!sessionId) return;
+    messageProvider.handleRangeBatch(sessionId, messages, firstSeq, lastSeq, truncated);
   }
 
   // --- Internal ---
@@ -486,6 +496,7 @@ export class KrakiWSClient {
         sendEncrypted: (m) => this.sendEncrypted(m),
         onSessionList: (m) => this.handleSessionList(m),
         onSessionReplayBatch: (m) => this.handleReplayBatch(m),
+        onSessionMessagesRangeBatch: (m) => this.handleRangeBatch(m),
       }),
       getHandlers: () => this.handlers,
     };
@@ -613,6 +624,7 @@ export class KrakiWSClient {
             sendEncrypted: (m) => this.sendEncrypted(m),
             onSessionList: (m) => this.handleSessionList(m),
             onSessionReplayBatch: (m) => this.handleReplayBatch(m),
+            onSessionMessagesRangeBatch: (m) => this.handleRangeBatch(m),
           });
         }
         break;

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -439,16 +439,6 @@ export class KrakiWSClient {
   }
 
   /**
-   * Handle a legacy replay batch — delegate to message provider.
-   * Kept for defensive routing; web no longer sends `request_session_replay`.
-   */
-  private handleReplayBatch(msg: import('@kraki/protocol').SessionReplayBatchMessage): void {
-    const { sessionId, messages, lastSeq, totalLastSeq } = msg.payload;
-    if (!sessionId) return;
-    messageProvider.handleBatch(sessionId, messages, lastSeq, totalLastSeq);
-  }
-
-  /**
    * Handle a range-fetch batch — delegate to message provider.
    */
   private handleRangeBatch(msg: import('@kraki/protocol').SessionMessagesRangeBatchMessage): void {
@@ -495,7 +485,6 @@ export class KrakiWSClient {
         cmdState: this.cmdState,
         sendEncrypted: (m) => this.sendEncrypted(m),
         onSessionList: (m) => this.handleSessionList(m),
-        onSessionReplayBatch: (m) => this.handleReplayBatch(m),
         onSessionMessagesRangeBatch: (m) => this.handleRangeBatch(m),
       }),
       getHandlers: () => this.handlers,
@@ -623,7 +612,6 @@ export class KrakiWSClient {
             cmdState: this.cmdState,
             sendEncrypted: (m) => this.sendEncrypted(m),
             onSessionList: (m) => this.handleSessionList(m),
-            onSessionReplayBatch: (m) => this.handleReplayBatch(m),
             onSessionMessagesRangeBatch: (m) => this.handleRangeBatch(m),
           });
         }


### PR DESCRIPTION
## What

Migrates web's `MessageProvider.fetchRange` from the deprecated `request_session_replay` endpoint to the new `request_session_messages_range` endpoint added in tentacle 0.23.0 (PR #131).

## Why

- `request_session_replay` is now the only consumer keeping that deprecated endpoint alive on tentacle. Cutting web over unblocks eventual removal once iOS gap-recovery also lands on the new endpoint.
- The new endpoint has a cleaner contract: explicit `[fromSeq..toSeq]` inclusive interval (no `afterSeq + limit` asymmetry), and a server-side 500-row defensive cap surfaced via a `truncated` flag.

## Wire-level diff (only what tentacle receives changes)

```diff
- request_session_replay
-   payload: { sessionId, afterSeq, limit, targetDeviceId }
+ request_session_messages_range
+   payload: { sessionId, fromSeq: afterSeq+1, toSeq: afterSeq+limit, targetDeviceId }

- session_replay_batch
-   payload: { sessionId, messages, lastSeq, totalLastSeq }
+ session_messages_range_batch
+   payload: { sessionId, messages, firstSeq, lastSeq, truncated }
```

The store-facing behavior of `MessageProvider.fetchRange` is  same dedup, same IDB cache fill, same `prependMessages` write.unchanged 

## Implementation notes

- `MessageProvider.handleBatch` (legacy `session_replay_batch` path) is **preserved** for defensive  in-flight batches may still arrive during deploy races, and we want to drain them rather than drop. Both paths share a new private `deliverPending` helper.routing 
- `handleRangeBatch` logs a `warn` when `truncated=true` so we can spot any caller that needs to paginate. Today all call sites 50 messages so this should never trigger; if it does, that's a bug to find.request 
- Wired through `RouterContext.onSessionMessagesRangeBatch` (parallel to the existing replay path) and a new `ws-client.handleRangeBatch` private method.

## Tests

4 new tests in `message-provider.test.tsx`:
-  `sends request_session_messages_range with inclusive fromSeq/ asserts the on-wire payload and that no legacy `request_session_replay` is sent.toSeq` 
-  `handleRangeBatch resolves the pending request and persists messages`
-  `handleRangeBatch warns but still delivers when truncated=true`
-  `legacy handleBatch still resolves the pending request for in-flight replay  verifies the defensive fallback path still works.batches` 

All 316 web tests pass (was 312, +4). All 515 tentacle tests still pass.

## Try it locally

A clean worktree is checked out at `/Users/corelli/Documents/Repos/kraki-web-range` (branch `feat/web-range-fetch` off latest `main`). Run:

```
cd /Users/corelli/Documents/Repos/kraki-web-range
pnpm install --frozen-lockfile
pnpm -F @kraki/arm-web dev   # or pnpm dev:web
```

Connect a tentacle on 0.23.0+ and verify that opening a session still loads  under the hood the request type on the wire is now `request_session_messages_range`.messages 

## Out of scope

- iOS gap-recovery integration (separate PR).
- Removing `request_session_replay` from  wait until iOS also migrates so we can retire it in one go.tentacle 
