### PR TITLE
feat(tentacle): add Claude + headless support to setup flow

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.24.6",
+  "version": "0.25.0",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/cli.test.ts
+++ b/packages/tentacle/src/__tests__/cli.test.ts
@@ -45,6 +45,10 @@ vi.mock('../config.js', () => ({
   getLogVerbosity: vi.fn((config: Record<string, unknown> | null) => (config?.logging as Record<string, unknown> | undefined)?.verbosity ?? 'normal'),
   getVersion: vi.fn(() => '1.2.3'),
   loadChannelKey: (...args: unknown[]) => mockLoadChannelKey(...args),
+  getOrCreateDeviceId: vi.fn(() => 'dev_test'),
+  saveGitHubToken: vi.fn(),
+  loadGitHubToken: vi.fn(() => null),
+  DEFAULT_LOG_VERBOSITY: 'normal',
 }));
 
 vi.mock('../daemon.js', () => ({
@@ -64,8 +68,10 @@ vi.mock('../banner.js', () => ({
   printStaticBanner: vi.fn(),
 }));
 
+const mockResolveRelay = vi.fn();
 vi.mock('../setup.js', () => ({
   runSetup: (...args: unknown[]) => mockRunSetup(...args),
+  resolveRelay: (...args: unknown[]) => mockResolveRelay(...args),
 }));
 
 vi.mock('../update.js', () => ({
@@ -111,18 +117,24 @@ vi.mock('node:fs', async () => {
 
 // Capture console output
 let consoleOutput: string[];
+let stdoutOutput: string[];
 let originalArgv: string[];
 const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
 
 beforeEach(() => {
   vi.resetAllMocks();
   consoleOutput = [];
+  stdoutOutput = [];
   vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
     consoleOutput.push(args.join(' '));
   });
   vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
     consoleOutput.push(args.join(' '));
   });
+  vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+    stdoutOutput.push(String(chunk));
+    return true;
+  }) as never);
   originalArgv = process.argv;
   // Reset mock defaults
   mockGetConfigDir.mockReturnValue('/tmp/fake-kraki');
@@ -163,6 +175,15 @@ describe('CLI --help', () => {
     expect(output).toContain('Usage:');
     expect(output).toContain('stop');
     expect(output).toContain('status');
+  });
+
+  it('documents the new multi-agent / headless commands', async () => {
+    await runCli(['--help']);
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('resolve-relay');
+    expect(output).toContain('fda');
+    expect(output).toContain('--agent');
+    expect(output).toContain('status --json');
   });
 
   it('-h also prints help', async () => {
@@ -243,6 +264,100 @@ describe('CLI status', () => {
     await runCli(['status']);
     const output = consoleOutput.join('\n');
     expect(output).toContain('stopped');
+  });
+
+  it('emits machine-readable JSON with --json', async () => {
+    mockGetDaemonStatus.mockReturnValue({ running: true, pid: 42 });
+    mockLoadConfig.mockReturnValue({
+      relay: 'wss://relay.test',
+      authMethod: 'github_token',
+      device: { name: 'laptop', id: 'dev_1' },
+      agents: ['claude'],
+      logging: { verbosity: 'normal' },
+    });
+    await runCli(['status', '--json']);
+    const json = JSON.parse(stdoutOutput.join('').trim());
+    expect(json.ok).toBe(true);
+    expect(json.daemon).toEqual({ running: true, pid: 42 });
+    expect(json.config.exists).toBe(true);
+    expect(json.config.relay).toBe('wss://relay.test');
+    expect(json.config.agents).toEqual(['claude']);
+  });
+});
+
+// ── resolve-relay ───────────────────────────────────────
+
+describe('CLI resolve-relay', () => {
+  it('prints resolved relay as JSON', async () => {
+    mockResolveRelay.mockResolvedValue({
+      ok: true,
+      relayUrl: 'wss://kraki-us.example',
+      region: 'us',
+      user: 'octocat',
+    });
+    await runCli(['resolve-relay', '--json', '--github-token', 'tok123']);
+    expect(mockResolveRelay).toHaveBeenCalledWith('tok123');
+    const json = JSON.parse(stdoutOutput.join('').trim());
+    expect(json).toMatchObject({
+      ok: true,
+      relayUrl: 'wss://kraki-us.example',
+      region: 'us',
+      user: 'octocat',
+    });
+  });
+
+  it('exits non-zero on resolve failure', async () => {
+    mockResolveRelay.mockResolvedValue({
+      ok: false,
+      relayUrl: 'wss://relay.kraki.chat',
+      fallback: true,
+      error: 'network error',
+    });
+    await runCli(['resolve-relay', '--json', '--github-token', 'tok']);
+    const json = JSON.parse(stdoutOutput.join('').trim());
+    expect(json.ok).toBe(false);
+    expect(json.fallback).toBe(true);
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});
+
+// ── setup --headless ────────────────────────────────────
+
+describe('CLI setup --headless', () => {
+  it('errors as JSON when --relay is missing', async () => {
+    await runCli(['setup', '--headless']);
+    const json = JSON.parse(stdoutOutput.join('').trim());
+    expect(json).toEqual({ ok: false, error: '--relay is required', code: 'missing_relay' });
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects an invalid --agent value', async () => {
+    await runCli(['setup', '--headless', '--relay', 'wss://r', '--agent', 'bogus']);
+    const json = JSON.parse(stdoutOutput.join('').trim());
+    expect(json.ok).toBe(false);
+    expect(json.code).toBe('bad_agent');
+  });
+
+  it('writes config and pins the chosen agent', async () => {
+    await runCli(['setup', '--headless', '--relay', 'wss://r', '--agent', 'claude', '--device-name', 'box']);
+    expect(mockSaveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relay: 'wss://r',
+        agents: ['claude'],
+        device: expect.objectContaining({ name: 'box' }),
+      }),
+    );
+    const json = JSON.parse(stdoutOutput.join('').trim());
+    expect(json.ok).toBe(true);
+    expect(json.agents).toEqual(['claude']);
+  });
+
+  it('omits agents (auto) when --agent is auto', async () => {
+    await runCli(['setup', '--headless', '--relay', 'wss://r', '--agent', 'auto']);
+    const cfg = mockSaveConfig.mock.calls[0][0];
+    expect(cfg.agents).toBeUndefined();
+    const json = JSON.parse(stdoutOutput.join('').trim());
+    expect(json.agents).toBe('auto');
   });
 });
 

--- a/packages/tentacle/src/__tests__/setup.test.ts
+++ b/packages/tentacle/src/__tests__/setup.test.ts
@@ -3,10 +3,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockSelect = vi.fn();
 const mockInput = vi.fn();
+const mockCheckbox = vi.fn();
+const mockConfirm = vi.fn();
+const mockPassword = vi.fn();
 
 vi.mock("@inquirer/prompts", () => ({
   select: (...args: unknown[]) => mockSelect(...args),
   input: (...args: unknown[]) => mockInput(...args),
+  checkbox: (...args: unknown[]) => mockCheckbox(...args),
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+  password: (...args: unknown[]) => mockPassword(...args),
 }));
 
 vi.mock("ora", () => {
@@ -73,9 +79,16 @@ vi.mock("../config.js", () => ({
 
 const mockWithRetry = vi.fn();
 const mockCheckGhAuth = vi.fn().mockReturnValue({ authenticated: true, username: 'testuser', token: 'fake-token' });
+// Default agent detection: only Copilot installed → runAgentStep leaves auto-detect.
+const mockCheckCopilotCli = vi.fn().mockReturnValue({ found: true, version: '1.0' });
+const mockCheckClaudeCli = vi.fn().mockReturnValue({ found: false });
+const mockCheckAnthropicCreds = vi.fn().mockReturnValue({ configured: false, source: null });
 vi.mock("../checks.js", () => ({
   checkGhAuth: (...args: unknown[]) => mockCheckGhAuth(...args),
-  checkCopilotCli: vi.fn(),
+  checkCopilotCli: (...args: unknown[]) => mockCheckCopilotCli(...args),
+  checkClaudeCli: (...args: unknown[]) => mockCheckClaudeCli(...args),
+  checkAnthropicCreds: (...args: unknown[]) => mockCheckAnthropicCreds(...args),
+  saveAnthropicKey: vi.fn(),
   withRetry: (...args: unknown[]) => mockWithRetry(...args),
   probeFda: vi.fn().mockResolvedValue('granted'),
   pollFda: vi.fn().mockResolvedValue('granted'),

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -6,7 +6,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { constants as fsConstants, promises as fsp, appendFileSync, mkdirSync } from 'node:fs';
+import { constants as fsConstants, promises as fsp, appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { input } from '@inquirer/prompts';
@@ -145,6 +145,110 @@ export function checkCopilotCli(): CliCheckResult {
   } catch {
     return { found: false };
   }
+}
+
+export function checkClaudeCli(): CliCheckResult {
+  try {
+    const output = execSync('claude --version', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    // `claude --version` prints e.g. "1.2.3 (Claude Code)" — keep the
+    // leading semver if present, otherwise the whole first line.
+    const first = output.split('\n')[0];
+    const match = first.match(/(\d+\.\d+\.\d+)/);
+    return { found: true, version: match?.[1] ?? first };
+  } catch {
+    return { found: false };
+  }
+}
+
+// ── Anthropic credentials ───────────────────────────────
+//
+// The Claude adapter resolves credentials from process.env merged with
+// the `env` block of ~/.claude/settings.json (see adapters/claude.ts
+// loadClaudeSettingsEnv). A daemon launched by launchd/systemd does NOT
+// inherit the interactive shell environment, so settings.json is the
+// canonical place a key lands. We mirror that resolution order here so
+// setup/doctor report the same truth the daemon will see at runtime.
+
+export type AnthropicCredSource = 'env' | 'settings' | 'provider';
+
+export interface AnthropicCredResult {
+  configured: boolean;
+  /** Where the credential was found, or null if none. */
+  source: AnthropicCredSource | null;
+}
+
+/** Read the `env` map from ~/.claude/settings.json (best-effort). */
+export function readClaudeSettingsEnv(): Record<string, string> {
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  try {
+    const raw = readFileSync(settingsPath, 'utf8');
+    const parsed = JSON.parse(raw) as { env?: Record<string, unknown> };
+    const out: Record<string, string> = {};
+    if (parsed.env && typeof parsed.env === 'object') {
+      for (const [k, v] of Object.entries(parsed.env)) {
+        if (typeof v === 'string') out[k] = v;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Probe whether the Claude SDK will find usable credentials. Mirrors the
+ * daemon's resolution: process.env wins, then ~/.claude/settings.json,
+ * then third-party provider flags. Never makes a network call.
+ */
+export function checkAnthropicCreds(): AnthropicCredResult {
+  const settingsEnv = readClaudeSettingsEnv();
+  const get = (key: string): string | undefined =>
+    process.env[key] ?? settingsEnv[key];
+  const sourceOf = (key: string): AnthropicCredSource =>
+    process.env[key] !== undefined ? 'env' : 'settings';
+
+  // Direct API key / auth token.
+  if (get('ANTHROPIC_API_KEY')) {
+    return { configured: true, source: sourceOf('ANTHROPIC_API_KEY') };
+  }
+  if (get('ANTHROPIC_AUTH_TOKEN')) {
+    return { configured: true, source: sourceOf('ANTHROPIC_AUTH_TOKEN') };
+  }
+
+  // Third-party providers (Bedrock / Vertex / Foundry) — credentials are
+  // resolved by their own SDKs, so the flag being set is sufficient.
+  for (const flag of ['CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX', 'CLAUDE_CODE_USE_FOUNDRY']) {
+    if (get(flag) === '1') return { configured: true, source: 'provider' };
+  }
+
+  return { configured: false, source: null };
+}
+
+/**
+ * Persist an Anthropic API key into ~/.claude/settings.json `env` block —
+ * the same file the daemon and Claude Code itself read. Merges into any
+ * existing settings, creating the file/dir if needed. Used by headless
+ * setup (`--anthropic-key`) so a GUI wizard can store the key where the
+ * launchd daemon will pick it up.
+ */
+export function saveAnthropicKey(key: string): void {
+  const dir = join(homedir(), '.claude');
+  const settingsPath = join(dir, 'settings.json');
+  mkdirSync(dir, { recursive: true });
+
+  let settings: { env?: Record<string, unknown>; [k: string]: unknown } = {};
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as typeof settings;
+  } catch {
+    /* missing or malformed — start fresh */
+  }
+  const env = (settings.env && typeof settings.env === 'object')
+    ? settings.env as Record<string, unknown>
+    : {};
+  env.ANTHROPIC_API_KEY = key;
+  settings.env = env;
+
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
 }
 
 // ── Retry wrapper ───────────────────────────────────────

--- a/packages/tentacle/src/cli.ts
+++ b/packages/tentacle/src/cli.ts
@@ -27,6 +27,7 @@ import { requestPairingToken, buildPairingUrl, renderQrToTerminal } from './pair
 import { printStaticBanner } from './banner.js';
 import { readStatusFile } from './status-file.js';
 import { ensureWindowsSystemPath } from './checks.js';
+import type { AgentId } from '@kraki/protocol';
 
 // Self-heal PATH on Windows BEFORE any setup/check spawns a child
 // process. If kraki is launched from a context with a minimal PATH
@@ -68,10 +69,18 @@ function printHelp(): void {
   kraki connect        Generate QR code to connect a device
   kraki connect --url-only
                        Print pairing URL only (for toolbar / scripts)
+  kraki connect --json Print pairing token + url + expiry as JSON
   kraki setup --headless
                        Non-interactive setup (for toolbar / scripts)
+                       [--relay --auth --device-name --github-token
+                        --agent copilot|claude|both|auto --anthropic-key]
+  kraki resolve-relay --json [--github-token <tok>]
+                       Resolve best relay + region as JSON
   kraki doctor         Print environment status as JSON
+  kraki fda --json     Print macOS Full Disk Access status as JSON
+  kraki fda --watch    Stream FDA status as NDJSON until granted
   kraki status         Show status and connection info
+  kraki status --json  Print status as JSON (for desktop apps)
   kraki logs [-f]      Tail log files (-f to follow)
   kraki config         Print current config
   kraki config log     Show current log verbosity
@@ -278,9 +287,37 @@ function cmdStop(): void {
   }
 }
 
-function cmdStatus(): void {
+function cmdStatus(jsonOutput = false): void {
   const status = getDaemonStatus();
   const config = loadConfig();
+  const statusFile = readStatusFile();
+
+  if (jsonOutput) {
+    // Machine-readable for desktop apps (mac toolbar, etc.). Schema is
+    // additive — only add fields, never remove, to keep older clients
+    // working.
+    const payload = {
+      ok: true,
+      version: getVersion(),
+      daemon: {
+        running: status.running,
+        pid: status.pid,
+      },
+      config: config
+        ? {
+            exists: true,
+            relay: config.relay,
+            authMethod: config.authMethod,
+            device: { name: config.device.name, id: config.device.id },
+            agents: config.agents ?? null,
+            region: statusFile?.region ?? null,
+            logVerbosity: getLogVerbosity(config),
+          }
+        : { exists: false },
+    };
+    process.stdout.write(JSON.stringify(payload) + '\n');
+    return;
+  }
 
   console.log('');
   console.log(chalk.bold(`${chalk.hex('#ea6046')('◈')} Kraki Status`));
@@ -296,7 +333,6 @@ function cmdStatus(): void {
     console.log(`  Relay:   ${chalk.cyan(config.relay)}`);
     console.log(`  Auth:    ${config.authMethod}`);
     console.log(`  Device:  ${config.device.name}`);
-    const statusFile = readStatusFile();
     if (statusFile?.region) {
       console.log(`  Region:  ${statusFile.region}`);
     }
@@ -377,10 +413,15 @@ async function cmdConfigReset(): Promise<void> {
   await runSetup();
 }
 
-async function cmdConnect(urlOnly = false): Promise<void> {
+async function cmdConnect(urlOnly = false, jsonOutput = false): Promise<void> {
   let config = loadConfig();
 
   if (!isDaemonRunning()) {
+    if (jsonOutput) {
+      process.stdout.write(JSON.stringify({ ok: false, error: 'daemon_not_running' }) + '\n');
+      gracefulExit(1);
+      return;
+    }
     if (urlOnly) {
       process.stderr.write('error: daemon not running\n');
       gracefulExit(1);
@@ -398,6 +439,11 @@ async function cmdConnect(urlOnly = false): Promise<void> {
   }
 
   if (!config) {
+    if (jsonOutput) {
+      process.stdout.write(JSON.stringify({ ok: false, error: 'no_config' }) + '\n');
+      gracefulExit(1);
+      return;
+    }
     if (urlOnly) {
       process.stderr.write('error: no config found\n');
       gracefulExit(1);
@@ -407,7 +453,7 @@ async function cmdConnect(urlOnly = false): Promise<void> {
     return;
   }
 
-  if (!urlOnly) {
+  if (!urlOnly && !jsonOutput) {
     console.log(chalk.dim('  Requesting pairing token from relay...'));
   }
 
@@ -429,6 +475,20 @@ async function cmdConnect(urlOnly = false): Promise<void> {
     const info = await requestPairingToken(config.relay, token);
     const pairingUrl = buildPairingUrl(info);
 
+    if (jsonOutput) {
+      const payload = {
+        ok: true,
+        url: pairingUrl,
+        token: info.pairingToken,
+        relay: info.relay,
+        publicKey: info.publicKey ?? null,
+        expiresInSeconds: info.expiresIn,
+        expiresAt: new Date(Date.now() + info.expiresIn * 1000).toISOString(),
+      };
+      process.stdout.write(JSON.stringify(payload) + '\n');
+      return;
+    }
+
     if (urlOnly) {
       // Machine-readable output for the desktop toolbar — just the URL, no decoration
       process.stdout.write(pairingUrl + '\n');
@@ -438,6 +498,11 @@ async function cmdConnect(urlOnly = false): Promise<void> {
     const qr = await renderQrToTerminal(pairingUrl);
     console.log(qr);
   } catch (err) {
+    if (jsonOutput) {
+      process.stdout.write(JSON.stringify({ ok: false, error: (err as Error).message }) + '\n');
+      gracefulExit(1);
+      return;
+    }
     if (urlOnly) {
       process.stderr.write(`error: ${(err as Error).message}\n`);
       gracefulExit(1);
@@ -455,15 +520,51 @@ function getArgValue(args: string[], flag: string): string | undefined {
 }
 
 async function cmdSetupHeadless(args: string[]): Promise<void> {
+  const fail = (code: string, message: string): void => {
+    process.stdout.write(JSON.stringify({ ok: false, error: message, code }) + '\n');
+    gracefulExit(1);
+  };
+
   const relay = getArgValue(args, '--relay');
   const auth = getArgValue(args, '--auth') ?? 'github_token';
   const deviceName = getArgValue(args, '--device-name');
   const githubToken = getArgValue(args, '--github-token');
+  const agentArg = getArgValue(args, '--agent'); // copilot | claude | both | auto
+  const anthropicKey = getArgValue(args, '--anthropic-key');
 
   if (!relay) {
-    process.stderr.write('error: --relay is required\n');
-    gracefulExit(1);
-    return;
+    return fail('missing_relay', '--relay is required');
+  }
+
+  // Map --agent to an explicit allow-list. Omit for auto-detection.
+  let agents: AgentId[] | undefined;
+  switch (agentArg) {
+    case undefined:
+    case 'auto':
+      agents = undefined;
+      break;
+    case 'copilot':
+      agents = ['copilot'];
+      break;
+    case 'claude':
+      agents = ['claude'];
+      break;
+    case 'both':
+      agents = ['copilot', 'claude'];
+      break;
+    default:
+      return fail('bad_agent', `--agent must be one of: copilot, claude, both, auto (got "${agentArg}")`);
+  }
+
+  // Persist an Anthropic key into ~/.claude/settings.json so the daemon
+  // (launched by launchd, no shell env) can read it.
+  if (anthropicKey) {
+    const { saveAnthropicKey } = await import('./checks.js');
+    try {
+      saveAnthropicKey(anthropicKey);
+    } catch (err) {
+      return fail('anthropic_key_write_failed', (err as Error).message);
+    }
   }
 
   // Resolve GitHub token: explicit flag > gh CLI > saved token
@@ -480,28 +581,156 @@ async function cmdSetupHeadless(args: string[]): Promise<void> {
     relay,
     authMethod: auth as KrakiConfig['authMethod'],
     device: { name: deviceName ?? hostname().replace(/\.local$/, ''), id: deviceId },
+    ...(agents && { agents }),
     logging: { verbosity: DEFAULT_LOG_VERBOSITY },
   };
 
   saveConfig(config);
-  process.stdout.write(JSON.stringify({ ok: true, configPath: getConfigPath() }) + '\n');
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    configPath: getConfigPath(),
+    agents: agents ?? 'auto',
+  }) + '\n');
+}
+
+// ── kraki resolve-relay — resolve best relay as JSON ────
+
+async function cmdResolveRelay(args: string[]): Promise<void> {
+  const jsonOutput = args.includes('--json');
+  let token = getArgValue(args, '--github-token');
+
+  // Fall back to gh CLI / saved token if not provided.
+  if (!token) {
+    try {
+      const { execSync } = await import('node:child_process');
+      token = execSync('gh auth token', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim() || undefined;
+    } catch { /* ignore */ }
+  }
+  if (!token) {
+    const { loadGitHubToken } = await import('./config.js');
+    token = loadGitHubToken() ?? undefined;
+  }
+
+  const { resolveRelay } = await import('./setup.js');
+  const result = await resolveRelay(token);
+
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify({
+      ok: result.ok,
+      relayUrl: result.relayUrl,
+      region: result.region ?? null,
+      user: result.user ?? null,
+      fallback: result.fallback ?? false,
+      ...(result.error && { error: result.error }),
+    }) + '\n');
+    if (!result.ok) gracefulExit(1);
+    return;
+  }
+
+  if (result.ok) {
+    console.log(`  Relay:  ${chalk.cyan(result.relayUrl)}`);
+    if (result.region) console.log(`  Region: ${chalk.cyan(result.region)}`);
+  } else {
+    console.log(chalk.yellow(`  Could not resolve — using default: ${result.relayUrl}`));
+    gracefulExit(1);
+  }
+}
+
+// ── kraki fda — macOS Full Disk Access status ───────────
+
+async function cmdFda(args: string[]): Promise<void> {
+  const watch = args.includes('--watch');
+  const { probeFda } = await import('./checks.js');
+
+  if (process.platform !== 'darwin') {
+    process.stdout.write(JSON.stringify({ ok: true, status: 'not_applicable', platform: process.platform }) + '\n');
+    return;
+  }
+
+  if (watch) {
+    // Stream NDJSON status updates until FDA is granted (or aborted).
+    const ac = new AbortController();
+    process.on('SIGINT', () => ac.abort());
+    process.on('SIGTERM', () => ac.abort());
+    let last: string | undefined;
+    while (!ac.signal.aborted) {
+      const status = await probeFda();
+      if (status !== last) {
+        last = status;
+        process.stdout.write(JSON.stringify({ ok: true, status }) + '\n');
+      }
+      if (status === 'granted') {
+        process.stdout.write(JSON.stringify({ ok: true, status: 'granted', done: true }) + '\n');
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    process.stdout.write(JSON.stringify({ ok: true, status: 'aborted', done: true }) + '\n');
+    return;
+  }
+
+  const status = await probeFda();
+  process.stdout.write(JSON.stringify({ ok: true, status }) + '\n');
 }
 
 // ── kraki doctor — environment status as JSON ───────────
 
 async function cmdDoctor(): Promise<void> {
-  const { checkGhAuth, checkCopilotCli } = await import('./checks.js');
+  const {
+    checkGhAuth, checkCopilotCli, checkClaudeCli, checkAnthropicCreds, probeFda,
+  } = await import('./checks.js');
+  // `kraki doctor` must emit a single clean JSON line on stdout. The
+  // multi-adapter logger (created at module load) defaults to info-level
+  // stdout (dev) which would interleave pino lines into the output, so
+  // force it silent before importing the module.
+  const prevLogLevel = process.env.LOG_LEVEL;
+  process.env.LOG_LEVEL = 'silent';
+  const { detectAvailableAgents } = await import('./adapters/multi.js');
+
   const config = loadConfig();
   const ghAuth = checkGhAuth();
   const copilot = checkCopilotCli();
+  const claude = checkClaudeCli();
+  const anthropic = checkAnthropicCreds();
+  const fda = await probeFda();
+
+  // SDK + CLI level "can actually start" detection (matches runtime).
+  let available: string[] = [];
+  try {
+    available = await detectAvailableAgents();
+  } catch { /* detection best-effort */ }
+  if (prevLogLevel === undefined) delete process.env.LOG_LEVEL;
+  else process.env.LOG_LEVEL = prevLogLevel;
+
+  const hasCopilotAuth = ghAuth.authenticated
+    || !!process.env.GITHUB_TOKEN || !!process.env.GH_TOKEN || !!process.env.COPILOT_GITHUB_TOKEN;
 
   const result = {
     configExists: config !== null,
     daemonRunning: isDaemonRunning(),
+    fda,
     ghAuth: ghAuth.authenticated,
     ghUser: ghAuth.username ?? null,
+    // Legacy fields — kept so existing consumers keep working.
     copilotCli: copilot.found,
     copilotVersion: copilot.version ?? null,
+    // Structured multi-agent view.
+    agents: {
+      copilot: {
+        cli: copilot.found,
+        version: copilot.version ?? null,
+        auth: hasCopilotAuth,
+      },
+      claude: {
+        cli: claude.found,
+        version: claude.version ?? null,
+        creds: anthropic.configured,
+        credsSource: anthropic.source,
+      },
+    },
+    // Agents that can actually be started right now (SDK importable + CLI present).
+    available,
+    pinnedAgents: config?.agents ?? null,
   };
 
   process.stdout.write(JSON.stringify(result) + '\n');
@@ -677,13 +906,14 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'status') {
-    cmdStatus();
+    cmdStatus(args.includes('--json'));
     return;
   }
 
   if (cmd === 'connect') {
     const urlOnly = args.includes('--url-only');
-    await cmdConnect(urlOnly);
+    const jsonOutput = args.includes('--json');
+    await cmdConnect(urlOnly, jsonOutput);
     return;
   }
 
@@ -699,6 +929,16 @@ async function main(): Promise<void> {
 
   if (cmd === 'doctor') {
     await cmdDoctor();
+    return;
+  }
+
+  if (cmd === 'resolve-relay') {
+    await cmdResolveRelay(args);
+    return;
+  }
+
+  if (cmd === 'fda') {
+    await cmdFda(args);
     return;
   }
 

--- a/packages/tentacle/src/config.ts
+++ b/packages/tentacle/src/config.ts
@@ -10,7 +10,7 @@ import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { isSea } from 'node:sea';
-import type { AuthMethod } from '@kraki/protocol';
+import type { AuthMethod, AgentId } from '@kraki/protocol';
 
 // ── Types ───────────────────────────────────────────────
 
@@ -20,6 +20,13 @@ export interface KrakiConfig {
   relay: string;
   authMethod: AuthMethod['method'];
   device: { name: string; id?: string };
+  /**
+   * Explicit agent allow-list. When omitted (or empty), the daemon
+   * auto-detects every installed agent at startup (legacy behaviour).
+   * When set, only these agents are started — letting setup / a GUI
+   * wizard pin the user's choice (e.g. Claude-only).
+   */
+  agents?: AgentId[];
   logging?: {
     verbosity?: KrakiLogVerbosity;
   };

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -47,6 +47,7 @@ import { KrakiMcpServer } from './mcp/index.js';
 import { createLogger } from './logger.js';
 import { initStatusFile, updateRelayState, updateRegion, clearStatusFile } from './status-file.js';
 import type { AgentAdapter } from './adapters/base.js';
+import type { AgentId } from '@kraki/protocol';
 
 const logger = createLogger('daemon');
 
@@ -145,9 +146,13 @@ export async function startWorker(): Promise<WorkerResult> {
     mcpServer = null;
   }
 
-  // 3c. Create multi-agent adapter (auto-detects available agents)
+  // 3c. Create multi-agent adapter. When config pins an explicit agent
+  // allow-list we honour it; otherwise the adapter auto-detects every
+  // installed agent at startup (legacy behaviour).
+  const pinnedAgents = config.agents?.filter((a): a is AgentId => a === 'copilot' || a === 'claude');
   const adapter = new MultiAgentAdapter({
     attachmentStore,
+    ...(pinnedAgents && pinnedAgents.length > 0 && { agentIds: pinnedAgents }),
     ...(mcpInfo && { krakiMcp: mcpInfo }),
   });
   const keyManager = new KeyManager();

--- a/packages/tentacle/src/setup.ts
+++ b/packages/tentacle/src/setup.ts
@@ -5,7 +5,7 @@
  * device naming, and agent verification.
  */
 
-import { select, input } from '@inquirer/prompts';
+import { select, input, checkbox, confirm, password } from '@inquirer/prompts';
 import chalk from 'chalk';
 import ora from 'ora';
 import { hostname, platform } from 'node:os';
@@ -21,9 +21,10 @@ import {
   getOrCreateDeviceId,
   getConfigPath,
 } from './config.js';
-import { checkGhAuth, checkCopilotCli, withRetry, probeFda, pollFda } from './checks.js';
+import { checkGhAuth, checkCopilotCli, checkClaudeCli, checkAnthropicCreds, saveAnthropicKey, withRetry, probeFda, pollFda } from './checks.js';
 import { printAnimatedBanner } from './banner.js';
 import { isSea } from 'node:sea';
+import type { AgentId } from '@kraki/protocol';
 
 /**
  * Silently install the current binary as `kraki` in a PATH directory.
@@ -183,6 +184,52 @@ function queryRelayInfo(url: string, timeoutMs = 5000): Promise<RelayInfo> {
   });
 }
 
+/**
+ * Resolve the best relay + region for a GitHub token via the login API.
+ * Shared by interactive setup and the headless `resolve-relay` command.
+ * Falls back to the official relay if the API can't be reached.
+ */
+export interface ResolveRelayResult {
+  ok: boolean;
+  relayUrl: string;
+  region?: string;
+  user?: string;
+  fallback?: boolean;
+  error?: string;
+}
+
+export async function resolveRelay(
+  ghToken: string | undefined,
+  apiBase: string = process.env.KRAKI_API_URL ?? OFFICIAL_API,
+): Promise<ResolveRelayResult> {
+  try {
+    const res = await fetch(`${apiBase}/api/login/resolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ auth: { method: 'github_token', token: ghToken } }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = await res.json() as {
+      ok?: boolean;
+      region?: string;
+      relayUrl?: string;
+      user?: { login?: string };
+    };
+
+    if (data.ok && data.relayUrl) {
+      return {
+        ok: true,
+        relayUrl: data.relayUrl,
+        region: data.region,
+        user: data.user?.login,
+      };
+    }
+    return { ok: false, relayUrl: OFFICIAL_RELAY, fallback: true, error: 'unresolved' };
+  } catch (err) {
+    return { ok: false, relayUrl: OFFICIAL_RELAY, fallback: true, error: (err as Error).message };
+  }
+}
+
 // ── Box drawing ─────────────────────────────────────────
 
 function printBox(lines: string[]): void {
@@ -313,6 +360,93 @@ async function githubDeviceFlow(clientId: string): Promise<string> {
 
 // ── Setup flow ──────────────────────────────────────────
 
+/**
+ * Detect installed agents (Copilot, Claude) and let the user choose which
+ * to enable. Returns an explicit allow-list to persist in config, or
+ * `undefined` to leave the daemon on auto-detect.
+ *
+ * For Claude, also offers to store an Anthropic API key in
+ * ~/.claude/settings.json so the launchd-spawned daemon can read it.
+ */
+async function runAgentStep(): Promise<AgentId[] | undefined> {
+  const copilotSpinner = ora({ text: 'Looking for Copilot CLI…', indent: 4 }).start();
+  const copilot = checkCopilotCli();
+  if (copilot.found) {
+    copilotSpinner.succeed(`Copilot CLI found (${copilot.version ?? 'unknown version'})`);
+  } else {
+    copilotSpinner.info('Copilot CLI not found');
+  }
+
+  const claudeSpinner = ora({ text: 'Looking for Claude CLI…', indent: 4 }).start();
+  const claude = checkClaudeCli();
+  if (claude.found) {
+    claudeSpinner.succeed(`Claude CLI found (${claude.version ?? 'unknown version'})`);
+  } else {
+    claudeSpinner.info('Claude CLI not found');
+  }
+
+  const available: AgentId[] = [];
+  if (copilot.found) available.push('copilot');
+  if (claude.found) available.push('claude');
+
+  // If Claude is present, make sure it has credentials it can actually use.
+  if (claude.found) {
+    let creds = checkAnthropicCreds();
+    if (!creds.configured) {
+      console.log(chalk.dim('    Claude needs an Anthropic API key (or Bedrock/Vertex env).'));
+      const enterKey = await confirm({
+        message: 'Add an Anthropic API key now?',
+        default: true,
+        theme: promptTheme,
+      });
+      if (enterKey) {
+        const key = await password({ message: 'Anthropic API key:', mask: '•' });
+        if (key.trim()) {
+          try {
+            saveAnthropicKey(key.trim());
+            console.log(chalk.green('    ✓ Saved to ~/.claude/settings.json'));
+            creds = { configured: true, source: 'settings' };
+          } catch (err) {
+            console.log(chalk.yellow(`    ! Could not save key: ${(err as Error).message}`));
+          }
+        }
+      }
+    } else {
+      console.log(chalk.green(`    ✓ Anthropic credentials available (${creds.source})`));
+    }
+  }
+
+  if (available.length === 0) {
+    console.log(chalk.yellow('    No agents detected. Install at least one to run sessions:'));
+    console.log(chalk.dim('      • Copilot CLI — https://github.com/features/copilot/cli/'));
+    console.log(chalk.dim('      • Claude CLI  — https://docs.anthropic.com/en/docs/claude-code'));
+    console.log(chalk.dim('    Continuing with auto-detect — install later and restart the daemon.'));
+    return undefined;
+  }
+
+  if (available.length === 1) {
+    const only = available[0];
+    // Only one agent installed — leave the daemon on auto-detect rather
+    // than pinning. If the user installs the other agent later it will be
+    // picked up automatically. (Explicit pinning is for the GUI wizard /
+    // `--agent` flag, where there's a real choice to constrain.)
+    console.log(chalk.dim(`    Using ${only === 'copilot' ? 'Copilot' : 'Claude'} (auto-detect).`));
+    return undefined;
+  }
+
+  // Both installed — let the user pick the allow-list.
+  const chosen = await checkbox<AgentId>({
+    message: 'Enable which agents?',
+    theme: promptTheme,
+    choices: [
+      { name: 'Copilot', value: 'copilot', checked: true },
+      { name: 'Claude', value: 'claude', checked: true },
+    ],
+    validate: (items) => (items.length > 0 ? true : 'Select at least one agent'),
+  });
+  return chosen;
+}
+
 export async function runSetup(): Promise<KrakiConfig> {
   await printAnimatedBanner();
 
@@ -370,31 +504,13 @@ export async function runSetup(): Promise<KrakiConfig> {
   let region: string | undefined;
 
   const resolveSpinner = ora({ text: 'Finding best relay…', indent: 4 }).start();
-  try {
-    const resolveRes = await fetch(`${apiBase}/api/login/resolve`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ auth: { method: 'github_token', token: ghToken } }),
-      signal: AbortSignal.timeout(10_000),
-    });
-    const resolveData = await resolveRes.json() as {
-      ok?: boolean;
-      region?: string;
-      relayUrl?: string;
-      user?: { login?: string };
-    };
-
-    if (resolveData.ok && resolveData.relayUrl) {
-      relay = resolveData.relayUrl;
-      region = resolveData.region;
-      resolveSpinner.succeed(`Relay assigned${region ? ` (${region})` : ''}`);
-    } else {
-      resolveSpinner.info('Could not resolve relay — using default');
-      relay = OFFICIAL_RELAY;
-    }
-  } catch {
-    resolveSpinner.info('Could not reach API — using default relay');
-    relay = OFFICIAL_RELAY;
+  const resolved = await resolveRelay(ghToken, apiBase);
+  relay = resolved.relayUrl;
+  region = resolved.region;
+  if (resolved.ok) {
+    resolveSpinner.succeed(`Relay assigned${region ? ` (${region})` : ''}`);
+  } else {
+    resolveSpinner.info('Could not resolve relay — using default');
   }
 
   // Verify relay is reachable
@@ -410,30 +526,9 @@ export async function runSetup(): Promise<KrakiConfig> {
 
   divider();
 
-  // 3. Agent check
-  console.log(`  ${icon} ${step(3, total)} ${chalk.bold('Agent Verification')}`);
-  if (isSea()) {
-    const agentSpinner = ora({ text: 'Looking for Copilot CLI…', indent: 4 }).start();
-    const copilotResult = await withRetry(
-      checkCopilotCli,
-      'Copilot CLI',
-      'Install from https://github.com/features/copilot/cli/',
-      agentSpinner,
-    );
-    agentSpinner.succeed(`Copilot CLI found (${copilotResult.version ?? 'unknown version'})`);
-
-    const authSpinner = ora({ text: 'Checking Copilot authentication…', indent: 4 }).start();
-    const hasGhToken = checkGhAuth().authenticated;
-    const hasEnvToken = !!process.env.GITHUB_TOKEN || !!process.env.GH_TOKEN || !!process.env.COPILOT_GITHUB_TOKEN;
-    if (hasGhToken || hasEnvToken) {
-      authSpinner.succeed('Copilot authentication available');
-    } else {
-      authSpinner.succeed('Copilot authentication available (via Copilot login)');
-    }
-  } else {
-    const agentSpinner = ora({ text: 'Checking Copilot SDK…', indent: 4 }).start();
-    agentSpinner.succeed('Copilot SDK available');
-  }
+  // 3. Agent selection (Copilot and/or Claude)
+  console.log(`  ${icon} ${step(3, total)} ${chalk.bold('Agents')}`);
+  const selectedAgents = await runAgentStep();
 
   divider();
 
@@ -458,6 +553,7 @@ export async function runSetup(): Promise<KrakiConfig> {
     relay,
     authMethod: 'github_token',
     device: { name: deviceName, id: deviceId },
+    ...(selectedAgents && selectedAgents.length > 0 && { agents: selectedAgents }),
     logging: { verbosity: DEFAULT_LOG_VERBOSITY },
   };
 
@@ -475,6 +571,7 @@ export async function runSetup(): Promise<KrakiConfig> {
     `${chalk.dim('Relay')}    ${chalk.cyan(relay)}`,
     ...(region ? [`${chalk.dim('Region')}   ${chalk.cyan(region)}`] : []),
     `${chalk.dim('Auth')}     ${chalk.cyan('github_token')}`,
+    `${chalk.dim('Agents')}   ${chalk.cyan(selectedAgents && selectedAgents.length > 0 ? selectedAgents.join(', ') : 'auto-detect')}`,
     `${chalk.dim('Device')}   ${chalk.cyan(deviceName)}`,
     `${chalk.dim('Logs')}     ${chalk.cyan(DEFAULT_LOG_VERBOSITY)}`,
     '',


### PR DESCRIPTION
## Summary

Adds **Claude + headless support** to the `@kraki/tentacle` CLI, plus ports the mac-app-only `--json` flags into main. This is groundwork for a future GUI setup wizard in the macOS app that programmatically drives tentacle commands and parses their JSON stdout.

## What's included

**Multi-agent detection & doctor**
- `checkClaudeCli()`, `checkAnthropicCreds()`, `readClaudeSettingsEnv()`, `saveAnthropicKey()` (settings file written mode `0600`)
- `doctor` now emits structured `agents:{copilot,claude}`, `available`, `pinnedAgents`

**Setup flow**
- Shared `resolveRelay(ghToken, apiBase)` helper (step 2)
- `runAgentStep` interactive agent selection (step 3); persists `config.agents` allow-list only when multiple agents are available and the user selects
- `config.agents?: AgentId[]` honored by `daemon-worker` when constructing the adapter

**Headless / JSON commands** (for GUI consumption)
- `status --json`, `connect --json` (ported from mac-app commit `b0c9deab`)
- `resolve-relay --json`
- `setup --headless` with `--agent` / `--anthropic-key`
- `LOG_LEVEL='silent'` set before the dynamic `import('./adapters/multi.js')` to keep JSON stdout clean (one line, no pino pollution)

## Testing
- `pnpm build` — clean
- `pnpm test` — **524 passing**
- `biome lint` — clean (123 files)
- Manual verification: every new JSON command emits exactly one clean JSON line (`doctor 2>/dev/null | wc -l` → `1`)

## Compatibility
Additive changes only; existing single-agent (copilot) setups keep the same config shape. Only the mac-app GUI wizard will consume the new JSON surfaces.
