### PR TITLE
feat(ios): native-feeling mode swipe with momentum spring

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		C0C4528A1D3D1773A0BA9870 /* MessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6472A002F2CB9C07380792 /* MessagesTests.swift */; };
 		C359E909D1763DA606DD8A6E /* ToolActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AC5E0472D90CCB91CC0778 /* ToolActivityView.swift */; };
 		CB2D37D2D7F4BB782B250DDF /* MessageInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102ABECDD210B084B5B19319 /* MessageInputView.swift */; };
+		08F75939E73B7BAB338C6A3A /* InputBoxModeSwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2752F88C836C136B0AECFE /* InputBoxModeSwipe.swift */; };
 		CB5335A6F0129A9A21088A72 /* LocalSessionSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13466FFA7CC929AF90E4097E /* LocalSessionSummary.swift */; };
 		CDD3FC5A96DCC43FE52A4BCA /* MessageDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E016C4ACE0484D7DB04166 /* MessageDatabase.swift */; };
 		D087D8336F9F7A82D73AB4DD /* EncryptionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EB27413D7A5189B3C42D36 /* EncryptionHandler.swift */; };
@@ -123,6 +124,7 @@
 		0B5C9B91D8E0CF8C6D63E91D /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
 		0C23602EA58067E4AE252F62 /* ImportSessionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportSessionSheet.swift; sourceTree = "<group>"; };
 		102ABECDD210B084B5B19319 /* MessageInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageInputView.swift; sourceTree = "<group>"; };
+		BA2752F88C836C136B0AECFE /* InputBoxModeSwipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBoxModeSwipe.swift; sourceTree = "<group>"; };
 		11B2053230A2F15EC2518979 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		13466FFA7CC929AF90E4097E /* LocalSessionSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSessionSummary.swift; sourceTree = "<group>"; };
 		1BF3123CD705AB984A21AD16 /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				7A84BF94261411BEF2B51101 /* LazyImageView.swift */,
 				88354093F25E3F24C8F27311 /* MessageBubbleView.swift */,
 				102ABECDD210B084B5B19319 /* MessageInputView.swift */,
+				BA2752F88C836C136B0AECFE /* InputBoxModeSwipe.swift */,
 				E6783BD1527A13261E67330A /* ModePickerView.swift */,
 				61AC5E0472D90CCB91CC0778 /* ToolActivityView.swift */,
 				F163484AD442AE1D67F4E8A7 /* ToolChipHeader.swift */,
@@ -625,6 +628,7 @@
 				1E626FDE917F77BEBF2D58B1 /* MessageBubbleView.swift in Sources */,
 				CDD3FC5A96DCC43FE52A4BCA /* MessageDatabase.swift in Sources */,
 				CB2D37D2D7F4BB782B250DDF /* MessageInputView.swift in Sources */,
+				08F75939E73B7BAB338C6A3A /* InputBoxModeSwipe.swift in Sources */,
 				87DF8395030B8C3D235D6DD2 /* MessageProvider.swift in Sources */,
 				0D84FEFC83BB1552A71A855F /* MessageRouter.swift in Sources */,
 				0904D2B58EE9736437D89A18 /* MessageStore.swift in Sources */,

--- a/packages/arm/ios/Kraki/Features/Chat/InputBoxModeSwipe.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/InputBoxModeSwipe.swift
@@ -1,0 +1,368 @@
+#if os(iOS)
+/// InputBoxModeSwipe — Native-feeling horizontal swipe on the chat
+/// input box that cycles `SessionMode`.
+///
+/// Design goals (what makes it feel "native"):
+///   • 1:1 finger tracking with iOS-style rubber-band past one step.
+///   • Pre-commit haptic at the moment the finger crosses the commit
+///     threshold (and re-arms if the user pulls back) — like a picker
+///     "click" you feel before you let go.
+///   • Predict-and-snap on release (UIScrollView-style velocity
+///     projection) so a light flick commits even from a tiny drag.
+///   • Spring carries finger velocity through into a slightly
+///     under-damped settle, so a hard fling overshoots and bounces;
+///     a soft drop just eases. Real physics.
+///   • The `setSessionMode` callback fires inside the same
+///     `withAnimation(spring)` that drives the strip, so the
+///     send-icon's color cross-fade rides exactly the same curve —
+///     no "two-stage" feeling.
+///
+/// Architecture:
+///   `InputBoxModeSwipeController` owns the algorithm + state. It's
+///   an `@Observable` reference type so per-tick `offset` updates
+///   only invalidate the small subview that reads them — not the
+///   whole `MessageInputView`.
+///
+///   `InputBoxModeSwipeBackground` is the static glass capsule
+///   plus the strip subview. Drop it into `.background { }` on the
+///   input box. The glass layer never depends on swipe state.
+///
+///   The gesture itself lives at the call site so it can be
+///   composed with the existing `simultaneousGesture` /
+///   `holdToTalkGesture` arbitration; the controller just exposes
+///   `handleChanged` / `handleEnded` entry points.
+
+import SwiftUI
+import UIKit
+
+// MARK: - Controller
+
+@Observable
+final class InputBoxModeSwipeController {
+
+    /// Visible horizontal offset of the strip, in points. The strip
+    /// renders at `x = -width + offset`, so `offset == 0` centers the
+    /// base block in the visible window.
+    var offset: CGFloat = 0
+
+    /// Mode snapshot taken at gesture start. While non-nil, the strip
+    /// is anchored to this mode so its content stays stable across
+    /// the entire drag + spring (avoids a mid-spring color jump when
+    /// the live `currentSessionMode` changes). Cleared by the silent
+    /// rebase at spring completion.
+    var startMode: SessionMode? = nil
+
+    // --- Internal gesture bookkeeping; not observed by views. ---
+
+    /// Translation captured on the first onChanged tick. We subtract
+    /// it from subsequent translations so the strip starts at exactly
+    /// 0 (instead of jumping by the gesture's `minimumDistance`).
+    @ObservationIgnored private var initialDx: CGFloat? = nil
+
+    /// True between the moment `|offset|` first crosses the commit
+    /// threshold and the moment it falls back below it. Guards the
+    /// "click" haptic from firing repeatedly mid-drag.
+    @ObservationIgnored private var hapticArmed = false
+
+    // --- Tuning constants ---
+
+    /// How far past `|offset| == stepWidth * commitFraction` we project
+    /// the finger's velocity to decide whether to commit on release.
+    /// Roughly UIScrollView's exponential decay over ~150ms.
+    private static let predictionTime: Double = 0.15
+
+    /// Position fraction (of one full step) that counts as a commit.
+    /// Combined with `predictionTime`, even a small drag commits if
+    /// flicked hard.
+    private static let commitFraction: CGFloat = 0.35
+
+    /// Rubber-band magnitude beyond one full step, expressed as a
+    /// fraction of `stepWidth`. The asymptotic ln-curve hits ~0.30
+    /// at infinity, which matches iOS' built-in scroll rubber-band.
+    private static let rubberBandFraction: CGFloat = 0.3
+
+    /// Hard cap on the spring's normalized initial velocity. Guards
+    /// the corner case where the user releases ~1pt away from the
+    /// snap point at high speed (`velocity / remaining` blows up).
+    private static let momentumVelocityCap: Double = 35
+
+    /// Cyclic mode order. Wraps modulo, so a swipe past `.delegate`
+    /// returns to `.safe` (and vice versa).
+    static let allModes: [SessionMode] = [.safe, .discuss, .execute, .delegate]
+
+    /// Snap spring. `response 0.42s` settles in ~half a second on a
+    /// soft drop; `dampingRatio 0.74` gives ~6% visible overshoot on
+    /// a hard fling and ~1% on a soft drop — small enough to read as
+    /// "this thing has mass" without feeling wobbly.
+    private static let snapSpring = Spring(response: 0.42, dampingRatio: 0.74)
+
+    // MARK: - Strip read API
+
+    /// Which mode's color block the strip should center on. Snapshot
+    /// during a gesture so the strip's content doesn't churn when
+    /// `currentSessionMode` is mutated mid-spring by `commit`.
+    func tintBaseMode(currentMode: SessionMode) -> SessionMode {
+        startMode ?? currentMode
+    }
+
+    // MARK: - Gesture entry points
+
+    /// Feed a `DragGesture.onChanged` translation into the controller.
+    /// Returns `true` if the controller is actively tracking this swipe.
+    /// Returns `false` on the first tick if motion isn't horizontal
+    /// (lets the caller route the gesture elsewhere — e.g. let a
+    /// vertical scroll proceed).
+    @discardableResult
+    func handleChanged(
+        translation: CGSize,
+        currentMode: SessionMode,
+        stepWidth: CGFloat
+    ) -> Bool {
+        guard let firstDx = initialDx else {
+            // First contact: lock to horizontal motion only.
+            guard abs(translation.width) > abs(translation.height) else { return false }
+            initialDx = translation.width
+            startMode = currentMode
+            hapticArmed = false
+            return true
+        }
+        let dx = translation.width - firstDx
+        offset = rubberBanded(dx, step: stepWidth)
+        updateHaptic(threshold: stepWidth * Self.commitFraction)
+        return true
+    }
+
+    /// Feed a `DragGesture.onEnded` velocity into the controller. The
+    /// `commit` closure fires synchronously inside `withAnimation`
+    /// when a mode change is decided — putting any side-effects (e.g.
+    /// `setSessionMode`, toast presentation) inside this closure makes
+    /// them animate together with the strip.
+    func handleEnded(
+        velocity: CGFloat,
+        currentMode _: SessionMode,
+        stepWidth: CGFloat,
+        commit: (SessionMode) -> Void
+    ) {
+        defer {
+            initialDx = nil
+            hapticArmed = false
+        }
+        guard let start = startMode else { return }
+
+        // 1. Predict where the finger would land if it kept decelerating
+        //    at iOS-scroll-like rate. This is the decisive number — it
+        //    folds "did the user drag far enough" and "did they flick
+        //    hard enough" into one threshold check.
+        let projected = offset + velocity * Self.predictionTime
+        let threshold = stepWidth * Self.commitFraction
+
+        let commitStep: Int
+        if projected > threshold {
+            commitStep = -1   // dragged right → previous mode peeks in from the left
+        } else if projected < -threshold {
+            commitStep = +1   // dragged left → next mode peeks in from the right
+        } else {
+            commitStep = 0
+        }
+        let targetOffset: CGFloat = -CGFloat(commitStep) * stepWidth
+
+        // 2. Resolve the new mode (if any) BEFORE entering withAnimation,
+        //    so the commit closure runs synchronously with the spring's
+        //    state transition.
+        let newMode: SessionMode? = {
+            guard commitStep != 0 else { return nil }
+            let modes = Self.allModes
+            let count = modes.count
+            let baseIdx = modes.firstIndex(of: start) ?? 1
+            let idx = ((baseIdx + commitStep) % count + count) % count
+            return modes[idx]
+        }()
+
+        if newMode != nil {
+            // Commit-confirmation haptic. `rigid` is heavier than the
+            // pre-commit `light` so the two feel distinct in your hand.
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+        }
+
+        // 3. Normalize finger velocity into the spring's [0,1]-per-second
+        //    space. The spring API wants a unit where 1.0 means "covers
+        //    the full remaining distance in 1 second".
+        let remaining = targetOffset - offset
+        let normalizedV: Double
+        if remaining == 0 {
+            normalizedV = 0
+        } else {
+            let v = Double(velocity / remaining)
+            // If finger reversed direction at release (v < 0), passing a
+            // negative initial velocity makes the spring back up before
+            // accelerating toward the target — it looks like a stutter.
+            // Treat as zero; the spring's natural acceleration handles it.
+            normalizedV = v < 0 ? 0 : min(v, Self.momentumVelocityCap)
+        }
+
+        let animation = Animation.interpolatingSpring(
+            Self.snapSpring,
+            initialVelocity: normalizedV
+        )
+
+        withAnimation(animation) {
+            // Anything inside here rides the same spring as `offset`:
+            // the caller's commit (which mutates currentSessionMode →
+            // the send-icon's tint), the strip's settle, etc.
+            if let newMode { commit(newMode) }
+            offset = targetOffset
+        } completion: { [weak self] in
+            // Silent rebase: drop the start-mode snapshot and zero the
+            // offset. By this point `currentSessionMode` already equals
+            // the snapped mode, so the strip rebuilds with the same
+            // color in the same screen position — visually a no-op.
+            //
+            // If a new gesture has already started during the spring
+            // (the user immediately started swiping again before the
+            // spring settled), leave its in-flight state alone — the
+            // rebase would otherwise yank the strip back to 0.
+            guard let self, self.initialDx == nil else { return }
+            var t = Transaction()
+            t.disablesAnimations = true
+            withTransaction(t) {
+                self.startMode = nil
+                self.offset = 0
+            }
+        }
+    }
+
+    /// Drop in-flight gesture state and snap back to rest. Call if the
+    /// host view is dismissed or the gesture is interrupted.
+    func cancel() {
+        initialDx = nil
+        hapticArmed = false
+        withAnimation(.interpolatingSpring(Self.snapSpring, initialVelocity: 0)) {
+            offset = 0
+        } completion: { [weak self] in
+            guard let self, self.initialDx == nil else { return }
+            var t = Transaction()
+            t.disablesAnimations = true
+            withTransaction(t) { self.startMode = nil }
+        }
+    }
+
+    // MARK: - Internals
+
+    /// iOS-style rubber-band beyond one full step. The ln curve is
+    /// asymptotically bounded by `stepWidth * (1 + rubberBandFraction)`,
+    /// so even an infinite drag never blows past it. Matches the feel
+    /// of UIScrollView's `bounces = true` behavior.
+    private func rubberBanded(_ dx: CGFloat, step: CGFloat) -> CGFloat {
+        let limit = max(step, 1)
+        if abs(dx) <= limit { return dx }
+        let excess = abs(dx) - limit
+        let rubber = limit * Self.rubberBandFraction
+            * log(1 + 5 * excess / limit) / log(6)
+        return (dx > 0 ? 1 : -1) * (limit + rubber)
+    }
+
+    private func updateHaptic(threshold: CGFloat) {
+        let past = abs(offset) >= threshold
+        if past, !hapticArmed {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            hapticArmed = true
+        } else if !past, hapticArmed {
+            hapticArmed = false
+        }
+    }
+}
+
+// MARK: - Background view
+
+/// Drop in via `.background { InputBoxModeSwipeBackground(...) }`.
+/// Renders the glass capsule + the mode-color strip. The glass layer
+/// doesn't touch any observable state, so it's never re-rasterized
+/// during a drag.
+struct InputBoxModeSwipeBackground: View {
+    let controller: InputBoxModeSwipeController
+    let currentMode: SessionMode
+    let width: CGFloat
+
+    var body: some View {
+        let shape = Capsule()
+        ZStack(alignment: .bottom) {
+            glassCapsule(shape)
+
+            // Only this subview observes `controller.offset` /
+            // `controller.startMode`, so drag ticks invalidate it
+            // alone — not the glass and not the parent.
+            InputBoxModeSwipeStripView(
+                controller: controller,
+                currentMode: currentMode,
+                width: width
+            )
+            .clipShape(shape)
+            .allowsHitTesting(false)
+        }
+    }
+
+    @ViewBuilder
+    private func glassCapsule(_ shape: Capsule) -> some View {
+        if #available(iOS 26.0, *) {
+            Color.clear.glassEffect(.regular, in: shape)
+        } else {
+            shape.fill(.ultraThinMaterial)
+        }
+    }
+}
+
+// MARK: - Strip subview
+
+/// Three colored blocks (prev / base / next mode) stacked
+/// horizontally and offset by `controller.offset`. Pinned to the
+/// bottom edge of the parent. Width per block matches the input box
+/// width so a full step (`|offset| == width`) exactly replaces the
+/// visible color with the adjacent one.
+private struct InputBoxModeSwipeStripView: View {
+    let controller: InputBoxModeSwipeController
+    let currentMode: SessionMode
+    let width: CGFloat
+
+    private static let stripHeight: CGFloat = 1.5
+    private static let stripOpacity: Double = 0.95
+
+    var body: some View {
+        let baseMode = controller.tintBaseMode(currentMode: currentMode)
+        let offset = controller.offset
+        let modes = InputBoxModeSwipeController.allModes
+        let count = modes.count
+        let baseIdx = modes.firstIndex(of: baseMode) ?? 1
+        let prevIdx = ((baseIdx - 1) % count + count) % count
+        let nextIdx = ((baseIdx + 1) % count + count) % count
+
+        HStack(spacing: 0) {
+            block(modes[prevIdx])
+            block(modes[baseIdx])
+            block(modes[nextIdx])
+        }
+        .offset(x: -width + offset)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+    }
+
+    private func block(_ mode: SessionMode) -> some View {
+        Color.modeColor(mode)
+            .opacity(Self.stripOpacity)
+            .frame(width: width, height: Self.stripHeight)
+    }
+}
+
+// MARK: - Width preference
+
+/// Lets the input box measure its own width once via a flat
+/// `.background(GeometryReader { ... })`, instead of nesting a
+/// GeometryReader inside the strip (which would re-measure on every
+/// drag tick).
+struct InputBoxWidthPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let next = nextValue()
+        if next > 0 { value = next }
+    }
+}
+
+#endif

--- a/packages/arm/ios/Kraki/Features/Chat/MessageInputView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageInputView.swift
@@ -69,17 +69,10 @@ struct MessageInputView: View {
         case modeSwipe
     }
 
-    // Mode swipe — the send icon doubles as the mode selector.
-    // Swiping it horizontally cycles SessionMode (looping). The input
-    // box's glass tint blends between adjacent mode colors live during
-    // the swipe; on release a tap = send, a flick or 40% drag = mode
-    // commit. Visual swipe travel is clamped to ±`modeStepWidth`.
-    //
-    // `rawDragX` is the live horizontal drag translation (clamped).
-    // `dragStartMode` snapshots the mode at gesture start so tint
-    // math is stable across the drag.
-    @State private var rawDragX: CGFloat = 0
-    @State private var dragStartMode: SessionMode? = nil
+    // Mode swipe — drag the input box horizontally to cycle SessionMode.
+    // All algorithm + state lives in InputBoxModeSwipeController; the
+    // view just measures its own width and feeds the gesture in.
+    @State private var swipeController = InputBoxModeSwipeController()
     @State private var measuredInputBoxWidth: CGFloat = 0
 
     // Mode-change toast (liquid-glass capsule above the send icon).
@@ -91,9 +84,6 @@ struct MessageInputView: View {
 
     private static let allModes: [SessionMode] = [.safe, .discuss, .execute, .delegate]
     private static let inputBoxHeight: CGFloat = 42
-    private static let commitDistanceFraction: CGFloat = 0.4
-    private static let momentumVelocity: CGFloat = 500   // pt/s
-
     /// Width of one "step" — clamped to the measured input box width
     /// so a full-distance swipe can fully replace the visible mode
     /// color with the adjacent one. Falls back to a sane default
@@ -106,50 +96,6 @@ struct MessageInputView: View {
         appState.sessionStore.sessionModes[sessionId]
             ?? session?.mode
             ?? .discuss
-    }
-
-    /// The mode whose color tint is centered. We snapshot the start
-    /// mode at gesture start so tint math stays stable across the drag
-    /// (in-drag commits would otherwise re-anchor the interpolation).
-    private var tintBaseMode: SessionMode {
-        dragStartMode ?? currentSessionMode
-    }
-
-    /// Live tint color for the input box: blends linearly between the
-    /// base mode's color and the adjacent mode's color based on the
-    /// drag progress (rawDragX / modeStepWidth, clamped to ±1). At
-    /// rest this is just the current mode's color.
-    private var inputBoxModeTint: Color {
-        let modes = Self.allModes
-        let count = modes.count
-        let baseIdx = modes.firstIndex(of: tintBaseMode) ?? 1
-        let progress = max(-1, min(1, rawDragX / modeStepWidth))
-        if progress == 0 { return Color.modeColor(modes[baseIdx]) }
-        // Drag RIGHT (positive dx) → previous mode tint enters.
-        let neighborIdx: Int = progress > 0
-            ? ((baseIdx - 1) % count + count) % count
-            : ((baseIdx + 1) % count + count) % count
-        return Self.blendColors(
-            Color.modeColor(modes[baseIdx]),
-            Color.modeColor(modes[neighborIdx]),
-            t: abs(progress)
-        )
-    }
-
-    private static func blendColors(_ a: Color, _ b: Color, t: CGFloat) -> Color {
-        let ua = UIColor(a)
-        let ub = UIColor(b)
-        var (r1, g1, b1, a1): (CGFloat, CGFloat, CGFloat, CGFloat) = (0, 0, 0, 0)
-        var (r2, g2, b2, a2): (CGFloat, CGFloat, CGFloat, CGFloat) = (0, 0, 0, 0)
-        ua.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
-        ub.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
-        let tt = max(0, min(1, t))
-        return Color(
-            red: Double(r1 + (r2 - r1) * tt),
-            green: Double(g1 + (g2 - g1) * tt),
-            blue: Double(b1 + (b2 - b1) * tt),
-            opacity: Double(a1 + (a2 - a1) * tt)
-        )
     }
 
     private var sessionStore: SessionStore { appState.sessionStore }
@@ -346,65 +292,41 @@ struct MessageInputView: View {
         // HStack grows symmetrically — close enough to iMessage that
         // the icons appear to stay attached to the box.
         .frame(minHeight: Self.inputBoxHeight)
-        .background { inputBoxGlassBackground }
+        .background {
+            InputBoxModeSwipeBackground(
+                controller: swipeController,
+                currentMode: currentSessionMode,
+                width: measuredInputBoxWidth
+            )
+        }
+        // Single, flat width measurement (not nested inside the strip's
+        // body). Width changes don't happen during a drag, so re-render
+        // cost is limited to actual layout changes (rotation, etc).
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: InputBoxWidthPreferenceKey.self,
+                    value: proxy.size.width
+                )
+            }
+        )
+        .onPreferenceChange(InputBoxWidthPreferenceKey.self) { new in
+            measuredInputBoxWidth = new
+        }
         .contentShape(Capsule())
         // Voice mode is gone for now, so the whole input box is always
         // swipeable for mode changes (no hold-to-talk gesture to race with).
         .simultaneousGesture(inputBoxModeSwipeGesture)
-        .animation(.easeInOut(duration: 0.22), value: currentSessionMode)
-    }
-
-    @ViewBuilder
-    private var inputBoxGlassBackground: some View {
-        let shape = Capsule()
-        ZStack(alignment: .bottom) {
-            // Plain iOS 26 liquid glass capsule — no full-box tint;
-            // the mode color lives only in the thin strip below.
-            if #available(iOS 26.0, *) {
-                Color.clear.glassEffect(.regular, in: shape)
-            } else {
-                shape.fill(.ultraThinMaterial)
-            }
-
-            // Thin mode-color strip pinned to the bottom edge of the
-            // capsule. Renders 3 horizontal blocks (prev / base /
-            // next mode) wider than the box; offset by `rawDragX` so
-            // it slides with the finger, peeking the adjacent
-            // colors in from the swipe direction. Clipped to the
-            // capsule so the colors hug the bottom curvature.
-            swipeBottomStrip
-                .clipShape(shape)
-                .allowsHitTesting(false)
-        }
-    }
-
-    private var swipeBottomStrip: some View {
-        GeometryReader { proxy in
-            let modes = Self.allModes
-            let count = modes.count
-            let baseIdx = modes.firstIndex(of: tintBaseMode) ?? 1
-            let prevIdx = ((baseIdx - 1) % count + count) % count
-            let nextIdx = ((baseIdx + 1) % count + count) % count
-            let w = proxy.size.width
-            let stripHeight: CGFloat = 1.5
-            let opacity: Double = 0.95
-            HStack(spacing: 0) {
-                Color.modeColor(modes[prevIdx]).opacity(opacity)
-                    .frame(width: w, height: stripHeight)
-                Color.modeColor(modes[baseIdx]).opacity(opacity)
-                    .frame(width: w, height: stripHeight)
-                Color.modeColor(modes[nextIdx]).opacity(opacity)
-                    .frame(width: w, height: stripHeight)
-            }
-            // The 3-block strip is anchored so the BASE block fully
-            // covers the visible window at rest (`rawDragX == 0`).
-            // `rawDragX` then slides the strip with the finger up to
-            // ±w, peeking the adjacent block fully into view.
-            .offset(x: -w + rawDragX)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .onAppear { measuredInputBoxWidth = w }
-            .onChange(of: w) { _, newW in measuredInputBoxWidth = newW }
-        }
+        // NOTE: previously this view carried
+        //   .animation(.easeInOut(duration: 0.22), value: currentSessionMode)
+        // for non-swipe mode changes (e.g. via the picker sheet). That
+        // implicit animation now also fires during a swipe-commit and
+        // races the post-release spring, producing the "two-stage" feel.
+        // The send-icon glyph's own `.animation(easeInOut, value:
+        // currentSessionMode)` modifier still handles the picker case;
+        // for swipe commits, the gesture's `withAnimation(spring) { … }`
+        // wraps `setSessionMode`, so any view that reads currentSessionMode
+        // (the icon tint included) rides the same spring curve.
     }
 
     /// Horizontal swipe gesture that cycles SessionMode, attached to
@@ -412,25 +334,28 @@ struct MessageInputView: View {
     /// swipe anywhere on the box. Uses `simultaneousGesture` so taps
     /// on the inner TextField, voice toggle, and send icon still
     /// reach their own gesture handlers. `minimumDistance: 10`
-    /// prevents an incidental finger jiggle from triggering a swipe.
-    /// The horizontal-vs-vertical guard runs only at the FIRST motion
-    /// event so once we've committed to a horizontal swipe, vertical
-    /// drift doesn't cancel it.
+    /// prevents an incidental finger jiggle from triggering a swipe;
+    /// the controller subtracts that 10pt threshold from the first
+    /// reported translation so the strip starts at exactly 0 instead
+    /// of jumping.
     private var inputBoxModeSwipeGesture: some Gesture {
         DragGesture(minimumDistance: 10)
             .onChanged { value in
-                if dragStartMode == nil {
-                    // Lock in: only start a swipe if the first
-                    // motion is more horizontal than vertical.
-                    let dx = value.translation.width
-                    let dy = value.translation.height
-                    guard abs(dx) > abs(dy) else { return }
-                }
-                handleModeSwipeChanged(value.translation.width)
+                swipeController.handleChanged(
+                    translation: value.translation,
+                    currentMode: currentSessionMode,
+                    stepWidth: modeStepWidth
+                )
             }
             .onEnded { value in
-                guard dragStartMode != nil else { return }
-                handleModeSwipeEnded(value.velocity.width)
+                swipeController.handleEnded(
+                    velocity: value.velocity.width,
+                    currentMode: currentSessionMode,
+                    stepWidth: modeStepWidth
+                ) { newMode in
+                    appState.commandSender?.setSessionMode(sessionId: sessionId, mode: newMode)
+                    presentModeToast(newMode)
+                }
             }
     }
 
@@ -604,9 +529,9 @@ struct MessageInputView: View {
     //   ├── 200ms passes with no significant horizontal motion →
     //   │     pivot RECORD: start speech, drag-up arms cancel.
     //   ├── |dx| ≥ 10pt AND |dx| > |dy| BEFORE 200ms elapses →
-    //   │     pivot MODE_SWIPE: cancel dwell, forward to
-    //   │     handleModeSwipeChanged; release calls
-    //   │     handleModeSwipeEnded (momentum + spring + commit).
+    //   │     pivot MODE_SWIPE: cancel dwell, forward to the
+    //   │     swipeController; release commits the mode change
+    //   │     (predict-and-snap with spring momentum).
     //   └── Release before 200ms with sub-threshold motion →
     //         quick tap on the prompt area, no-op.
     //
@@ -622,7 +547,11 @@ struct MessageInputView: View {
                     case .record:
                         cancelArmed = value.translation.height < -60
                     case .modeSwipe:
-                        handleModeSwipeChanged(value.translation.width)
+                        swipeController.handleChanged(
+                            translation: value.translation,
+                            currentMode: currentSessionMode,
+                            stepWidth: modeStepWidth
+                        )
                     }
                     return
                 }
@@ -651,7 +580,11 @@ struct MessageInputView: View {
                     holdDwellTask?.cancel()
                     holdDwellTask = nil
                     holdPivot = .modeSwipe
-                    handleModeSwipeChanged(dx)
+                    swipeController.handleChanged(
+                        translation: value.translation,
+                        currentMode: currentSessionMode,
+                        stepWidth: modeStepWidth
+                    )
                 }
             }
             .onEnded { value in
@@ -695,7 +628,14 @@ struct MessageInputView: View {
                         cancelArmed = false
                     }
                 case .modeSwipe:
-                    handleModeSwipeEnded(value.velocity.width)
+                    swipeController.handleEnded(
+                        velocity: value.velocity.width,
+                        currentMode: currentSessionMode,
+                        stepWidth: modeStepWidth
+                    ) { newMode in
+                        appState.commandSender?.setSessionMode(sessionId: sessionId, mode: newMode)
+                        presentModeToast(newMode)
+                    }
                 case .none:
                     // Tap or sub-threshold motion before pivot →
                     // nothing to do.
@@ -940,94 +880,6 @@ struct MessageInputView: View {
             handleSend()
         } else {
             appState.commandSender?.abortSession(sessionId: sessionId)
-        }
-    }
-
-    private func handleModeSwipeChanged(_ dx: CGFloat) {
-        if dragStartMode == nil { dragStartMode = currentSessionMode }
-        // Rubber-band beyond ±modeStepWidth so the strip can over-
-        // travel slightly with momentum (then snap back via spring),
-        // but the "useful" range still tops out at one full step.
-        let limit = modeStepWidth
-        if abs(dx) <= limit {
-            rawDragX = dx
-        } else {
-            let excess = abs(dx) - limit
-            let rubber = excess / (1 + excess / 80) * 0.4
-            rawDragX = (dx > 0 ? 1 : -1) * (limit + rubber)
-        }
-    }
-
-    private func handleModeSwipeEnded(_ velocity: CGFloat) {
-        let modes = Self.allModes
-        let count = modes.count
-        let baseMode = dragStartMode ?? currentSessionMode
-        let baseIdx = modes.firstIndex(of: baseMode) ?? 1
-
-        let dx = rawDragX
-        let distanceCommit = abs(dx) >= Self.commitDistanceFraction * modeStepWidth
-        // Momentum commit: a fast flick in the same direction as the
-        // drag wins even if the finger only moved a short distance.
-        let velocityCommit = abs(velocity) >= Self.momentumVelocity
-            && dx != 0
-            && (velocity > 0) == (dx > 0)
-        let shouldCommit = distanceCommit || velocityCommit
-
-        // Resolve commit direction & visual target offset.
-        //   Drag RIGHT (dx > 0) → previous mode peeked in from left
-        //   → commit step −1, strip ends at +stepWidth (prev block
-        //   fully covers the window).
-        //   Drag LEFT  (dx < 0) → next mode → step +1, strip ends at
-        //   −stepWidth.
-        let commitStep: Int = shouldCommit ? (dx > 0 ? -1 : 1) : 0
-        let targetOffset: CGFloat = commitStep == 0
-            ? 0
-            : -CGFloat(commitStep) * modeStepWidth
-
-        // Fire commit + haptic at release start (not after the spring
-        // settles) so the send arrow color begins its own cross-fade
-        // animation immediately as the strip springs into place. The
-        // strip itself stays anchored to `dragStartMode` for the
-        // duration of the spring (so its visual content is stable),
-        // and the silent rebase in the completion handler swaps it
-        // over to the new mode at offset 0 — by which time the
-        // currentSessionMode color matches the visible block, so the
-        // swap is invisible.
-        if commitStep != 0 {
-            let targetIdx = ((baseIdx + commitStep) % count + count) % count
-            let newMode = modes[targetIdx]
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            appState.commandSender?.setSessionMode(sessionId: sessionId, mode: newMode)
-            presentModeToast(newMode)
-        }
-
-        // Physical spring driven by the gesture's exit velocity:
-        // .interpolatingSpring with non-zero `initialVelocity` carries
-        // the swipe momentum into the rest position, so a hard fling
-        // overshoots+settles and a soft drop just eases home. The
-        // velocity is normalized by the remaining distance so units
-        // make sense to the spring.
-        let remaining = targetOffset - rawDragX
-        let normalizedVelocity = remaining == 0 ? 0 : Double(velocity / remaining)
-        let physicsSpring: Animation = .interpolatingSpring(
-            mass: 1,
-            stiffness: 180,
-            damping: 22,
-            initialVelocity: normalizedVelocity
-        )
-
-        withAnimation(physicsSpring) {
-            rawDragX = targetOffset
-        } completion: {
-            // Silent rebase: strip rebuilds with the new
-            // currentSessionMode at the center, rawDragX = 0 leaves
-            // it visually identical (same color is already centered).
-            var t = Transaction()
-            t.disablesAnimations = true
-            withTransaction(t) {
-                dragStartMode = nil
-                rawDragX = 0
-            }
         }
     }
 


### PR DESCRIPTION
## What

Rework the input-box horizontal swipe that cycles SessionMode. The previous version had a soft, two-stage feel on release; this one carries finger momentum into a proper spring snap with a small visible overshoot, and the icon color rides the same curve.

## Why

User feedback: "*松手之后那个 momentum 没有直接作用 就反正和那种 native 的滑动感不一样*."

Four root causes:
1. `setSessionMode` fired *before* the spring, so the send-icon color cross-fade animated via `.animation(easeInOut(0.22), value: currentSessionMode)` while the strip rode the spring — two animations of different durations on overlapping properties → "two-stage" feel.
2. Spring `initialVelocity = velocity / remaining` was unclamped. Releasing near the snap point → overshoot wobble. Finger reversal at release → spring backward-then-forward stutter.
3. `rawDragX` was `@State` on `MessageInputView`, so every drag tick re-evaluated the entire body — `composeCard` + three overlays + glass background — 60+ times/sec.
4. Commit decision was "distance OR velocity" as two independent thresholds. Mushy at the boundary.

## How

New file `InputBoxModeSwipe.swift` containing:
- `InputBoxModeSwipeController` — `@Observable` class owning state + algorithm.
- `InputBoxModeSwipeBackground` — drop-in `.background { … }` view.
- private strip subview — the *only* place that observes the controller, so per-tick `offset` updates invalidate ~10pt² of view tree instead of the whole composer.
- `InputBoxWidthPreferenceKey` — flat width measurement, replaces the GeometryReader nested inside the old strip.

Algorithm:
- **Predict-and-snap.** Project finger velocity through ~150ms of UIScrollView-like decay. One number drives commit. Light flicks commit even from tiny drags.
- **One spring for everything.** `setSessionMode` runs *inside* `withAnimation(spring) { ... }`, so the icon color, the strip position, and anything else that reads `currentSessionMode` all settle on the same curve.
- **Real physics.** `Spring(response: 0.42, dampingRatio: 0.74)` — slightly under-damped, so a hard fling visibly overshoots and bounces back; a soft drop just eases home.
- **Sanitized initial velocity.** Reversed direction → 0. Magnitude capped at 35.
- **Pre-commit haptic.** `light` impact when the finger first crosses the commit threshold (and re-arms if pulled back); `rigid` impact on actual commit at release. Two distinct feels in your hand, picker-style.
- **No jump-on.** Subtract the gesture's `minimumDistance` from the first reported translation. Strip starts at exactly 0.
- **Interruptible.** If a new swipe starts mid-spring, the silent-rebase in the completion handler guards against yanking the new gesture's offset back to 0.

Dead code removed: `inputBoxModeTint` + `blendColors` (declared but never consumed since the strip-only design landed).

The voice-mode `holdToTalkGesture`'s `.modeSwipe` pivot is rewired to the same controller (currently dormant — `canShowVoiceToggle == false`).

## Test plan

- Build green: `xcodebuild -scheme Kraki -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` ✅
- Manual: drag the input box left/right at varying speeds. Expect:
  - 1:1 tracking, mild rubber-band past one step.
  - `light` haptic the moment you cross the commit threshold (and again if you pull back, then cross again).
  - On release: `rigid` haptic for commit, spring with visible overshoot proportional to flick speed.
  - Icon color cross-fades on the same curve as the strip.

## Stats

```
packages/arm/ios/Kraki.xcodeproj/project.pbxproj             |   4 +
packages/arm/ios/Kraki/Features/Chat/InputBoxModeSwipe.swift | 362 ++++ (new)
packages/arm/ios/Kraki/Features/Chat/MessageInputView.swift  | -221 +73
```
