### PR TITLE
fix(claude): key AskUserQuestion answers by question text (v0.25.1)

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/claude-askuserquestion.test.ts
+++ b/packages/tentacle/src/__tests__/claude-askuserquestion.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for the Claude AskUserQuestion answers-key bug.
+ *
+ * The Claude Code SDK's AskUserQuestion tool expects the pre-populated
+ * `answers` (returned from canUseTool.updatedInput) to be a Record keyed by
+ * each question's `question` TEXT — not a literal `"answer"` key. Passing
+ * `{ answer }` made the SDK treat every question as unanswered, so the
+ * tool_result Claude received was "The user did not answer the questions."
+ * and every user answer was silently dropped.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ClaudeAdapter } from '../adapters/claude.js';
+
+type CapturedResult = {
+  behavior: string;
+  updatedInput?: { questions?: unknown; answers?: Record<string, string> };
+  message?: string;
+};
+
+type PendingLike = {
+  resolve: (r: CapturedResult) => void;
+  questionId: string;
+  questions?: Array<{ question: string; options?: unknown }>;
+};
+
+type EntryLike = {
+  pendingPermissions: Map<string, { resolve: (r: CapturedResult) => void; toolKind?: string }>;
+  pendingQuestions: Map<string, PendingLike>;
+};
+
+const asSessions = (a: ClaudeAdapter) =>
+  (a as unknown as { sessions: Map<string, EntryLike> }).sessions;
+const asModes = (a: ClaudeAdapter) =>
+  (a as unknown as { sessionModes: Map<string, string> }).sessionModes;
+
+describe('Claude AskUserQuestion answers key', () => {
+  it('respondToQuestion keys the answer by the question TEXT (not "answer")', async () => {
+    const adapter = new ClaudeAdapter();
+    let captured: CapturedResult | undefined;
+    const questionText = '关于 primeExpanded 的修复，你想让我按哪个方向动手？';
+    const questions = [{ question: questionText, options: [{ label: 'A' }] }];
+    const pendingQuestions = new Map<string, PendingLike>([
+      ['q1', { resolve: (r) => { captured = r; }, questionId: 'q1', questions }],
+    ]);
+    asSessions(adapter).set('s1', { pendingPermissions: new Map(), pendingQuestions });
+
+    await adapter.respondToQuestion('s1', 'q1', '你给我做一个详细的带图示的html report', false);
+
+    expect(captured?.behavior).toBe('allow');
+    expect(captured?.updatedInput?.questions).toEqual(questions);
+    expect(captured?.updatedInput?.answers).toEqual({
+      [questionText]: '你给我做一个详细的带图示的html report',
+    });
+    // The literal-"answer" key that caused the bug must NOT be present.
+    expect(Object.keys(captured?.updatedInput?.answers ?? {})).not.toContain('answer');
+    // pending question is consumed
+    expect(asSessions(adapter).get('s1')?.pendingQuestions.size).toBe(0);
+  });
+
+  it('delegate-mode auto-answer keys EVERY question by its text', async () => {
+    const adapter = new ClaudeAdapter();
+    asModes(adapter).set('s1', 'delegate');
+    const input = { questions: [{ question: 'Q one' }, { question: 'Q two' }] };
+
+    const res = await (
+      adapter as unknown as {
+        handleAskUserQuestion: (
+          s: string,
+          i: Record<string, unknown>,
+          p: Map<string, PendingLike>,
+        ) => Promise<CapturedResult>;
+      }
+    ).handleAskUserQuestion('s1', input, new Map());
+
+    expect(res.behavior).toBe('allow');
+    expect(res.updatedInput?.questions).toEqual(input.questions);
+    expect(res.updatedInput?.answers).toEqual({
+      'Q one': 'proceed with your best judgment',
+      'Q two': 'proceed with your best judgment',
+    });
+  });
+
+  it('broadcastPendingResolutions echoes questions with an empty answers map', () => {
+    const adapter = new ClaudeAdapter();
+    let captured: CapturedResult | undefined;
+    const questions = [{ question: 'still open?' }];
+    const pendingQuestions = new Map<string, PendingLike>([
+      ['q1', { resolve: (r) => { captured = r; }, questionId: 'q1', questions }],
+    ]);
+    asSessions(adapter).set('s1', { pendingPermissions: new Map(), pendingQuestions });
+
+    (adapter as unknown as { broadcastPendingResolutions: (s: string) => void })
+      .broadcastPendingResolutions('s1');
+
+    expect(captured?.behavior).toBe('allow');
+    expect(captured?.updatedInput?.questions).toEqual(questions);
+    expect(captured?.updatedInput?.answers).toEqual({});
+  });
+});

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -95,11 +95,21 @@ interface PendingPermission {
   toolKind: string;
 }
 
+/** One AskUserQuestion entry from the SDK's `questions` array. */
+interface AskUserQuestionItem {
+  question: string;
+  options?: Array<{ label: string; description?: string; preview?: string }>;
+  multiSelect?: boolean;
+  header?: string;
+}
+
 interface PendingQuestion {
   resolve: (result: PermissionResult) => void;
   questionId: string;
-  /** Original questions payload from the SDK, echoed back in the answer. */
-  questions?: unknown;
+  /** Original questions payload from the SDK, echoed back in the answer.
+   *  The SDK's AskUserQuestion `answers` map is keyed by each question's
+   *  `question` text, so we need this to build the answer. */
+  questions?: AskUserQuestionItem[];
 }
 
 /** A message pushed into the streaming input channel. */
@@ -738,12 +748,20 @@ export class ClaudeAdapter extends AgentAdapter {
       return;
     }
 
+    // SDK schema: AskUserQuestion's `answers` is a Record keyed by each
+    // question's `question` TEXT (not a literal "answer" key), and `questions`
+    // is required. kraki only surfaces questions[0] to the user, so key the
+    // answer off questions[0].question; any remaining questions are left blank
+    // (the SDK renders them as unanswered). Passing `{ answer }` here was the
+    // bug that made every answer read as "The user did not answer the questions."
+    const qs = pending.questions ?? [];
+    const answers: Record<string, string> = {};
+    const firstQuestionText = qs[0]?.question;
+    if (firstQuestionText) answers[firstQuestionText] = answer;
+
     pending.resolve({
       behavior: 'allow',
-      updatedInput: {
-        answers: { answer },
-        ...(pending.questions ? { questions: pending.questions } : {}),
-      },
+      updatedInput: { questions: qs, answers },
     });
     entry.pendingQuestions.delete(questionId);
     logger.debug({ questionId, sessionId }, 'question answered');
@@ -1258,21 +1276,21 @@ export class ClaudeAdapter extends AgentAdapter {
     // Delegate mode: auto-answer questions
     if (mode === 'delegate') {
       logger.debug({ sessionId }, 'question auto-answered (delegate mode)');
+      // Key each answer by its question TEXT (SDK schema), not a literal
+      // "answer" key — otherwise the SDK sees every question as unanswered.
+      const qs = (input.questions as AskUserQuestionItem[] | undefined) ?? [];
+      const answers: Record<string, string> = {};
+      for (const q of qs) {
+        if (q?.question) answers[q.question] = 'proceed with your best judgment';
+      }
       return Promise.resolve({
         behavior: 'allow',
-        updatedInput: {
-          questions: input.questions,
-          answers: { answer: 'proceed with your best judgment' },
-        },
+        updatedInput: { questions: qs, answers },
       });
     }
 
     const qId = makeId('q');
-    const questions = input.questions as Array<{
-      question: string;
-      options?: Array<{ label: string; description?: string }>;
-      multiSelect?: boolean;
-    }> | undefined;
+    const questions = input.questions as AskUserQuestionItem[] | undefined;
 
     const firstQuestion = questions?.[0];
     const questionText = firstQuestion?.question ?? (input.question as string) ?? 'The agent has a question';
@@ -1292,7 +1310,7 @@ export class ClaudeAdapter extends AgentAdapter {
     });
 
     return new Promise<PermissionResult>((resolve) => {
-      pendingQuestions.set(qId, { resolve, questionId: qId, questions: input.questions });
+      pendingQuestions.set(qId, { resolve, questionId: qId, questions });
     });
   }
 
@@ -1317,7 +1335,13 @@ export class ClaudeAdapter extends AgentAdapter {
     }
     entry.pendingPermissions.clear();
     for (const [qId, q] of entry.pendingQuestions) {
-      q.resolve({ behavior: 'allow', updatedInput: { answers: { answer: '' } } });
+      // Session ending with the question still open: echo `questions` back
+      // (required by the SDK schema) with an empty `answers` map so the SDK
+      // renders them unanswered rather than throwing on missing `questions`.
+      q.resolve({
+        behavior: 'allow',
+        updatedInput: { questions: q.questions ?? [], answers: {} },
+      });
       this.onQuestionAutoResolved?.(sessionId, qId);
     }
     entry.pendingQuestions.clear();


### PR DESCRIPTION
## Problem

Every user answer to Claude's **AskUserQuestion** (button or freeform) was silently dropped. Claude received a `tool_result` of `"The user did not answer the questions."` and behaved as if the user skipped.

Repro session `mr37em22-5mk5cyp8`: the user answered *"你给我做一个详细的带图示的html report"* via AskUserQuestion (`messages.jsonl` seq 32 `question_resolved`), but seq 33's tool_result was the 38-byte *"The user did not answer the questions."*, and Claude later insisted it was never asked to make a report.

## Root cause

The Claude Code SDK (`@anthropic-ai/claude-agent-sdk` v0.3.156) AskUserQuestion tool expects the pre-populated answers returned from `canUseTool`'s `PermissionResult.updatedInput` to be:

```
{ questions: [...],                       // required
  answers: Record<questionText, answerString> }   // keyed by the question's TEXT
```

The SDK maps `answers[question.question]` per question to build the tool_result. kraki was passing `answers: { answer }` — a literal `"answer"` key — which matches no question text, so the SDK saw every question as unanswered.

Verified against the SDK binary: the schema field `answers` is documented *"User answers collected by the permission component"*, the success path renders *"Your questions have been answered: …"*, and `questions` is required (*"Cannot destructure property 'questions' from null or undefined value"*).

## Fix (`packages/tentacle/src/adapters/claude.ts`)

Key `answers` off each question's `question` text at all three sites:

- **`respondToQuestion`** — the real answer-return path (keys `questions[0].question`; kraki only surfaces the first question).
- **delegate-mode auto-answer** in `handleAskUserQuestion` — keys every question.
- **`broadcastPendingResolutions`** (session-end fallback) — echoes `questions` back with an empty `answers` map (avoids the SDK throwing on missing `questions`).

Also tightens `PendingQuestion.questions` from `unknown` to a typed shape, and adds a regression test (`claude-askuserquestion.test.ts`) — confirmed it fails when the literal-`"answer"` key is reintroduced.

## Validation

- `pnpm --filter @kraki/tentacle build` ✓
- `pnpm --filter @kraki/tentacle test` → **527 passed** (incl. 3 new) ✓
- biome lint clean ✓
- Regression test proven to have teeth (fails on the old code) ✓

Bumps `@kraki/tentacle` → **0.25.1**. Web arm needs no change.

## Follow-ups (not in this PR)

- Multi-question support: SDK allows 1–4 questions; kraki emits only `questions[0]`. The rest are left blank (reasonable degradation).
- `relay-client.ts` hardcodes `wasFreeform=false`; protocol `AnswerMessage` lacks the field. Claude ignores it (`_wasFreeform`); copilot uses it. Separate PR.
