### PR TITLE
fix: wrap macOS CLI in .app bundle to preserve FDA across updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,57 @@ jobs:
             --sign "${{ secrets.APPLE_SIGNING_IDENTITY }}" \
             packages/tentacle/dist/sea/${{ matrix.asset_name }}
 
+      - name: Create .app bundle (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          BINARY="packages/tentacle/dist/sea/${{ matrix.asset_name }}"
+          VERSION=$(node -p "require('./packages/tentacle/package.json').version")
+          APP_DIR="packages/tentacle/dist/sea/Kraki.app"
+
+          mkdir -p "$APP_DIR/Contents/MacOS"
+          cp "$BINARY" "$APP_DIR/Contents/MacOS/kraki"
+
+          cat > "$APP_DIR/Contents/Info.plist" << PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>CFBundleIdentifier</key>
+              <string>chat.kraki.cli</string>
+              <key>CFBundleName</key>
+              <string>Kraki</string>
+              <key>CFBundleExecutable</key>
+              <string>kraki</string>
+              <key>CFBundleVersion</key>
+              <string>${VERSION}</string>
+              <key>CFBundleShortVersionString</key>
+              <string>${VERSION}</string>
+              <key>CFBundlePackageType</key>
+              <string>APPL</string>
+              <key>LSUIElement</key>
+              <true/>
+              <key>LSBackgroundOnly</key>
+              <true/>
+          </dict>
+          </plist>
+          PLIST
+
+          # Sign the bundle — this re-signs the executable inside too
+          codesign --force --deep --options runtime \
+            --entitlements packages/tentacle/entitlements.plist \
+            --sign "${{ secrets.APPLE_SIGNING_IDENTITY }}" \
+            "$APP_DIR"
+
+          # Create tar.gz for distribution
+          ARCH="${{ matrix.asset_name }}"
+          ARCH="${ARCH#kraki-cli-macos-}"
+          tar -czf "packages/tentacle/dist/sea/kraki-macos-${ARCH}.app.tar.gz" \
+            -C packages/tentacle/dist/sea Kraki.app
+
+          echo "Created kraki-macos-${ARCH}.app.tar.gz"
+          ls -lh "packages/tentacle/dist/sea/kraki-macos-${ARCH}.app.tar.gz"
+
       - name: Notarize binary (macOS)
         if: runner.os == 'macOS' && needs.prepare.outputs.publish_mode == 'publish'
         env:
@@ -239,12 +290,19 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          # Notarize the standalone binary
           zip $RUNNER_TEMP/binary.zip packages/tentacle/dist/sea/${{ matrix.asset_name }}
           xcrun notarytool submit $RUNNER_TEMP/binary.zip \
             --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" --wait
           # Mach-O binaries cannot be stapled (error 73); macOS verifies
           # the notarization ticket online at first launch instead.
+
+          # Notarize the .app bundle
+          zip -r $RUNNER_TEMP/app-bundle.zip packages/tentacle/dist/sea/Kraki.app
+          xcrun notarytool submit $RUNNER_TEMP/app-bundle.zip \
+            --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" --wait
 
       - name: Smoke test tentacle binary
         run: node packages/tentacle/scripts/smoke-test-binary.mjs packages/tentacle/dist/sea/${{ matrix.asset_name }}
@@ -254,6 +312,14 @@ jobs:
         with:
           name: build-${{ matrix.asset_name }}
           path: packages/tentacle/dist/sea/${{ matrix.asset_name }}
+          if-no-files-found: error
+
+      - name: Upload .app bundle artifact (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-${{ matrix.asset_name }}-app
+          path: packages/tentacle/dist/sea/kraki-macos-*.app.tar.gz
           if-no-files-found: error
 
   # ─── Build Toolbar ──────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,10 @@ detect_platform() {
   if [ "$PLATFORM" = "windows" ]; then
     ASSET="kraki-cli-${PLATFORM}-${ARCH}.exe"
     BINARY_NAME="kraki.exe"
+  elif [ "$PLATFORM" = "macos" ]; then
+    # macOS: install as .app bundle so TCC/FDA grants survive binary updates
+    ASSET="kraki-macos-${ARCH}.app.tar.gz"
+    APP_BUNDLE=1
   else
     ASSET="kraki-cli-${PLATFORM}-${ARCH}"
   fi
@@ -50,23 +54,25 @@ fetch_latest_version() {
 install() {
   URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
   TMP=$(mktemp -d)
-  TARGET="${TMP}/${BINARY_NAME}"
 
   echo "  Installing Kraki ${VERSION} (${PLATFORM}/${ARCH})..."
 
-  if ! curl -fSL# -o "$TARGET" "$URL"; then
+  if ! curl -fSL# -o "${TMP}/${ASSET}" "$URL"; then
     echo "Error: Download failed — ${URL}"
     rm -rf "$TMP"
     exit 1
   fi
 
-  chmod +x "$TARGET"
-
-  # macOS: remove quarantine/provenance xattrs so Gatekeeper doesn't
-  # SIGKILL the daemon child process even when the binary is signed.
-  if [ "$PLATFORM" = "macos" ]; then
-    xattr -cr "$TARGET" 2>/dev/null || true
+  # macOS: install as .app bundle with a symlink in $INSTALL_DIR
+  if [ "${APP_BUNDLE:-}" = "1" ]; then
+    install_app_bundle "$TMP"
+    rm -rf "$TMP"
+    return
   fi
+
+  TARGET="${TMP}/${BINARY_NAME}"
+  mv "${TMP}/${ASSET}" "$TARGET"
+  chmod +x "$TARGET"
 
   # Windows (Git Bash): install to user's local bin
   if [ "$PLATFORM" = "windows" ]; then
@@ -99,6 +105,49 @@ install() {
     exit 1
   fi
 
+  ensure_path_configured
+
+  rm -rf "$TMP"
+}
+
+# ── macOS .app bundle install ────────────────────────────
+
+install_app_bundle() {
+  TMP="$1"
+  APP_HOME="${HOME}/.local/share/kraki"
+  APP_PATH="${APP_HOME}/Kraki.app"
+
+  # Extract .app bundle
+  mkdir -p "$APP_HOME"
+  rm -rf "$APP_PATH"
+  tar -xzf "${TMP}/${ASSET}" -C "$APP_HOME"
+
+  # Strip quarantine/provenance xattrs
+  xattr -cr "$APP_PATH" 2>/dev/null || true
+
+  chmod +x "$APP_PATH/Contents/MacOS/kraki"
+
+  # --global flag: install symlink to /usr/local/bin
+  if [ "${KRAKI_INSTALL_GLOBAL:-}" = "1" ]; then
+    INSTALL_DIR="/usr/local/bin"
+  fi
+
+  mkdir -p "$INSTALL_DIR"
+
+  # Remove existing binary/symlink and create symlink to the .app binary
+  LINK_TARGET="${INSTALL_DIR}/${BINARY_NAME}"
+  rm -f "$LINK_TARGET" 2>/dev/null || true
+  ln -sf "$APP_PATH/Contents/MacOS/kraki" "$LINK_TARGET"
+
+  echo "  Installed to ${APP_PATH}"
+  echo "  Symlinked ${LINK_TARGET} → .app bundle"
+
+  ensure_path_configured
+}
+
+# ── PATH configuration ───────────────────────────────────
+
+ensure_path_configured() {
   case ":$PATH:" in
     *":${INSTALL_DIR}:"*) ;;
     *)
@@ -121,8 +170,6 @@ install() {
       fi
       ;;
   esac
-
-  rm -rf "$TMP"
 }
 
 # ── Main ─────────────────────────────────────────────────

--- a/packages/arm/web/public/install.sh
+++ b/packages/arm/web/public/install.sh
@@ -29,6 +29,10 @@ detect_platform() {
   if [ "$PLATFORM" = "windows" ]; then
     ASSET="kraki-cli-${PLATFORM}-${ARCH}.exe"
     BINARY_NAME="kraki.exe"
+  elif [ "$PLATFORM" = "macos" ]; then
+    # macOS: install as .app bundle so TCC/FDA grants survive binary updates
+    ASSET="kraki-macos-${ARCH}.app.tar.gz"
+    APP_BUNDLE=1
   else
     ASSET="kraki-cli-${PLATFORM}-${ARCH}"
   fi
@@ -50,23 +54,25 @@ fetch_latest_version() {
 install() {
   URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
   TMP=$(mktemp -d)
-  TARGET="${TMP}/${BINARY_NAME}"
 
   echo "  Installing Kraki ${VERSION} (${PLATFORM}/${ARCH})..."
 
-  if ! curl -fSL# -o "$TARGET" "$URL"; then
+  if ! curl -fSL# -o "${TMP}/${ASSET}" "$URL"; then
     echo "Error: Download failed — ${URL}"
     rm -rf "$TMP"
     exit 1
   fi
 
-  chmod +x "$TARGET"
-
-  # macOS: remove quarantine/provenance xattrs so Gatekeeper doesn't
-  # SIGKILL the daemon child process even when the binary is signed.
-  if [ "$PLATFORM" = "macos" ]; then
-    xattr -cr "$TARGET" 2>/dev/null || true
+  # macOS: install as .app bundle with a symlink in $INSTALL_DIR
+  if [ "${APP_BUNDLE:-}" = "1" ]; then
+    install_app_bundle "$TMP"
+    rm -rf "$TMP"
+    return
   fi
+
+  TARGET="${TMP}/${BINARY_NAME}"
+  mv "${TMP}/${ASSET}" "$TARGET"
+  chmod +x "$TARGET"
 
   # Windows (Git Bash): install to user's local bin
   if [ "$PLATFORM" = "windows" ]; then
@@ -98,6 +104,52 @@ install() {
   fi
 
   rm -rf "$TMP"
+}
+
+# ── macOS .app bundle install ────────────────────────────
+
+install_app_bundle() {
+  TMP="$1"
+  APP_HOME="${HOME}/.local/share/kraki"
+  APP_PATH="${APP_HOME}/Kraki.app"
+
+  # Extract .app bundle
+  mkdir -p "$APP_HOME"
+  rm -rf "$APP_PATH"
+  tar -xzf "${TMP}/${ASSET}" -C "$APP_HOME"
+
+  # Strip quarantine/provenance xattrs
+  xattr -cr "$APP_PATH" 2>/dev/null || true
+
+  chmod +x "$APP_PATH/Contents/MacOS/kraki"
+
+  mkdir -p "$INSTALL_DIR"
+
+  # Remove existing binary/symlink and create symlink to the .app binary
+  LINK_TARGET="${INSTALL_DIR}/${BINARY_NAME}"
+  if [ -w "$INSTALL_DIR" ] || command -v sudo >/dev/null 2>&1; then
+    if [ -w "$INSTALL_DIR" ]; then
+      rm -f "$LINK_TARGET" 2>/dev/null || true
+      ln -sf "$APP_PATH/Contents/MacOS/kraki" "$LINK_TARGET"
+    else
+      sudo rm -f "$LINK_TARGET" 2>/dev/null || true
+      sudo ln -sf "$APP_PATH/Contents/MacOS/kraki" "$LINK_TARGET"
+    fi
+    echo "  Installed to ${APP_PATH}"
+    echo "  Symlinked ${LINK_TARGET} → .app bundle"
+  else
+    INSTALL_DIR="${HOME}/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+    LINK_TARGET="${INSTALL_DIR}/${BINARY_NAME}"
+    rm -f "$LINK_TARGET" 2>/dev/null || true
+    ln -sf "$APP_PATH/Contents/MacOS/kraki" "$LINK_TARGET"
+    echo "  Installed to ${APP_PATH}"
+    echo "  Symlinked ${LINK_TARGET} → .app bundle"
+    case ":$PATH:" in
+      *":${INSTALL_DIR}:"*) ;;
+      *) echo "  ⚠  Add to PATH:  export PATH=\"\$PATH:${INSTALL_DIR}\"" ;;
+    esac
+  fi
 }
 
 # ── Main ─────────────────────────────────────────────────

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -9,8 +9,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, createWriteStream, unlinkSync, chmodSync, renameSync, copyFileSync, realpathSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, createWriteStream, unlinkSync, chmodSync, renameSync, copyFileSync, realpathSync, rmSync, symlinkSync, lstatSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
 import { tmpdir, platform } from 'node:os';
 import { request as httpRequest, type IncomingMessage, type RequestOptions as HttpRequestOptions } from 'node:http';
 import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from 'node:https';
@@ -419,6 +419,9 @@ export async function performUpdate(currentVersion: string): Promise<void> {
       console.log('');
       console.log(chalk.dim('  💡 Grant Full Disk Access to eliminate the "data from other apps" dialog.'));
       console.log(chalk.dim('  Open: System Settings → Privacy & Security → Full Disk Access → add kraki'));
+      if (detectAppBundle()) {
+        console.log(chalk.dim('  (The .app bundle preserves FDA across updates — grant once only)'));
+      }
       console.log('');
     }
 
@@ -492,11 +495,41 @@ function getPlatformAssetName(): string {
   return `kraki-cli-${platform}-${arch}${ext}`;
 }
 
+/**
+ * Detect if the current binary lives inside a .app bundle.
+ * Returns the .app directory path, or null if standalone.
+ *
+ * Expected layout: <prefix>/Kraki.app/Contents/MacOS/kraki
+ */
+function detectAppBundle(): string | null {
+  const realPath = realpathSync(process.execPath);
+  const macosDir = dirname(realPath);
+  const contentsDir = dirname(macosDir);
+  const appDir = dirname(contentsDir);
+
+  if (
+    macosDir.endsWith('/MacOS') &&
+    contentsDir.endsWith('/Contents') &&
+    appDir.endsWith('.app') &&
+    existsSync(join(contentsDir, 'Info.plist'))
+  ) {
+    return appDir;
+  }
+  return null;
+}
+
+/**
+ * Get the .app bundle asset name for macOS.
+ * e.g. "kraki-macos-arm64.app.tar.gz"
+ */
+function getAppBundleAssetName(): string {
+  return `kraki-macos-${process.arch}.app.tar.gz`;
+}
+
 async function updateViaBinary(
   version: string,
   onProgress?: (received: number, total: number) => void,
 ): Promise<void> {
-  const assetName = getPlatformAssetName();
   // Try v* tag first, fall back to tentacle-v*
   let release: GitHubRelease;
   try {
@@ -505,6 +538,18 @@ async function updateViaBinary(
     release = await fetchJson(`https://api.github.com/repos/${GITHUB_REPO}/releases/tags/tentacle-v${version}`);
   }
 
+  // macOS: prefer .app bundle update to preserve TCC/FDA grants
+  if (process.platform === 'darwin') {
+    const appBundleName = getAppBundleAssetName();
+    const appAsset = release.assets?.find((a) => a.name === appBundleName);
+    if (appAsset) {
+      await updateViaAppBundle(release, appAsset, onProgress);
+      return;
+    }
+    // Fall through to standalone binary update if .app asset not found
+  }
+
+  const assetName = getPlatformAssetName();
   const asset = release.assets?.find((a) => a.name === assetName);
   if (!asset) {
     throw new Error(`No binary found for ${assetName} in release v${version}`);
@@ -546,6 +591,95 @@ async function updateViaBinary(
 
   // Replace current binary — try direct first, sudo fallback for system dirs
   replaceBinary(tmpPath, currentBinary);
+}
+
+// ── macOS .app bundle update ────────────────────────────
+
+async function updateViaAppBundle(
+  release: GitHubRelease,
+  appAsset: { name: string; browser_download_url: string },
+  onProgress?: (received: number, total: number) => void,
+): Promise<void> {
+  const tmpDir = join(tmpdir(), 'kraki-app-update');
+  const tarPath = join(tmpDir, appAsset.name);
+
+  // Clean up any prior failed attempt
+  rmSync(tmpDir, { recursive: true, force: true });
+  mkdirSync(tmpDir, { recursive: true });
+
+  // Download tar.gz
+  await downloadFile(appAsset.browser_download_url, tarPath, onProgress);
+
+  // Verify checksum
+  const checksumAsset = release.assets?.find((a) => a.name === 'SHA256SUMS.txt');
+  if (checksumAsset) {
+    const checksumData = await fetchText(checksumAsset.browser_download_url);
+    const expectedHash = parseChecksum(checksumData, appAsset.name);
+    if (expectedHash) {
+      const actualHash = hashFile(tarPath);
+      if (actualHash !== expectedHash) {
+        rmSync(tmpDir, { recursive: true, force: true });
+        throw new Error(`Checksum mismatch for ${appAsset.name}`);
+      }
+    }
+  }
+
+  // Extract
+  execSync(`tar -xzf "${tarPath}" -C "${tmpDir}"`, { stdio: 'ignore' });
+  const extractedApp = join(tmpDir, 'Kraki.app');
+  if (!existsSync(extractedApp)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    throw new Error('Extracted .app bundle not found');
+  }
+
+  // Strip quarantine/provenance xattrs
+  stripProvenance(extractedApp);
+
+  // Determine target location
+  const existingAppDir = detectAppBundle();
+  const appHome = join(
+    process.env.HOME || process.env.USERPROFILE || '',
+    '.local', 'share', 'kraki',
+  );
+  const targetAppDir = existingAppDir || join(appHome, 'Kraki.app');
+
+  // Replace .app bundle
+  mkdirSync(dirname(targetAppDir), { recursive: true });
+  const backupDir = targetAppDir + '.bak';
+  rmSync(backupDir, { recursive: true, force: true });
+
+  try {
+    if (existsSync(targetAppDir)) {
+      renameSync(targetAppDir, backupDir);
+    }
+    renameSync(extractedApp, targetAppDir);
+
+    // If migrating from standalone binary → .app bundle, create symlink
+    if (!existingAppDir) {
+      const currentBinary = process.execPath;
+      const binDir = dirname(currentBinary);
+      const binName = 'kraki';
+      const linkPath = join(binDir, binName);
+      const appBinary = join(targetAppDir, 'Contents', 'MacOS', 'kraki');
+
+      // Remove the old standalone binary and replace with symlink
+      try { unlinkSync(linkPath); } catch { /* ignore */ }
+      symlinkSync(appBinary, linkPath);
+    }
+
+    // Clean up backup
+    rmSync(backupDir, { recursive: true, force: true });
+  } catch (err) {
+    // Restore backup on failure
+    if (existsSync(backupDir)) {
+      rmSync(targetAppDir, { recursive: true, force: true });
+      try { renameSync(backupDir, targetAppDir); } catch { /* ignore */ }
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+    throw err;
+  }
+
+  rmSync(tmpDir, { recursive: true, force: true });
 }
 
 function replaceBinary(source: string, target: string): void {


### PR DESCRIPTION
## Problem

macOS TCC tracks standalone binaries by `path + cdhash`. Every `kraki update` replaces the binary → new cdhash → FDA grant invalidated → user must re-add kraki in System Settings → Full Disk Access every single time.

**Evidence from TCC logs:**
```
identifier_type=Path    → standalone binary (cdhash-based, breaks on update)
identifier_type=Bundle ID → .app bundle (survives updates)
```

## Solution

Wrap the macOS CLI binary in a minimal `.app` bundle (`chat.kraki.cli`). macOS TCC uses Bundle ID tracking for `.app` bundles, which persists across updates as long as the Developer ID signing identity stays the same.

### Changes

- **Release workflow**: After signing the macOS binary, create a `Kraki.app` bundle, sign + notarize it, upload as `kraki-macos-{arch}.app.tar.gz`
- **Install scripts**: On macOS, download `.app.tar.gz`, extract to `~/.local/share/kraki/Kraki.app/`, symlink `~/.local/bin/kraki` → `.app/Contents/MacOS/kraki`
- **Update code**: On macOS, download `.app.tar.gz` and replace the entire bundle. Standalone binary fallback if `.app` asset not found.
- **Migration**: First update from standalone binary to `.app` bundle is automatic — replaces the binary file with a symlink.

### .app bundle structure
```
~/.local/share/kraki/Kraki.app/
  Contents/
    Info.plist          (CFBundleIdentifier=chat.kraki.cli, LSUIElement=true)
    MacOS/
      kraki             (Developer ID signed binary)
~/.local/bin/kraki → symlink to above
```

## Testing

- All 516 tentacle tests pass
- Verified via `codesign -dvvv` that macOS resolves symlinks and correctly identifies the binary as belonging to the `.app` bundle (`Identifier=chat.kraki.cli, Format=app bundle`)
- TCC log analysis confirms `identifier_type=Bundle ID` for `.app` bundles vs `identifier_type=Path` for standalone binaries