### PR TITLE
Copilot-backed Claude mode + Anthropic proxy

### DIFF
--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -21,11 +21,56 @@ import {
 } from './base.js';
 import type { SessionContext } from '../session-manager.js';
 import { createLogger } from '../logger.js';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync, symlinkSync, lstatSync, unlinkSync, cpSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getConfigDir } from '../config.js';
 
 const logger = createLogger('claude-adapter');
+
+/**
+ * Copilot-backed Claude mode.
+ *
+ * When `KRAKI_CLAUDE_COPILOT_URL` points at a running copilot-anthropic-proxy
+ * (tools/copilot-proxy), the claude adapter routes Claude Code through GitHub
+ * Copilot's Claude models instead of the real Anthropic API (or the DeepSeek
+ * gateway configured in ~/.claude/settings.json). This gives a full-power,
+ * full-reasoning CC-grade harness on a Copilot subscription.
+ *
+ * The proxy translates Anthropic `/v1/messages` ⇄ Copilot chat/completions and
+ * ignores the auth token, so a placeholder token is fine.
+ */
+interface CopilotConfig {
+  baseUrl: string;
+  model: string;
+  sonnet: string;
+  haiku: string;
+}
+
+function copilotConfig(): CopilotConfig | null {
+  const baseUrl = process.env.KRAKI_CLAUDE_COPILOT_URL;
+  if (!baseUrl) return null;
+  return {
+    baseUrl,
+    model: process.env.KRAKI_CLAUDE_COPILOT_MODEL || 'claude-opus-4.8',
+    sonnet: process.env.KRAKI_CLAUDE_COPILOT_SONNET || 'claude-sonnet-4.5',
+    haiku: process.env.KRAKI_CLAUDE_COPILOT_HAIKU || 'claude-haiku-4.5',
+  };
+}
+
+/** The Anthropic env block that points Claude Code at the Copilot proxy. */
+function copilotEnvBlock(cfg: CopilotConfig): Record<string, string> {
+  return {
+    ANTHROPIC_BASE_URL: cfg.baseUrl,
+    ANTHROPIC_AUTH_TOKEN: 'kraki-copilot-proxy',
+    ANTHROPIC_MODEL: cfg.model,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: cfg.model,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: cfg.sonnet,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: cfg.haiku,
+    CLAUDE_CODE_SUBAGENT_MODEL: cfg.haiku,
+    CLAUDE_CODE_EFFORT_LEVEL: 'high',
+  };
+}
 
 /**
  * Load `env` overrides from `~/.claude/settings.json` (the same file
@@ -333,6 +378,73 @@ export class ClaudeAdapter extends AgentAdapter {
     this.claudeExecutablePath = options.claudeExecutablePath;
   }
 
+  // ── Co-located storage ────────────────────────────────────
+  // Claude's private transcript (its LLM-context store) is relocated INTO the
+  // Kraki session dir via a per-session CLAUDE_CONFIG_DIR. Auth/config is shared
+  // by symlinking every ~/.claude entry except `projects` (the transcript store)
+  // into a per-session shadow home, so the transcript lands co-located while
+  // login still works. A small sidecar persists the bits needed to resume after
+  // a daemon restart: cwd (the transcript path is cwd-mangled) and the SDK's own
+  // session UUID (the value the SDK `resume` option actually expects).
+
+  private storeDir(sessionId: string): string {
+    return join(getConfigDir(), 'sessions', sessionId);
+  }
+  /** Per-session shadow CLAUDE_CONFIG_DIR (auth symlinked in, projects fresh). */
+  private claudeHome(sessionId: string): string {
+    return join(this.storeDir(sessionId), 'claude-home');
+  }
+  private sidecarPath(sessionId: string): string {
+    return join(this.storeDir(sessionId), '.claude-adapter.json');
+  }
+
+  /** Build the per-session shadow home: symlink every ~/.claude entry except
+   *  `projects` so the SDK writes its transcript into our co-located dir while
+   *  reusing the real login/config. Returns the shadow home path. */
+  private setupShadowHome(sessionId: string): string {
+    const home = this.claudeHome(sessionId);
+    mkdirSync(home, { recursive: true });
+    const real = join(homedir(), '.claude');
+    const copilot = copilotConfig();
+    if (existsSync(real)) {
+      for (const entry of readdirSync(real)) {
+        if (entry === 'projects') continue; // keep transcript store co-located
+        // In Copilot mode the shadow settings.json must point at the proxy, so
+        // don't symlink the real (DeepSeek/Anthropic) settings — we write our
+        // own below. The claude CLI's config-dir settings.json wins over
+        // inherited env, so this is the authoritative control point.
+        if (copilot && (entry === 'settings.json' || entry === 'settings.local.json')) continue;
+        const dest = join(home, entry);
+        try { lstatSync(dest); unlinkSync(dest); } catch { /* dest absent */ }
+        try { symlinkSync(join(real, entry), dest); } catch { /* best effort */ }
+      }
+    }
+    if (copilot) {
+      writeFileSync(
+        join(home, 'settings.json'),
+        JSON.stringify({ env: copilotEnvBlock(copilot) }, null, 2),
+        'utf8',
+      );
+    }
+    return home;
+  }
+
+  private persistMeta(sessionId: string, meta: { cwd?: string; sdkSessionId?: string; model?: string }): void {
+    try {
+      mkdirSync(this.storeDir(sessionId), { recursive: true });
+      const prev = this.loadMeta(sessionId) ?? {};
+      writeFileSync(this.sidecarPath(sessionId), JSON.stringify({ ...prev, ...meta }), 'utf8');
+    } catch (err) {
+      logger.debug({ err: (err as Error).message }, 'claude persistMeta failed');
+    }
+  }
+
+  private loadMeta(sessionId: string): { cwd?: string; sdkSessionId?: string; model?: string } | null {
+    const p = this.sidecarPath(sessionId);
+    if (!existsSync(p)) return null;
+    try { return JSON.parse(readFileSync(p, 'utf8')); } catch { return null; }
+  }
+
   /** System prompt appended to Claude Code's built-in prompt. */
   private static readonly SYSTEM_PROMPT = [
     'You are running inside Kraki, a remote control platform. A human operator is',
@@ -395,6 +507,17 @@ export class ClaudeAdapter extends AgentAdapter {
   // ── Lifecycle ───────────────────────────────────────
 
   async start(): Promise<void> {
+    // Copilot-backed mode: inject the proxy env FIRST so it wins over any
+    // DeepSeek/Anthropic values in ~/.claude/settings.json (loadClaudeSettingsEnv
+    // only fills keys not already present in process.env).
+    const copilot = copilotConfig();
+    if (copilot) {
+      for (const [k, v] of Object.entries(copilotEnvBlock(copilot))) {
+        process.env[k] = v;
+      }
+      logger.info({ baseUrl: copilot.baseUrl, model: copilot.model }, 'Claude adapter in Copilot-proxy mode');
+    }
+
     // Daemons launched via launchd / systemd do not inherit interactive
     // shell env, so we honour the same `env` block Claude Code itself
     // reads from ~/.claude/settings.json before checking auth. Anything
@@ -425,6 +548,34 @@ export class ClaudeAdapter extends AgentAdapter {
     // Fetch available models via a throwaway query. The SDK requires a
     // prompt to create a query, but we can call supportedModels() on it
     // and then immediately abort — no actual API call is made for models.
+    //
+    // In Copilot-proxy mode we skip SDK enumeration entirely: the SDK
+    // subprocess reads the real ~/.claude (DeepSeek) config and would leak a
+    // spurious "deepseek-*" entry into the list. The proxy only serves the
+    // three copilot models, so publish those directly.
+    if (copilot) {
+      this.modelAliasMap.clear();
+      const list: Array<[string, string]> = [
+        [copilot.model, 'opus'],
+        [copilot.sonnet, 'sonnet'],
+        [copilot.haiku, 'haiku'],
+      ];
+      this.cachedModels = list.map(([id, alias]) => {
+        this.modelAliasMap.set(id, alias);
+        return {
+          id,
+          name: id,
+          supportsReasoningEffort: alias === 'opus',
+          ...(alias === 'opus' && {
+            supportedReasoningEfforts: ['low', 'medium', 'high'] as import('@kraki/protocol').ReasoningEffort[],
+          }),
+        };
+      });
+      logger.info({ count: this.cachedModels.length }, 'Copilot-proxy model list published');
+      logger.info({ models: this.cachedModels.map(m => m.id) }, 'Claude adapter started');
+      return;
+    }
+
     try {
       const ac = new AbortController();
       const noop = (async function* () { /* never yields — query blocks waiting for input */ })();
@@ -521,6 +672,10 @@ export class ClaudeAdapter extends AgentAdapter {
     this.sessions.set(sessionId, entry);
     logger.info({ sessionId, model: config.model }, 'session created (deferred — query starts on first message)');
 
+    // Persist the durable resume bits up-front (cwd is needed to locate the
+    // cwd-mangled transcript; the SDK session UUID is filled in at init).
+    this.persistMeta(sessionId, { cwd: config.cwd, model: config.model });
+
     this.onSessionCreated?.({
       sessionId,
       agent: 'claude',
@@ -536,6 +691,14 @@ export class ClaudeAdapter extends AgentAdapter {
     const abortController = new AbortController();
     const { iterable, channel } = createInputChannel();
 
+    // Recover the durable bits from the co-located sidecar. The SDK `resume`
+    // option expects the SDK's own session UUID (NOT Kraki's id), and the
+    // transcript path is cwd-mangled — so without these a fresh daemon spawns a
+    // blank session (the daemon-restart "no context" bug). Fall back to the
+    // Kraki id / process cwd for sessions created before co-location.
+    const meta = this.loadMeta(sessionId);
+    if (meta?.sdkSessionId) this.sdkSessionIds.set(sessionId, meta.sdkSessionId);
+
     const entry: SessionEntry = {
       query: null,
       abortController,
@@ -544,12 +707,18 @@ export class ClaudeAdapter extends AgentAdapter {
       pendingPermissions,
       pendingQuestions,
       sessionId,
+      model: meta?.model,
       consumerLoop: Promise.resolve(),
-      deferredConfig: { resume: sessionId },
+      deferredConfig: {
+        resume: meta?.sdkSessionId ?? sessionId,
+        ...(meta?.cwd && { cwd: meta.cwd }),
+        ...(meta?.model && { model: meta.model }),
+        sessionId,
+      },
     };
 
     this.sessions.set(sessionId, entry);
-    logger.info({ sessionId }, 'session resumed (deferred)');
+    logger.info({ sessionId, sdkSessionId: meta?.sdkSessionId }, 'session resumed (deferred)');
     return { sessionId };
   }
 
@@ -558,6 +727,21 @@ export class ClaudeAdapter extends AgentAdapter {
     const pendingQuestions = new Map<string, PendingQuestion>();
     const abortController = new AbortController();
     const { iterable, channel } = createInputChannel();
+
+    // A fork must read the source transcript from the NEW session's co-located
+    // config dir, so seed it by copying the source projects/ across, and resume
+    // with the source's SDK session UUID (not the Kraki id).
+    const srcMeta = this.loadMeta(sourceSessionId);
+    const srcProjects = join(this.claudeHome(sourceSessionId), 'projects');
+    if (existsSync(srcProjects)) {
+      try {
+        mkdirSync(this.claudeHome(newSessionId), { recursive: true });
+        cpSync(srcProjects, join(this.claudeHome(newSessionId), 'projects'), { recursive: true });
+      } catch (err) {
+        logger.debug({ err: (err as Error).message }, 'claude fork copy failed');
+      }
+    }
+    const resumeId = srcMeta?.sdkSessionId ?? this.sdkSessionIds.get(sourceSessionId) ?? sourceSessionId;
 
     const entry: SessionEntry = {
       query: null,
@@ -568,10 +752,17 @@ export class ClaudeAdapter extends AgentAdapter {
       pendingQuestions,
       sessionId: newSessionId,
       consumerLoop: Promise.resolve(),
-      deferredConfig: { resume: sourceSessionId, fork: true, sessionId: newSessionId },
+      deferredConfig: {
+        resume: resumeId,
+        fork: true,
+        ...(srcMeta?.cwd && { cwd: srcMeta.cwd }),
+        ...(srcMeta?.model && { model: srcMeta.model }),
+        sessionId: newSessionId,
+      },
     };
 
     this.sessions.set(newSessionId, entry);
+    if (srcMeta) this.persistMeta(newSessionId, { cwd: srcMeta.cwd, model: srcMeta.model });
 
     this.onSessionCreated?.({
       sessionId: newSessionId,
@@ -652,6 +843,9 @@ export class ClaudeAdapter extends AgentAdapter {
 
     const options: Options = {
       abortController: entry.abortController,
+      // Relocate Claude's private transcript INTO the Kraki session dir while
+      // reusing the real login (symlinked into the per-session shadow home).
+      env: { ...process.env, CLAUDE_CONFIG_DIR: this.setupShadowHome(sessionId) },
       ...(this.claudeExecutablePath && { pathToClaudeCodeExecutable: this.claudeExecutablePath }),
       ...(config?.model && { model: this.modelAliasMap.get(config.model) ?? config.model }),
       ...(config?.cwd && { cwd: config.cwd }),
@@ -675,6 +869,7 @@ export class ClaudeAdapter extends AgentAdapter {
     entry.query = q;
     entry.deferredConfig = undefined;
     entry.consumerLoop = this.consumeMessages(sessionId, q);
+    if (config?.cwd) this.persistMeta(sessionId, { cwd: config.cwd, model: config.model });
     logger.debug({ sessionId }, 'SDK query spawned');
   }
 
@@ -944,6 +1139,9 @@ export class ClaudeAdapter extends AgentAdapter {
           const sdkSessionId = sysMsg.session_id;
           if (sdkSessionId) {
             this.sdkSessionIds.set(sessionId, sdkSessionId);
+            // Persist the SDK's own session UUID — the value its `resume`
+            // option expects — so a fresh daemon can re-attach this transcript.
+            this.persistMeta(sessionId, { sdkSessionId });
             if (sdkSessionId !== sessionId) {
               const entry = this.sessions.get(sessionId);
               if (entry) entry.sessionId = sdkSessionId;

--- a/tools/copilot-proxy/.gitignore
+++ b/tools/copilot-proxy/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/copilot-proxy/README.md
+++ b/tools/copilot-proxy/README.md
@@ -1,0 +1,55 @@
+# copilot-anthropic-proxy
+
+An Anthropic-compatible (`/v1/messages`) proxy that fronts **GitHub Copilot's
+Claude models**, so Kraki's `claude` SDK adapter (which embeds the Claude Code
+harness via `@anthropic-ai/claude-agent-sdk`) can run **full-power,
+full-reasoning `claude-opus-4.8` on a Copilot subscription** instead of the real
+Anthropic API.
+
+It reuses the `github-copilot` OAuth token that `pi` already stores in
+`~/.pi/agent/auth.json`, mints short-lived Copilot API tokens, and translates
+Anthropic `/v1/messages` ⇄ Copilot chat/completions (including streaming,
+thinking/reasoning, and tool calls).
+
+## Run
+
+```bash
+cd tools/copilot-proxy
+npm install          # installs undici (ProxyAgent for HTTPS_PROXY geo-gating)
+PORT=8788 npm start
+curl -s localhost:8788/health   # {"ok":true,"model":"claude-opus-4.8"}
+```
+
+Endpoints: `POST /v1/messages` (stream + non-stream), `GET /v1/models`,
+`POST /v1/messages/count_tokens`, `GET /health`.
+
+Env: `PORT` (default 8788), `COPILOT_FORCE_EFFORT` (default `high`).
+
+## Wire into Kraki's claude adapter
+
+Set `KRAKI_CLAUDE_COPILOT_URL` to the proxy base URL before starting the
+tentacle daemon:
+
+```bash
+export KRAKI_CLAUDE_COPILOT_URL=http://127.0.0.1:8788
+```
+
+The adapter then:
+
+- injects the copilot `ANTHROPIC_*` env (base URL → proxy, opus-4.8 /
+  sonnet-4.5 / haiku-4.5, reasoning `high`) so the auth gate passes and the
+  model list shows the copilot names;
+- writes a per-session shadow `settings.json` pointing at the proxy (this is the
+  authoritative control point — the CLI's config-dir `settings.json` wins over
+  inherited env), instead of the real `~/.claude/settings.json`.
+
+Optional overrides: `KRAKI_CLAUDE_COPILOT_MODEL`, `KRAKI_CLAUDE_COPILOT_SONNET`,
+`KRAKI_CLAUDE_COPILOT_HAIKU`.
+
+## Notes
+
+- Requires a valid `github-copilot` entry in `~/.pi/agent/auth.json`.
+- If the environment routes egress through an `HTTPS_PROXY` (geo-gating for
+  model availability), the proxy honours it via undici's `ProxyAgent`.
+- Using a Copilot subscription this way may be subject to GitHub's terms; use at
+  your own discretion.

--- a/tools/copilot-proxy/package-lock.json
+++ b/tools/copilot-proxy/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "copilot-anthropic-proxy",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copilot-anthropic-proxy",
+      "version": "0.1.0",
+      "dependencies": {
+        "undici": "^7.0.0"
+      },
+      "bin": {
+        "copilot-anthropic-proxy": "server.mjs"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    }
+  }
+}

--- a/tools/copilot-proxy/package.json
+++ b/tools/copilot-proxy/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "copilot-anthropic-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Anthropic-compatible proxy in front of GitHub Copilot's Claude models (for Kraki's claude SDK adapter).",
+  "bin": { "copilot-anthropic-proxy": "server.mjs" },
+  "scripts": { "start": "node server.mjs" },
+  "dependencies": { "undici": "^7.0.0" }
+}

--- a/tools/copilot-proxy/server.mjs
+++ b/tools/copilot-proxy/server.mjs
@@ -1,0 +1,137 @@
+// Anthropic-compatible proxy in front of GitHub Copilot's Claude models.
+//
+// Exposes the endpoints the Anthropic SDK / Claude Code call, translates each
+// request to Copilot's OpenAI-format chat/completions, and streams the reply
+// back as Anthropic SSE (text + thinking + tool_use).
+//
+// Usage:  node server.mjs            (PORT env, default 8788)
+//         COPILOT_FORCE_EFFORT=high  force reasoning effort (default: high)
+
+import { createServer } from 'node:http';
+import { getCopilotToken, COPILOT_HEADERS } from './token.mjs';
+import {
+  toOpenAIRequest,
+  streamAnthropicFromOpenAI,
+  buildAnthropicMessage,
+} from './translate.mjs';
+
+const PORT = Number(process.env.PORT || 8788);
+const DEFAULT_MODEL = process.env.COPILOT_MODEL || 'claude-opus-4.8';
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function log(...a) {
+  if (process.env.PROXY_QUIET !== '1') console.error('[copilot-proxy]', ...a);
+}
+
+// A small, static model catalogue so the SDK's model list works.
+const MODELS = [
+  'claude-opus-4.8', 'claude-opus-4.7', 'claude-opus-4.6', 'claude-opus-4.5',
+  'claude-sonnet-4.5', 'claude-haiku-4.5',
+].map((id) => ({
+  type: 'model', id, display_name: id, created_at: '2025-01-01T00:00:00Z',
+}));
+
+async function callCopilot(openaiBody) {
+  const { token, apiBase } = await getCopilotToken();
+  return fetch(`${apiBase}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...COPILOT_HEADERS,
+    },
+    body: JSON.stringify(openaiBody),
+  });
+}
+
+async function handleMessages(req, res, body) {
+  const anthropic = JSON.parse(body);
+  const model = DEFAULT_MODEL; // pin to copilot's model id regardless of what SDK asked
+  const wantStream = anthropic.stream !== false;
+  const openaiBody = toOpenAIRequest(anthropic, model);
+  openaiBody.stream = wantStream;
+
+  const upstream = await callCopilot(openaiBody);
+
+  if (!upstream.ok) {
+    const errText = await upstream.text().catch(() => '');
+    log('upstream error', upstream.status, errText.slice(0, 300));
+    res.writeHead(upstream.status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'api_error', message: `Copilot upstream ${upstream.status}: ${errText.slice(0, 300)}` },
+    }));
+    return;
+  }
+
+  if (!wantStream) {
+    const j = await upstream.json();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(buildAnthropicMessage(j, model)));
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  try {
+    for await (const ev of streamAnthropicFromOpenAI(upstream.body, model)) {
+      res.write(ev);
+    }
+  } catch (err) {
+    log('stream error', err?.message);
+    res.write(`event: error\ndata: ${JSON.stringify({ type: 'error', error: { type: 'api_error', message: String(err?.message || err) } })}\n\n`);
+  }
+  res.end();
+}
+
+function handleCountTokens(res, body) {
+  // Cheap heuristic; the SDK only needs a ballpark for context budgeting.
+  const approx = Math.ceil(body.length / 4);
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ input_tokens: approx }));
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = req.url || '';
+    if (req.method === 'GET' && (url === '/health' || url === '/')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, model: DEFAULT_MODEL }));
+      return;
+    }
+    if (req.method === 'GET' && url.startsWith('/v1/models')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: MODELS, has_more: false, first_id: MODELS[0].id, last_id: MODELS.at(-1).id }));
+      return;
+    }
+    if (req.method === 'POST' && url.startsWith('/v1/messages/count_tokens')) {
+      handleCountTokens(res, await readBody(req));
+      return;
+    }
+    if (req.method === 'POST' && url.startsWith('/v1/messages')) {
+      await handleMessages(req, res, await readBody(req));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `No route ${req.method} ${url}` } }));
+  } catch (err) {
+    log('handler error', err?.stack || err?.message);
+    if (!res.headersSent) res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'api_error', message: String(err?.message || err) } }));
+  }
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  log(`listening on http://127.0.0.1:${PORT}  (model=${DEFAULT_MODEL})`);
+});

--- a/tools/copilot-proxy/token.mjs
+++ b/tools/copilot-proxy/token.mjs
@@ -1,0 +1,75 @@
+// Copilot token manager.
+//
+// Reuses the GitHub OAuth token that `pi` already stores
+// (`~/.pi/agent/auth.json` → github-copilot.refresh, a `ghu_...` token) to mint
+// short-lived Copilot API tokens (`tid=...`, ~30 min TTL) via GitHub's
+// copilot_internal token endpoint, and keeps one cached + auto-refreshed.
+
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+
+// Copilot gates model access by egress region. This box routes through a local
+// forward proxy (HTTPS_PROXY); curl honours it automatically but Node's global
+// fetch (undici) does not — so opt in explicitly, matching curl's path.
+const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy;
+if (proxyUrl) setGlobalDispatcher(new ProxyAgent(proxyUrl));
+
+const AUTH_PATH = process.env.COPILOT_AUTH_PATH
+  || join(homedir(), '.pi', 'agent', 'auth.json');
+
+const EDITOR_VERSION = 'vscode/1.95.0';
+const PLUGIN_VERSION = 'copilot-chat/0.22.0';
+const USER_AGENT = 'GitHubCopilotChat/0.22.0';
+
+/** Read the long-lived GitHub OAuth (`ghu_`) token pi persists. */
+function readGithubToken() {
+  const explicit = process.env.COPILOT_GITHUB_TOKEN;
+  if (explicit) return explicit;
+  const raw = JSON.parse(readFileSync(AUTH_PATH, 'utf8'));
+  const gc = raw['github-copilot'];
+  if (!gc?.refresh) {
+    throw new Error(`No github-copilot.refresh token in ${AUTH_PATH}`);
+  }
+  return gc.refresh;
+}
+
+let cached = null; // { token, apiBase, expiresAt }
+
+async function mint() {
+  const ghToken = readGithubToken();
+  const res = await fetch('https://api.github.com/copilot_internal/v2/token', {
+    headers: {
+      Authorization: `token ${ghToken}`,
+      'Editor-Version': EDITOR_VERSION,
+      'Editor-Plugin-Version': PLUGIN_VERSION,
+      'User-Agent': USER_AGENT,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Copilot token exchange failed: ${res.status} ${body.slice(0, 200)}`);
+  }
+  const data = await res.json();
+  if (!data.token) throw new Error('Copilot token exchange returned no token');
+  const apiBase = data.endpoints?.api || 'https://api.githubcopilot.com';
+  // expires_at is unix seconds; refresh a bit early.
+  const expiresAt = (data.expires_at ? data.expires_at * 1000 : Date.now() + 25 * 60_000);
+  cached = { token: data.token, apiBase, expiresAt };
+  return cached;
+}
+
+/** Get a valid Copilot API token + base URL, refreshing when close to expiry. */
+export async function getCopilotToken() {
+  const skewMs = 2 * 60_000;
+  if (cached && cached.expiresAt - skewMs > Date.now()) return cached;
+  return mint();
+}
+
+export const COPILOT_HEADERS = {
+  'Editor-Version': EDITOR_VERSION,
+  'Editor-Plugin-Version': PLUGIN_VERSION,
+  'Copilot-Integration-Id': 'vscode-chat',
+  'User-Agent': USER_AGENT,
+};

--- a/tools/copilot-proxy/translate.mjs
+++ b/tools/copilot-proxy/translate.mjs
@@ -1,0 +1,314 @@
+// Anthropic Messages API  <->  Copilot (OpenAI chat/completions) translation.
+//
+// Two directions:
+//   toOpenAIRequest(anthropicBody)  — request shape translation
+//   streamAnthropicFromOpenAI(...)  — stateful OpenAI SSE -> Anthropic SSE
+//   buildAnthropicMessage(...)      — non-streaming OpenAI -> Anthropic JSON
+
+let idCounter = 0;
+const genId = (p) => `${p}_${Date.now().toString(36)}${(idCounter++).toString(36)}`;
+
+function textFromBlocks(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.filter((b) => b?.type === 'text').map((b) => b.text).join('');
+}
+
+/** Map Anthropic thinking config (or a forced default) to a Copilot reasoning_effort. */
+function reasoningEffort(body) {
+  const forced = process.env.COPILOT_FORCE_EFFORT; // e.g. "high"
+  if (forced) return forced;
+  const t = body.thinking;
+  if (t && t.type === 'enabled') {
+    const b = t.budget_tokens || 0;
+    if (b >= 16000) return 'high';
+    if (b >= 4000) return 'medium';
+    return 'low';
+  }
+  // Default: full power. The whole point of this proxy is 满血 reasoning.
+  return 'high';
+}
+
+/** Anthropic request body -> OpenAI chat/completions request body. */
+export function toOpenAIRequest(body, model) {
+  const messages = [];
+
+  // system: string or array of text blocks
+  if (body.system) {
+    const sys = textFromBlocks(body.system);
+    if (sys) messages.push({ role: 'system', content: sys });
+  }
+
+  for (const msg of body.messages || []) {
+    const role = msg.role;
+    const content = msg.content;
+
+    if (typeof content === 'string') {
+      messages.push({ role, content });
+      continue;
+    }
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      const textParts = [];
+      const toolCalls = [];
+      for (const b of content) {
+        if (b.type === 'text') textParts.push(b.text);
+        else if (b.type === 'tool_use') {
+          toolCalls.push({
+            id: b.id,
+            type: 'function',
+            function: { name: b.name, arguments: JSON.stringify(b.input ?? {}) },
+          });
+        }
+        // thinking blocks are dropped on the way back in (Copilot has no
+        // thinking-input channel); the model re-reasons each turn.
+      }
+      const m = { role: 'assistant' };
+      m.content = textParts.join('') || null;
+      if (toolCalls.length) m.tool_calls = toolCalls;
+      messages.push(m);
+      continue;
+    }
+
+    // role === 'user' (or tool results carried on a user turn)
+    const userParts = [];
+    for (const b of content) {
+      if (b.type === 'text') {
+        userParts.push({ type: 'text', text: b.text });
+      } else if (b.type === 'image' && b.source?.type === 'base64') {
+        userParts.push({
+          type: 'image_url',
+          image_url: { url: `data:${b.source.media_type};base64,${b.source.data}` },
+        });
+      } else if (b.type === 'tool_result') {
+        // OpenAI requires tool results as their own role:tool messages.
+        let c = b.content;
+        if (Array.isArray(c)) c = c.map((x) => (x?.type === 'text' ? x.text : '')).join('');
+        messages.push({ role: 'tool', tool_call_id: b.tool_use_id, content: String(c ?? '') });
+      }
+    }
+    if (userParts.length) {
+      // collapse to a plain string when it's only text (wider compatibility)
+      const onlyText = userParts.every((p) => p.type === 'text');
+      messages.push({
+        role: 'user',
+        content: onlyText ? userParts.map((p) => p.text).join('') : userParts,
+      });
+    }
+  }
+
+  const out = {
+    model,
+    messages,
+    max_tokens: body.max_tokens ?? 32000,
+    stream: body.stream !== false,
+  };
+  if (out.stream) out.stream_options = { include_usage: true };
+  if (typeof body.temperature === 'number') out.temperature = body.temperature;
+  out.reasoning_effort = reasoningEffort(body);
+
+  if (Array.isArray(body.tools) && body.tools.length) {
+    out.tools = body.tools.map((t) => ({
+      type: 'function',
+      function: {
+        name: t.name,
+        description: t.description ?? '',
+        parameters: t.input_schema ?? { type: 'object', properties: {} },
+      },
+    }));
+    if (body.tool_choice) {
+      const tc = body.tool_choice;
+      if (tc.type === 'auto') out.tool_choice = 'auto';
+      else if (tc.type === 'any') out.tool_choice = 'required';
+      else if (tc.type === 'tool' && tc.name) {
+        out.tool_choice = { type: 'function', function: { name: tc.name } };
+      }
+    }
+  }
+  return out;
+}
+
+const STOP_MAP = {
+  stop: 'end_turn',
+  length: 'max_tokens',
+  tool_calls: 'tool_use',
+  content_filter: 'end_turn',
+  function_call: 'tool_use',
+};
+
+/**
+ * Consume an OpenAI SSE ReadableStream (web stream of Uint8Array) and yield
+ * Anthropic SSE event strings ("event: ...\ndata: ...\n\n").
+ *
+ * Handles three block types in Anthropic order: thinking -> text -> tool_use.
+ */
+export async function* streamAnthropicFromOpenAI(openaiBody, model) {
+  const enc = (event, data) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  const msgId = genId('msg');
+
+  yield enc('message_start', {
+    type: 'message_start',
+    message: {
+      id: msgId, type: 'message', role: 'assistant', model,
+      content: [], stop_reason: null, stop_sequence: null,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    },
+  });
+  yield enc('ping', { type: 'ping' });
+
+  let blockIndex = -1;
+  let openType = null; // 'thinking' | 'text' | 'tool_use'
+  let sigBuf = '';
+  let stopReason = 'end_turn';
+  let usage = { input_tokens: 0, output_tokens: 0 };
+  // openai tool_call index -> anthropic block index
+  const toolBlocks = new Map();
+
+  function* closeOpen() {
+    if (openType === null) return;
+    if (openType === 'thinking' && sigBuf) {
+      yield enc('content_block_delta', {
+        type: 'content_block_delta', index: blockIndex,
+        delta: { type: 'signature_delta', signature: sigBuf },
+      });
+    }
+    yield enc('content_block_stop', { type: 'content_block_stop', index: blockIndex });
+    openType = null;
+    sigBuf = '';
+  }
+
+  function* openBlock(type, contentBlock) {
+    yield* closeOpen();
+    blockIndex += 1;
+    openType = type;
+    yield enc('content_block_start', {
+      type: 'content_block_start', index: blockIndex, content_block: contentBlock,
+    });
+    return blockIndex;
+  }
+
+  const reader = openaiBody.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line.startsWith('data:')) continue;
+        const payload = line.slice(5).trim();
+        if (payload === '[DONE]') continue;
+        let chunk;
+        try { chunk = JSON.parse(payload); } catch { continue; }
+
+        if (chunk.usage) {
+          const cached = chunk.usage.prompt_tokens_details?.cached_tokens ?? 0;
+          usage = {
+            input_tokens: chunk.usage.prompt_tokens ?? usage.input_tokens,
+            output_tokens: chunk.usage.completion_tokens ?? usage.output_tokens,
+            cache_read_input_tokens: cached,
+          };
+        }
+        const choice = chunk.choices?.[0];
+        if (!choice) continue;
+        const delta = choice.delta || {};
+
+        // 1) reasoning / thinking
+        if (delta.reasoning_text) {
+          if (openType !== 'thinking') {
+            yield* openBlock('thinking', { type: 'thinking', thinking: '' });
+          }
+          yield enc('content_block_delta', {
+            type: 'content_block_delta', index: blockIndex,
+            delta: { type: 'thinking_delta', thinking: delta.reasoning_text },
+          });
+        }
+        if (delta.reasoning_opaque) sigBuf += delta.reasoning_opaque;
+
+        // 2) assistant text
+        if (delta.content) {
+          if (openType !== 'text') {
+            yield* openBlock('text', { type: 'text', text: '' });
+          }
+          yield enc('content_block_delta', {
+            type: 'content_block_delta', index: blockIndex,
+            delta: { type: 'text_delta', text: delta.content },
+          });
+        }
+
+        // 3) tool calls
+        if (Array.isArray(delta.tool_calls)) {
+          for (const tc of delta.tool_calls) {
+            const oaIdx = tc.index ?? 0;
+            if (!toolBlocks.has(oaIdx)) {
+              yield* openBlock('tool_use', {
+                type: 'tool_use',
+                id: tc.id || genId('toolu'),
+                name: tc.function?.name || '',
+                input: {},
+              });
+              toolBlocks.set(oaIdx, blockIndex);
+            }
+            const arg = tc.function?.arguments;
+            if (arg) {
+              yield enc('content_block_delta', {
+                type: 'content_block_delta', index: toolBlocks.get(oaIdx),
+                delta: { type: 'input_json_delta', partial_json: arg },
+              });
+            }
+          }
+        }
+
+        if (choice.finish_reason) {
+          stopReason = STOP_MAP[choice.finish_reason] || 'end_turn';
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+
+  yield* closeOpen();
+  yield enc('message_delta', {
+    type: 'message_delta',
+    delta: { stop_reason: stopReason, stop_sequence: null },
+    usage: {
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+      cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+    },
+  });
+  yield enc('message_stop', { type: 'message_stop' });
+}
+
+/** Non-streaming: OpenAI completion JSON -> Anthropic message JSON. */
+export function buildAnthropicMessage(openaiJson, model) {
+  const choice = openaiJson.choices?.[0] || {};
+  const m = choice.message || {};
+  const content = [];
+  if (m.content) content.push({ type: 'text', text: m.content });
+  for (const tc of m.tool_calls || []) {
+    let input = {};
+    try { input = JSON.parse(tc.function?.arguments || '{}'); } catch { /* keep {} */ }
+    content.push({ type: 'tool_use', id: tc.id || genId('toolu'), name: tc.function?.name, input });
+  }
+  return {
+    id: genId('msg'),
+    type: 'message',
+    role: 'assistant',
+    model,
+    content,
+    stop_reason: STOP_MAP[choice.finish_reason] || 'end_turn',
+    stop_sequence: null,
+    usage: {
+      input_tokens: openaiJson.usage?.prompt_tokens ?? 0,
+      output_tokens: openaiJson.usage?.completion_tokens ?? 0,
+    },
+  };
+}


### PR DESCRIPTION
## What

Opt-in mode that routes Kraki's **Claude SDK adapter** (the Claude Code harness) through **GitHub Copilot's Claude models** — full-power, full-reasoning `claude-opus-4.8` on a Copilot subscription instead of the real Anthropic API.

Isolated from the pi work: this PR touches only `packages/tentacle/src/adapters/claude.ts` and the new `tools/copilot-proxy/`. No pi adapter changes.

## How

**`tools/copilot-proxy/`** — an Anthropic-compatible proxy fronting Copilot chat/completions:
- reuses pi's `github-copilot` OAuth token (`~/.pi/agent/auth.json`), mints/refreshes Copilot API tokens (`token.mjs`)
- translates `/v1/messages` <-> OpenAI: streaming, thinking/reasoning, tool calls, and **input+cache+output** usage (`translate.mjs`)
- pins opus-4.8, forces high reasoning (`COPILOT_FORCE_EFFORT` overrides)

**claude adapter** — when `KRAKI_CLAUDE_COPILOT_URL` is set:
- injects the Copilot `ANTHROPIC_*` env before `loadClaudeSettingsEnv` so it wins over DeepSeek/Anthropic values in `~/.claude/settings.json`
- writes a per-session **shadow `settings.json`** pointing at the proxy (config-dir settings wins over inherited env) — the authoritative control point that prevents silent fallback
- publishes the three Copilot models directly (skips SDK enumeration, which would leak a spurious deepseek entry)

Carries the per-session **co-located transcript storage** the shadow-home mechanism depends on, scoped to `claude.ts`.

## Usage

    # 1. start the proxy (needs pi's copilot auth)
    cd tools/copilot-proxy && npm i
    COPILOT_FORCE_EFFORT=xhigh node server.mjs   # listens on :8788

    # 2. point the claude adapter at it
    export KRAKI_CLAUDE_COPILOT_URL=http://127.0.0.1:8788
    # then run kraki as usual; the claude adapter now serves opus-4.8 via Copilot

## Verification

- `tsc --noEmit` clean
- `biome lint` clean
- `vitest run` — **524/524** pass
