### PR TITLE
feat: context tier & reasoning effort improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "esbuild"
     ],
     "overrides": {
-      "@github/copilot": "1.0.48"
+      "@github/copilot": "1.0.63"
     }
   },
   "devDependencies": {

--- a/packages/arm/web/src/components/devices/SessionInfoPanel.tsx
+++ b/packages/arm/web/src/components/devices/SessionInfoPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import { useStore } from '../../hooks/useStore';
 import { wsClient } from '../../lib/ws-client';
-import type { SessionSummary, SessionUsage, ModelDetail } from '@kraki/protocol';
+import type { SessionSummary, SessionUsage, ModelDetail, ContextTier } from '@kraki/protocol';
 import { MessageSquare, GitFork, Trash2, Pencil } from 'lucide-react';
 
 function formatTokens(n: number): string {
@@ -26,6 +26,7 @@ export function SessionInfoPanel({ session, usage, models, modelDetails, onClose
   const [showModelPicker, setShowModelPicker] = useState(false);
   const [pendingModel, setPendingModel] = useState<string | null>(null);
   const [pendingEffort, setPendingEffort] = useState<string | undefined>(undefined);
+  const [pendingContextTier, setPendingContextTier] = useState<ContextTier | undefined>(undefined);
   const [editing, setEditing] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
   const titleInputRef = useRef<HTMLInputElement>(null);
@@ -37,6 +38,7 @@ export function SessionInfoPanel({ session, usage, models, modelDetails, onClose
   const openPicker = () => {
     setPendingModel(session.model ?? null);
     setPendingEffort(undefined);
+    setPendingContextTier(undefined);
     setShowModelPicker(true);
   };
 
@@ -44,15 +46,17 @@ export function SessionInfoPanel({ session, usage, models, modelDetails, onClose
     setShowModelPicker(false);
     setPendingModel(null);
     setPendingEffort(undefined);
+    setPendingContextTier(undefined);
   };
 
   const applyModel = () => {
     if (pendingModel) {
-      wsClient.setSessionModel(session.id, pendingModel, pendingEffort);
+      wsClient.setSessionModel(session.id, pendingModel, pendingEffort, pendingContextTier === 'long_context' ? pendingContextTier : undefined);
     }
     setShowModelPicker(false);
     setPendingModel(null);
     setPendingEffort(undefined);
+    setPendingContextTier(undefined);
   };
 
   const sessionName = session.title ?? session.autoTitle ?? `${session.agent}${session.model ? ` · ${session.model}` : ''}`;
@@ -177,9 +181,34 @@ export function SessionInfoPanel({ session, usage, models, modelDetails, onClose
                           : 'bg-surface-tertiary text-text-secondary hover:bg-surface-tertiary/80 hover:text-text-primary'
                       }`}
                     >
-                      {effort === 'xhigh' ? 'Max' : effort.charAt(0).toUpperCase() + effort.slice(1)}
+                      {effort === 'xhigh' ? 'XHigh' : effort === 'max' ? 'Max' : effort.charAt(0).toUpperCase() + effort.slice(1)}
                     </button>
                   ))}
+                </div>
+              )}
+              {activeModelDetail?.supportedContextTiers && activeModelDetail.supportedContextTiers.length > 1 && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[10px] text-text-muted">Context</span>
+                  <button
+                    onClick={() => setPendingContextTier('default')}
+                    className={`rounded-md px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      pendingContextTier !== 'long_context'
+                        ? 'bg-ocean-500/15 text-ocean-400'
+                        : 'bg-surface-tertiary text-text-secondary hover:bg-surface-tertiary/80 hover:text-text-primary'
+                    }`}
+                  >
+                    Default
+                  </button>
+                  <button
+                    onClick={() => setPendingContextTier('long_context')}
+                    className={`rounded-md px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      pendingContextTier === 'long_context'
+                        ? 'bg-ocean-500/15 text-ocean-400'
+                        : 'bg-surface-tertiary text-text-secondary hover:bg-surface-tertiary/80 hover:text-text-primary'
+                    }`}
+                  >
+                    1M tokens
+                  </button>
                 </div>
               )}
               <div className="flex justify-end gap-2">

--- a/packages/arm/web/src/components/sessions/NewSessionDialog.tsx
+++ b/packages/arm/web/src/components/sessions/NewSessionDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useStore } from '../../hooks/useStore';
 import { wsClient } from '../../lib/ws-client';
-import type { ReasoningEffort } from '@kraki/protocol';
+import type { ReasoningEffort, ContextTier } from '@kraki/protocol';
 
 interface Props {
   open: boolean;
@@ -12,12 +12,14 @@ const LAST_DEVICE_KEY = 'kraki:last-device';
 const AGENT_PREF_KEY = 'kraki:last-agent';
 const MODEL_PREF_KEY = 'kraki:last-model';
 const EFFORT_PREF_KEY = 'kraki:last-effort';
+const CONTEXT_TIER_PREF_KEY = 'kraki:last-context-tier';
 
 const EFFORT_LABELS: Record<ReasoningEffort, string> = {
   low: 'Low',
   medium: 'Medium',
   high: 'High',
-  xhigh: 'Max',
+  xhigh: 'XHigh',
+  max: 'Max',
 };
 
 function getModelPrefs(): Record<string, string> {
@@ -40,6 +42,16 @@ function saveEffortPref(modelId: string, effort: ReasoningEffort) {
   localStorage.setItem(EFFORT_PREF_KEY, JSON.stringify(prefs));
 }
 
+function getContextTierPrefs(): Record<string, ContextTier> {
+  try { return JSON.parse(localStorage.getItem(CONTEXT_TIER_PREF_KEY) ?? '{}'); } catch { return {}; }
+}
+
+function saveContextTierPref(modelId: string, tier: ContextTier) {
+  const prefs = getContextTierPrefs();
+  prefs[modelId] = tier;
+  localStorage.setItem(CONTEXT_TIER_PREF_KEY, JSON.stringify(prefs));
+}
+
 export function NewSessionDialog({ open, onClose }: Props) {
   const devices = useStore((s) => s.devices);
   const deviceAgents = useStore((s) => s.deviceAgents);
@@ -49,6 +61,7 @@ export function NewSessionDialog({ open, onClose }: Props) {
   const [selectedAgent, setSelectedAgent] = useState('');
   const [model, setModel] = useState('');
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort | undefined>();
+  const [contextTier, setContextTier] = useState<ContextTier | undefined>();
   const listRef = useRef<HTMLDivElement>(null);
 
   // Default to last selected device, or single tentacle
@@ -93,6 +106,7 @@ export function NewSessionDialog({ open, onClose }: Props) {
     [modelDetails, model],
   );
   const supportedEfforts = selectedModelDetail?.supportedReasoningEfforts;
+  const supportedContextTiers = selectedModelDetail?.supportedContextTiers;
 
   // Restore last model for this device+agent, or auto-select first
   useEffect(() => {
@@ -121,6 +135,21 @@ export function NewSessionDialog({ open, onClose }: Props) {
       setReasoningEffort(selectedModelDetail.defaultReasoningEffort);
     }
   }, [model, selectedModelDetail, supportedEfforts]);
+
+  // Restore or default context tier when model changes
+  useEffect(() => {
+    if (!model || !supportedContextTiers || supportedContextTiers.length <= 1) {
+      setContextTier(undefined);
+      return;
+    }
+    const prefs = getContextTierPrefs();
+    const lastTier = prefs[model];
+    if (lastTier && supportedContextTiers.includes(lastTier)) {
+      setContextTier(lastTier);
+    } else {
+      setContextTier('default');
+    }
+  }, [model, supportedContextTiers]);
 
   // Scroll selected model into view
   useEffect(() => {
@@ -151,12 +180,18 @@ export function NewSessionDialog({ open, onClose }: Props) {
     saveEffortPref(model, effort);
   };
 
+  const handleSelectContextTier = (tier: ContextTier) => {
+    setContextTier(tier);
+    saveContextTierPref(model, tier);
+  };
+
   const handleSubmit = () => {
     if (!canSubmit) return;
     wsClient.createSession({
       targetDeviceId: selectedDevice,
       model,
       reasoningEffort,
+      contextTier: contextTier === 'long_context' ? contextTier : undefined,
       agentId: selectedAgentId,
     });
     onClose();
@@ -285,6 +320,35 @@ export function NewSessionDialog({ open, onClose }: Props) {
                       {EFFORT_LABELS[effort] ?? effort}
                     </button>
                   ))}
+                </div>
+              </div>
+            )}
+
+            {/* Context tier picker — only shown when model supports long_context */}
+            {supportedContextTiers && supportedContextTiers.length > 1 && (
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-text-secondary">Context</label>
+                <div className="flex gap-1.5">
+                  <button
+                    onClick={() => handleSelectContextTier('default')}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                      contextTier !== 'long_context'
+                        ? 'bg-ocean-500 text-white'
+                        : 'bg-surface-tertiary text-text-secondary hover:bg-surface-tertiary/80 hover:text-text-primary'
+                    }`}
+                  >
+                    Default
+                  </button>
+                  <button
+                    onClick={() => handleSelectContextTier('long_context')}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                      contextTier === 'long_context'
+                        ? 'bg-ocean-500 text-white'
+                        : 'bg-surface-tertiary text-text-secondary hover:bg-surface-tertiary/80 hover:text-text-primary'
+                    }`}
+                  >
+                    1M tokens
+                  </button>
                 </div>
               </div>
             )}

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -281,11 +281,12 @@ export function setSessionModel(
   model: string,
   send: (msg: Record<string, unknown>) => void,
   reasoningEffort?: string,
+  contextTier?: string,
 ): void {
   send({
     type: 'set_session_model',
     sessionId,
-    payload: { model, ...(reasoningEffort && { reasoningEffort }) },
+    payload: { model, ...(reasoningEffort && { reasoningEffort }), ...(contextTier && { contextTier }) },
   });
   // Optimistically update the local session model
   const store = getStore();
@@ -296,7 +297,7 @@ export function setSessionModel(
 }
 
 export function createSession(
-  opts: { targetDeviceId: string; model: string; reasoningEffort?: string; prompt?: string; cwd?: string; agentId?: string },
+  opts: { targetDeviceId: string; model: string; reasoningEffort?: string; contextTier?: string; prompt?: string; cwd?: string; agentId?: string },
   send: (msg: Record<string, unknown>) => void,
   state: CommandState,
 ): void {
@@ -313,6 +314,7 @@ export function createSession(
       agentId: opts.agentId ?? 'copilot',
       model: opts.model,
       ...(opts.reasoningEffort && { reasoningEffort: opts.reasoningEffort }),
+      ...(opts.contextTier && { contextTier: opts.contextTier }),
       prompt: opts.prompt,
       cwd: opts.cwd,
     },

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -140,8 +140,8 @@ export class KrakiWSClient {
     commands.setSessionMode(sessionId, mode, (msg) => this.sendEncrypted(msg), this.cmdState);
   }
 
-  setSessionModel(sessionId: string, model: string, reasoningEffort?: string) {
-    commands.setSessionModel(sessionId, model, (msg) => this.sendEncrypted(msg), reasoningEffort);
+  setSessionModel(sessionId: string, model: string, reasoningEffort?: string, contextTier?: string) {
+    commands.setSessionModel(sessionId, model, (msg) => this.sendEncrypted(msg), reasoningEffort, contextTier);
   }
 
   deleteSession(sessionId: string) {
@@ -162,7 +162,7 @@ export class KrakiWSClient {
     getStore().removeSession(sessionId);
   }
 
-  createSession(opts: { targetDeviceId: string; model: string; reasoningEffort?: string; prompt?: string; cwd?: string; agentId?: string }) {
+  createSession(opts: { targetDeviceId: string; model: string; reasoningEffort?: string; contextTier?: string; prompt?: string; cwd?: string; agentId?: string }) {
     commands.createSession(opts, (msg) => this.sendEncrypted(msg), this.cmdState);
   }
 

--- a/packages/protocol/src/devices.ts
+++ b/packages/protocol/src/devices.ts
@@ -73,7 +73,9 @@ export type PushProviderType = 'apns' | 'fcm' | 'web_push';
 
 // ── Model metadata ──────────────────────────────────────
 
-export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export type ContextTier = 'default' | 'long_context';
 
 /** Model info exposed through the protocol (subset of SDK ModelInfo). */
 export interface ModelDetail {
@@ -84,4 +86,6 @@ export interface ModelDetail {
   defaultReasoningEffort?: ReasoningEffort;
   /** Total token ceiling for the model (e.g. 200000). */
   contextWindow?: number;
+  /** Available context tiers (omitted = only default). */
+  supportedContextTiers?: ContextTier[];
 }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -298,6 +298,7 @@ export interface SessionModelSetMessage extends BaseEnvelope {
   payload: {
     model: string;
     reasoningEffort?: import('./devices.js').ReasoningEffort;
+    contextTier?: import('./devices.js').ContextTier;
   };
 }
 
@@ -619,6 +620,8 @@ export interface CreateSessionMessage extends BaseEnvelope {
     model: string;
     /** Reasoning effort level (only for models that support it) */
     reasoningEffort?: import('./devices.js').ReasoningEffort;
+    /** Context tier (only for models that support long_context) */
+    contextTier?: import('./devices.js').ContextTier;
     /** Initial prompt to send after session is created */
     prompt?: string;
     /** Working directory for the session */
@@ -638,6 +641,7 @@ export interface SetSessionModelMessage extends BaseEnvelope {
   payload: {
     model: string;
     reasoningEffort?: import('./devices.js').ReasoningEffort;
+    contextTier?: import('./devices.js').ContextTier;
   };
 }
 

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.156",
-    "@github/copilot-sdk": "^0.3.0",
+    "@github/copilot-sdk": "^1.0.1",
     "@inquirer/prompts": "^8.3.2",
     "@kraki/crypto": "workspace:*",
     "@kraki/protocol": "workspace:*",

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -432,7 +432,7 @@ describe('RelayClient set_session_model', () => {
     // resolves synchronously here because getMeta returns a non-disconnected
     // session, so the .then fires after a microtask).
     await vi.runAllTimersAsync();
-    expect(adapter.setSessionModel).toHaveBeenCalledWith('sess_1', 'claude-opus-4', undefined);
+    expect(adapter.setSessionModel).toHaveBeenCalledWith('sess_1', 'claude-opus-4', undefined, undefined);
   });
 
   it('broadcasts session_model_set after handling set_session_model', () => {
@@ -519,7 +519,7 @@ describe('RelayClient set_session_model', () => {
     // The adapter call is chained behind ensureSessionResumed.
     await vi.runAllTimersAsync();
     expect(adapter.resumeSession).toHaveBeenCalledWith('sess_d', expect.anything());
-    expect(adapter.setSessionModel).toHaveBeenCalledWith('sess_d', 'claude-opus-4', undefined);
+    expect(adapter.setSessionModel).toHaveBeenCalledWith('sess_d', 'claude-opus-4', undefined, undefined);
   });
 
   it('de-duplicates concurrent lazy resumes for the same session (resume once, not twice)', async () => {

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -1188,7 +1188,7 @@ describe('CopilotAdapter', () => {
 
     it('merges SDK list with local active sessions', async () => {
       mockListSessions.mockResolvedValue([
-        { sessionId: 'sess-1', summary: 'first', context: { cwd: '/tmp' } },
+        { sessionId: 'sess-1', summary: 'first', context: { workingDirectory: '/tmp' } },
         { sessionId: 'sess-old', summary: 'old' },
       ]);
       await adapter.start();
@@ -1204,7 +1204,7 @@ describe('CopilotAdapter', () => {
       await adapter.start();
       await adapter.createSession({}); // mock-sess-1
       mockListSessions.mockResolvedValue([
-        { sessionId: 'mock-sess-1', context: { cwd: '/home' } },
+        { sessionId: 'mock-sess-1', context: { workingDirectory: '/home' } },
       ]);
       const list = await adapter.listSessions();
       expect(list[0]).toMatchObject({ id: 'mock-sess-1', state: 'active' });
@@ -1758,7 +1758,7 @@ describe('CopilotAdapter', () => {
 
       await adapter.setSessionModel(sessionId, 'claude-opus-4');
 
-      expect(mockSessions[0].setModel).toHaveBeenCalledWith('claude-opus-4');
+      expect(mockSessions[0].setModel).toHaveBeenCalledWith('claude-opus-4', undefined);
     });
 
     it('does not throw for unknown session', async () => {

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -76,6 +76,8 @@ export interface CreateSessionConfig {
   model?: string;
   /** Reasoning effort level (for models that support it) */
   reasoningEffort?: string;
+  /** Context tier (for models that support long_context) */
+  contextTier?: string;
   /** Working directory for the session */
   cwd?: string;
   /** Caller-supplied session ID (adapter may ignore) */
@@ -194,8 +196,8 @@ export abstract class AgentAdapter {
   /** Generate a title for a session via LLM. Override in concrete adapters. */
   async generateTitle(_context: { firstUserMessage: string; lastUserMessage?: string; recentMessages?: string[]; currentTitle?: string }): Promise<string | null> { return null; }
 
-  /** Change model (and optionally reasoning effort) for a session. Override in concrete adapters. */
-  async setSessionModel(_sessionId: string, _model: string, _reasoningEffort?: string): Promise<void> { /* no-op by default */ }
+  /** Change model (and optionally reasoning effort / context tier) for a session. Override in concrete adapters. */
+  async setSessionModel(_sessionId: string, _model: string, _reasoningEffort?: string, _contextTier?: string): Promise<void> { /* no-op by default */ }
 
   /** Get current cumulative usage for a session. Override in concrete adapters. */
   getSessionUsage(_sessionId: string): SessionUsage | null { return null; }

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -414,9 +414,7 @@ export class ClaudeAdapter extends AgentAdapter {
               name: m.displayName ?? displayId,
               supportsReasoningEffort: !!m.supportsEffort,
               ...(m.supportedEffortLevels && {
-                supportedReasoningEfforts: m.supportedEffortLevels.filter(
-                  (e): e is 'low' | 'medium' | 'high' | 'xhigh' => e !== 'max',
-                ),
+                supportedReasoningEfforts: m.supportedEffortLevels as import('@kraki/protocol').ReasoningEffort[],
               }),
             });
           }
@@ -769,7 +767,7 @@ export class ClaudeAdapter extends AgentAdapter {
     logger.debug({ sessionId, mode }, 'Session permission mode changed');
   }
 
-  async setSessionModel(sessionId: string, model: string, _reasoningEffort?: string): Promise<void> {
+  async setSessionModel(sessionId: string, model: string, _reasoningEffort?: string, _contextTier?: string): Promise<void> {
     const entry = this.sessions.get(sessionId);
     if (!entry) {
       logger.warn({ sessionId }, 'setSessionModel: session not found');

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -23,6 +23,7 @@ import type {
   PermissionRequestResult,
   SessionMetadata,
   MCPServerConfig,
+  ContextTier,
 } from '@github/copilot-sdk';
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, cpSync, mkdtempSync, mkdirSync, unlinkSync, readdirSync, symlinkSync, lstatSync, statSync, renameSync } from 'node:fs';
@@ -463,23 +464,18 @@ export class CopilotAdapter extends AgentAdapter {
   private lastActivityAt = new Map<string, number>();
   private evictionTimer: ReturnType<typeof setInterval> | null = null;
 
-  private static readonly CONTEXT_WINDOWS: Record<string, number> = {
-    'claude-sonnet-4.6': 200_000,
-    'claude-sonnet-4.5': 200_000,
-    'claude-haiku-4.5': 200_000,
-    'claude-opus-4.7': 200_000,
-    'claude-opus-4.7-1m-internal': 1_000_000,
-    'claude-opus-4.6': 200_000,
-    'claude-opus-4.5': 200_000,
-    'gpt-5.5': 400_000,
-    'gpt-5.4': 400_000,
-    'gpt-5.3-codex': 400_000,
-    'gpt-5.2': 400_000,
-    'gpt-5.2-codex': 400_000,
-    'gpt-5.4-mini': 128_000,
-    'gpt-5-mini': 128_000,
-    'gpt-4.1': 1_000_000,
-  };
+  /** Models known to support long_context tier (updated from Copilot docs).
+   *  Used to populate supportedContextTiers in model details. */
+  private static readonly LONG_CONTEXT_MODELS = new Set([
+    'claude-sonnet-4.6',
+    'claude-opus-4.6',
+    'claude-opus-4.7',
+    'claude-opus-4.8',
+    'gpt-5.3-codex',
+    'gpt-5.4',
+    'gpt-5.5',
+    'gemini-3.1-pro-preview',
+  ]);
 
   /** Set of attachment ids already broadcast for this session — prevents
    *  re-broadcasting bytes when the same image is shown twice. */
@@ -900,6 +896,10 @@ export class CopilotAdapter extends AgentAdapter {
       ? config.reasoningEffort as SessionConfig['reasoningEffort']
       : undefined;
 
+    const contextTier = config.contextTier === 'long_context'
+      ? 'long_context' as ContextTier
+      : undefined;
+
     // Two-phase MCP wiring: create session WITHOUT kraki MCP server first
     // (we need the SDK-assigned sessionId to scope the MCP URL), then the
     // adapter re-wires through resumeSession with the kraki entry below.
@@ -937,8 +937,9 @@ export class CopilotAdapter extends AgentAdapter {
       ...(config.sessionId && { sessionId: config.sessionId }),
       ...(config.model && { model: config.model }),
       ...(effort && { reasoningEffort: effort }),
+      ...(contextTier && { contextTier }),
       ...(config.cwd && { workingDirectory: config.cwd }),
-      configDir: getCopilotConfigDir(),
+      configDirectory: getCopilotConfigDir(),
       ...(mcpServers && { mcpServers }),
       systemMessage: { mode: 'append' as const, content: systemPromptContent },
       streaming: true,
@@ -1222,7 +1223,7 @@ export class CopilotAdapter extends AgentAdapter {
       id: s.sessionId,
       state: this.sessions.has(s.sessionId) ? 'active' as const : 'ended' as const,
       model: undefined,
-      cwd: s.context?.cwd,
+      cwd: s.context?.workingDirectory,
       summary: s.summary ?? '',
     }));
   }
@@ -1254,7 +1255,8 @@ export class CopilotAdapter extends AgentAdapter {
         supportsReasoningEffort: m.capabilities?.supports?.reasoningEffort ?? false,
         ...(m.supportedReasoningEfforts && { supportedReasoningEfforts: m.supportedReasoningEfforts }),
         ...(m.defaultReasoningEffort && { defaultReasoningEffort: m.defaultReasoningEffort }),
-        ...(CopilotAdapter.CONTEXT_WINDOWS[m.id] && { contextWindow: CopilotAdapter.CONTEXT_WINDOWS[m.id] }),
+        ...(m.capabilities?.limits?.max_context_window_tokens && { contextWindow: m.capabilities.limits.max_context_window_tokens }),
+        ...(CopilotAdapter.LONG_CONTEXT_MODELS.has(m.id) && { supportedContextTiers: ['default', 'long_context'] as import('@kraki/protocol').ContextTier[] }),
       }));
     } catch (err) {
       logger.warn({ err: (err as Error).message }, 'listModelDetails failed');
@@ -1273,7 +1275,7 @@ export class CopilotAdapter extends AgentAdapter {
   }
 
   /** Change model for a session via SDK */
-  async setSessionModel(sessionId: string, model: string, _reasoningEffort?: string): Promise<void> {
+  async setSessionModel(sessionId: string, model: string, reasoningEffort?: string, contextTier?: string): Promise<void> {
     const entry = this.sessions.get(sessionId);
     if (!entry) {
       logger.warn({ sessionId }, 'setSessionModel: session not found');
@@ -1281,8 +1283,16 @@ export class CopilotAdapter extends AgentAdapter {
     }
     this.expectedModels.set(sessionId, model);
     this.userRequestedModels.set(sessionId, model);
-    await entry.session.setModel(model);
-    logger.info({ sessionId, model }, 'Session model changed');
+    const validEfforts = new Set(['low', 'medium', 'high', 'xhigh']);
+    const options: { reasoningEffort?: SessionConfig['reasoningEffort']; contextTier?: ContextTier } = {};
+    if (reasoningEffort && validEfforts.has(reasoningEffort)) {
+      options.reasoningEffort = reasoningEffort as SessionConfig['reasoningEffort'];
+    }
+    if (contextTier === 'long_context') {
+      options.contextTier = 'long_context';
+    }
+    await entry.session.setModel(model, Object.keys(options).length > 0 ? options : undefined);
+    logger.info({ sessionId, model, ...options }, 'Session model changed');
   }
 
   /** Get current cumulative usage for a session */
@@ -1412,7 +1422,7 @@ export class CopilotAdapter extends AgentAdapter {
       : CopilotAdapter.SYSTEM_PROMPT;
 
     return {
-      configDir: getCopilotConfigDir(),
+      configDirectory: getCopilotConfigDir(),
       streaming: true,
       ...(mcpServers && { mcpServers }),
       systemMessage: { mode: 'append' as const, content: systemPromptContent },
@@ -1977,7 +1987,7 @@ export class CopilotAdapter extends AgentAdapter {
     try {
       logger.debug('Creating throwaway session for title generation');
       session = await this.client.createSession({
-        configDir: getCopilotConfigDir(),
+        configDirectory: getCopilotConfigDir(),
         systemMessage: { mode: 'replace' as const, content: CopilotAdapter.TITLE_SYSTEM_PROMPT },
         streaming: true,
         onPermissionRequest: () => ({ kind: 'approve-once' as const }),

--- a/packages/tentacle/src/adapters/multi.ts
+++ b/packages/tentacle/src/adapters/multi.ts
@@ -298,8 +298,8 @@ export class MultiAgentAdapter extends AgentAdapter {
     this.getSessionAdapter(sessionId).setSessionMode(sessionId, mode);
   }
 
-  async setSessionModel(sessionId: string, model: string, reasoningEffort?: string): Promise<void> {
-    return this.getSessionAdapter(sessionId).setSessionModel(sessionId, model, reasoningEffort);
+  async setSessionModel(sessionId: string, model: string, reasoningEffort?: string, contextTier?: string): Promise<void> {
+    return this.getSessionAdapter(sessionId).setSessionModel(sessionId, model, reasoningEffort, contextTier);
   }
 
   getSessionUsage(sessionId: string): SessionUsage | null {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -737,20 +737,20 @@ export class RelayClient {
           break;
         }
         case 'set_session_model': {
-          const { model, reasoningEffort } = msg.payload;
+          const { model, reasoningEffort, contextTier } = msg.payload;
           // Persist + ack immediately so the choice survives even if the
           // session is currently disconnected and lazy-resume fails.
           this.sessionManager.setModel(sessionId, model);
           this.send({
             type: 'session_model_set',
             sessionId,
-            payload: { model, reasoningEffort },
+            payload: { model, reasoningEffort, contextTier },
           });
           // Lazy resume: ensure the SDK session is live before pushing the
           // new model into it; otherwise the adapter would silently drop it
           // (and the user's selection would be lost on next interaction).
           this.ensureSessionResumed(sessionId)
-            .then(() => this.adapter.setSessionModel(sessionId, model, reasoningEffort))
+            .then(() => this.adapter.setSessionModel(sessionId, model, reasoningEffort, contextTier))
             .catch((err) => {
               logger.error({ err, sessionId }, 'setSessionModel failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to change model: ${(err as Error).message}` } });
@@ -777,7 +777,7 @@ export class RelayClient {
 
   private async handleCreateSession(msg: ConsumerMessage): Promise<void> {
     if (msg.type !== 'create_session') return;
-    const { model, reasoningEffort, cwd, prompt, requestId, agentId } = msg.payload;
+    const { model, reasoningEffort, contextTier, cwd, prompt, requestId, agentId } = msg.payload;
 
     // Pre-generate a stable sessionId and map requestId BEFORE calling the adapter.
     // This is concurrency-safe: each request gets its own unique key.
@@ -787,7 +787,7 @@ export class RelayClient {
     }
 
     try {
-      const result = await this.adapter.createSession({ model, reasoningEffort, cwd: cwd || '/', sessionId: preSessionId, agentId });
+      const result = await this.adapter.createSession({ model, reasoningEffort, contextTier, cwd: cwd || '/', sessionId: preSessionId, agentId });
 
       // If an initial prompt was provided, send it to the new session.
       // Otherwise mark idle — the SDK only fires session.idle after a turn

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@github/copilot': 1.0.48
+  '@github/copilot': 1.0.63
 
 importers:
 
@@ -188,8 +188,8 @@ importers:
         specifier: ^0.3.156
         version: 0.3.156(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@github/copilot-sdk':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^1.0.1
+        version: 1.0.1(typescript@5.9.3)
       '@inquirer/prompts':
         specifier: ^8.3.2
         version: 8.3.2(@types/node@25.5.0)
@@ -931,48 +931,64 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@github/copilot-darwin-arm64@1.0.48':
-    resolution: {integrity: sha512-82MLoMQwPVVFM8EYssihFxSEPUYtZADE8rMzQ3jG9HgRg2qjQSfnHQS1mKe64dlXswZUK/onw6/8kjnW5I4pPg==}
+  '@github/copilot-darwin-arm64@1.0.63':
+    resolution: {integrity: sha512-z6CMBxNDlKvT6bvOpqhu4M2bhb0daEbVwSe9SN9WfDUJbt7bpoL7OKKas428iyPSWHoL2WXwxSsy/FjIwSLV6w==}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@github/copilot-darwin-x64@1.0.48':
-    resolution: {integrity: sha512-1VQ5r5F0h8GwboXmZTcutqcJT+iCpPXAF27QqodmpKEvW9aYfG8g9X2kFJOzDZoX+SA3Uaka9qXdYKF2xT6Uog==}
+  '@github/copilot-darwin-x64@1.0.63':
+    resolution: {integrity: sha512-YKd7cXZgAGxhudzrtWdWh2NS35p2G5bV22Gz3jhEyBTqmq45o4sD4OwO87+UpkvM+3nZpwsHaLd3a+ILYX6OXg==}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@github/copilot-linux-arm64@1.0.48':
-    resolution: {integrity: sha512-PmsGnb0DZlI+Bf53l9HM1PAHHkUcMyB4y8v/7tnC/jDOV5dGF124n0HnDNfJLOLiJGiQGodthIif6QtPaAxpeA==}
+  '@github/copilot-linux-arm64@1.0.63':
+    resolution: {integrity: sha512-A3DOeEfmsJH9j1N+QLc7WXmESBskbezmhDyhyAJcHkw0ngRbKctuWQf/evUHFMh/kgwy1Lr/+9jXJm3NZqr0MA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     hasBin: true
 
-  '@github/copilot-linux-x64@1.0.48':
-    resolution: {integrity: sha512-b2cc4euSlke9fYHXXsS2EL9UYbctN0h4lZvtAcKUDY+RCnpYAQOVBZK+c1R9dQrtsT6Z/yUv7PuFPSs8qdtc2Q==}
+  '@github/copilot-linux-x64@1.0.63':
+    resolution: {integrity: sha512-OMKfZJRoDaJOV7vuWX/nFPNdLa9/H+nhajdE83v4YT9mKLXr86aWrkXE3pPoDYsKWvgQFHg4APA6oZPao0Fyow==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     hasBin: true
 
-  '@github/copilot-sdk@0.3.0':
-    resolution: {integrity: sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==}
-    engines: {node: '>=20.0.0'}
+  '@github/copilot-linuxmusl-arm64@1.0.63':
+    resolution: {integrity: sha512-jcIo6B3uHgcOluNfUHp+6atShKKrXYBPLaRyF6aDT699lwI83gW9KTDuEvDs5FDg8qWsWFfOl+al2dkWDYD3CQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+    hasBin: true
 
-  '@github/copilot-win32-arm64@1.0.48':
-    resolution: {integrity: sha512-VEEOwddtpJ3DTbXGhnK6K8im4ofl9m08q1m/K++sNvWV8wkkOSOQBTiPdyUsuU/TXAoFhb8tZMIJv+6NnMBtMw==}
+  '@github/copilot-linuxmusl-x64@1.0.63':
+    resolution: {integrity: sha512-BEdBbEF3fG7VqXzuaAY4JtmbdGSkpJFeb2ZQYaMpq7OP3aS7ssGe1cCX8ehZNegcMM/eb4GC6PXNXsvl3X/PAQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+    hasBin: true
+
+  '@github/copilot-sdk@1.0.1':
+    resolution: {integrity: sha512-w6AaS0WqqTE/3iyUrZznvgCLQhsUF7ZmEVCneacuHCfOzlH0r6ww9WUmyA0zgqmXO75V0IYrkIcnFke/qJkkDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@github/copilot-win32-arm64@1.0.63':
+    resolution: {integrity: sha512-7FqUwOmtoeBoOn4zkKQqRL+WGFwektVRSr5Po2FvPAbKxGXGyFXApZTmRLqVcHhMKDRzMb8KLST1LU1TMTY/wg==}
     cpu: [arm64]
     os: [win32]
     hasBin: true
 
-  '@github/copilot-win32-x64@1.0.48':
-    resolution: {integrity: sha512-93BzvXLPHTyy1gWBXQY/IWIHor4IAwZuuo7/obG80/Qa6U0WeaN9slz/FBJvrsgVNrrRfEID5Xm3At+S6Kj67Q==}
+  '@github/copilot-win32-x64@1.0.63':
+    resolution: {integrity: sha512-RC/6y9KHdw/YRCrCEksF2RzbeblfBUNE7bkYZxygaQGYThuv1GeZL2YD2jVqxC2LxKzsUmWGvwEMxerfR6pmeQ==}
     cpu: [x64]
     os: [win32]
     hasBin: true
 
-  '@github/copilot@1.0.48':
-    resolution: {integrity: sha512-U5SzyTEq376UU9A4Sd3TEKz+Y2nRUd90cLO4Hc1otaB8yFSy9Ur2UVGcI2/wCoodL3a39k6WbdgNzFxr0gWFRQ==}
+  '@github/copilot@1.0.63':
+    resolution: {integrity: sha512-e8DRYiWJQc4kepVXsXjC8vpDU2FXS/TfR+Z6p/KAojfcwIUZzKMAfCV5D1lD25hV4CryVH1Z9t7mHqChickj0Q==}
     hasBin: true
 
   '@hono/node-server@1.19.14':
@@ -1148,6 +1164,21 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@os-theme/darwin-arm64@0.0.8':
+    resolution: {integrity: sha512-gMsOs+8Ju396a5yyMWigkbA0dMTxD78U3HzG3mlpiAyn6hfd5dbyI4VGP+sfTB82KGgWLzIhWWTFX5UYY6iX0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@os-theme/linux-x64@0.0.8':
+    resolution: {integrity: sha512-zvjmBUiSQPjM1RbhpsfCDYMJxW4eLlGmkFPnpteC/03X2lz6CjiX2hfbN2EWLxXjNnIje3Jqaen8IsqEnWrRBg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@os-theme/win32-x64@0.0.8':
+    resolution: {integrity: sha512-N3yxKNbVl2IBa/ncDuq55QhwqwUjnYLJxDKMEmYeJbLIV950qZNojPw3scXA6PbfxPZfIiRa8iz1pzNg9XxP8w==}
+    cpu: [x64]
+    os: [win32]
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -2865,6 +2896,11 @@ packages:
     resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
     engines: {node: '>=20'}
 
+  os-theme@0.0.8:
+    resolution: {integrity: sha512-u1q3bLSv5uMHNIiPItkfDrHXu6ZFs2juwqxWREFM/uVBa+7Kkhy2v49LmJev2JcinGwqiEccElB/XsH9gwasuA==}
+    peerDependencies:
+      typescript: ^5
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -4114,38 +4150,53 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@github/copilot-darwin-arm64@1.0.48':
+  '@github/copilot-darwin-arm64@1.0.63':
     optional: true
 
-  '@github/copilot-darwin-x64@1.0.48':
+  '@github/copilot-darwin-x64@1.0.63':
     optional: true
 
-  '@github/copilot-linux-arm64@1.0.48':
+  '@github/copilot-linux-arm64@1.0.63':
     optional: true
 
-  '@github/copilot-linux-x64@1.0.48':
+  '@github/copilot-linux-x64@1.0.63':
     optional: true
 
-  '@github/copilot-sdk@0.3.0':
+  '@github/copilot-linuxmusl-arm64@1.0.63':
+    optional: true
+
+  '@github/copilot-linuxmusl-x64@1.0.63':
+    optional: true
+
+  '@github/copilot-sdk@1.0.1(typescript@5.9.3)':
     dependencies:
-      '@github/copilot': 1.0.48
+      '@github/copilot': 1.0.63(typescript@5.9.3)
       vscode-jsonrpc: 8.2.1
       zod: 4.3.6
+    transitivePeerDependencies:
+      - typescript
 
-  '@github/copilot-win32-arm64@1.0.48':
+  '@github/copilot-win32-arm64@1.0.63':
     optional: true
 
-  '@github/copilot-win32-x64@1.0.48':
+  '@github/copilot-win32-x64@1.0.63':
     optional: true
 
-  '@github/copilot@1.0.48':
+  '@github/copilot@1.0.63(typescript@5.9.3)':
+    dependencies:
+      detect-libc: 2.1.2
+      os-theme: 0.0.8(typescript@5.9.3)
     optionalDependencies:
-      '@github/copilot-darwin-arm64': 1.0.48
-      '@github/copilot-darwin-x64': 1.0.48
-      '@github/copilot-linux-arm64': 1.0.48
-      '@github/copilot-linux-x64': 1.0.48
-      '@github/copilot-win32-arm64': 1.0.48
-      '@github/copilot-win32-x64': 1.0.48
+      '@github/copilot-darwin-arm64': 1.0.63
+      '@github/copilot-darwin-x64': 1.0.63
+      '@github/copilot-linux-arm64': 1.0.63
+      '@github/copilot-linux-x64': 1.0.63
+      '@github/copilot-linuxmusl-arm64': 1.0.63
+      '@github/copilot-linuxmusl-x64': 1.0.63
+      '@github/copilot-win32-arm64': 1.0.63
+      '@github/copilot-win32-x64': 1.0.63
+    transitivePeerDependencies:
+      - typescript
 
   '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
@@ -4321,6 +4372,15 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@os-theme/darwin-arm64@0.0.8':
+    optional: true
+
+  '@os-theme/linux-x64@0.0.8':
+    optional: true
+
+  '@os-theme/win32-x64@0.0.8':
+    optional: true
 
   '@pinojs/redact@0.4.0': {}
 
@@ -6107,6 +6167,14 @@ snapshots:
       log-symbols: 7.0.1
       stdin-discarder: 0.3.1
       string-width: 8.2.0
+
+  os-theme@0.0.8(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+    optionalDependencies:
+      '@os-theme/darwin-arm64': 0.0.8
+      '@os-theme/linux-x64': 0.0.8
+      '@os-theme/win32-x64': 0.0.8
 
   p-limit@2.3.0:
     dependencies:


### PR DESCRIPTION
## Changes

- **Copilot SDK upgrade**: 0.3.0 → 1.0.1 (runtime 1.0.48 → 1.0.63)
- **Context tier selection**: models that support 1M token context (claude-sonnet-4.6, gpt-5.4, etc.) now show a Default/1M toggle in the model picker
- **Reasoning effort passthrough**: `setSessionModel` now properly passes reasoningEffort + contextTier to the SDK (was silently dropped before)
- **`max` effort level**: added to protocol, Claude adapter no longer filters it out
- **Removed hardcoded CONTEXT_WINDOWS**: uses SDK's `max_context_window_tokens` directly
- **SDK breaking changes adapted**: `configDir` → `configDirectory`, `context.cwd` → `context.workingDirectory`

## UI

Both NewSessionDialog and SessionInfoPanel now show:
- **Thinking** pills when model supports reasoning effort (including `max`)
- **Context** toggle (Default / 1M tokens) when model supports long_context tier

All 315 tests pass.