### PR TITLE
fix: robust FDA probe with multiple TCC-gated paths

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/checks.test.ts
+++ b/packages/tentacle/src/__tests__/checks.test.ts
@@ -331,21 +331,28 @@ describe('ensureWindowsSystemPath()', () => {
 // ── probeFda() ──────────────────────────────────────────
 
 describe('probeFda()', () => {
-  it('returns granted when TCC.db is readable', async () => {
+  it('returns granted when any probe path is readable', async () => {
     mockAccess.mockResolvedValue(undefined);
     expect(await probeFda()).toBe('granted');
   });
 
-  it('returns denied when TCC.db returns EPERM', async () => {
+  it('returns denied when all probe paths return EPERM', async () => {
     mockAccess.mockRejectedValue(Object.assign(new Error('perm'), { code: 'EPERM' }));
     expect(await probeFda()).toBe('denied');
   });
 
-  it('returns missing when TCC.db does not exist', async () => {
-    mockExistsSync.mockImplementation((p: string) => {
-      if (typeof p === 'string' && p.includes('TCC.db')) return false;
-      return true;
+  it('returns granted if first path blocked but second readable', async () => {
+    let calls = 0;
+    mockAccess.mockImplementation(() => {
+      calls++;
+      if (calls === 1) return Promise.reject(Object.assign(new Error('perm'), { code: 'EPERM' }));
+      return Promise.resolve(undefined);
     });
+    expect(await probeFda()).toBe('granted');
+  });
+
+  it('returns missing when all probe paths return ENOENT', async () => {
+    mockAccess.mockRejectedValue(Object.assign(new Error('enoent'), { code: 'ENOENT' }));
     expect(await probeFda()).toBe('missing');
   });
 
@@ -359,7 +366,7 @@ describe('probeFda()', () => {
     expect(await probeFda()).toBe('granted');
   });
 
-  it('returns denied when TCC.db returns EACCES', async () => {
+  it('returns denied when all paths return EACCES', async () => {
     mockAccess.mockRejectedValue(Object.assign(new Error('eacces'), { code: 'EACCES' }));
     expect(await probeFda()).toBe('denied');
   });

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -6,7 +6,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, constants as fsConstants, promises as fsp, appendFileSync, mkdirSync } from 'node:fs';
+import { constants as fsConstants, promises as fsp, appendFileSync, mkdirSync } from 'node:fs';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { input } from '@inquirer/prompts';
@@ -184,31 +184,50 @@ export async function withRetry<T extends { found?: boolean; authenticated?: boo
 
 export type FdaStatus = 'granted' | 'denied' | 'missing';
 
+// Paths that macOS gates behind FDA (kTCCServiceSystemPolicyAllFiles).
+// A process without FDA receives EPERM when accessing any of these.
+// Multiple targets guard against Apple removing protection from any single
+// path in a future macOS release.
+const FDA_PROBE_TARGETS = [
+  'Library/Mail',
+  'Library/Safari/Databases',
+  'Library/Application Support/com.apple.TCC/TCC.db',
+];
+
 /**
- * Probe macOS Full Disk Access by attempting to read the user-level TCC
- * database. This file is only readable when FDA has been granted.
+ * Probe macOS Full Disk Access by attempting to read known TCC-protected
+ * paths. Tries multiple targets so the check stays reliable across macOS
+ * versions even if Apple changes protection on individual paths.
  *
  * Never triggers a system dialog — it only checks the current state.
  */
 export async function probeFda(): Promise<FdaStatus> {
   if (platform() !== 'darwin') return 'granted'; // non-macOS: not applicable
-  const target = join(homedir(), 'Library', 'Application Support', 'com.apple.TCC', 'TCC.db');
-  if (!existsSync(target)) return 'missing';
-  try {
-    await fsp.access(target, fsConstants.R_OK);
-    return 'granted';
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'EPERM' || code === 'EACCES') return 'denied';
-    if (code === 'ENOENT') return 'missing';
-    return 'denied';
+
+  const home = homedir();
+  let sawBlocked = false;
+
+  for (const rel of FDA_PROBE_TARGETS) {
+    const target = join(home, rel);
+    try {
+      await fsp.access(target, fsConstants.R_OK);
+      return 'granted';
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EPERM' || code === 'EACCES') {
+        sawBlocked = true;
+      }
+      // ENOENT → path doesn't exist on this machine, try next
+    }
   }
+
+  return sawBlocked ? 'denied' : 'missing';
 }
 
 /**
  * Poll Full Disk Access at regular intervals until granted or the signal
- * is aborted. Never triggers a system dialog — uses the same read-only
- * TCC.db probe as `probeFda()`.
+ * is aborted. Never triggers a system dialog — uses the same multi-path
+ * probe as `probeFda()`.
  *
  * Returns the final observed status ('granted' once the user toggles FDA
  * in System Settings, or the last polled status if aborted early).


### PR DESCRIPTION
probe multiple FDA-gated paths for reliability across macOS versions. Bump v0.23.1