### PR TITLE
docs: mark project unstable / do-not-use in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 <p align="center"><strong>Control your coding agents from your phone</strong></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/status-preview-orange" alt="Preview">
+  <img src="https://img.shields.io/badge/status-unstable%20%C2%B7%20do%20not%20use-red" alt="Unstable — do not use">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License"></a>
   <img src="https://img.shields.io/badge/E2E-AES--256--GCM-green?logo=letsencrypt&logoColor=white" alt="E2E Encrypted">
   <a href="https://github.com/corelli18512/kraki/actions/workflows/ci.yml"><img src="https://github.com/corelli18512/kraki/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 </p>
 
-> 🐣 **Preview:** Kraki is early-stage. Currently supports GitHub Copilot CLI only. Expect breaking changes.
+> ⚠️ **Not usable right now — please don't use it.** Kraki is going through a large wave of breaking changes and is currently unstable and unsupported. Things will break without notice. If you're curious about where it's heading and want to follow along, [DM me](mailto:corelli@corelli.cloud).
 
 Kraki bridges your coding agent to your phone or browser. Watch sessions in real time, approve tool calls, answer questions, and send follow-up instructions — from anywhere, on any device. All traffic is end-to-end encrypted.
 


### PR DESCRIPTION
Replaces the preview banner with a clear "not usable right now — please don't use it" notice (large wave of breaking changes, currently unstable/unsupported) plus a hidden `mailto:` contact link for anyone interested in following along. Flips the status badge to red.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>