### PR TITLE
voice-broker: handshake-time capability advertisement

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Kraki relay server \u2014 the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",

--- a/packages/head/src/__tests__/integration-helpers.ts
+++ b/packages/head/src/__tests__/integration-helpers.ts
@@ -45,6 +45,8 @@ export async function createTestEnv(options?: Partial<HeadServerOptions>): Promi
 export interface MockDevice {
   ws: WebSocket;
   deviceId: string;
+  /** The full auth_ok message returned by the server (post-handshake). */
+  authOk: Record<string, unknown>;
   /** All messages received (raw parsed JSON) */
   messages: Record<string, unknown>[];
   /** Wait for a message of a specific type */
@@ -132,6 +134,7 @@ export async function connectDevice(
   return {
     ws,
     deviceId: authOk.deviceId,
+    authOk,
     messages,
     waitFor,
     waitForN,

--- a/packages/head/src/__tests__/voice-capability.test.ts
+++ b/packages/head/src/__tests__/voice-capability.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for handshake-time voice capability advertisement.
+ *
+ * Contract under test (see protocol/voice.ts → VoiceCapability and
+ * server.ts → getVoiceCapability):
+ *
+ *   1. When `voiceBrokerUrl` is configured, head advertises
+ *      `auth_ok.voice = { brokerUrl, resource: 'voice/doubao' }`.
+ *   2. When `voiceBrokerUrl` is unset, the `voice` field is OMITTED from
+ *      `auth_ok` entirely (not present as `undefined` or `null`) — arm
+ *      uses key presence as the "should I render mic UI" signal, so the
+ *      wire shape matters.
+ *   3. `voiceBrokerUrl` is the only switch that controls advertisement —
+ *      having `leaseIssuer` configured but no broker URL still results in
+ *      no advertisement (cli enforces this combo can't ship to prod, but
+ *      the server tolerates it for unit-test ergonomics).
+ *
+ * The cli-level interlock (refusing mismatched env at startup) is tested
+ * separately by exercising cli.ts directly — out of scope for the server
+ * integration tests here.
+ */
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { LeaseIssuer } from '../lease-issuer.js';
+import { createTestEnv, connectDevice, type TestEnv, type MockDevice } from './integration-helpers.js';
+
+function mkTmpLeaseDir(): string {
+  return mkdtempSync(join(tmpdir(), 'kraki-cap-test-'));
+}
+function rm(dir: string) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+describe('voice capability advertisement (auth_ok.voice)', () => {
+  let env: TestEnv;
+  let device: MockDevice;
+  let leaseDir: string | undefined;
+
+  afterEach(async () => {
+    try { device?.close(); } catch { /* ignore */ }
+    if (env) await env.cleanup();
+    if (leaseDir) rm(leaseDir);
+    leaseDir = undefined;
+  });
+
+  describe('when voiceBrokerUrl is configured', () => {
+    beforeEach(async () => {
+      leaseDir = mkTmpLeaseDir();
+      env = await createTestEnv({
+        leaseIssuer: LeaseIssuer.loadOrGenerate(leaseDir),
+        voiceBrokerUrl: 'wss://cn.stt.kraki.chat/voice',
+      });
+      device = await connectDevice(env.port, 'arm-test', 'app', { kind: 'web' });
+    });
+
+    it('advertises voice capability in auth_ok', () => {
+      expect(device.authOk.voice).toEqual({
+        brokerUrl: 'wss://cn.stt.kraki.chat/voice',
+        resource: 'voice/doubao',
+      });
+    });
+  });
+
+  describe('when voiceBrokerUrl is NOT configured', () => {
+    beforeEach(async () => {
+      // No leaseIssuer, no broker URL — represents a region with no voice
+      // (e.g. current US main).
+      env = await createTestEnv({});
+      device = await connectDevice(env.port, 'arm-test', 'app', { kind: 'web' });
+    });
+
+    it('omits the voice field from auth_ok entirely', () => {
+      // Strict: must be absent, not just falsy. arm distinguishes "voice
+      // disabled" from "voice config error" by key presence — a stray
+      // `voice: undefined` would be ambiguous on the wire post-JSON.
+      expect('voice' in device.authOk).toBe(false);
+    });
+  });
+
+  describe('when leaseIssuer is configured but voiceBrokerUrl is not', () => {
+    // Reflects the no-prod-cli case: at the server layer this is a
+    // legal config (issues leases, but doesn't advertise where to use
+    // them). cli.ts refuses to start in this state, but the server itself
+    // shouldn't crash — we want isolated unit testing without env coupling.
+    beforeEach(async () => {
+      leaseDir = mkTmpLeaseDir();
+      env = await createTestEnv({
+        leaseIssuer: LeaseIssuer.loadOrGenerate(leaseDir),
+        // no voiceBrokerUrl
+      });
+      device = await connectDevice(env.port, 'arm-test', 'app', { kind: 'web' });
+    });
+
+    it('still omits the voice field (broker URL is the advertise switch, not issuer)', () => {
+      expect('voice' in device.authOk).toBe(false);
+    });
+  });
+});

--- a/packages/head/src/__tests__/voice-config.test.ts
+++ b/packages/head/src/__tests__/voice-config.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the cli-side env interlock.
+ *
+ * These pin the rules that say a head can only run with both lease
+ * issuance + broker advertisement, or neither. The cli surfaces violations
+ * as a fatal startup error; here we verify the underlying rules in
+ * isolation, without spawning the cli.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateVoiceConfig } from '../voice-config.js';
+
+describe('validateVoiceConfig', () => {
+  it('returns disabled when both env vars are unset', () => {
+    expect(validateVoiceConfig({
+      voiceLeaseEnabled: undefined,
+      voiceBrokerUrl: undefined,
+    })).toEqual({ enabled: false, brokerUrl: undefined });
+  });
+
+  it('returns disabled when VOICE_LEASE_ENABLED is set to a non-"1" value', () => {
+    // Truthy-looking strings other than "1" must NOT enable. This matches
+    // the existing convention in cli.ts ("0", "true", "yes" all → off).
+    for (const v of ['0', 'true', 'yes', 'on', '']) {
+      expect(validateVoiceConfig({
+        voiceLeaseEnabled: v,
+        voiceBrokerUrl: undefined,
+      })).toEqual({ enabled: false, brokerUrl: undefined });
+    }
+  });
+
+  it('returns enabled with broker URL when both env vars are set correctly', () => {
+    expect(validateVoiceConfig({
+      voiceLeaseEnabled: '1',
+      voiceBrokerUrl: 'wss://cn.stt.kraki.chat/voice',
+    })).toEqual({
+      enabled: true,
+      brokerUrl: 'wss://cn.stt.kraki.chat/voice',
+    });
+  });
+
+  it('trims whitespace around the broker URL', () => {
+    // Operators paste URLs with trailing newlines/spaces all the time.
+    expect(validateVoiceConfig({
+      voiceLeaseEnabled: '1',
+      voiceBrokerUrl: '  wss://cn.stt.kraki.chat/voice\n',
+    }).brokerUrl).toBe('wss://cn.stt.kraki.chat/voice');
+  });
+
+  it('treats a whitespace-only broker URL as unset (falls into the unset branch)', () => {
+    // " " trimmed is "" → undefined → not_set. With enabled=undefined too,
+    // both are unset → no error.
+    expect(validateVoiceConfig({
+      voiceLeaseEnabled: undefined,
+      voiceBrokerUrl: '   ',
+    })).toEqual({ enabled: false, brokerUrl: undefined });
+  });
+
+  describe('interlock', () => {
+    it('throws when broker URL is set but lease issuance is disabled', () => {
+      expect(() => validateVoiceConfig({
+        voiceLeaseEnabled: undefined,
+        voiceBrokerUrl: 'wss://cn.stt.kraki.chat/voice',
+      })).toThrow(/VOICE_BROKER_URL is set but VOICE_LEASE_ENABLED is not "1"/);
+    });
+
+    it('throws when broker URL is set but lease issuance is "0"', () => {
+      expect(() => validateVoiceConfig({
+        voiceLeaseEnabled: '0',
+        voiceBrokerUrl: 'wss://cn.stt.kraki.chat/voice',
+      })).toThrow(/VOICE_BROKER_URL is set but VOICE_LEASE_ENABLED is not "1"/);
+    });
+
+    it('throws when lease issuance is "1" but broker URL is unset', () => {
+      expect(() => validateVoiceConfig({
+        voiceLeaseEnabled: '1',
+        voiceBrokerUrl: undefined,
+      })).toThrow(/VOICE_LEASE_ENABLED=1 requires VOICE_BROKER_URL to be set/);
+    });
+
+    it('throws when lease issuance is "1" but broker URL is whitespace-only', () => {
+      expect(() => validateVoiceConfig({
+        voiceLeaseEnabled: '1',
+        voiceBrokerUrl: '   ',
+      })).toThrow(/VOICE_LEASE_ENABLED=1 requires VOICE_BROKER_URL to be set/);
+    });
+  });
+
+  describe('URL schema validation', () => {
+    it('accepts wss:// URLs', () => {
+      expect(validateVoiceConfig({
+        voiceLeaseEnabled: '1',
+        voiceBrokerUrl: 'wss://cn.stt.kraki.chat/voice',
+      }).brokerUrl).toBe('wss://cn.stt.kraki.chat/voice');
+    });
+
+    it('accepts ws:// URLs (e.g. local dev)', () => {
+      expect(validateVoiceConfig({
+        voiceLeaseEnabled: '1',
+        voiceBrokerUrl: 'ws://127.0.0.1:7800/voice',
+      }).brokerUrl).toBe('ws://127.0.0.1:7800/voice');
+    });
+
+    it('rejects http:// URLs (paste-typo from the http console)', () => {
+      expect(() => validateVoiceConfig({
+        voiceLeaseEnabled: '1',
+        voiceBrokerUrl: 'http://cn.stt.kraki.chat/voice',
+      })).toThrow(/must start with ws:\/\/ or wss:\/\//);
+    });
+
+    it('rejects https:// URLs', () => {
+      expect(() => validateVoiceConfig({
+        voiceLeaseEnabled: '1',
+        voiceBrokerUrl: 'https://cn.stt.kraki.chat/voice',
+      })).toThrow(/must start with ws:\/\/ or wss:\/\//);
+    });
+
+    it('rejects bare hostnames (missing scheme)', () => {
+      expect(() => validateVoiceConfig({
+        voiceLeaseEnabled: '1',
+        voiceBrokerUrl: 'cn.stt.kraki.chat/voice',
+      })).toThrow(/must start with ws:\/\/ or wss:\/\//);
+    });
+  });
+});

--- a/packages/head/src/cli.ts
+++ b/packages/head/src/cli.ts
@@ -36,6 +36,7 @@ import { HeadServer } from './server.js';
 import { GitHubAuthProvider, OpenAuthProvider, ApiKeyAuthProvider, ThrottledAuthProvider, safeEqual } from './auth.js';
 import type { AuthProvider } from './auth.js';
 import { LeaseIssuer, defaultVoiceLeaseDir } from './lease-issuer.js';
+import { validateVoiceConfig } from './voice-config.js';
 import { Logger, setGlobalLogger } from './logger.js';
 import { PushManager, ApnsProvider, WebPushProvider } from './push/index.js';
 import type { PushProvider as IPushProvider } from './push/index.js';
@@ -97,6 +98,12 @@ if (args.includes('--help') || args.includes('-h')) {
     VOICE_LEASE_QUOTA_SEC          Per-lease audio quota in seconds (default: 7200 = 2h).
     VOICE_DAILY_QUOTA_SEC          Per-user-per-day cap on issued lease quota
                                    (default: 7200 = 2h).
+    VOICE_BROKER_URL               Public WSS URL of this region's voice broker
+                                   (e.g. wss://cn.stt.kraki.chat/voice).
+                                   Advertised in auth_ok so clients render the
+                                   mic UI. MUST be set together with
+                                   VOICE_LEASE_ENABLED=1 — head fails to start
+                                   otherwise.
     kraki-relay print-voice-pubkey Prints the lease public key PEM to stdout
                                    (for pinning into the voice-broker).
 
@@ -442,11 +449,24 @@ if (IS_CONNECTED_MODE) {
 }
 
 // --- Voice lease issuance (optional) ---
-const VOICE_LEASE_ENABLED = process.env.VOICE_LEASE_ENABLED === '1';
 const VOICE_LEASE_DIR = process.env.VOICE_LEASE_DIR || defaultVoiceLeaseDir();
 const VOICE_LEASE_TTL_SEC = Math.max(60, parseInt(process.env.VOICE_LEASE_TTL_SEC || '86400', 10) || 86400);
 const VOICE_LEASE_QUOTA_SEC = Math.max(1, parseInt(process.env.VOICE_LEASE_QUOTA_SEC || '7200', 10) || 7200);
 const VOICE_DAILY_QUOTA_SEC = Math.max(VOICE_LEASE_QUOTA_SEC, parseInt(process.env.VOICE_DAILY_QUOTA_SEC || '7200', 10) || 7200);
+
+let voiceConfig;
+try {
+  voiceConfig = validateVoiceConfig({
+    voiceLeaseEnabled: process.env.VOICE_LEASE_ENABLED,
+    voiceBrokerUrl: process.env.VOICE_BROKER_URL,
+  });
+} catch (err) {
+  console.error(`[fatal] ${(err as Error).message}`);
+  process.exit(1);
+}
+const VOICE_LEASE_ENABLED = voiceConfig.enabled;
+const VOICE_BROKER_URL = voiceConfig.brokerUrl;
+
 let voiceLeaseIssuer: LeaseIssuer | undefined;
 if (VOICE_LEASE_ENABLED) {
   voiceLeaseIssuer = LeaseIssuer.loadOrGenerate(VOICE_LEASE_DIR);
@@ -455,6 +475,7 @@ if (VOICE_LEASE_ENABLED) {
     ttlSec: VOICE_LEASE_TTL_SEC,
     quotaSec: VOICE_LEASE_QUOTA_SEC,
     dailyQuotaSec: VOICE_DAILY_QUOTA_SEC,
+    brokerUrl: VOICE_BROKER_URL,
   });
 }
 
@@ -469,6 +490,7 @@ const head = new HeadServer(storage!, {
   voiceLeaseTtlSec: VOICE_LEASE_TTL_SEC,
   voiceLeaseQuotaSec: VOICE_LEASE_QUOTA_SEC,
   voiceDailyQuotaSec: VOICE_DAILY_QUOTA_SEC,
+  voiceBrokerUrl: VOICE_BROKER_URL,
 });
 
 const startedAt = Date.now();

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -6,7 +6,7 @@ import type { Server } from 'http';
 import type {
   AuthMessage, AuthErrorCode, AuthMethod,
   UnicastEnvelope, BroadcastEnvelope, DeviceSummary, DeviceRole, DeviceKind,
-  VoiceResource,
+  VoiceResource, VoiceCapability,
 } from '@kraki/protocol';
 import { Storage } from './storage.js';
 import { LeaseIssuer } from './lease-issuer.js';
@@ -110,6 +110,20 @@ export interface HeadServerOptions {
   voiceLeaseQuotaSec?: number;
   /** Per-user-per-day cap on total issued lease quota. Default 7200 (2h). */
   voiceDailyQuotaSec?: number;
+  /**
+   * Public WSS URL of the voice broker for this region (e.g.
+   * `wss://cn.stt.kraki.chat/voice`). When set, head advertises a
+   * `VoiceCapability` inside `auth_ok.voice` so arm can render the mic UI.
+   * When unset, the field is omitted entirely — arm hides the mic UI.
+   *
+   * Must be set together with `leaseIssuer`: cli-side interlock refuses to
+   * start in either-without-the-other configurations because:
+   *   - Advertising a broker URL but having no issuer would mean clients
+   *     show the mic UI then get `not_entitled` on every press.
+   *   - Having an issuer but no advertised URL means clients have no way
+   *     to actually use the leases they're being issued.
+   */
+  voiceBrokerUrl?: string;
 }
 
 const DEFAULT_VOICE_LEASE_TTL_SEC = 86_400;
@@ -462,6 +476,22 @@ export class HeadServer {
 
   private getVapidPublicKey(): string | undefined {
     return this.options.pushManager?.getVapidPublicKey();
+  }
+
+  /**
+   * Build the voice capability advertisement for `auth_ok` from this head's
+   * config. Returns `undefined` (omit the field) when no broker URL is
+   * configured for this region.
+   *
+   * Note: the per-region nature falls out for free in edge mode — the edge's
+   * own `voiceBrokerUrl` config drives this, never main's. So Beijing edge
+   * advertises Beijing's broker, and US main advertises nothing, all from a
+   * single helper.
+   */
+  private getVoiceCapability(): VoiceCapability | undefined {
+    const url = this.options.voiceBrokerUrl;
+    if (!url) return undefined;
+    return { brokerUrl: url, resource: 'voice/doubao' };
   }
 
   private findGitHubProvider(): GitHubAuthProvider | undefined {
@@ -1312,6 +1342,7 @@ export class HeadServer {
       vapidPublicKey: params.vapidPublicKey ?? this.getVapidPublicKey(),
       relayVersion: this.options.version,
       ...(pendingMessages.length > 0 && { pendingMessages }),
+      ...(this.getVoiceCapability() && { voice: this.getVoiceCapability() }),
     }));
 
     this.broadcastDeviceJoined(params.userId, params.deviceId);

--- a/packages/head/src/voice-config.ts
+++ b/packages/head/src/voice-config.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure validation of voice-broker-related environment configuration.
+ *
+ * This module exists separately from cli.ts so the validation rules can be
+ * unit-tested without spawning a child process. cli.ts imports `validate`
+ * and exits on the first error.
+ *
+ * The rules encode the operational invariant:
+ *
+ *   VOICE_LEASE_ENABLED ⇔ VOICE_BROKER_URL set
+ *
+ * If only one side is set, head fails to start — it'd be either advertising
+ * a broker for which it can't issue leases (clients see UI but every press
+ * fails) or issuing leases that no client knows where to use.
+ */
+
+export interface VoiceConfigInput {
+  /** Raw value of `VOICE_LEASE_ENABLED` env (only `'1'` enables). */
+  voiceLeaseEnabled: string | undefined;
+  /** Raw value of `VOICE_BROKER_URL` env (whitespace tolerated). */
+  voiceBrokerUrl: string | undefined;
+}
+
+export interface VoiceConfigResolved {
+  /** True when leases should be issued (VOICE_LEASE_ENABLED === '1'). */
+  enabled: boolean;
+  /** Trimmed broker URL, or undefined when unset. */
+  brokerUrl: string | undefined;
+}
+
+/**
+ * Validate the (enabled, brokerUrl) pair. Returns the resolved config on
+ * success, or throws an Error with a human-readable message on the first
+ * rule violation. Caller (cli.ts) is responsible for printing the message
+ * and exiting with non-zero status.
+ */
+export function validateVoiceConfig(input: VoiceConfigInput): VoiceConfigResolved {
+  const enabled = input.voiceLeaseEnabled === '1';
+  const brokerUrl = (input.voiceBrokerUrl ?? '').trim() || undefined;
+
+  if (brokerUrl && !enabled) {
+    throw new Error(
+      'VOICE_BROKER_URL is set but VOICE_LEASE_ENABLED is not "1". ' +
+      'Set VOICE_LEASE_ENABLED=1 to advertise + issue, or unset VOICE_BROKER_URL.',
+    );
+  }
+  if (enabled && !brokerUrl) {
+    throw new Error(
+      'VOICE_LEASE_ENABLED=1 requires VOICE_BROKER_URL to be set ' +
+      '(the public WSS URL clients should connect to, e.g. wss://cn.stt.kraki.chat/voice).',
+    );
+  }
+  if (brokerUrl && !/^wss?:\/\//.test(brokerUrl)) {
+    throw new Error(
+      `VOICE_BROKER_URL must start with ws:// or wss:// (got: ${brokerUrl})`,
+    );
+  }
+
+  return { enabled, brokerUrl };
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -852,6 +852,12 @@ export interface AuthOkMessage {
   relayVersion?: string;
   /** Queued unicast envelopes received while this device was offline */
   pendingMessages?: UnicastEnvelope[];
+  /**
+   * Voice dictation capability for this region. Absent when the head has
+   * no voice broker configured — arm should hide the mic UI in that case.
+   * See `VoiceCapability` for the contract.
+   */
+  voice?: VoiceCapability;
 }
 
 export type AuthErrorCode =
@@ -1042,4 +1048,5 @@ export type Message = RelayEnvelope | ControlMessage;
 import type { DeviceSummary, DeviceRole, DeviceInfo, DeviceCapabilities, PushProviderType } from './devices.js';
 import type { SessionSummary, SessionDigest, SessionMode, SessionUsage } from './sessions.js';
 import type { ToolArgs } from './tools.js';
+import type { VoiceCapability } from './voice.js';
 export type { DeviceSummary, DeviceRole, DeviceInfo, DeviceCapabilities, PushProviderType, SessionSummary, SessionDigest, SessionMode, SessionUsage, ToolArgs };

--- a/packages/protocol/src/voice.ts
+++ b/packages/protocol/src/voice.ts
@@ -56,6 +56,35 @@ export interface VoiceLease {
 }
 
 // ============================================================
+// Capability advertisement — handshake-time
+// ============================================================
+
+/**
+ * head → arm: voice dictation capability for this region. Sent inside
+ * `auth_ok.voice` when the head is configured with a broker URL.
+ *
+ * Absence of this field means voice is not available in this region — arm
+ * should hide the mic UI rather than probe with `request_voice_lease`.
+ *
+ * Why advertise at handshake (instead of letting arm discover via the
+ * reactive `voice_lease_denied: not_entitled` path):
+ *   1. UI can render the correct affordance from the first frame.
+ *   2. No "blind probe" — arm doesn't speculatively request a lease.
+ *   3. Each region (main / edge) advertises its own broker independently,
+ *      so the multi-region story stays local: edge head config decides.
+ */
+export interface VoiceCapability {
+  /**
+   * Public WSS URL of the voice broker for this region (e.g.
+   * `wss://cn.stt.kraki.chat/voice`). arm connects directly here after
+   * obtaining a lease via `request_voice_lease`.
+   */
+  brokerUrl: string;
+  /** Resource id arm should pass when calling `request_voice_lease`. */
+  resource: VoiceResource;
+}
+
+// ============================================================
 // WebSocket messages — arm ↔ head
 // ============================================================
 


### PR DESCRIPTION
## What

Lets head advertise the per-region voice broker URL inside `auth_ok` so arm can render the mic UI conditionally on whether its region has voice support, instead of speculatively probing with `request_voice_lease` and handling `not_entitled` reactively.

Stacks on top of #139 (the lease-auth foundation) — purely additive wire change.

## Wire change (additive, back-compat)

```ts
// protocol/voice.ts (new)
export interface VoiceCapability {
  brokerUrl: string;          // wss://cn.stt.kraki.chat/voice
  resource: VoiceResource;    // 'voice/doubao'
}

// protocol/messages.ts
export interface AuthOkMessage {
  // ... existing fields ...
  voice?: VoiceCapability;    // OMITTED when no broker — arm uses key presence
}
```

Same pattern as the existing `githubClientId?` / `vapidPublicKey?` advertisement — region/feature flags pass through `auth_ok` so the client can render the right affordances from the first frame.

## Head wiring

- `HeadServerOptions.voiceBrokerUrl?: string` → emitted in `auth_ok.voice`
- `cli.ts` reads new `VOICE_BROKER_URL` env, validates via the new pure function `validateVoiceConfig` in `voice-config.ts`
- **Interlock**: `VOICE_LEASE_ENABLED=1 ⇔ VOICE_BROKER_URL set`. cli refuses to start otherwise. Reasoning:
  - URL set, lease disabled → clients see mic UI then get `not_entitled` on every press
  - Lease enabled, URL unset → leases issued but nobody knows where to use them
- Light schema check: broker URL must start with `ws://` or `wss://`

## Multi-region story

Falls out for free — each edge head's own env decides what it advertises. After this lands:
- Beijing edge sets `VOICE_BROKER_URL=wss://cn.stt.kraki.chat/voice` → arm sees voice cap → renders mic
- US main leaves `VOICE_BROKER_URL` unset → arm hides mic
- No coordination between regions needed

## Tests (head 242 → 259, +17)

- `voice-config.test.ts` — 14 unit tests on the env interlock (pure function, no spawning)
  - both unset → disabled, no error
  - URL set + enabled unset → throws
  - enabled set + URL unset → throws
  - http/https/bare-host → throws (schema)
  - whitespace tolerance, etc.
- `voice-capability.test.ts` — 3 integration tests on the `auth_ok` wire shape
  - configured → `auth_ok.voice = { brokerUrl, resource: 'voice/doubao' }`
  - unconfigured → field is OMITTED entirely (`'voice' in authOk === false`)
  - issuer-but-no-URL → still omitted (URL is the advertise switch)

`pnpm lint` clean, all suites green:
- protocol: types only
- crypto: 36 ✓
- head: 259 ✓ (+17)
- voice-broker: 40 ✓
- @kraki/tests: 49 ✓

## Out of scope

- arm-side rendering changes (will follow once we deploy Beijing broker and start wiring web mic page)
- Any iOS app changes
- Pre-auth advertisement via `auth_info_response` — voice is post-auth-only so handshake-time is sufficient

## Deploy after this lands

Per `plan.md`:
1. Deploy this branch to Beijing edge head
2. Set `VOICE_LEASE_ENABLED=1` + `VOICE_BROKER_URL=wss://cn.stt.kraki.chat/voice`
3. Stand up `@kraki/voice-broker` sidecar pinned to head's pubkey
4. nginx vhost `cn.stt.kraki.chat` → `127.0.0.1:7800`
5. DNS A record `cn.stt.kraki.chat` → `82.156.207.66`
6. Wire arm web mic page

US main stays exactly as today (no env set → no advertisement → no behavior change).
