### PR TITLE
chore(web): bump to 0.13.0 for production release

### DIFF
--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/arm-web",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Kraki web receiver — view and control your agents from any browser",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Bump `@kraki/arm-web` from **0.12.2 → 0.13.0**.

## Why

Production (`stable` channel → `/var/www/kraki`) has fallen well behind beta. Beta auto-deploys on every CI pass, but the production job only runs on manual `workflow_dispatch` — and it hasn't been triggered in a long time. So non-internal users (who default to the stable channel) are stuck on a much older build.

This bump marks a production release. After merge, I'll dispatch **Deploy Web → production** so non-internal users consume the current web.

Minor bump (not patch) to reflect the large gap being closed.

## Follow-up

- [ ] Merge after CI `Validate` passes
- [ ] Run `Deploy Web` workflow with target=`production`