### PR TITLE
fix(tentacle): make Claude SDK work inside SEA binary

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/scripts/build-local-binary.mjs
+++ b/packages/tentacle/scripts/build-local-binary.mjs
@@ -94,6 +94,16 @@ async function bundleCli() {
     },
     define: {
       __KRAKI_VERSION__: JSON.stringify(version),
+      // esbuild rewrites `import.meta` to an empty object `{}` when
+      // bundling .mjs sources into CJS, so any `import.meta.url` access
+      // becomes `undefined`. The Claude Agent SDK reads `import.meta.url`
+      // at module-load time via `createRequire` and `fileURLToPath`, both
+      // of which throw on `undefined`. Replace it with a runtime constant
+      // that points at the SEA executable so those calls succeed.
+      'import.meta.url': '__kraki_import_meta_url',
+    },
+    banner: {
+      js: 'const __kraki_import_meta_url = require("url").pathToFileURL(__filename).href;',
     },
   });
 }

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -264,6 +264,14 @@ export class ClaudeAdapter extends AgentAdapter {
     urlForSession: (sessionId: string) => string;
     bearerToken: string;
   };
+  /**
+   * Absolute path to the `claude` binary, set by the multi-adapter via
+   * `which claude` / `where claude`. We pass this to every SDK query() as
+   * `pathToClaudeCodeExecutable` to bypass the SDK's own resolution code,
+   * which calls `createRequire(import.meta.url)` and fails inside our SEA
+   * binary (no node_modules next to the executable).
+   */
+  private readonly claudeExecutablePath?: string;
 
   constructor(options: {
     attachmentStore?: import('../attachment-store.js').AttachmentStore;
@@ -271,10 +279,12 @@ export class ClaudeAdapter extends AgentAdapter {
       urlForSession: (sessionId: string) => string;
       bearerToken: string;
     };
+    claudeExecutablePath?: string;
   } = {}) {
     super();
     this.attachmentStore = options.attachmentStore;
     this.krakiMcp = options.krakiMcp;
+    this.claudeExecutablePath = options.claudeExecutablePath;
   }
 
   /** System prompt appended to Claude Code's built-in prompt. */
@@ -368,7 +378,11 @@ export class ClaudeAdapter extends AgentAdapter {
       const noop = (async function* () { /* never yields — query blocks waiting for input */ })();
       const q = sdk.query({
         prompt: noop,
-        options: { abortController: ac, permissionMode: 'default' as PermissionMode },
+        options: {
+          abortController: ac,
+          permissionMode: 'default' as PermissionMode,
+          ...(this.claudeExecutablePath && { pathToClaudeCodeExecutable: this.claudeExecutablePath }),
+        },
       });
       const models = await q.supportedModels();
       ac.abort();
@@ -588,6 +602,7 @@ export class ClaudeAdapter extends AgentAdapter {
 
     const options: Options = {
       abortController: entry.abortController,
+      ...(this.claudeExecutablePath && { pathToClaudeCodeExecutable: this.claudeExecutablePath }),
       ...(config?.model && { model: this.modelAliasMap.get(config.model) ?? config.model }),
       ...(config?.cwd && { cwd: config.cwd }),
       ...(config?.resume && { resume: config.resume }),
@@ -812,6 +827,7 @@ export class ClaudeAdapter extends AgentAdapter {
       const q = queryFn({
         prompt,
         options: {
+          ...(this.claudeExecutablePath && { pathToClaudeCodeExecutable: this.claudeExecutablePath }),
           systemPrompt: ClaudeAdapter.TITLE_SYSTEM_PROMPT,
           maxTurns: 1,
           permissionMode: 'bypassPermissions' as PermissionMode,

--- a/packages/tentacle/src/adapters/multi.ts
+++ b/packages/tentacle/src/adapters/multi.ts
@@ -62,6 +62,26 @@ function cliExists(name: string): boolean {
   }
 }
 
+/**
+ * Resolve the absolute path to a CLI on PATH, or undefined if not present.
+ * On `where` (Windows) and `which` (Unix), the first line of stdout is the
+ * resolved path. We strip whitespace and return that path so callers can
+ * pass it to SDKs that need the binary location (e.g. Claude SDK's
+ * pathToClaudeCodeExecutable, which is required when running inside SEA
+ * binaries because the SDK's own resolution via createRequire/import.meta
+ * cannot find a node_modules tree).
+ */
+function resolveCliPath(name: string): string | undefined {
+  try {
+    const cmd = platform() === 'win32' ? `where ${name}` : `which ${name}`;
+    const out = execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+    const first = out.split(/\r?\n/).find((line) => line.trim().length > 0);
+    return first?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Detect which agents can be started on this machine. */
 export async function detectAvailableAgents(): Promise<AgentId[]> {
   const agents: AgentId[] = [];
@@ -128,6 +148,13 @@ export class MultiAgentAdapter extends AgentAdapter {
       ...(this.opts.krakiMcp && { krakiMcp: this.opts.krakiMcp }),
     };
 
+    // Claude SDK uses createRequire(import.meta.url) and fileURLToPath to
+    // locate the bundled `claude` binary. Inside our SEA binary that path
+    // resolution fails (no node_modules next to the executable), so we
+    // resolve the system-installed `claude` path up-front and hand it to
+    // the adapter via pathToClaudeCodeExecutable.
+    const claudeExecutablePath = ids.includes('claude') ? resolveCliPath('claude') : undefined;
+
     for (const id of ids) {
       try {
         let adapter: AgentAdapter;
@@ -136,7 +163,7 @@ export class MultiAgentAdapter extends AgentAdapter {
           adapter = new CopilotAdapter(adapterOpts);
         } else if (id === 'claude') {
           const { ClaudeAdapter } = await import('./claude.js');
-          adapter = new ClaudeAdapter(adapterOpts);
+          adapter = new ClaudeAdapter({ ...adapterOpts, claudeExecutablePath });
         } else {
           logger.warn({ id }, 'Unknown agent ID, skipping');
           continue;


### PR DESCRIPTION
## Problem

After v0.24.1 statically bundled the Claude SDK into the SEA binary, Claude detection still fails. Daemon logs:
```
@anthropic-ai/claude-agent-sdk import failed
error: The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received undefined
sdk: false, cli: true → Claude Code not available
```

## Root cause

Two separate bugs needed to be fixed:

### 1. `import.meta.url` becomes `undefined` in CJS bundle

esbuild rewrites `import.meta` to an empty object `{}` when bundling `.mjs` sources into CJS, so any `import.meta.url` read returns `undefined`. The Claude SDK calls:
- `createRequire(import.meta.url)` — at module load
- `fileURLToPath(import.meta.url)` — to locate the bundled `claude` binary

Both throw on `undefined`.

### 2. Bundled binary lookup also fails

Even with `import.meta.url` fixed, the SDK's internal `createRequire.resolve` for the `claude` binary expects a `node_modules` tree next to the executable. The SEA binary has none.

## Fix

1. **`build-local-binary.mjs`**: Inject a runtime constant via esbuild's `define` + `banner`:
   ```js
   define: { 'import.meta.url': '__kraki_import_meta_url' }
   banner: { js: 'const __kraki_import_meta_url = require("url").pathToFileURL(__filename).href;' }
   ```

2. **`multi.ts`**: Add `resolveCliPath()` that returns the absolute path from `which`/`where` output, then pass it to ClaudeAdapter.

3. **`claude.ts`**: Accept `claudeExecutablePath` and pass it as `pathToClaudeCodeExecutable` on every `query()` (model-list probe, real session, title generation). The SDK uses it verbatim instead of self-resolving.

## Verification

- ✅ Type-check clean
- ✅ All 516 tentacle tests pass
- ✅ Local SEA build verified — bundle now contains `const __kraki_import_meta_url = require("url").pathToFileURL(__filename).href;` and all `import.meta.url` references rewritten to that constant
- ⚠️ Did not restart local daemon to E2E-test (would have killed the kraki session running this fix). Will validate after release.

Bumps tentacle to **0.24.3**.