### PR TITLE
fix(pi): stop tracing the trailing narration that graduates into the bubble

### DIFF
--- a/packages/tentacle/src/__tests__/multi-adapter-wiring.test.ts
+++ b/packages/tentacle/src/__tests__/multi-adapter-wiring.test.ts
@@ -18,6 +18,7 @@ describe('MultiAgentAdapter.wireCallbacks forwards sub-adapter callbacks', () =>
       onMessageDelta: null,
       onFinalizeDelta: null,
       onNarration: null,
+      onNarrationTrace: null,
       onPermissionRequest: null,
       onPermissionAutoResolved: null,
       onQuestionAutoResolved: null,
@@ -45,6 +46,18 @@ describe('MultiAgentAdapter.wireCallbacks forwards sub-adapter callbacks', () =>
     stub.onNarration?.('s1', { content: 'thinking out loud' });
 
     expect(seen).toHaveBeenCalledWith('s1', { content: 'thinking out loud' });
+  });
+
+  it('forwards onNarrationTrace (TRACE axis — regression guard, same class as onNarration)', () => {
+    const multi = new MultiAgentAdapter({ agentIds: ['pi'] });
+    const stub = makeStubAdapter();
+    (multi as unknown as { wireCallbacks(id: string, a: AgentAdapter): void }).wireCallbacks('pi', stub);
+
+    const seen = vi.fn();
+    multi.onNarrationTrace = seen;
+    stub.onNarrationTrace?.('s1', { content: 'a traced step' });
+
+    expect(seen).toHaveBeenCalledWith('s1', { content: 'a traced step' });
   });
 
   it('forwards onFinalizeDelta (regression — same missing-wiring class as onNarration)', () => {

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -49,6 +49,7 @@ function makeAdapter() {
     narrationSegments: 0,
     toolSinceLastNarration: false,
     lastNarration: '',
+    pendingNarration: '',
     finalizing: false,
     finalizeResolved: false,
     finalizeNarration: '',
@@ -65,20 +66,27 @@ function makeAdapter() {
 type Sess = ReturnType<typeof makeAdapter>['session'];
 
 describe('pi narration → draft + TRACE', () => {
-  it('message_end prose → onNarration (TRACE) and tracks it as the kept draft', () => {
+  it('message_end prose → onNarration RECONCILE now, TRACE deferred (may still graduate)', () => {
     const { adapter, session, narrate } = makeAdapter();
     const onNarration = vi.fn();
+    const onNarrationTrace = vi.fn();
     const onMessage = vi.fn();
     adapter.onNarration = onNarration;
+    adapter.onNarrationTrace = onNarrationTrace;
     adapter.onMessage = onMessage;
 
     narrate('  let me think...  ');
 
+    // Live draft reconcile fires immediately on every segment.
     expect(onNarration).toHaveBeenCalledWith('s1', { content: 'let me think...' });
+    // But the TRACE mirror is DEFERRED — this segment might graduate into the
+    // concluding bubble, so it isn't traced until confirmed intermediate.
+    expect(onNarrationTrace).not.toHaveBeenCalled();
     // Narration is NOT itself a spine bubble — it graduates at idle.
     expect(onMessage).not.toHaveBeenCalled();
     expect(session.narrationSegments).toBe(1);
     expect(session.lastNarration).toBe('let me think...');
+    expect(session.pendingNarration).toBe('let me think...');
     expect(session.toolSinceLastNarration).toBe(false);
   });
 
@@ -109,15 +117,22 @@ describe('pi narration → draft + TRACE', () => {
     expect(session.narrationSegments).toBe(0);
   });
 
-  it('a real tool marks toolSinceLastNarration and flows through TRACE', () => {
+  it('a real tool marks toolSinceLastNarration and FLUSHES the pending narration to TRACE', () => {
     const { adapter, session, emit, narrate } = makeAdapter();
     const onToolStart = vi.fn();
     const onToolComplete = vi.fn();
+    const onNarrationTrace = vi.fn();
     adapter.onToolStart = onToolStart;
     adapter.onToolComplete = onToolComplete;
+    adapter.onNarrationTrace = onNarrationTrace;
     narrate('working on it');
     expect(session.toolSinceLastNarration).toBe(false);
+    expect(onNarrationTrace).not.toHaveBeenCalled(); // still deferred
     emit({ type: 'tool_execution_start', toolName: 'bash', args: { command: 'ls' }, toolCallId: 't9' });
+    // A tool follows → the narration is confirmed intermediate → traced now,
+    // BEFORE the tool step so trace order is chronological, and pending cleared.
+    expect(onNarrationTrace).toHaveBeenCalledWith('s1', { content: 'working on it' });
+    expect(session.pendingNarration).toBe('');
     emit({ type: 'tool_execution_end', toolName: 'bash', result: 'files', toolCallId: 't9', isError: false });
     expect(onToolStart).toHaveBeenCalledTimes(1);
     expect(onToolComplete).toHaveBeenCalledTimes(1);
@@ -170,7 +185,7 @@ describe('pi outbound images (tool result → attachment store)', () => {
     (adapter as unknown as { sessions: Map<string, unknown> }).sessions.set(sid, {
       proc, cwd: '/tmp', model: 'm', mode: 'execute', usage: {}, lastActivity: Date.now(),
       pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0,
-      toolSinceLastNarration: false, lastNarration: '', finalizing: false,
+      toolSinceLastNarration: false, lastNarration: '', pendingNarration: '', finalizing: false,
       finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0,
     });
     const emit = (e: Record<string, unknown>) =>
@@ -250,21 +265,28 @@ describe('pi skip-finalize rule (one trailing narration → direct reply)', () =
     const { adapter, proc, emit, narrate } = makeAdapter();
     const onMessage = vi.fn();
     const onIdle = vi.fn();
+    const onNarrationTrace = vi.fn();
     adapter.onMessage = onMessage;
     adapter.onIdle = onIdle;
+    adapter.onNarrationTrace = onNarrationTrace;
 
     narrate('Here is your answer.');
     emit({ type: 'agent_end' });
 
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'Here is your answer.' });
+    // The trailing narration graduated INTO the bubble — it must NOT also be
+    // traced as a Step (the duplication bug this fix targets).
+    expect(onNarrationTrace).not.toHaveBeenCalled();
     expect(onIdle).toHaveBeenCalledTimes(1);
     expect(proc.send).not.toHaveBeenCalled(); // no finalize prompt injected
   });
 
-  it('tool THEN one explanation (git → explain) → skip, direct reply', () => {
+  it('tool THEN one explanation (git → explain) → skip, direct reply, no dup Step', () => {
     const { adapter, proc, emit, narrate } = makeAdapter();
     const onMessage = vi.fn();
+    const onNarrationTrace = vi.fn();
     adapter.onMessage = onMessage;
+    adapter.onNarrationTrace = onNarrationTrace;
 
     emit({ type: 'tool_execution_start', toolName: 'bash', args: { command: 'git status' }, toolCallId: 't1' });
     emit({ type: 'tool_execution_end', toolName: 'bash', result: 'clean', toolCallId: 't1', isError: false });
@@ -272,7 +294,53 @@ describe('pi skip-finalize rule (one trailing narration → direct reply)', () =
     emit({ type: 'agent_end' });
 
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'Your tree is clean.' });
+    // The explanation is the reply (bubble), not a Step.
+    expect(onNarrationTrace).not.toHaveBeenCalled();
     expect(proc.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('pi Steps dedup — trailing narration never traced as its own bubble', () => {
+  it('two narrations, finalize keep-last → first is a Step, the graduating last is NOT', () => {
+    const { adapter, proc, emit, narrate } = makeAdapter();
+    const onMessage = vi.fn();
+    const onNarrationTrace = vi.fn();
+    adapter.onMessage = onMessage;
+    adapter.onNarrationTrace = onNarrationTrace;
+
+    narrate('First I will look around.');
+    narrate('Now here is the conclusion.');
+    // The SECOND narration supersedes the first → first is traced immediately.
+    expect(onNarrationTrace).toHaveBeenCalledTimes(1);
+    expect(onNarrationTrace).toHaveBeenCalledWith('s1', { content: 'First I will look around.' });
+
+    emit({ type: 'agent_end' }); // 2 segments → finalize round
+    // Model keeps the last drafted line as the reply.
+    emit({ type: 'tool_execution_start', toolName: 'finalize_reply', args: { resummarize: false }, toolCallId: 'f1' });
+
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'Now here is the conclusion.' });
+    // The concluding narration graduated into the bubble → still exactly ONE trace step.
+    expect(onNarrationTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('two narrations, finalize resummarize → the last narration IS a Step (distinct from summary)', () => {
+    const { adapter, emit, narrate } = makeAdapter();
+    const onMessage = vi.fn();
+    const onNarrationTrace = vi.fn();
+    adapter.onMessage = onMessage;
+    adapter.onNarrationTrace = onNarrationTrace;
+
+    narrate('First pass thoughts.');
+    narrate('Second pass thoughts.');
+    emit({ type: 'agent_end' });
+    emit({ type: 'tool_execution_start', toolName: 'finalize_reply', args: { resummarize: true, text: 'A tidy summary.' }, toolCallId: 'f1' });
+
+    // Bubble is the fresh summary, distinct from either narration.
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'A tidy summary.' });
+    // BOTH narrations are genuine steps (neither equals the summary bubble).
+    expect(onNarrationTrace).toHaveBeenCalledTimes(2);
+    expect(onNarrationTrace).toHaveBeenNthCalledWith(1, 's1', { content: 'First pass thoughts.' });
+    expect(onNarrationTrace).toHaveBeenNthCalledWith(2, 's1', { content: 'Second pass thoughts.' });
   });
 });
 

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -1066,7 +1066,7 @@ describe('RelayClient turn step counter (payload.steps hint)', () => {
       toolName: 'bash', args: { command: 'echo ' + id }, toolCallId: id,
     });
   const narrate = (adapter: Record<string, unknown>, content: string) =>
-    (adapter.onNarration as ((sid: string, e: { content: string }) => void))('sess_1', { content });
+    (adapter.onNarrationTrace as ((sid: string, e: { content: string }) => void))('sess_1', { content });
   const conclude = (adapter: Record<string, unknown>, content: string) =>
     (adapter.onMessage as ((sid: string, e: { content: string }) => void))('sess_1', { content });
   const userMsg = (client: RelayClient) =>

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -128,6 +128,15 @@ export abstract class AgentAdapter {
    *  `agent_narration` step, interleaved with tool steps, so a turn's steps can
    *  be pulled later. NEVER a spine bubble (that is the final reply only). */
   onNarration: ((sessionId: string, event: MessageEvent) => void) | null = null;
+  /** Called to MIRROR a finalized narration segment to the TRACE axis
+   *  (trace.jsonl) as an `agent_narration` step — the durable "Steps" history,
+   *  distinct from onNarration's live draft reconcile. Split from onNarration so
+   *  an adapter can reconcile the live draft on EVERY segment (avoiding a
+   *  draft→bubble size-jump) while tracing ONLY the segments that are genuine
+   *  intermediate steps — never the trailing segment that graduates into the
+   *  concluding bubble (which would otherwise show duplicated: once as the last
+   *  Step and once as the bubble). */
+  onNarrationTrace: ((sessionId: string, event: MessageEvent) => void) | null = null;
   onPermissionRequest: ((sessionId: string, event: PermissionRequestEvent) => void) | null = null;
   /** Called when a permission is auto-resolved (e.g. by "Always Allow" for same tool kind, or cancelled on cleanup) */
   onPermissionAutoResolved: ((sessionId: string, permissionId: string, resolution: 'approved' | 'cancelled') => void) | null = null;

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -1087,7 +1087,10 @@ export class ClaudeAdapter extends AgentAdapter {
     if (!entry) return;
     const text = (entry.pendingText ?? '').trim();
     entry.pendingText = '';
-    if (text) this.onNarration?.(sessionId, { content: text });
+    if (text) {
+      this.onNarration?.(sessionId, { content: text });
+      this.onNarrationTrace?.(sessionId, { content: text });
+    }
   }
 
   /**

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -1583,7 +1583,10 @@ export class CopilotAdapter extends AgentAdapter {
   private flushNarration(sessionId: string): void {
     const text = (this.pendingNarration.get(sessionId) ?? '').trim();
     this.pendingNarration.delete(sessionId);
-    if (text) this.onNarration?.(sessionId, { content: text });
+    if (text) {
+      this.onNarration?.(sessionId, { content: text });
+      this.onNarrationTrace?.(sessionId, { content: text });
+    }
   }
 
   /**

--- a/packages/tentacle/src/adapters/multi.ts
+++ b/packages/tentacle/src/adapters/multi.ts
@@ -389,6 +389,7 @@ export class MultiAgentAdapter extends AgentAdapter {
     adapter.onMessageDelta = (sid, e) => this.onMessageDelta?.(sid, e);
     adapter.onFinalizeDelta = (sid, e) => this.onFinalizeDelta?.(sid, e);
     adapter.onNarration = (sid, e) => this.onNarration?.(sid, e);
+    adapter.onNarrationTrace = (sid, e) => this.onNarrationTrace?.(sid, e);
     adapter.onPermissionRequest = (sid, e) => this.onPermissionRequest?.(sid, e);
     adapter.onPermissionAutoResolved = (sid, pid, r) => this.onPermissionAutoResolved?.(sid, pid, r);
     adapter.onQuestionAutoResolved = (sid, qid) => this.onQuestionAutoResolved?.(sid, qid);

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -311,6 +311,14 @@ interface PiSession {
   /** The most recent narration segment's finalized prose — the kept "draft" text
    *  (keep-last). Seeds the finalize prompt and is the fallback reply. */
   lastNarration: string;
+  /** The most recent narration segment whose TRACE mirror is still DEFERRED —
+   *  not yet emitted as an `agent_narration` step because it might still
+   *  graduate verbatim into the concluding bubble (skip-finalize / finalize
+   *  keep-last / fallback). It is FLUSHED to the trace (a confirmed intermediate
+   *  step) when superseded by a newer narration or by a following tool, and
+   *  DISCARDED (never traced) when it becomes the bubble — so the trailing reply
+   *  never shows twice (last Step + bubble). Empty when nothing is pending. */
+  pendingNarration: string;
   /** True while the injected finalize round is in flight (between sending the
    *  finalize prompt and the following agent_end). During it, ordinary narration
    *  is suppressed so the draft stays frozen at `lastNarration`. */
@@ -503,7 +511,7 @@ export class PiAdapter extends AgentAdapter {
       extensionPath: this.ensureToolsExtension(),
       env,
     });
-    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', finalizing: false, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
+    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', pendingNarration: '', finalizing: false, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
     proc.onEvent = (e) => this.handleEvent(sessionId, e);
     proc.onExit = () => {
       // Process gone (crash/kill) → no agent_end will arrive. Clear the active
@@ -547,6 +555,16 @@ export class PiAdapter extends AgentAdapter {
   private touch(id: string) {
     const s = this.sessions.get(id);
     if (s) s.lastActivity = Date.now();
+  }
+
+  /** Emit the DEFERRED narration segment (if any) to the TRACE axis — it is now
+   *  a confirmed intermediate step (superseded by a newer narration or a tool),
+   *  so it can never be the graduating reply. Clears the pending slot. */
+  private flushPendingNarration(sessionId: string, s: PiSession): void {
+    if (s.pendingNarration) {
+      this.onNarrationTrace?.(sessionId, { content: s.pendingNarration });
+      s.pendingNarration = '';
+    }
   }
 
   // ── Event mapping: pi session.subscribe → Kraki callbacks ──
@@ -616,12 +634,18 @@ export class PiAdapter extends AgentAdapter {
               s.finalizeNarration = prose;
             } else if (s) {
               // Ordinary NARRATION: streams live to the draft bubble (see
-              // message_update) and is the agent's reply. The finalized prose is
-              // kept (keep-last) as the draft/fallback and mirrored to the TRACE
-              // axis (agent_narration) for the lazy "Steps" history. Tracked for
-              // the skip-finalize rule: count segments, remember it, and note that
-              // no tool has run since (so a trailing narration counts as a reply).
+              // message_update). RECONCILE the live draft NOW on every segment
+              // (onNarration → card.onNarrationFinal) so the throttled draft is
+              // squared with the finalized prose before the bubble lands — no
+              // draft→spine size-jump. But DEFER the TRACE mirror: this segment
+              // might still graduate verbatim into the concluding bubble, so we
+              // hold it as `pendingNarration` and only trace it once it is
+              // confirmed intermediate (a newer narration or a tool follows) —
+              // never the trailing reply. Flush the PREVIOUS pending here (a new
+              // segment supersedes it). Tracked for the skip-finalize rule.
               this.onNarration?.(sessionId, { content: prose });
+              this.flushPendingNarration(sessionId, s);
+              s.pendingNarration = prose;
               s.narrationSegments += 1;
               s.lastNarration = prose;
               s.toolSinceLastNarration = false;
@@ -642,7 +666,17 @@ export class PiAdapter extends AgentAdapter {
             const resummarize = args.resummarize === true;
             const text = typeof args.text === 'string' ? args.text.trim() : '';
             s.finalizeResolved = true;
-            const reply = resummarize && text ? text : s.lastNarration.trim();
+            const useResummarized = resummarize && text.length > 0;
+            const reply = useResummarized ? text : s.lastNarration.trim();
+            if (useResummarized) {
+              // The reply is a fresh summary distinct from the drafted narration,
+              // so that last narration IS a genuine step — flush it to the trace.
+              this.flushPendingNarration(sessionId, s);
+            } else {
+              // keep-last: the pending narration graduates verbatim into the
+              // bubble — DISCARD it so it isn't ALSO traced as the last Step.
+              s.pendingNarration = '';
+            }
             if (reply) {
               // For resummarize the streamed text already replaced the draft; for
               // keep (resummarize:false) the draft is still the frozen narration.
@@ -659,8 +693,13 @@ export class PiAdapter extends AgentAdapter {
         if (toolName === 'ask_user') break;
         // A real tool ran — mark that the current narration (if any) is no longer
         // the trailing reply, so the skip-finalize rule requires a finalize round.
+        // The pending narration is now confirmed intermediate (a tool follows it),
+        // so FLUSH it to the trace BEFORE the tool step to keep chronological order.
         const s = this.sessions.get(sessionId);
-        if (s) s.toolSinceLastNarration = true;
+        if (s) {
+          this.flushPendingNarration(sessionId, s);
+          s.toolSinceLastNarration = true;
+        }
         this.onToolStart?.(sessionId, {
           toolName,
           args: (e.args as Record<string, unknown>) ?? {},
@@ -741,9 +780,21 @@ export class PiAdapter extends AgentAdapter {
           // finalize_reply, the reply was already crystallized. Otherwise fall
           // back to its finalize-round prose, then the kept draft, then a notice.
           if (!s.finalizeResolved) {
-            const fallback = (s.finalizeNarration || s.lastNarration).trim();
-            if (fallback) this.onMessage?.(sessionId, { content: fallback });
-            else this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
+            // Prefer the finalize-round's own prose; if the model produced none,
+            // fall back to the kept draft. When the fallback is the finalize
+            // prose (distinct from the draft), the pending narration is a genuine
+            // step → flush it; when it IS the kept draft, that draft graduates
+            // into the bubble → discard so it isn't ALSO traced.
+            const finalizeProse = s.finalizeNarration.trim();
+            if (finalizeProse) {
+              this.flushPendingNarration(sessionId, s);
+              this.onMessage?.(sessionId, { content: finalizeProse });
+            } else {
+              s.pendingNarration = '';
+              const draft = s.lastNarration.trim();
+              if (draft) this.onMessage?.(sessionId, { content: draft });
+              else this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
+            }
           }
           s.finalizing = false;
           this.onIdle?.(sessionId);
@@ -757,6 +808,9 @@ export class PiAdapter extends AgentAdapter {
         // to settle a single clean closing message via finalize_reply.
         const skip = s.narrationSegments === 1 && !s.toolSinceLastNarration;
         if (skip) {
+          // The single trailing narration graduates verbatim into the bubble —
+          // discard the deferred trace so it isn't ALSO shown as the last Step.
+          s.pendingNarration = '';
           const reply = s.lastNarration.trim();
           if (reply) this.onMessage?.(sessionId, { content: reply });
           this.onIdle?.(sessionId);
@@ -772,7 +826,9 @@ export class PiAdapter extends AgentAdapter {
           s.proc.send('prompt', { message: finalizePrompt(s.lastNarration) });
           break;
         }
-        // Process gone before we could finalize — best-effort crystallize.
+        // Process gone before we could finalize — best-effort crystallize the
+        // kept draft, which graduates into the bubble → discard its deferred trace.
+        s.pendingNarration = '';
         const fallback = s.lastNarration.trim();
         if (fallback) this.onMessage?.(sessionId, { content: fallback });
         this.onIdle?.(sessionId);
@@ -925,6 +981,7 @@ export class PiAdapter extends AgentAdapter {
     s.narrationSegments = 0;
     s.toolSinceLastNarration = false;
     s.lastNarration = '';
+    s.pendingNarration = '';
     s.finalizing = false;
     s.finalizeResolved = false;
     s.finalizeNarration = '';

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1271,12 +1271,19 @@ export class RelayClient {
       this.card.onDelta(sessionId, event.content);
     };
 
-    // Finalized narration prose → TRACE axis only: mirrored to trace.jsonl for
-    // the lazy "Steps" history and marked as the end of the draft's current
-    // segment (the next delta starts fresh). Never broadcast standalone.
+    // Finalized narration prose. Two decoupled axes:
+    //  • onNarration → LIVE card reconcile only (onNarrationFinal). Fires on
+    //    EVERY finalized segment so the streamed draft is reconciled in place
+    //    before the concluding bubble lands (no draft→spine size-jump).
+    //  • onNarrationTrace → TRACE axis only: mirror to trace.jsonl for the lazy
+    //    "Steps" history. Adapters fire this ONLY for segments that are genuine
+    //    intermediate steps — never the trailing one that graduates into the
+    //    bubble — so a reply never shows duplicated (last Step + bubble).
     this.adapter.onNarration = (sessionId, event) => {
-      this.recordTrace({ type: 'agent_narration', sessionId, payload: { content: event.content } });
       this.card.onNarrationFinal(sessionId, event.content);
+    };
+    this.adapter.onNarrationTrace = (sessionId, event) => {
+      this.recordTrace({ type: 'agent_narration', sessionId, payload: { content: event.content } });
     };
 
     this.adapter.onPermissionRequest = (sessionId, event) => {


### PR DESCRIPTION
## Problem

In **pi** sessions, the concluding message shows up **duplicated** in the "Steps" view — once as the last Step, once as the reply bubble.

Root cause: pi mirrored **every** finalized narration segment to the TRACE axis (`agent_narration`), including the last one. But on a keep / skip-finalize turn that final segment **is** the reply, so the tentacle *also* lands it as the concluding `agent_message`. The trailing narration was recorded on both axes.

## Fix (at the source, not a web-side filter)

`onNarration` was doing two jobs at once. The trailing segment must still reconcile the live draft (or the draft→bubble swap visibly jumps in size), so we can't just defer the whole callback. Instead **decouple the two axes**:

| callback | job | fires for |
|---|---|---|
| `onNarration` | LIVE card reconcile (`card.onNarrationFinal`) | **every** finalized segment (unchanged — prevents the draft→spine size-jump) |
| `onNarrationTrace` *(new)* | TRACE mirror → `trace.jsonl` | **only** segments confirmed to be intermediate steps |

**pi** now defers the trace: a narration is held as `pendingNarration` and only mirrored once it's confirmed intermediate (superseded by a newer narration, or a following tool). When it graduates into the bubble (skip-finalize / finalize keep-last / process-gone fallback) it is **discarded**, never traced. A **resummarized** reply (distinct from the draft) flushes the narration — that's a genuine step.

This mirrors the architecture **copilot/claude** already use (they only trace prose when a tool follows). Both now emit `onNarrationTrace` alongside `onNarration` in `flushNarration`, so their behavior is unchanged.

Chosen over a web-side dedup so `trace.jsonl` is correct **at rest** for every consumer (web / iOS / replay), not just one renderer.

## Files

- `adapters/pi.ts` — defer/flush/discard logic + `pendingNarration` state
- `adapters/base.ts`, `adapters/multi.ts` — new `onNarrationTrace` callback + forwarding
- `relay-client.ts` — split reconcile (`onNarration`) from trace (`onNarrationTrace`)
- `adapters/copilot.ts`, `adapters/claude.ts` — emit `onNarrationTrace` alongside `onNarration` (no behavior change)

## Verification

- **Unit:** tentacle **643 pass** — adds skip-finalize / finalize keep-last / resummarize / tool-order-flush coverage
- **Lint + build:** biome clean (134 files), tentacle builds
- **Live:** fresh pi turn → reply lands as `agent_message` with `steps:0` and **zero** trace entries for the turn (vs. the old code's duplicate)

## Caveat

Source fix only affects **new** recordings. Pre-existing `trace.jsonl` from historical/migrated sessions still contains the dup and is **not** retroactively healed — a one-off trace backfill could clean those if desired.
