### PR TITLE
fix: multi-question + wasFreeform + unicast approve test (v0.26.1)

### DIFF
--- a/packages/arm/web/src/components/actions/QuestionInput.tsx
+++ b/packages/arm/web/src/components/actions/QuestionInput.tsx
@@ -15,8 +15,8 @@ export function QuestionInput({ question, sessionId }: { question: PendingQuesti
     inputRef.current?.focus();
   }, [id, shouldAutoFocus]);
 
-  const handleAnswer = (answer: string) => {
-    wsClient.answer(id, sessionId, answer);
+  const handleAnswer = (answer: string, wasFreeform: boolean) => {
+    wsClient.answer(id, sessionId, answer, wasFreeform);
     // On mobile, blur to dismiss the keyboard after answering
     if (!shouldAutoFocus) {
       inputRef.current?.blur();
@@ -31,7 +31,7 @@ export function QuestionInput({ question, sessionId }: { question: PendingQuesti
             {choices.map((choice, i) => (
               <button
                 key={i}
-                onClick={() => handleAnswer(choice)}
+                onClick={() => handleAnswer(choice, false)}
                 className="w-full rounded-lg border border-border-primary px-3 py-2 text-left text-sm text-text-primary transition-all hover:border-violet-500 hover:bg-violet-500/10 active:scale-[0.98]"
               >
                 <Markdown components={{ p: ({ children }) => <>{children}</> }}>{choice}</Markdown>
@@ -48,7 +48,7 @@ export function QuestionInput({ question, sessionId }: { question: PendingQuesti
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.nativeEvent.isComposing && e.keyCode !== 229 && freeform.trim()) {
                 e.preventDefault();
-                handleAnswer(freeform.trim());
+                handleAnswer(freeform.trim(), true);
               }
             }}
             placeholder="Type your answer…"
@@ -58,7 +58,7 @@ export function QuestionInput({ question, sessionId }: { question: PendingQuesti
             className="flex-1 rounded-xl border border-border-primary bg-surface-secondary px-4 py-2.5 text-base text-text-primary placeholder-text-muted focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500 sm:text-sm"
           />
           <button
-            onClick={() => { if (freeform.trim()) handleAnswer(freeform.trim()); }}
+            onClick={() => { if (freeform.trim()) handleAnswer(freeform.trim(), true); }}
             disabled={!freeform.trim()}
             aria-label="Send answer"
             className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-violet-500 text-white transition-all hover:bg-violet-600 active:scale-95 disabled:opacity-40 disabled:hover:bg-violet-500"

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -178,11 +178,12 @@ export function answer(
   sessionId: string,
   answerText: string,
   send: (msg: Record<string, unknown>) => void,
+  wasFreeform = false,
 ): void {
   send({
     type: 'answer',
     sessionId,
-    payload: { questionId, answer: answerText },
+    payload: { questionId, answer: answerText, wasFreeform },
   });
   getStore().removeQuestion(questionId);
   resolveQuestionMessage(sessionId, questionId, answerText);

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -124,8 +124,8 @@ export class KrakiWSClient {
     commands.alwaysAllow(permissionId, sessionId, (msg) => this.sendEncrypted(msg), toolKind);
   }
 
-  answer(questionId: string, sessionId: string, answerText: string) {
-    commands.answer(questionId, sessionId, answerText, (msg) => this.sendEncrypted(msg));
+  answer(questionId: string, sessionId: string, answerText: string, wasFreeform = false) {
+    commands.answer(questionId, sessionId, answerText, (msg) => this.sendEncrypted(msg), wasFreeform);
   }
 
   killSession(sessionId: string) {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -594,6 +594,11 @@ export interface AnswerMessage extends BaseEnvelope {
   payload: {
     questionId: string;
     answer: string;
+    /** True when the answer was typed freely rather than picked from a
+     *  provided choice. Adapters (e.g. copilot) use this to decide whether the
+     *  answer maps to a listed option or is custom text. Optional for backward
+     *  compatibility; treated as `false` when absent. */
+    wasFreeform?: boolean;
   };
 }
 

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/claude-askuserquestion.test.ts
+++ b/packages/tentacle/src/__tests__/claude-askuserquestion.test.ts
@@ -97,4 +97,51 @@ describe('Claude AskUserQuestion answers key', () => {
     expect(captured?.updatedInput?.questions).toEqual(questions);
     expect(captured?.updatedInput?.answers).toEqual({});
   });
+
+  it('asks multiple questions one at a time and resolves with every answer keyed by text', async () => {
+    const adapter = new ClaudeAdapter();
+    const emitted: Array<{ id: string; question: string }> = [];
+    (adapter as unknown as {
+      onQuestionRequest?: (s: string, q: { id: string; question: string }) => void;
+    }).onQuestionRequest = (_s, q) => emitted.push({ id: q.id, question: q.question });
+
+    const pendingQuestions = new Map<string, PendingLike>();
+    asSessions(adapter).set('s1', { pendingPermissions: new Map(), pendingQuestions });
+
+    const input = {
+      questions: [
+        { question: 'Which database?', options: [{ label: 'pg' }] },
+        { question: 'Which cache?', options: [{ label: 'redis' }] },
+      ],
+    };
+    const permission = (adapter as unknown as {
+      handleAskUserQuestion: (
+        s: string,
+        i: Record<string, unknown>,
+        p: Map<string, PendingLike>,
+      ) => Promise<CapturedResult>;
+    }).handleAskUserQuestion('s1', input, pendingQuestions);
+
+    // Only the first question surfaces initially.
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].question).toBe('Which database?');
+    expect(pendingQuestions.size).toBe(1);
+
+    // Answer the first → the second question surfaces, permission still pending.
+    await adapter.respondToQuestion('s1', emitted[0].id, 'postgres', false);
+    expect(emitted).toHaveLength(2);
+    expect(emitted[1].question).toBe('Which cache?');
+    expect(pendingQuestions.size).toBe(1);
+
+    // Answer the second → permission resolves with BOTH answers, keyed by text.
+    await adapter.respondToQuestion('s1', emitted[1].id, 'redis', true);
+    const result = await permission;
+    expect(result.behavior).toBe('allow');
+    expect(result.updatedInput?.answers).toEqual({
+      'Which database?': 'postgres',
+      'Which cache?': 'redis',
+    });
+    expect(result.updatedInput?.questions).toEqual(input.questions);
+    expect(pendingQuestions.size).toBe(0);
+  });
 });

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -111,6 +111,13 @@ interface PendingQuestion {
    *  The SDK's AskUserQuestion `answers` map is keyed by each question's
    *  `question` text, so we need this to build the answer. */
   questions?: AskUserQuestionItem[];
+  /** Index (into `questions`) of the question THIS card represents. The SDK
+   *  may ask 1–4 questions per call; kraki surfaces them to the user one card
+   *  at a time and advances on each answer. */
+  qIndex?: number;
+  /** Answers collected so far across the serial cards of one AskUserQuestion
+   *  call, keyed by question text. Shared (mutated) across the chain. */
+  collected?: Record<string, string>;
 }
 
 /** A message pushed into the streaming input channel. */
@@ -849,21 +856,32 @@ export class ClaudeAdapter extends AgentAdapter {
 
     // SDK schema: AskUserQuestion's `answers` is a Record keyed by each
     // question's `question` TEXT (not a literal "answer" key), and `questions`
-    // is required. kraki only surfaces questions[0] to the user, so key the
-    // answer off questions[0].question; any remaining questions are left blank
-    // (the SDK renders them as unanswered). Passing `{ answer }` here was the
-    // bug that made every answer read as "The user did not answer the questions."
+    // is required. Passing `{ answer }` here was the bug that made every answer
+    // read as "The user did not answer the questions."
+    //
+    // The SDK may ask 1–4 questions per call. We surface them one card at a
+    // time: record this card's answer, then either emit the next question or,
+    // once all are answered, resolve the tool permission with the full map.
     const qs = pending.questions ?? [];
-    const answers: Record<string, string> = {};
-    const firstQuestionText = qs[0]?.question;
-    if (firstQuestionText) answers[firstQuestionText] = answer;
+    const collected = pending.collected ?? {};
+    const index = pending.qIndex ?? 0;
+    const thisQuestionText = qs[index]?.question;
+    if (thisQuestionText) collected[thisQuestionText] = answer;
+
+    entry.pendingQuestions.delete(questionId);
+
+    const nextIndex = index + 1;
+    if (nextIndex < qs.length) {
+      this.emitQuestionCard(sessionId, pending.resolve, qs, nextIndex, collected, entry.pendingQuestions);
+      logger.debug({ questionId, sessionId, index, nextIndex, total: qs.length }, 'question answered, advancing');
+      return;
+    }
 
     pending.resolve({
       behavior: 'allow',
-      updatedInput: { questions: qs, answers },
+      updatedInput: { questions: qs, answers: collected },
     });
-    entry.pendingQuestions.delete(questionId);
-    logger.debug({ questionId, sessionId }, 'question answered');
+    logger.debug({ questionId, sessionId, answered: Object.keys(collected).length }, 'all questions answered');
   }
 
   async killSession(sessionId: string): Promise<void> {
@@ -1391,29 +1409,62 @@ export class ClaudeAdapter extends AgentAdapter {
       });
     }
 
-    const qId = makeId('q');
     const questions = input.questions as AskUserQuestionItem[] | undefined;
 
-    const firstQuestion = questions?.[0];
-    const questionText = firstQuestion?.question ?? (input.question as string) ?? 'The agent has a question';
-    const choices = firstQuestion?.options?.map(o => o.label);
+    return new Promise<PermissionResult>((resolve) => {
+      const qs = questions ?? [];
+      if (qs.length === 0) {
+        // Malformed AskUserQuestion with no questions: surface a single
+        // best-effort prompt so the user isn't stuck, resolve empty.
+        const qId = makeId('q');
+        this.onQuestionRequest?.(sessionId, {
+          id: qId,
+          question: (input.question as string) ?? 'The agent has a question',
+          choices: undefined,
+          allowFreeform: true,
+        });
+        pendingQuestions.set(qId, { resolve, questionId: qId, questions: qs, qIndex: 0, collected: {} });
+        return;
+      }
+      // Surface the first question; subsequent questions are emitted one at a
+      // time as each is answered (see respondToQuestion).
+      this.emitQuestionCard(sessionId, resolve, qs, 0, {}, pendingQuestions);
+    });
+  }
+
+  /**
+   * Emit a single AskUserQuestion card (question[index]) to the app and record
+   * a pending entry. Shared by the initial emit and the serial advance in
+   * respondToQuestion.
+   */
+  private emitQuestionCard(
+    sessionId: string,
+    resolve: (result: PermissionResult) => void,
+    questions: AskUserQuestionItem[],
+    index: number,
+    collected: Record<string, string>,
+    pendingQuestions: Map<string, PendingQuestion>,
+  ): void {
+    const qId = makeId('q');
+    const q = questions[index];
+    const choices = q?.options?.map(o => o.label);
 
     logger.debug({
       questionId: qId,
       sessionId,
+      index,
+      total: questions.length,
       choicesCount: choices?.length ?? 0,
     }, 'question requested');
 
     this.onQuestionRequest?.(sessionId, {
       id: qId,
-      question: questionText,
+      question: q?.question ?? 'The agent has a question',
       choices,
       allowFreeform: true,
     });
 
-    return new Promise<PermissionResult>((resolve) => {
-      pendingQuestions.set(qId, { resolve, questionId: qId, questions });
-    });
+    pendingQuestions.set(qId, { resolve, questionId: qId, questions, qIndex: index, collected });
   }
 
   // ── Helpers ───────────────────────────────────────
@@ -1437,12 +1488,13 @@ export class ClaudeAdapter extends AgentAdapter {
     }
     entry.pendingPermissions.clear();
     for (const [qId, q] of entry.pendingQuestions) {
-      // Session ending with the question still open: echo `questions` back
-      // (required by the SDK schema) with an empty `answers` map so the SDK
-      // renders them unanswered rather than throwing on missing `questions`.
+      // Session ending with a question still open: echo `questions` back
+      // (required by the SDK schema) with whatever answers were collected so
+      // far in this serial chain (empty if none), so the SDK renders the rest
+      // as unanswered rather than throwing on a missing `questions` field.
       q.resolve({
         behavior: 'allow',
-        updatedInput: { questions: q.questions ?? [], answers: {} },
+        updatedInput: { questions: q.questions ?? [], answers: q.collected ?? {} },
       });
       this.onQuestionAutoResolved?.(sessionId, qId);
     }

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -650,7 +650,7 @@ export class RelayClient {
           this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'always_allowed' } });
           break;
         case 'answer':
-          this.adapter.respondToQuestion(sessionId, msg.payload.questionId, msg.payload.answer, false)
+          this.adapter.respondToQuestion(sessionId, msg.payload.questionId, msg.payload.answer, msg.payload.wasFreeform ?? false)
             .catch((err) => {
               logger.error({ err, sessionId }, 'respondToQuestion failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver answer: ${(err as Error).message}` } });

--- a/packages/tests/src/head-tentacle.live.test.ts
+++ b/packages/tests/src/head-tentacle.live.test.ts
@@ -16,7 +16,7 @@
  * Requires: copilot CLI installed and authenticated
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { createTestEnv, connectApp, createTmpSessionDir, waitMs, type TestEnv, type MockApp } from "./helpers.js";
+import { createTestEnv, connectApp, createTmpSessionDir, waitMs, sendToTentacle, type TestEnv, type MockApp } from "./helpers.js";
 import { CopilotAdapter, SessionManager, RelayClient, KeyManager } from "@kraki/tentacle";
 import type { AgentAdapter } from "@kraki/tentacle";
 import { getOrCreateDeviceId } from "@kraki/tentacle";
@@ -101,8 +101,10 @@ describe("Full E2E: Real Daemon Wiring + Copilot + Head", () => {
       const perm = await app.waitFor("permission", 30_000);
       expect(perm.payload.id).toBeTruthy();
 
-      // Approve from app → head → relay client → adapter (full round trip)
-      app.send({ type: "approve", sessionId: sid, payload: { permissionId: perm.payload.id } });
+      // Approve from app → head → relay client → adapter (full round trip).
+      // App→tentacle commands must be encrypted unicast, not a plain send
+      // (the head drops unknown plain types).
+      sendToTentacle(app, { type: "approve", sessionId: sid, payload: { permissionId: perm.payload.id } });
       const response = await app.waitFor("agent_message", 30_000);
       expect(response.payload.content).toBeTruthy();
     });

--- a/packages/tests/src/helpers.ts
+++ b/packages/tests/src/helpers.ts
@@ -89,6 +89,33 @@ export interface MockApp {
 }
 
 /**
+ * Resolve the tentacle (daemon) device + its encryption key from an app's
+ * auth_ok device roster.
+ */
+export function tentacleTarget(app: MockApp): { id: string; key: string } {
+  const devs = (app.authOk.devices as Array<Record<string, unknown>>) ?? [];
+  const t =
+    devs.find((d) => d.role === 'tentacle') ??
+    devs.find((d) => typeof d.name === 'string' && (d.name as string).includes('Daemon')) ??
+    devs.find((d) => d.id !== app.deviceId && (d.encryptionKey || d.publicKey));
+  if (!t) throw new Error(`tentacle device not in auth_ok: ${JSON.stringify(devs)}`);
+  return { id: t.id as string, key: (t.encryptionKey ?? t.publicKey) as string };
+}
+
+/**
+ * Send an app→tentacle session command (answer / set_session_mode / approve).
+ *
+ * These are NOT plain `app.send`: the head only routes encrypted `unicast`
+ * envelopes to the tentacle, which decrypts and runs the inner ConsumerMessage.
+ * A plain send of these types is silently dropped by the head. This mirrors the
+ * real web arm's behavior exactly.
+ */
+export function sendToTentacle(app: MockApp, inner: Record<string, unknown>): void {
+  const t = tentacleTarget(app);
+  app.sendUnicast(t.id, inner, t.key);
+}
+
+/**
  * Connect a mock app client with E2E crypto support.
  * Generates a keypair, authenticates, and auto-decrypts broadcast/unicast envelopes.
  */

--- a/packages/tests/src/pi-claude-fixes.live.test.ts
+++ b/packages/tests/src/pi-claude-fixes.live.test.ts
@@ -22,7 +22,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import {
-  createTestEnv, connectApp, createTmpSessionDir, waitMs,
+  createTestEnv, connectApp, createTmpSessionDir, waitMs, sendToTentacle,
   type TestEnv, type MockApp,
 } from "./helpers.js";
 import { SessionManager, RelayClient, KeyManager } from "@kraki/tentacle";
@@ -98,25 +98,10 @@ async function withSession(
 }
 
 /**
- * app -> tentacle session commands (answer / set_session_mode / approve) are
- * NOT plain sends: the head only routes encrypted `unicast` envelopes. The
- * tentacle decrypts them and runs the inner ConsumerMessage. This mirrors the
- * web arm exactly. Resolve the tentacle device + its key from auth_ok.
+ * app -> tentacle session commands (answer / set_session_mode / approve) go
+ * through `sendToTentacle` (encrypted unicast), mirroring the web arm. See
+ * helpers.ts for why a plain send is dropped by the head.
  */
-function tentacleTarget(app: MockApp): { id: string; key: string } {
-  const devs = ((app.authOk.devices as Array<Record<string, unknown>>) ?? []);
-  const t =
-    devs.find((d) => d.role === "tentacle") ??
-    devs.find((d) => typeof d.name === "string" && (d.name as string).includes("Daemon")) ??
-    devs.find((d) => d.id !== app.deviceId && (d.encryptionKey || d.publicKey));
-  if (!t) throw new Error(`tentacle device not in auth_ok: ${JSON.stringify(devs)}`);
-  return { id: t.id as string, key: (t.encryptionKey ?? t.publicKey) as string };
-}
-
-function sendToTentacle(app: MockApp, inner: Record<string, unknown>): void {
-  const t = tentacleTarget(app);
-  app.sendUnicast(t.id, inner, t.key);
-}
 
 // ── A. pi ────────────────────────────────────────────────
 describe("pi: mode-change mid-turn + co-located transcript", () => {
@@ -194,11 +179,12 @@ describe("claude: AskUserQuestion answer reaches the model", () => {
       const questionId = (q.payload as Record<string, unknown>).id as string;
       expect(questionId).toBeTruthy();
 
-      // Answer it freeform, exactly like the web arm: { answer }.
+      // Answer it freeform, exactly like the web arm: choice-click sends
+      // wasFreeform=false, typed text sends wasFreeform=true.
       sendToTentacle(app, {
         type: "answer",
         sessionId: sid,
-        payload: { questionId, answer: `My secret fruit is ${MARKER}` },
+        payload: { questionId, answer: `My secret fruit is ${MARKER}`, wasFreeform: true },
       });
 
       // Relay-client emits question_resolved only after respondToQuestion is


### PR DESCRIPTION
Follow-up to #144 — clears the three known loose ends, ships as a patch.

## 1. Claude multi-question support
AskUserQuestion allows 1–4 questions per call. Previously only questions[0] was surfaced/answered; the rest were left blank. Now questions are surfaced **serially** (each answer advances to the next) and the tool permission resolves once with **every answer keyed by its question text**. Single-question behavior is unchanged. Session-end mid-chain preserves partial answers.

## 2. wasFreeform plumbing (copilot correctness)
The web arm knows whether an answer was a **clicked choice** (wasFreeform=false) or **typed text** (wasFreeform=true), but relay-client hardcoded false. Copilot uses this flag to decide whether the answer maps to a listed option or is custom text — so custom text was mislabeled as a choice.

- protocol: AnswerMessage.payload.wasFreeform?: boolean (optional, defaults false)
- relay-client: forwards msg.payload.wasFreeform ?? false
- arm/web: QuestionInput sends false on choice-click, true on typed/Enter

## 3. Copilot live test used a plain app.send for approve
App→tentacle commands must be **encrypted unicast** (the head drops unknown plain types), so the approve round-trip only "passed" incidentally. Promoted sendToTentacle/tentacleTarget into helpers.ts, used them for approve, and deduped the pi-claude-fixes copy.

## Tests / verification
- New claude **multi-question unit test** (serial emit, both answers keyed by text)
- Live e2e now exercises wasFreeform:true over the wire
- tentacle test → **528 pass**; arm-web → **315 pass**; biome lint clean
- Live e2e through the **real relay path**: copilot unicast approve ✓, claude answer ✓, pi mode-change ✓
- Fresh **dev-stack** boot: head healthy, daemon detects copilot/claude/pi, web serving

### Note (pre-existing, out of scope)
head-tentacle.live.test.ts "7. replay works for newly connected app" fails on pristine main too — it's the request_session_replay path, unrelated to these fixes. Flagging for a separate look.

Bumps @kraki/tentacle 0.26.0 → **0.26.1** and @kraki/protocol 0.16.1 → **0.16.2**.
