### PR TITLE
fix(pi): durable question recovery, abort history, and live mode switching

### DIFF
--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -96,6 +96,7 @@ final class MessageRouter {
     private static let persistentTypes: Set<String> = [
         "session_created",
         "agent_message",
+        "interrupted_turn",
         "user_message",
         "permission",
         "permission_resolved",
@@ -382,6 +383,13 @@ final class MessageRouter {
             if let content = payload?["content"] as? String {
                 appState.sessionStore.setAgentTextActivity(sessionId, text: content)
             }
+
+        case "interrupted_turn":
+            appState.sessionStore.flushDelta(sessionId)
+            appState.messageProvider?.ingestTailCandidate(sessionId, json: json)
+            let draft = payload?["draft"] as? String ?? ""
+            updatePreview(sessionId, text: draft.isEmpty ? "Turn aborted" : draft,
+                          type: "agent", timestamp: timestamp)
 
         case "agent_message_delta":
             if let content = payload?["content"] as? String {

--- a/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
@@ -142,6 +142,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Sendable {
     // MARK: Convenience Accessors
 
     var content: String? { payload["content"]?.stringValue }
+    var interruptedDraft: String? { payload["draft"]?.stringValue }
     var toolName: String? { payload["toolName"]?.stringValue }
     var toolCallId: String? { payload["toolCallId"]?.stringValue }
     var result: String? { payload["result"]?.stringValue }
@@ -234,7 +235,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Sendable {
     /// True for message types that should be rendered in the chat.
     var isRenderable: Bool {
         switch type {
-        case "user_message", "agent_message", "pending_input", "send_input",
+        case "user_message", "agent_message", "interrupted_turn", "pending_input", "send_input",
              "permission", "question", "tool_start", "tool_complete",
              "idle", "active", "error", "session_created", "session_ended",
              "session_deleted", "kill_session", "answer",

--- a/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
@@ -77,6 +77,7 @@ final class MessageStore {
     static let persistentTypes: Set<String> = [
         "session_created",
         "agent_message",
+        "interrupted_turn",
         "user_message",
         "permission",
         "permission_resolved",

--- a/packages/arm/ios/Kraki/Core/Storage/TurnGrouper.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/TurnGrouper.swift
@@ -187,6 +187,7 @@ private let thinkingTypes: Set<String> = [
     "tool_start",
     "tool_complete",
     "agent_message",
+    "interrupted_turn",
     "permission",
     "permission_resolved",
     "question",
@@ -323,7 +324,7 @@ func groupMessagesIntoTurns(
             // block) leave finalMessage nil.
             var lastAgentIdx = -1
             for i in stride(from: currentThinking.count - 1, through: 0, by: -1) {
-                if currentThinking[i].type == "agent_message" {
+                if currentThinking[i].type == "agent_message" || currentThinking[i].type == "interrupted_turn" {
                     lastAgentIdx = i
                     break
                 }

--- a/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
@@ -258,6 +258,9 @@ struct MessageBubbleView: View {
         case "agent_message":
             agentBubble
 
+        case "interrupted_turn":
+            interruptedTurnBubble
+
         case "session_created":
             sessionCreatedBanner
 
@@ -310,6 +313,36 @@ struct MessageBubbleView: View {
 
         default:
             EmptyView()
+        }
+    }
+
+    // MARK: - Interrupted Turn
+
+    private var interruptedTurnBubble: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 8) {
+                if let draft = message.interruptedDraft, !draft.isEmpty {
+                    messageBody(draft, foreground: .primary.opacity(0.8))
+                }
+                if let action = message.payload["action"]?.dictValue,
+                   let actionPayload = action["payload"]?.dictValue {
+                    let summary = actionPayload["question"]?.stringValue
+                        ?? actionPayload["description"]?.stringValue
+                        ?? actionPayload["headline"]?.stringValue
+                    if let summary, !summary.isEmpty {
+                        Text(summary)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Label("Turn aborted", systemImage: "stop.circle.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color.secondary.opacity(0.08), in: bubbleShape(isUser: false))
+            Spacer(minLength: WindowSize.width * 0.05)
         }
     }
 

--- a/packages/arm/web/e2e/pi-question-abort-refresh.spec.ts
+++ b/packages/arm/web/e2e/pi-question-abort-refresh.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect, type Page } from '@playwright/test';
+import { MockRelayServer } from './helpers/mock-ws-server';
+import type { WebSocket } from 'ws';
+
+const SESSION_ID = 'session-abort-refresh';
+const DEVICE_ID = 'tentacle-abort-refresh';
+const DEVICE = {
+  id: DEVICE_ID,
+  name: 'Pi verification tentacle',
+  role: 'tentacle',
+  kind: 'cli',
+  online: true,
+};
+const SESSION = {
+  id: SESSION_ID,
+  deviceId: DEVICE_ID,
+  deviceName: 'Pi verification tentacle',
+  agent: 'pi',
+  model: 'claude-sonnet-4',
+  state: 'idle',
+  messageCount: 0,
+  lastSeq: 0,
+};
+
+async function connect(page: Page, server: MockRelayServer, session = SESSION): Promise<WebSocket> {
+  const connection = server.waitForConnection();
+  await page.goto(`/?relay=${encodeURIComponent(server.url)}`);
+  const ws = await connection;
+  await server.waitForMessage(ws); // auth
+  server.sendAuthOk(ws, { sessions: [session], devices: [DEVICE] });
+  await server.waitForMessage(ws); // pulse/control bootstrap
+  const sessionCard = page.getByRole('button', { name: /Pi Pi verification tentacle/ }).first();
+  await expect(sessionCard).toBeVisible({ timeout: 5_000 });
+  await sessionCard.click();
+  await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 5_000 });
+  return ws;
+}
+
+function interrupted(seq = 40) {
+  return {
+    type: 'interrupted_turn',
+    deviceId: DEVICE_ID,
+    sessionId: SESSION_ID,
+    seq,
+    timestamp: '2026-07-12T11:46:00.000Z',
+    payload: {
+      reason: 'user_aborted',
+      draft: 'I started the second deployment check and was inspecting the rollout status.',
+      action: {
+        type: 'tool_start',
+        payload: { toolCallId: 'tool-aborted', toolName: 'bash', headline: 'kubectl rollout status deployment/api' },
+      },
+      interruptedAt: '2026-07-12T11:46:00.000Z',
+      cancelled: true,
+      steps: 2,
+    },
+  };
+}
+
+test.describe('Pi question → continue → abort → refresh recovery', () => {
+  let server: MockRelayServer;
+
+  test.beforeEach(async () => { server = await MockRelayServer.create(); });
+  test.afterEach(async () => { await server.close(); });
+
+  test('continues after answering, freezes Abort history across reload, then accepts a new turn', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    const ws = await connect(page, server);
+    expect(ws.readyState).toBe(ws.OPEN);
+
+    server.sendMessage(ws, { type: 'active', sessionId: SESSION_ID, payload: {} });
+    server.sendMessage(ws, {
+      type: 'agent_message_delta', sessionId: SESSION_ID,
+      payload: { content: 'I found two deployment paths.', reset: true },
+    });
+    server.sendMessage(ws, {
+      type: 'card_action', sessionId: SESSION_ID,
+      payload: { action: { type: 'question', payload: {
+        id: 'q-deploy', question: 'Which deployment strategy should I use?',
+        choices: ['Rolling deployment', 'Blue-green deployment'], allowFreeform: false,
+      } } },
+    });
+
+    await expect(page.getByText('Which deployment strategy should I use?')).toBeVisible();
+    await page.getByRole('button', { name: 'Rolling deployment' }).click();
+    server.sendMessage(ws, {
+      type: 'card_action', sessionId: SESSION_ID,
+      payload: { action: { type: 'question', payload: {
+        id: 'q-deploy', question: 'Which deployment strategy should I use?',
+        choices: ['Rolling deployment', 'Blue-green deployment'], allowFreeform: false,
+        answer: 'Rolling deployment',
+      } } },
+    });
+    await expect(page.getByText('✓ Answered')).toBeVisible();
+
+    server.sendMessage(ws, { type: 'card_action', sessionId: SESSION_ID, payload: { action: null } });
+    server.sendMessage(ws, {
+      type: 'agent_message', sessionId: SESSION_ID,
+      payload: { content: 'Rolling deployment selected. The first rollout completed successfully.' },
+    });
+    server.sendMessage(ws, { type: 'idle', sessionId: SESSION_ID, payload: { reason: 'completed' } });
+    await expect(page.getByText('The first rollout completed successfully.', { exact: false })).toBeVisible();
+
+    const composer = page.getByPlaceholder('Send a message…');
+    await composer.fill('Check the second deployment too');
+    await page.getByRole('button', { name: 'Send message' }).click();
+    await expect(page.locator('main').getByText('Check the second deployment too')).toBeVisible();
+
+    server.sendMessage(ws, { type: 'active', sessionId: SESSION_ID, payload: {} });
+    server.sendMessage(ws, {
+      type: 'agent_message_delta', sessionId: SESSION_ID,
+      payload: { content: 'I started the second deployment check and was inspecting the rollout status.', reset: true },
+    });
+    server.sendMessage(ws, {
+      type: 'card_action', sessionId: SESSION_ID,
+      payload: { action: { type: 'tool_start', payload: {
+        toolCallId: 'tool-aborted', toolName: 'bash', headline: 'kubectl rollout status deployment/api',
+      } } },
+    });
+    await expect(page.getByRole('button', { name: 'Stop' })).toBeVisible();
+    await page.getByRole('button', { name: 'Stop' }).click();
+
+    server.sendMessage(ws, interrupted());
+    server.sendMessage(ws, { type: 'card_action', sessionId: SESSION_ID, payload: { action: null } });
+    server.sendMessage(ws, { type: 'agent_message_delta', sessionId: SESSION_ID, payload: { content: '', reset: true } });
+    server.sendMessage(ws, { type: 'idle', sessionId: SESSION_ID, payload: { reason: 'aborted' } });
+
+    await expect(page.getByText('Turn aborted')).toBeVisible();
+    await expect(page.getByText('kubectl rollout status deployment/api')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Rolling deployment' })).toHaveCount(0);
+    await expect(page.getByPlaceholder('Type your answer…')).toHaveCount(0);
+    const abortedCard = page.getByText('Turn aborted').locator('xpath=ancestor::div[contains(@class,"rounded-2xl")]').first();
+    await abortedCard.screenshot({ path: '/tmp/kraki-pi-question-abort-screens/09-after-real-ui-abort.png' });
+
+    const reconnect = server.waitForConnection();
+    await page.reload();
+    const ws2 = await reconnect;
+    await server.waitForMessage(ws2);
+    server.sendAuthOk(ws2, {
+      sessions: [{ ...SESSION, state: 'idle', messageCount: 1, lastSeq: 40 }],
+      devices: [DEVICE],
+    });
+    await server.waitForMessage(ws2);
+
+    server.sendMessage(ws2, {
+      type: 'session_messages_range_batch',
+      payload: { sessionId: SESSION_ID, messages: [interrupted()], firstSeq: 40, lastSeq: 40, truncated: false },
+    });
+
+    await expect(page.getByText('Turn aborted')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('kubectl rollout status deployment/api')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Rolling deployment' })).toHaveCount(0);
+    await expect(page.getByPlaceholder('Type your answer…')).toHaveCount(0);
+    const replayedCard = page.getByText('Turn aborted').locator('xpath=ancestor::div[contains(@class,"rounded-2xl")]').first();
+    await replayedCard.screenshot({ path: '/tmp/kraki-pi-question-abort-screens/10-after-refresh-replay.png' });
+
+    const refreshedComposer = page.getByPlaceholder('Send a message…');
+    await refreshedComposer.fill('Continue with a safer rollout plan');
+    await page.getByRole('button', { name: 'Send message' }).click();
+    await expect(page.locator('main').getByText('Continue with a safer rollout plan')).toBeVisible();
+  });
+});

--- a/packages/arm/web/src/components/actions/QuestionInput.tsx
+++ b/packages/arm/web/src/components/actions/QuestionInput.tsx
@@ -6,15 +6,15 @@ import type { CardActionState } from '@kraki/protocol';
 import { shouldAutoFocusTextInput } from '../../lib/mobile-input';
 
 export function QuestionInput({ action, sessionId }: { action: Extract<CardActionState, { type: 'question' }>; sessionId: string }) {
-  const { id, question: text, choices, answer } = action.payload;
+  const { id, question: text, choices, answer, cancelled } = action.payload;
   const [freeform, setFreeform] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const shouldAutoFocus = shouldAutoFocusTextInput();
 
   useEffect(() => {
-    if (!shouldAutoFocus || answer !== undefined) return;
+    if (!shouldAutoFocus || answer !== undefined || cancelled) return;
     inputRef.current?.focus();
-  }, [id, shouldAutoFocus, answer]);
+  }, [id, shouldAutoFocus, answer, cancelled]);
 
   const handleAnswer = (value: string, wasFreeform: boolean) => {
     wsClient.answer(id, sessionId, value, wasFreeform);
@@ -23,6 +23,17 @@ export function QuestionInput({ action, sessionId }: { action: Extract<CardActio
       inputRef.current?.blur();
     }
   };
+
+  if (cancelled) {
+    return (
+      <div className="max-h-[40vh] shrink-0 overflow-y-auto border-t border-slate-500/30 bg-slate-500/5 px-3 pb-3 pt-2.5 sm:px-4 sm:pb-4">
+        <div className="mx-auto max-w-3xl">
+          {text && <div className="text-sm text-text-primary"><Markdown>{text}</Markdown></div>}
+          <p className="mt-2 text-xs font-semibold text-text-muted">Turn aborted</p>
+        </div>
+      </div>
+    );
+  }
 
   // Resolved: read-only view showing the chosen answer, no input controls.
   if (answer !== undefined) {

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -141,7 +141,7 @@ export const ChatView = memo(function ChatView() {
     cardAction?.type === 'permission' ||
     cardAction?.type === 'question';
   const livePending =
-    (cardAction?.type === 'question' && cardAction.payload.answer === undefined) ||
+    (cardAction?.type === 'question' && cardAction.payload.answer === undefined && !cardAction.payload.cancelled) ||
     (cardAction?.type === 'permission' && !cardAction.payload.decision)
       ? 1
       : 0;
@@ -180,7 +180,7 @@ export const ChatView = memo(function ChatView() {
     if (!sessionId || !isTentacleEncryptable) return;
     for (let i = spine.length - 1; i >= 0; i--) {
       const msg = spine[i];
-      if (msg.type === 'agent_message') {
+      if (msg.type === 'agent_message' || msg.type === 'interrupted_turn') {
         if ((msg.payload.steps ?? 0) > 0) messageProvider.requestTurnTrace(sessionId, getSeq(msg));
         break;
       }
@@ -206,7 +206,7 @@ export const ChatView = memo(function ChatView() {
       }
     }
     for (let i = spine.length - 1; i >= 0; i--) {
-      if (spine[i].type === 'agent_message') return i;
+      if (spine[i].type === 'agent_message' || spine[i].type === 'interrupted_turn') return i;
     }
     return -1;
   }, [spine, sessionIdle]);

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -1,7 +1,7 @@
 import Markdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
-import type { PermissionRequest as ProtocolPermissionRequest, QuestionRequest as ProtocolQuestionRequest, Attachment } from '@kraki/protocol';
+import type { PermissionRequest as ProtocolPermissionRequest, QuestionRequest as ProtocolQuestionRequest, Attachment, CardActionState } from '@kraki/protocol';
 import type { ChatMessage } from '../../types/store';
 import { formatTime, agentInfo } from '../../lib/format';
 import { stringToHue } from '../../lib/color';
@@ -87,6 +87,55 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
           </div>
         </CopyableBubble>
       );
+
+    case 'interrupted_turn': {
+      const payload = message.payload;
+      const action = payload.action as CardActionState | null;
+      const actionText = action?.type === 'question'
+        ? action.payload.question
+        : action?.type === 'permission'
+          ? action.payload.description
+          : action?.type === 'tool_start' || action?.type === 'tool_complete'
+            ? action.payload.headline
+            : action?.type === 'tool_batch'
+              ? `${action.payload.running} tools were running`
+              : '';
+      return (
+        <div className="flex gap-2">
+          <div className="mt-0.5 shrink-0">
+            <AgentAvatar agent={agent ?? ''} sessionId={sessionId} size="sm" />
+          </div>
+          <div className="min-w-0 max-w-[85%] overflow-hidden rounded-2xl rounded-bl-md border border-slate-500/30 bg-slate-500/5 shadow-sm sm:max-w-[70%]">
+            {payload.draft && (
+              <div className="markdown-content px-4 py-2.5 text-sm leading-relaxed text-text-primary opacity-80">
+                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
+                  {payload.draft}
+                </Markdown>
+              </div>
+            )}
+            {(actionText || !payload.draft) && (
+              <div className="border-t border-slate-500/20 bg-slate-500/10 px-4 py-2.5">
+                {actionText && <p className="text-sm text-text-secondary">{actionText}</p>}
+                <p className="mt-1 flex items-center gap-1 text-xs font-medium text-text-muted">
+                  <CircleStop className="h-3.5 w-3.5" /> Turn aborted
+                </p>
+              </div>
+            )}
+            <div className="flex items-center gap-2 px-4 pb-2">
+              {!actionText && payload.draft && (
+                <p className="flex items-center gap-1 text-xs font-medium text-text-muted">
+                  <CircleStop className="h-3.5 w-3.5" /> Turn aborted
+                </p>
+              )}
+              <p className="text-[10px] text-text-muted">{formatTime(message.timestamp)}</p>
+              {sessionId && typeof message.seq === 'number' && message.seq > 0 && (
+                <StepsButton sessionId={sessionId} bubbleSeq={message.seq} agent={agent} stepHint={payload.steps} />
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     case 'system_message': {
       const noReply = message.payload.kind === 'no_reply';

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -67,6 +67,11 @@ function rebuildPreview(sessionId: string): void {
       preview = { text: stripMarkdown(msg).slice(0, PREVIEW_MAX), type: 'error', timestamp: ts };
       break;
     }
+    if (m.type === 'interrupted_turn' && payload) {
+      const draft = typeof payload.draft === 'string' ? payload.draft : '';
+      preview = { text: stripMarkdown(draft || 'Turn aborted').slice(0, PREVIEW_MAX), type: 'agent', timestamp: ts };
+      break;
+    }
     if (m.type === 'agent_message' && payload) {
       const content = typeof payload.content === 'string' ? payload.content : '';
       if (content) {

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -212,6 +212,17 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
       }, !replaying);
       break;
 
+    case 'interrupted_turn': {
+      store.appendMessage(sid, msg);
+      const draft = typeof msg.payload.draft === 'string' ? msg.payload.draft : '';
+      updatePreview(sid, {
+        text: truncPreview(draft || 'Turn aborted'),
+        type: 'agent',
+        timestamp: msg.timestamp,
+      }, !replaying);
+      break;
+    }
+
     case 'system_message': {
       // Kraki-originated spine notice (e.g. no_reply). Behaves like an
       // agent_message boundary: clear the ephemeral narration draft and land a

--- a/packages/arm/web/src/lib/session-status.ts
+++ b/packages/arm/web/src/lib/session-status.ts
@@ -32,7 +32,7 @@ export function cardActionKey(a: CardActionState | null): string {
     case 'permission':
       return `perm:${a.payload.id}:${a.payload.decision ?? 'pending'}`;
     case 'question':
-      return `q:${a.payload.id}:${a.payload.answer === undefined ? 'pending' : 'answered'}`;
+      return `q:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer === undefined ? 'pending' : 'answered'}`;
   }
 }
 
@@ -42,7 +42,7 @@ export function countPendingQuestions(
   cards: Map<string, SessionCard>,
 ): number {
   const action = cards.get(sessionId)?.action;
-  return action?.type === 'question' && action.payload.answer === undefined ? 1 : 0;
+  return action?.type === 'question' && action.payload.answer === undefined && !action.payload.cancelled ? 1 : 0;
 }
 
 export function getSessionStatus(

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -261,6 +261,8 @@ export interface QuestionRequest extends BaseEnvelope {
     /** Only set when this request occupies a RESOLVED card slot — see
      *  {@link PermissionRequest} `decision`. */
     answer?: string;
+    /** A cancelled question remains visible but is never actionable. */
+    cancelled?: boolean;
   };
 }
 
@@ -436,6 +438,26 @@ export interface SystemMessage extends BaseEnvelope {
     content?: string;
     /** See {@link AgentMessage.payload.steps}. A `no_reply` notice also anchors
      *  a turn's Steps history, so it carries the same running step count. */
+    steps?: number;
+  };
+}
+
+/**
+ * Durable snapshot of the live turn at the instant the user explicitly aborted.
+ * Unlike the transient CardManager state, this lives on the conversation spine
+ * and is replayed forever. It is Kraki UI history only and is never injected into
+ * the agent/model transcript.
+ */
+export interface InterruptedTurnMessage extends BaseEnvelope {
+  type: 'interrupted_turn';
+  payload: {
+    reason: 'user_aborted' | 'process_lost';
+    draft: string;
+    action: CardActionState | null;
+    interruptedAt: string;
+    /** Running tool actions are frozen as cancelled in history. */
+    cancelled: true;
+    /** Trace-step count accumulated before interruption. */
     steps?: number;
   };
 }
@@ -752,6 +774,7 @@ export type ProducerMessage =
   | ActiveMessage
   | ErrorMessage
   | SystemMessage
+  | InterruptedTurnMessage
   | SessionModeSetMessage
   | SessionTitleUpdatedMessage
   | SessionModelSetMessage
@@ -814,6 +837,7 @@ export interface AnswerMessage extends BaseEnvelope {
   payload: {
     questionId: string;
     answer: string;
+    attachments?: Attachment[];
     /** True when the answer was typed freely rather than picked from a
      *  provided choice. Adapters (e.g. copilot) use this to decide whether the
      *  answer maps to a listed option or is custom text. Optional for backward

--- a/packages/tentacle/src/__tests__/card-manager.test.ts
+++ b/packages/tentacle/src/__tests__/card-manager.test.ts
@@ -281,12 +281,12 @@ describe('CardManager action part', () => {
     expect(a[a.length - 1]).toMatchObject({ type: 'permission', payload: { id: 'p1', decision: 'approve' } });
   });
 
-  it('resolving without a resolution (auto-cancel) clears the slot', () => {
+  it('resolving without a resolution freezes a question as cancelled', () => {
     const { card, sent } = setup();
     card.onPrompt('s1', question('q1', 'a?'));
     card.resolvePrompt('s1', 'q1');
     const a = actions(sent);
-    expect(a[a.length - 1]).toBeNull();
+    expect(a[a.length - 1]).toMatchObject({ type: 'question', payload: { id: 'q1', cancelled: true } });
   });
 
   it('an UNRESOLVED prompt blocks a subsequent tool from taking the slot', () => {

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -163,6 +163,20 @@ describe('pi abort', () => {
     expect(resolved).toBe(true);
   });
 
+  it('cancels pending question and permission UI requests before aborting', async () => {
+    const { adapter, sid, proc, session } = makeAdapter();
+    session.pendingQuestions.set('q1', 'q1');
+    session.pendingPerms.set('p1', 'p1');
+
+    await adapter.abortSession(sid);
+
+    expect(proc.sendRaw).toHaveBeenNthCalledWith(1, { type: 'extension_ui_response', id: 'q1', cancelled: true });
+    expect(proc.sendRaw).toHaveBeenNthCalledWith(2, { type: 'extension_ui_response', id: 'p1', confirmed: false });
+    expect(proc.request).toHaveBeenCalledWith('abort');
+    expect(session.pendingQuestions.size).toBe(0);
+    expect(session.pendingPerms.size).toBe(0);
+  });
+
   it('suppresses finalize when pi emits agent_end during abort', async () => {
     const { adapter, sid, proc, emit } = makeAdapter();
     const onIdle = vi.fn();
@@ -250,6 +264,38 @@ describe('pi model switching', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('pi prompt recovery', () => {
+  it('awaits abort and idle reconciliation before retrying the prompt', async () => {
+    const { adapter, proc } = makeAdapter();
+    let releaseAbort!: () => void;
+    const abortGate = new Promise<void>((resolve) => { releaseAbort = resolve; });
+    proc.request
+      .mockRejectedValueOnce(new Error('Agent is already processing'))
+      .mockImplementationOnce(async (type: string) => {
+        expect(type).toBe('abort');
+        await abortGate;
+        return {};
+      })
+      .mockResolvedValueOnce({ isStreaming: false, isCompacting: false })
+      .mockResolvedValueOnce({});
+
+    const sending = adapter.sendMessage('s1', 'retry me');
+    await Promise.resolve();
+    expect(proc.request.mock.calls.map(call => call[0])).toEqual(['prompt', 'abort']);
+    releaseAbort();
+    await sending;
+    expect(proc.request.mock.calls.map(call => call[0])).toEqual(['prompt', 'abort', 'get_state', 'prompt']);
+  });
+
+  it('does not abort a live pending human prompt', async () => {
+    const { adapter, proc, session } = makeAdapter();
+    session.pendingQuestions.set('q1', 'q1');
+    proc.request.mockRejectedValueOnce(new Error('Agent is already processing'));
+    await expect(adapter.sendMessage('s1', 'wrong route')).rejects.toThrow('waiting for a human response');
+    expect(proc.request.mock.calls.map(call => call[0])).toEqual(['prompt']);
   });
 });
 
@@ -762,6 +808,30 @@ describe('pi ask_user → question card', () => {
     expect(proc.sendRaw).toHaveBeenCalledWith({ type: 'extension_ui_response', id: 'p1', confirmed: true });
   });
 
+  it('switching to execute auto-approves an existing permission without steering Pi', async () => {
+    const { adapter, proc, session, emit } = makeAdapter();
+    session.mode = 'safe';
+    const onPermissionRequest = vi.fn();
+    const onPermissionAutoResolved = vi.fn();
+    adapter.onPermissionRequest = onPermissionRequest;
+    adapter.onPermissionAutoResolved = onPermissionAutoResolved;
+
+    emit({ type: 'extension_ui_request', method: 'confirm', id: 'p1', title: 'bash', message: JSON.stringify({ command: 'rm -f build.tmp' }) });
+    expect(onPermissionRequest).toHaveBeenCalledTimes(1);
+    expect(session.pendingPerms.has('p1')).toBe(true);
+
+    adapter.setSessionMode('s1', 'execute');
+
+    expect(proc.sendRaw).toHaveBeenLastCalledWith({ type: 'extension_ui_response', id: 'p1', confirmed: true });
+    expect(session.pendingPerms.has('p1')).toBe(false);
+    expect(onPermissionAutoResolved).toHaveBeenCalledWith('s1', 'p1', 'approved');
+    expect(proc.send).not.toHaveBeenCalledWith('steer', expect.anything());
+
+    const responseCount = proc.sendRaw.mock.calls.length;
+    await adapter.respondToPermission('s1', 'p1', 'approve');
+    expect(proc.sendRaw).toHaveBeenCalledTimes(responseCount);
+  });
+
   it('ask_user tool_execution_start is swallowed (not TRACE)', () => {
     const { adapter, emit } = makeAdapter();
     const onToolStart = vi.fn();
@@ -781,12 +851,31 @@ describe('pi ask_user → question card', () => {
     expect(session.toolSinceLastNarration).toBe(false);
   });
 
-  it('respondToQuestion sends extension_ui_response value and clears pending', async () => {
+  it('respondToQuestion sends a structured extension_ui_response and clears pending', async () => {
     const { adapter, proc, session } = makeAdapter();
     session.pendingQuestions.set('q1', 'q1');
-    await adapter.respondToQuestion('s1', 'q1', 'red', false);
-    expect(proc.sendRaw).toHaveBeenCalledWith({ type: 'extension_ui_response', id: 'q1', value: 'red' });
+    const result = await adapter.respondToQuestion('s1', 'q1', 'red', false);
+    expect(proc.sendRaw).toHaveBeenCalledWith({
+      type: 'extension_ui_response',
+      id: 'q1',
+      value: JSON.stringify({ __krakiAnswer: 1, text: 'red' }),
+    });
+    expect(result).toBe('accepted');
     expect(session.pendingQuestions.has('q1')).toBe(false);
+  });
+
+  it('respondToQuestion carries inline images through the structured response', async () => {
+    const { adapter, proc, session } = makeAdapter();
+    session.pendingQuestions.set('q1', 'q1');
+    await adapter.respondToQuestion('s1', 'q1', {
+      text: '',
+      attachments: [{ type: 'image', mimeType: 'image/png', data: 'abc' }],
+    }, true);
+    expect(proc.sendRaw).toHaveBeenCalledWith({
+      type: 'extension_ui_response',
+      id: 'q1',
+      value: JSON.stringify({ __krakiAnswer: 1, text: '', images: [{ type: 'image', data: 'abc', mimeType: 'image/png' }] }),
+    });
   });
 
   it('respondToQuestion for an unknown question is a no-op', async () => {

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -135,6 +135,12 @@ function createAdapter(): Record<string, unknown> {
     getSessionUsage: vi.fn(() => null),
     setSessionUsage: vi.fn(),
     registerSessionAgent: vi.fn(),
+    sendMessage: vi.fn(async () => {}),
+    respondToQuestion: vi.fn(async () => 'accepted'),
+    respondToPermission: vi.fn(async () => {}),
+    abortSession: vi.fn(async () => {}),
+    killSession: vi.fn(async () => {}),
+    resumeSession: vi.fn(async (sessionId: string) => ({ sessionId })),
   };
 }
 
@@ -156,6 +162,9 @@ function createSessionManager(): Record<string, unknown> {
     deleteSession: vi.fn(),
     markRead: vi.fn(),
     getSessionList: vi.fn(() => []),
+    getPendingHumanAction: vi.fn(() => null),
+    savePendingHumanAction: vi.fn(),
+    clearPendingHumanAction: vi.fn(),
     getMessagesAfterSeq: vi.fn(() => []),
     appendMessage: vi.fn(() => 1),
     appendTrace: vi.fn(),
@@ -1930,13 +1939,17 @@ describe('RelayClient pending-question digest', () => {
     expect(preview()).toMatchObject({ type: 'question', text: 'Q q2' });
   });
 
-  it('reverts the preview as questions are answered (answering one leaves the rest)', () => {
+  it('reverts the preview as questions are answered (answering one leaves the rest)', async () => {
     const { askQ, answerQ, preview } = buildClient();
     askQ('q1');
     askQ('q2');
     answerQ('q2');
+    await Promise.resolve();
+    await Promise.resolve();
     expect(preview()).toMatchObject({ type: 'question', text: 'Q q1' });
     answerQ('q1');
+    await Promise.resolve();
+    await Promise.resolve();
     expect(preview()?.type).not.toBe('question');
   });
 
@@ -1953,6 +1966,132 @@ describe('RelayClient pending-question digest', () => {
     askQ('q1');
     (adapter.onQuestionAutoResolved as (sid: string, qid: string) => void)('sess_1', 'q1');
     expect(preview()?.type).not.toBe('question');
+  });
+
+  it('serializes distinct composer prompts until the preceding turn idles', async () => {
+    const { adapter, ws } = buildClient();
+    for (const [seq, text] of [[600, 'first'], [601, 'second']] as const) {
+      ws.emit('message', Buffer.from(JSON.stringify({
+        type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq,
+        timestamp: new Date().toISOString(), payload: { text },
+      })));
+    }
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    expect(adapter.sendMessage).toHaveBeenNthCalledWith(1, 'sess_1', 'first', undefined);
+
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+    expect(adapter.sendMessage).toHaveBeenNthCalledWith(2, 'sess_1', 'second', undefined);
+  });
+
+  it('routes ordinary composer input to the sole pending question', async () => {
+    const { adapter, askQ, ws, sm } = buildClient();
+    askQ('q1');
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 500,
+      timestamp: new Date().toISOString(), payload: { text: 'my answer', clientId: 'c1' },
+    })));
+    await vi.waitFor(() => {
+      expect(adapter.respondToQuestion).toHaveBeenCalledWith(
+        'sess_1', 'q1', { text: 'my answer', attachments: undefined }, true,
+      );
+    });
+    expect(adapter.sendMessage).not.toHaveBeenCalled();
+    expect(sm.clearPendingHumanAction).toHaveBeenCalledWith('sess_1');
+  });
+
+  it('uses a recovery prompt when the live question request was lost', async () => {
+    const { adapter, askQ, ws } = buildClient();
+    (adapter.respondToQuestion as ReturnType<typeof vi.fn>).mockResolvedValueOnce('not_found');
+    askQ('q1');
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 501,
+      timestamp: new Date().toISOString(), payload: {
+        text: 'answer after restart',
+        attachments: [{ type: 'image', mimeType: 'image/png', data: 'abc' }],
+      },
+    })));
+    await vi.runAllTimersAsync();
+    expect(adapter.sendMessage).toHaveBeenCalledWith(
+      'sess_1',
+      expect.stringContaining('answer after restart'),
+      [{ type: 'image', mimeType: 'image/png', data: 'abc' }],
+    );
+  });
+
+  it('keeps the pending sidecar when recovery delivery fails', async () => {
+    const { adapter, askQ, ws, sm } = buildClient();
+    (adapter.respondToQuestion as ReturnType<typeof vi.fn>).mockResolvedValueOnce('not_found');
+    (adapter.sendMessage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('replacement prompt failed'));
+    askQ('q1');
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'answer', sessionId: 'sess_1', deviceId: 'app-x', seq: 504,
+      timestamp: new Date().toISOString(), payload: { questionId: 'q1', answer: 'keep me pending' },
+    })));
+    await vi.runAllTimersAsync();
+    expect(sm.savePendingHumanAction).toHaveBeenCalledWith('sess_1', expect.objectContaining({ questionId: 'q1' }));
+    expect(sm.clearPendingHumanAction).not.toHaveBeenCalledWith('sess_1');
+  });
+
+  it('rejects ambiguous composer text when multiple questions are pending', async () => {
+    const { adapter, askQ, ws } = buildClient();
+    askQ('q1');
+    askQ('q2');
+    ws.sent.length = 0;
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 505,
+      timestamp: new Date().toISOString(), payload: { text: 'ambiguous answer' },
+    })));
+    await vi.runAllTimersAsync();
+    expect(adapter.respondToQuestion).not.toHaveBeenCalled();
+    expect(adapter.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('routes image-only composer input to the sole pending question', async () => {
+    const { adapter, askQ, ws } = buildClient();
+    askQ('q1');
+    const image = { type: 'image' as const, mimeType: 'image/png', data: 'abc' };
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 506,
+      timestamp: new Date().toISOString(), payload: { text: '[image]', attachments: [image] },
+    })));
+    await vi.waitFor(() => expect(adapter.respondToQuestion).toHaveBeenCalledWith(
+      'sess_1', 'q1', { text: '', attachments: [image] }, true,
+    ));
+    expect(adapter.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not persist interrupted history when explicit abort sees an empty card', async () => {
+    const { adapter, ws, sm } = buildClient();
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'abort_session', sessionId: 'sess_1', deviceId: 'app-x', seq: 507,
+      timestamp: new Date().toISOString(), payload: {},
+    })));
+    await vi.runAllTimersAsync();
+    expect(adapter.abortSession).toHaveBeenCalledWith('sess_1');
+    expect((sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.some((call) => call[1] === 'interrupted_turn')).toBe(false);
+  });
+
+  it('persists the full visible card as interrupted_turn on explicit abort', async () => {
+    const { adapter, askQ, ws, sm } = buildClient();
+    askQ('q1');
+    ws.sent.length = 0;
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'abort_session', sessionId: 'sess_1', deviceId: 'app-x', seq: 502,
+      timestamp: new Date().toISOString(), payload: {},
+    })));
+    await Promise.resolve();
+    await Promise.resolve();
+    const interruptedCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls
+      .find((call) => call[1] === 'interrupted_turn');
+    expect(interruptedCall).toBeDefined();
+    const interrupted = JSON.parse(interruptedCall![2]) as { payload: Record<string, unknown> };
+    expect(interrupted.payload).toMatchObject({
+      reason: 'user_aborted',
+      cancelled: true,
+      action: { type: 'question', payload: { id: 'q1', question: 'Q q1', cancelled: true } },
+    });
+    expect(sm.clearPendingHumanAction).toHaveBeenCalledWith('sess_1');
   });
 
   it('pushes the active card snapshot to a freshly-joined device', () => {

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -59,6 +59,33 @@ describe('SessionManager', () => {
     });
   });
 
+  describe('durable pending human action', () => {
+    it('round-trips and clears a pending question sidecar', () => {
+      const { sessionId } = sm.createSession('pi');
+      const pending = {
+        version: 1 as const,
+        kind: 'question' as const,
+        questionId: 'q1',
+        question: 'Which backend?',
+        choices: ['A', 'B'],
+        allowFreeform: true,
+        draft: 'I inspected the project.',
+        action: {
+          type: 'question' as const,
+          payload: { id: 'q1', question: 'Which backend?', choices: ['A', 'B'], allowFreeform: true },
+        },
+        createdAt: new Date().toISOString(),
+      };
+
+      sm.savePendingHumanAction(sessionId, pending);
+      expect(sm.getPendingHumanAction(sessionId)).toEqual(pending);
+      expect(existsSync(join(dir, sessionId, 'pending-human-action.json'))).toBe(true);
+
+      sm.clearPendingHumanAction(sessionId);
+      expect(sm.getPendingHumanAction(sessionId)).toBeNull();
+    });
+  });
+
   // ── Context updates ───────────────────────────────────
 
   describe('context updates', () => {

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -412,10 +412,10 @@ describe('CopilotAdapter', () => {
         .resolves.toBeUndefined();
     });
 
-    it('respondToQuestion returns silently for unknown session', async () => {
+    it('respondToQuestion reports an unknown session', async () => {
       await adapter.start();
       await expect(adapter.respondToQuestion('nonexistent', 'q1', 'yes', true))
-        .resolves.toBeUndefined();
+        .resolves.toBe('session_gone');
     });
 
     it('respondToPermission returns silently for unknown permissionId', async () => {
@@ -425,11 +425,11 @@ describe('CopilotAdapter', () => {
         .resolves.toBeUndefined();
     });
 
-    it('respondToQuestion returns silently for unknown questionId', async () => {
+    it('respondToQuestion reports an unknown questionId', async () => {
       await adapter.start();
       const { sessionId } = await adapter.createSession({});
       await expect(adapter.respondToQuestion(sessionId, 'nonexistent', 'yes', true))
-        .resolves.toBeUndefined();
+        .resolves.toBe('not_found');
     });
   });
 

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -107,6 +107,13 @@ export interface SessionInfo {
 
 export type PermissionDecision = 'approve' | 'deny' | 'always_allow';
 
+export interface QuestionAnswer {
+  text: string;
+  attachments?: import('@kraki/protocol').Attachment[];
+}
+
+export type QuestionResponseResult = 'accepted' | 'not_found' | 'session_gone';
+
 // ── The adapter interface ───────────────────────────────
 
 export abstract class AgentAdapter {
@@ -200,13 +207,14 @@ export abstract class AgentAdapter {
     decision: PermissionDecision,
   ): Promise<void>;
 
-  /** Respond to a pending agent question. */
+  /** Respond to a pending agent question. Returns whether the live runtime
+   *  actually accepted the answer; callers must not resolve UI state earlier. */
   abstract respondToQuestion(
     sessionId: string,
     questionId: string,
-    answer: string,
+    answer: QuestionAnswer | string,
     wasFreeform: boolean,
-  ): Promise<void>;
+  ): Promise<QuestionResponseResult>;
 
   /** Kill / disconnect a session. */
   abstract killSession(sessionId: string): Promise<void>;

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -18,6 +18,8 @@ import {
   type CreateSessionConfig,
   type SessionInfo,
   type PermissionDecision,
+  type QuestionAnswer,
+  type QuestionResponseResult,
 } from './base.js';
 import type { SessionContext } from '../session-manager.js';
 import { createLogger } from '../logger.js';
@@ -850,19 +852,21 @@ export class ClaudeAdapter extends AgentAdapter {
   async respondToQuestion(
     sessionId: string,
     questionId: string,
-    answer: string,
+    answer: QuestionAnswer | string,
     _wasFreeform: boolean,
-  ): Promise<void> {
+  ): Promise<QuestionResponseResult> {
     const entry = this.sessions.get(sessionId);
     if (!entry) {
       logger.warn({ sessionId }, 'respondToQuestion: session not found');
-      return;
+      return 'session_gone';
     }
     const pending = entry.pendingQuestions.get(questionId);
     if (!pending) {
       logger.warn({ questionId }, 'respondToQuestion: no pending question');
-      return;
+      return 'not_found';
     }
+    const answerValue = typeof answer === 'string' ? { text: answer } : answer;
+    const answerText = answerValue.text || (answerValue.attachments?.length ? 'The user answered with image attachment(s).' : '');
 
     // SDK schema: AskUserQuestion's `answers` is a Record keyed by each
     // question's `question` TEXT (not a literal "answer" key), and `questions`
@@ -876,7 +880,7 @@ export class ClaudeAdapter extends AgentAdapter {
     const collected = pending.collected ?? {};
     const index = pending.qIndex ?? 0;
     const thisQuestionText = qs[index]?.question;
-    if (thisQuestionText) collected[thisQuestionText] = answer;
+    if (thisQuestionText) collected[thisQuestionText] = answerText;
 
     entry.pendingQuestions.delete(questionId);
 
@@ -884,7 +888,7 @@ export class ClaudeAdapter extends AgentAdapter {
     if (nextIndex < qs.length) {
       this.emitQuestionCard(sessionId, pending.resolve, qs, nextIndex, collected, entry.pendingQuestions);
       logger.debug({ questionId, sessionId, index, nextIndex, total: qs.length }, 'question answered, advancing');
-      return;
+      return 'accepted';
     }
 
     pending.resolve({
@@ -892,6 +896,7 @@ export class ClaudeAdapter extends AgentAdapter {
       updatedInput: { questions: qs, answers: collected },
     });
     logger.debug({ questionId, sessionId, answered: Object.keys(collected).length }, 'all questions answered');
+    return 'accepted';
   }
 
   async killSession(sessionId: string): Promise<void> {

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -38,6 +38,8 @@ import {
   type CreateSessionConfig,
   type SessionInfo,
   type PermissionDecision,
+  type QuestionAnswer,
+  type QuestionResponseResult,
 } from './base.js';
 import { parsePermission } from '../parse-permission.js';
 import { createLogger } from '../logger.js';
@@ -1184,23 +1186,26 @@ export class CopilotAdapter extends AgentAdapter {
   async respondToQuestion(
     sessionId: string,
     questionId: string,
-    answer: string,
+    answer: QuestionAnswer | string,
     wasFreeform: boolean,
-  ): Promise<void> {
+  ): Promise<QuestionResponseResult> {
     const entry = this.sessions.get(sessionId);
     if (!entry) {
       logger.warn(`respondToQuestion: session not found: ${sessionId}`);
-      return;
+      return 'session_gone';
     }
     const pending = entry.pendingQuestions.get(questionId);
     if (!pending) {
       logger.warn(`respondToQuestion: no pending question: ${questionId}`);
-      return;
+      return 'not_found';
     }
 
-    pending.resolve({ answer, wasFreeform });
+    const answerValue = typeof answer === 'string' ? { text: answer } : answer;
+    const answerText = answerValue.text || (answerValue.attachments?.length ? 'The user answered with image attachment(s).' : '');
+    pending.resolve({ answer: answerText, wasFreeform });
     entry.pendingQuestions.delete(questionId);
     this.touchSession(sessionId);
+    return 'accepted';
   }
 
   async killSession(sessionId: string): Promise<void> {

--- a/packages/tentacle/src/adapters/multi.ts
+++ b/packages/tentacle/src/adapters/multi.ts
@@ -19,6 +19,8 @@ import {
   type CreateSessionConfig,
   type SessionInfo,
   type PermissionDecision,
+  type QuestionAnswer,
+  type QuestionResponseResult,
 } from './base.js';
 import type { SessionContext } from '../session-manager.js';
 import { createLogger } from '../logger.js';
@@ -287,7 +289,7 @@ export class MultiAgentAdapter extends AgentAdapter {
     return this.getSessionAdapter(sessionId).respondToPermission(sessionId, permissionId, decision);
   }
 
-  async respondToQuestion(sessionId: string, questionId: string, answer: string, wasFreeform: boolean): Promise<void> {
+  async respondToQuestion(sessionId: string, questionId: string, answer: QuestionAnswer | string, wasFreeform: boolean): Promise<QuestionResponseResult> {
     return this.getSessionAdapter(sessionId).respondToQuestion(sessionId, questionId, answer, wasFreeform);
   }
 

--- a/packages/tentacle/src/adapters/pi-kraki-tools.ts
+++ b/packages/tentacle/src/adapters/pi-kraki-tools.ts
@@ -62,7 +62,7 @@ export default function krakiTools(pi) {
       required: ["question"],
       additionalProperties: false,
     },
-    async execute(_id, params, _signal, _onUpdate, ctx) {
+    async execute(_id, params, signal, _onUpdate, ctx) {
       const q = String((params && params.question) || "");
       const choices = params && Array.isArray(params.choices) ? params.choices : null;
       if (!ctx || !ctx.hasUI) {
@@ -70,12 +70,35 @@ export default function krakiTools(pi) {
       }
       let answer;
       if (choices && choices.length) {
-        answer = await ctx.ui.select(q, choices);
+        answer = await ctx.ui.select(q, choices, { signal });
       } else {
-        answer = await ctx.ui.input(q, "");
+        answer = await ctx.ui.input(q, "", { signal });
       }
-      const text = answer == null ? "(the user did not answer)" : String(answer);
-      return { content: [{ type: "text", text }], details: { answer: text } };
+      if (answer == null) {
+        return { content: [{ type: "text", text: "(the user did not answer)" }], details: { cancelled: true } };
+      }
+      let decoded = null;
+      try {
+        const value = JSON.parse(String(answer));
+        if (value && value.__krakiAnswer === 1) decoded = value;
+      } catch (_err) {
+        // Legacy/non-Kraki UI response: use the raw string below.
+      }
+      if (!decoded) {
+        const text = String(answer);
+        return { content: [{ type: "text", text }], details: { answer: text } };
+      }
+      const text = typeof decoded.text === "string" ? decoded.text : "";
+      const content = [];
+      if (text) content.push({ type: "text", text });
+      const images = Array.isArray(decoded.images) ? decoded.images : [];
+      for (const image of images) {
+        if (image && typeof image.data === "string" && typeof image.mimeType === "string") {
+          content.push({ type: "image", data: image.data, mimeType: image.mimeType });
+        }
+      }
+      if (content.length === 0) content.push({ type: "text", text: "The user answered with an image." });
+      return { content, details: { answer: text, imageCount: images.length } };
     },
   });
 

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -23,6 +23,8 @@ import {
   type CreateSessionConfig,
   type SessionInfo,
   type PermissionDecision,
+  type QuestionAnswer,
+  type QuestionResponseResult,
 } from './base.js';
 import type { SessionContext } from '../session-manager.js';
 import type { ModelDetail, SessionUsage, ReasoningEffort, ToolArgs } from '@kraki/protocol';
@@ -619,10 +621,11 @@ export class PiAdapter extends AgentAdapter {
     const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingNarration: '', aborting: false, finalizing: false, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
     proc.onEvent = (e) => this.handleEvent(sessionId, e);
     proc.onExit = () => {
-      // Process gone (crash/kill) → no agent_end will arrive. Clear the active
-      // spinner so the session doesn't hang "active" forever, then evict.
+      // Process gone (crash/kill) → no agent_end will arrive. Permissions cannot
+      // be reconstructed, but ask_user is durable at RelayClient/CardManager:
+      // keep its id/card so the next answer can transparently use a recovery
+      // prompt after lazy resume.
       this.clearPendingPerms(sessionId);
-      this.clearPendingQuestions(sessionId);
       this.pendingModeSignals.delete(sessionId);
       this.onIdle?.(sessionId);
       this.onSessionEvicted?.(sessionId);
@@ -676,7 +679,6 @@ export class PiAdapter extends AgentAdapter {
   private async handleEvent(sessionId: string, e: { type: string; [k: string]: unknown }): Promise<void> {
     this.touch(sessionId);
     switch (e.type) {
-      case 'agent_start':
       case 'agent_start':
         break;
       case 'message_update': {
@@ -1152,16 +1154,27 @@ export class PiAdapter extends AgentAdapter {
       const message = (err as Error).message;
       // pi can get into a state where the adapter has emitted idle (agent_end
       // was received) but pi's internal RPC layer still thinks it's processing.
-      // Try aborting the phantom turn and retry once before giving up.
+      // A genuinely live human prompt must never enter this path — RelayClient
+      // answers it directly, and this guard prevents a stale caller from aborting
+      // it. For a phantom run, await abort + authoritative idle reconciliation
+      // before retrying exactly once.
       if (message.includes('already processing') || message.includes('still processing')) {
-        logger.warn({ sessionId }, 'pi stuck in processing state — aborting and retrying');
-        try { s.proc.send('abort'); } catch { /* ignore */ }
-        try {
-          await s.proc.request('prompt', promptPayload);
-          return;
-        } catch (retryErr) {
-          logger.warn({ sessionId, err: (retryErr as Error).message }, 'pi prompt retry also failed');
+        if (s.pendingQuestions.size > 0 || s.pendingPerms.size > 0) {
+          throw new Error('Pi is waiting for a human response; the message was not sent as a new prompt.');
         }
+        logger.warn({ sessionId }, 'pi stuck in processing state — awaiting abort before retry');
+        s.aborting = true;
+        try {
+          await s.proc.request('abort');
+          const state = await s.proc.request<{ isStreaming?: boolean; isCompacting?: boolean }>('get_state');
+          if (state.isStreaming || state.isCompacting) {
+            throw new Error('Pi remained busy after abort acknowledgement');
+          }
+        } finally {
+          s.aborting = false;
+        }
+        await s.proc.request('prompt', promptPayload);
+        return;
       }
       logger.warn({ sessionId, err: message }, 'pi prompt request failed');
       this.onError?.(sessionId, { message });
@@ -1172,6 +1185,18 @@ export class PiAdapter extends AgentAdapter {
   async abortSession(sessionId: string): Promise<void> {
     const s = this.sessions.get(sessionId);
     if (!s?.proc.alive) return;
+
+    // First resolve any extension UI promises that ignore/precede the agent abort
+    // signal. The RelayClient already captured the visible card snapshot, so
+    // these transport cancellations cannot erase the durable abort history.
+    for (const questionId of s.pendingQuestions.keys()) {
+      s.proc.sendRaw({ type: 'extension_ui_response', id: questionId, cancelled: true });
+    }
+    s.pendingQuestions.clear();
+    for (const permissionId of s.pendingPerms.keys()) {
+      s.proc.sendRaw({ type: 'extension_ui_response', id: permissionId, confirmed: false });
+    }
+    s.pendingPerms.clear();
 
     // Pi emits agent_end before resolving this RPC. Keep that event from
     // entering the normal finalize flow, which would start a new model turn
@@ -1202,17 +1227,31 @@ export class PiAdapter extends AgentAdapter {
     logger.debug({ sessionId, permissionId, confirmed }, 'pi permission answered');
   }
 
-  async respondToQuestion(sessionId: string, questionId: string, answer: string, _wasFreeform: boolean): Promise<void> {
+  async respondToQuestion(sessionId: string, questionId: string, answer: QuestionAnswer | string, _wasFreeform: boolean): Promise<QuestionResponseResult> {
     const s = this.sessions.get(sessionId);
-    if (!s) { logger.warn({ sessionId }, 'respondToQuestion: session not found'); return; }
-    if (!s.pendingQuestions.delete(questionId)) {
-      logger.warn({ sessionId, questionId }, 'respondToQuestion: no pending question');
-      return;
+    if (!s) {
+      logger.warn({ sessionId }, 'respondToQuestion: session not found');
+      return 'session_gone';
     }
-    // Echo the pi UI request id verbatim; `value` resolves ctx.ui.select/input in
-    // the ask_user tool, which returns the answer to the model as the tool result.
-    s.proc.sendRaw({ type: 'extension_ui_response', id: questionId, value: answer });
-    logger.debug({ sessionId, questionId }, 'pi question answered');
+    if (!s.pendingQuestions.has(questionId)) {
+      logger.warn({ sessionId, questionId }, 'respondToQuestion: no pending question');
+      return 'not_found';
+    }
+    if (!s.proc.alive) return 'session_gone';
+
+    const answerValue = typeof answer === 'string' ? { text: answer } : answer;
+    const images = (answerValue.attachments ?? [])
+      .filter((a): a is import('@kraki/protocol').ImageAttachment => a.type === 'image')
+      .map(a => ({ type: 'image' as const, data: a.data, mimeType: a.mimeType }));
+    const envelope = JSON.stringify({
+      __krakiAnswer: 1,
+      text: answerValue.text,
+      ...(images.length > 0 && { images }),
+    });
+    s.proc.sendRaw({ type: 'extension_ui_response', id: questionId, value: envelope });
+    s.pendingQuestions.delete(questionId);
+    logger.debug({ sessionId, questionId, images: images.length }, 'pi question answered');
+    return 'accepted';
   }
 
   async killSession(sessionId: string): Promise<void> {
@@ -1256,29 +1295,18 @@ export class PiAdapter extends AgentAdapter {
     this.persistMeta(sessionId, s);
     // Edge-triggered: prepend a one-shot marker to the next user message.
     this.pendingModeSignals.set(sessionId, mode);
-    // If a turn is streaming right now, also nudge the model mid-run via steer so
-    // it re-checks its permission envelope before acting on a stale one.
-    void this.steerModeNudge(sessionId);
-    logger.debug({ sessionId, mode }, 'pi session mode changed');
-  }
-
-  /** Steer a mode-agnostic nudge into an active turn so the model re-checks its
-   *  permission envelope. No-op when the session is idle (the prepend on the next
-   *  message covers that). Active state is read from pi's get_state
-   *  (isStreaming/isCompacting) rather than a hand-tracked flag, because pi's
-   *  auto-retry and compaction continuations run AFTER agent_end. */
-  private async steerModeNudge(sessionId: string): Promise<void> {
-    const s = this.sessions.get(sessionId);
-    if (!s?.proc.alive) return;
-    try {
-      const state = await s.proc.request<{ isStreaming?: boolean; isCompacting?: boolean }>('get_state');
-      if (state.isStreaming || state.isCompacting) {
-        s.proc.send('steer', { message: '[kraki: permission mode changed — call kraki_get_mode before acting]' });
-        logger.debug({ sessionId }, 'pi mode-change steer nudge sent');
+    // Switching into an automatic mode must also release permissions that are
+    // already waiting on the human. Use the existing UI response rather than a
+    // Pi steer: steer creates an independent agent lifecycle whose agent_end can
+    // incorrectly settle the real user turn.
+    if (mode === 'execute' || mode === 'delegate') {
+      for (const permissionId of s.pendingPerms.keys()) {
+        s.proc.sendRaw({ type: 'extension_ui_response', id: permissionId, confirmed: true });
+        s.pendingPerms.delete(permissionId);
+        this.onPermissionAutoResolved?.(sessionId, permissionId, 'approved');
       }
-    } catch (err) {
-      logger.debug({ err: (err as Error).message }, 'steer mode nudge failed');
     }
+    logger.debug({ sessionId, mode }, 'pi session mode changed');
   }
 
   async setSessionModel(sessionId: string, model: string, reasoningEffort?: string): Promise<void> {
@@ -1385,7 +1413,14 @@ export class PiAdapter extends AgentAdapter {
   private sweepIdle(): void {
     const now = Date.now();
     for (const [id, s] of this.sessions) {
-      if (s.proc.alive && now - s.lastActivity > IDLE_TTL_MS) {
+      if (
+        s.proc.alive
+        && s.pendingQuestions.size === 0
+        && s.pendingPerms.size === 0
+        && !s.aborting
+        && !s.finalizing
+        && now - s.lastActivity > IDLE_TTL_MS
+      ) {
         logger.info({ id }, 'Evicting idle pi session');
         s.proc.kill();
         this.onSessionEvicted?.(id);

--- a/packages/tentacle/src/card-manager.ts
+++ b/packages/tentacle/src/card-manager.ts
@@ -120,7 +120,7 @@ export class CardManager {
     }
     if (a.type === 'tool_batch') return `batch:${a.payload.running}`;
     if (a.type === 'permission') return `permission:${a.payload.id}:${a.payload.decision ?? ''}`;
-    return `question:${a.payload.id}:${a.payload.answer !== undefined ? '1' : '0'}`;
+    return `question:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer !== undefined ? 'answered' : 'pending'}`;
   }
 
   /** The action a session's live tools should occupy the slot with, derived from
@@ -262,7 +262,8 @@ export class CardManager {
   /** Resolve a permission or question. If it still occupies the slot, update it
    *  IN PLACE to a resolved (read-only) state showing the decision/answer and
    *  keep it displayed — no fallback to any prior tool. An auto-resolve without
-   *  a resolution (e.g. cancellation) clears the slot instead. */
+   *  a resolution marks questions cancelled instead of making the user's
+   *  pending decision disappear. */
   resolvePrompt(sessionId: string, id: string, resolution?: PromptResolution): void {
     const c = this.cards.get(sessionId);
     const a = c?.action;
@@ -270,11 +271,29 @@ export class CardManager {
     if (a.type === 'permission' && resolution && 'decision' in resolution) {
       c.action = { ...a, payload: { ...a.payload, decision: resolution.decision } };
     } else if (a.type === 'question' && resolution && 'answer' in resolution) {
-      c.action = { ...a, payload: { ...a.payload, answer: resolution.answer } };
+      c.action = { ...a, payload: { ...a.payload, answer: resolution.answer, cancelled: undefined } };
+    } else if (a.type === 'question') {
+      c.action = { ...a, payload: { ...a.payload, cancelled: true } };
     } else {
       c.action = null;
     }
     this.syncAction(sessionId, c);
+  }
+
+  /** Authoritative full state used for durable pending and abort history. */
+  state(sessionId: string): { draft: string; action: CardActionState | null } {
+    const c = this.cards.get(sessionId);
+    return { draft: c?.draftText ?? '', action: c?.action ?? null };
+  }
+
+  /** Rehydrate a durable pending card after a daemon/process restart. */
+  restore(sessionId: string, snapshot: { draft: string; action: CardActionState | null }): void {
+    const c = this.get(sessionId);
+    c.draftText = snapshot.draft;
+    c.resetNext = false;
+    c.action = snapshot.action;
+    c.runningTools.clear();
+    c.lastActionKey = this.actionKey(snapshot.action);
   }
 
   // ── Lifecycle ─────────────────────────────────────────

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -19,7 +19,7 @@ import { HEAD_PULSE_TARGET } from '@kraki/protocol';
 import { importPublicKey, encryptToBlob, decryptFromBlob, signChallenge } from '@kraki/crypto';
 import type { RecipientKey } from '@kraki/crypto';
 import type { AgentAdapter } from './adapters/base.js';
-import type { SessionManager, SessionContext } from './session-manager.js';
+import type { SessionManager, SessionContext, PendingHumanAction } from './session-manager.js';
 import type { KeyManager } from './key-manager.js';
 import { scanLocalSessions, filterSessions } from './session-scanner.js';
 import { parseSessionHistory } from './history-parser.js';
@@ -118,6 +118,7 @@ export class RelayClient {
     'user_message',
     'error',
     'system_message',
+    'interrupted_turn',
     'session_ended',
     'idle',
   ]);
@@ -155,6 +156,27 @@ export class RelayClient {
   /** In-flight `ensureSessionResumed` promises keyed by sessionId, so two
    *  concurrent callers don't double-resume the same SDK session. */
   private resumeInFlight = new Map<string, Promise<boolean>>();
+
+  /** Per-session input chain. Distinct user sends are serialized until the
+   *  preceding turn reaches a real idle boundary. */
+  private inputChains = new Map<string, Promise<void>>();
+  private turnIdleWaiters = new Map<string, { promise: Promise<void>; resolve: () => void }>();
+
+  private waitForTurnIdle(sessionId: string): Promise<void> {
+    const existing = this.turnIdleWaiters.get(sessionId);
+    if (existing) return existing.promise;
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    this.turnIdleWaiters.set(sessionId, { promise, resolve });
+    return promise;
+  }
+
+  private resolveTurnIdle(sessionId: string): void {
+    const waiter = this.turnIdleWaiters.get(sessionId);
+    if (!waiter) return;
+    this.turnIdleWaiters.delete(sessionId);
+    waiter.resolve();
+  }
 
   // ── Push preview state ─────────────────────────────
   /** Last agent message content per session (for idle push preview) */
@@ -266,16 +288,17 @@ export class RelayClient {
    *  yet — the question no longer persists to the spine, so the file-based
    *  preview can't surface it. Insertion order is preserved so the newest open
    *  question wins the preview slot. */
-  private openQuestions = new Map<string, Map<string, string>>();
+  private openQuestions = new Map<string, Map<string, PendingHumanAction>>();
 
-  /** Record a newly-opened question for a session (keyed by id → prompt text). */
-  private addOpenQuestion(sessionId: string, questionId: string, question: string): void {
+  /** Record a newly-opened question and persist the full recoverable card. */
+  private addOpenQuestion(sessionId: string, pending: PendingHumanAction): void {
     let map = this.openQuestions.get(sessionId);
     if (!map) {
       map = new Map();
       this.openQuestions.set(sessionId, map);
     }
-    map.set(questionId, question);
+    map.set(pending.questionId, pending);
+    this.sessionManager.savePendingHumanAction(sessionId, pending);
   }
 
   /** Drop a resolved/cancelled question for a session. */
@@ -283,12 +306,26 @@ export class RelayClient {
     const map = this.openQuestions.get(sessionId);
     if (!map) return;
     map.delete(questionId);
-    if (map.size === 0) this.openQuestions.delete(sessionId);
+    if (map.size === 0) {
+      this.openQuestions.delete(sessionId);
+      this.sessionManager.clearPendingHumanAction(sessionId);
+    } else {
+      let newest: PendingHumanAction | undefined;
+      for (const pending of map.values()) newest = pending;
+      if (newest) this.sessionManager.savePendingHumanAction(sessionId, newest);
+    }
   }
 
   /** Clear all open questions for a session (turn ended / session gone). */
   private clearOpenQuestions(sessionId: string): void {
     this.openQuestions.delete(sessionId);
+    this.sessionManager.clearPendingHumanAction(sessionId);
+  }
+
+  private soleOpenQuestion(sessionId: string): PendingHumanAction | null {
+    const map = this.openQuestions.get(sessionId);
+    if (!map || map.size !== 1) return null;
+    return map.values().next().value ?? null;
   }
 
   /** The newest open (human-blocking) question's text, or undefined if none. */
@@ -296,8 +333,59 @@ export class RelayClient {
     const map = this.openQuestions.get(sessionId);
     if (!map || map.size === 0) return undefined;
     let last: string | undefined;
-    for (const q of map.values()) last = q;
+    for (const q of map.values()) last = q.question;
     return last;
+  }
+
+  /** Rehydrate durable pending cards before session-list/card snapshots. */
+  private restorePendingHumanActions(): void {
+    for (const meta of this.sessionManager.getSessionList()) {
+      const pending = this.sessionManager.getPendingHumanAction(meta.id);
+      if (!pending) continue;
+      let map = this.openQuestions.get(meta.id);
+      if (!map) {
+        map = new Map();
+        this.openQuestions.set(meta.id, map);
+      }
+      map.set(pending.questionId, pending);
+      this.card.restore(meta.id, { draft: pending.draft, action: pending.action });
+    }
+  }
+
+  /** Deliver through the original live request when possible. If the daemon/Pi
+   *  process was reconstructed, continue transparently with a recovery prompt;
+   *  the arm sees the same pending card throughout. */
+  private async deliverQuestionAnswer(
+    sessionId: string,
+    pending: PendingHumanAction,
+    answer: { text: string; attachments?: import('@kraki/protocol').Attachment[] },
+    wasFreeform: boolean,
+  ): Promise<void> {
+    await this.ensureSessionResumed(sessionId);
+    const result = await this.adapter.respondToQuestion(sessionId, pending.questionId, answer, wasFreeform);
+    if (result !== 'accepted') {
+      const answerText = answer.text || (answer.attachments?.length ? '[image attachment]' : '(no text)');
+      const recoveryPrompt = [
+        'A previous turn was interrupted while waiting for the user to answer this question:',
+        pending.question,
+        '',
+        'The user has now answered:',
+        answerText,
+        '',
+        'Continue the previous task using this answer. Do not ask the same question again unless the answer is genuinely insufficient.',
+      ].join('\n');
+      this.send({ type: 'active', sessionId, payload: {} });
+      this.sessionManager.markActive(sessionId);
+      await this.adapter.sendMessage(sessionId, recoveryPrompt, answer.attachments);
+    }
+
+    this.removeOpenQuestion(sessionId, pending.questionId);
+    this.card.resolvePrompt(sessionId, pending.questionId, { answer: answer.text || 'Answered with image' });
+    this.send({
+      type: 'question_resolved',
+      sessionId,
+      payload: { questionId: pending.questionId, answer: answer.text || 'Answered with image' },
+    });
   }
 
   /** Build a ContentRef for the args JSON if the serialized size exceeds the
@@ -493,6 +581,7 @@ export class RelayClient {
       this.pulse.onConnected();
       // Initialize events watcher for imported sessions
       this.initEventsWatcher();
+      this.restorePendingHumanActions();
       this.resumeDisconnectedSessions();
       this.sendGreetingBroadcast();
       this.broadcastSessionList();
@@ -748,10 +837,6 @@ export class RelayClient {
             textLen: (msg.payload.text || '').length,
             hasAttachments: !!msg.payload.attachments?.length,
           });
-          // Broadcast user_message back to apps (round-trip confirmation).
-          // Echo the optional `clientId` so the originating client can
-          // correlate this broadcast with its optimistic pending_input
-          // placeholder (see UserMessage.payload.clientId).
           this.send({
             type: 'user_message',
             sessionId,
@@ -761,24 +846,49 @@ export class RelayClient {
               ...(msg.payload.clientId && { clientId: msg.payload.clientId }),
             },
           });
-          this.send({ type: 'active', sessionId, payload: {} });
-          // Lazy resume must run BEFORE markActive — otherwise the meta flip
-          // from disconnected → active defeats ensureSessionResumed's state
-          // gate, sessions never get loaded, and every send fails with
-          // "Session not found". (Regression discovered post-v0.21.1.)
-          this.ensureSessionResumed(sessionId)
-            .then(() => {
+
+          const pendingAtArrival = this.soleOpenQuestion(sessionId);
+          if (pendingAtArrival) {
+            void this.deliverQuestionAnswer(sessionId, pendingAtArrival, {
+              text: msg.payload.text === '[image]' ? '' : msg.payload.text,
+              attachments: msg.payload.attachments,
+            }, true).catch((err) => {
+              logger.error({ err, sessionId }, 'question answer from composer failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver answer: ${(err as Error).message}` } });
+            });
+            break;
+          }
+          if ((this.openQuestions.get(sessionId)?.size ?? 0) > 1) {
+            this.send({ type: 'error', sessionId, payload: { message: 'Multiple questions are pending. Answer the intended question card directly.' } });
+            break;
+          }
+
+          const previous = this.inputChains.get(sessionId) ?? Promise.resolve();
+          const next = previous
+            .catch(() => {})
+            .then(async () => {
+              this.send({ type: 'active', sessionId, payload: {} });
+              await this.ensureSessionResumed(sessionId);
               traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId });
               this.sessionManager.markActive(sessionId);
-              return this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
-            })
-            .then(() => {
-              traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-DONE', sessionId, clientId });
+              const idle = this.waitForTurnIdle(sessionId);
+              try {
+                await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
+                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-DONE', sessionId, clientId });
+                await idle;
+              } catch (err) {
+                this.resolveTurnIdle(sessionId);
+                throw err;
+              }
             })
             .catch((err) => {
-              logger.error({ err, sessionId }, 'sendMessage failed');
+              logger.error({ err, sessionId }, 'send input failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver message: ${(err as Error).message}` } });
+            })
+            .finally(() => {
+              if (this.inputChains.get(sessionId) === next) this.inputChains.delete(sessionId);
             });
+          this.inputChains.set(sessionId, next);
           break;
         }
         case 'approve':
@@ -788,57 +898,78 @@ export class RelayClient {
           // pulse resend is safe.)
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'approve')
             .then(() => {
+              this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'approve' });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'approved' } });
             })
             .catch((err) => {
               logger.error({ err, sessionId }, 'respondToPermission failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to approve permission: ${(err as Error).message}` } });
             });
-          this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'approve' });
           break;
         case 'deny':
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'deny')
             .then(() => {
+              this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'deny' });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'denied' } });
             })
             .catch((err) => {
               logger.error({ err, sessionId }, 'respondToPermission failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to deny permission: ${(err as Error).message}` } });
             });
-          this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'deny' });
           break;
         case 'always_allow':
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'always_allow')
             .then(() => {
+              this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'always_allow' });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'always_allowed' } });
             })
             .catch((err) => {
               logger.error({ err, sessionId }, 'respondToPermission failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to set always-allow: ${(err as Error).message}` } });
             });
-          this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'always_allow' });
           break;
-        case 'answer':
-          this.removeOpenQuestion(sessionId, msg.payload.questionId);
-          this.adapter.respondToQuestion(sessionId, msg.payload.questionId, msg.payload.answer, msg.payload.wasFreeform ?? false)
-            .then(() => {
-              this.send({ type: 'question_resolved', sessionId, payload: { questionId: msg.payload.questionId, answer: msg.payload.answer } });
-            })
-            .catch((err) => {
-              logger.error({ err, sessionId }, 'respondToQuestion failed');
-              this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver answer: ${(err as Error).message}` } });
-            });
-          this.card.resolvePrompt(sessionId, msg.payload.questionId, { answer: msg.payload.answer });
+        case 'answer': {
+          const pending = this.openQuestions.get(sessionId)?.get(msg.payload.questionId);
+          if (!pending) {
+            this.send({ type: 'error', sessionId, payload: { message: 'That question is no longer pending.' } });
+            break;
+          }
+          void this.deliverQuestionAnswer(sessionId, pending, {
+            text: msg.payload.answer,
+            attachments: msg.payload.attachments,
+          }, msg.payload.wasFreeform ?? false).catch((err) => {
+            logger.error({ err, sessionId }, 'respondToQuestion failed');
+            this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver answer: ${(err as Error).message}` } });
+          });
           break;
+        }
         case 'kill_session':
           this.adapter.killSession(sessionId)
             .catch((err) => logger.error({ err, sessionId }, 'killSession failed'));
           break;
-        case 'abort_session':
+        case 'abort_session': {
+          const snapshot = this.card.state(sessionId);
           this.adapter.abortSession(sessionId)
             .then(() => {
+              const frozenAction = snapshot.action?.type === 'question'
+                ? { ...snapshot.action, payload: { ...snapshot.action.payload, cancelled: true } }
+                : snapshot.action;
+              if (snapshot.draft || frozenAction) {
+                this.send({
+                  type: 'interrupted_turn',
+                  sessionId,
+                  payload: {
+                    reason: 'user_aborted',
+                    draft: snapshot.draft,
+                    action: frozenAction,
+                    interruptedAt: new Date().toISOString(),
+                    cancelled: true,
+                  },
+                });
+              }
               this.clearOpenQuestions(sessionId);
               this.card.clear(sessionId);
+              this.resolveTurnIdle(sessionId);
               this.sessionManager.markIdle(sessionId);
               this.send({ type: 'idle', sessionId, payload: { reason: 'aborted' } });
             })
@@ -847,6 +978,7 @@ export class RelayClient {
               this.send({ type: 'error', sessionId, payload: { message: `Failed to abort session: ${(err as Error).message}` } });
             });
           break;
+        }
         case 'delete_session':
           // Remove from local session state SYNCHRONOUSLY. The adapter's
           // killSession runs async and may take a while to talk to the
@@ -1364,15 +1496,27 @@ export class RelayClient {
     };
 
     this.adapter.onQuestionRequest = (sessionId, event) => {
-      this.addOpenQuestion(sessionId, event.id, event.question);
-      this.card.onPrompt(sessionId, {
-        type: 'question',
+      const action = {
+        type: 'question' as const,
         payload: {
           id: event.id,
           question: event.question,
           ...(event.choices ? { choices: event.choices } : {}),
           allowFreeform: event.allowFreeform,
         },
+      };
+      this.card.onPrompt(sessionId, action);
+      const snapshot = this.card.state(sessionId);
+      this.addOpenQuestion(sessionId, {
+        version: 1,
+        kind: 'question',
+        questionId: event.id,
+        question: event.question,
+        ...(event.choices ? { choices: event.choices } : {}),
+        allowFreeform: event.allowFreeform,
+        draft: snapshot.draft,
+        action,
+        createdAt: new Date().toISOString(),
       });
     };
 
@@ -1499,8 +1643,12 @@ export class RelayClient {
     };
 
     this.adapter.onIdle = (sessionId) => {
+      // Idle carries no run/turn identity. Never let a late idle callback erase
+      // a newer card. Permanent bubble boundaries retire settled card state;
+      // explicit abort owns its own freeze+clear path; pending questions stay.
+      if (this.soleOpenQuestion(sessionId)) return;
       this.clearOpenQuestions(sessionId);
-      this.card.clear(sessionId);
+      this.resolveTurnIdle(sessionId);
       this.sessionManager.markIdle(sessionId);
       const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
       if (usage) this.sessionManager.setUsage(sessionId, usage);
@@ -1528,6 +1676,7 @@ export class RelayClient {
     // bubble so the turn — which produced no final reply — still has an
     // anchor for its "Steps" history.
     this.adapter.onSystemMessage = (sessionId, event) => {
+      this.card.onBubble(sessionId);
       this.send({
         type: 'system_message',
         sessionId,
@@ -1543,6 +1692,7 @@ export class RelayClient {
       this.lastAgentContent.delete(sessionId);
       this.purgeSessionToolState(sessionId);
       this.broadcastedAttachmentIds.delete(sessionId);
+      this.resolveTurnIdle(sessionId);
       this.card.delete(sessionId);
       this.send({
         type: 'session_ended',
@@ -1557,7 +1707,7 @@ export class RelayClient {
     // through ensureSessionResumed and lazy-loads transparently.
     this.adapter.onSessionEvicted = (sessionId) => {
       this.sessionManager.markDisconnected(sessionId);
-      this.card.delete(sessionId);
+      if (!this.soleOpenQuestion(sessionId)) this.card.delete(sessionId);
     };
 
     // SDK title fallback — use as fast placeholder while LLM generation runs
@@ -2267,7 +2417,7 @@ export class RelayClient {
     if (sessionId) {
       if (type === 'user_message') {
         this.turnStepCounts.set(sessionId, 0);
-      } else if (type === 'agent_message' || type === 'system_message') {
+      } else if (type === 'agent_message' || type === 'system_message' || type === 'interrupted_turn') {
         const p = enriched.payload as Record<string, unknown> | undefined;
         if (p && typeof p === 'object') p.steps = this.turnStepCounts.get(sessionId) ?? 0;
       }

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -10,6 +10,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, rename
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { getConfigDir } from './config.js';
+import type { CardActionState } from '@kraki/protocol';
 
 const PREVIEW_MAX = 80;
 
@@ -135,6 +136,19 @@ export interface RunRecord {
   startedAt: string;
   endedAt?: string;
   endReason?: string;
+}
+
+/** Durable human-blocking state kept outside the model transcript. */
+export interface PendingHumanAction {
+  version: 1;
+  kind: 'question';
+  questionId: string;
+  question: string;
+  choices?: string[];
+  allowFreeform?: boolean;
+  draft: string;
+  action: CardActionState;
+  createdAt: string;
 }
 
 // ── Session Manager ─────────────────────────────────────
@@ -705,6 +719,35 @@ export class SessionManager {
     this.writeMeta(sessionId, meta);
   }
 
+  // ── Durable human-action state ─────────────────────────
+
+  private pendingActionPath(sessionId: string): string {
+    return join(this.sessionDir(sessionId), 'pending-human-action.json');
+  }
+
+  savePendingHumanAction(sessionId: string, pending: PendingHumanAction): void {
+    const path = this.pendingActionPath(sessionId);
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(pending), 'utf8');
+    renameSync(tmp, path);
+  }
+
+  getPendingHumanAction(sessionId: string): PendingHumanAction | null {
+    const path = this.pendingActionPath(sessionId);
+    if (!existsSync(path)) return null;
+    try {
+      const value = JSON.parse(readFileSync(path, 'utf8')) as PendingHumanAction;
+      if (value?.version !== 1 || value.kind !== 'question' || !value.questionId) return null;
+      return value;
+    } catch {
+      return null;
+    }
+  }
+
+  clearPendingHumanAction(sessionId: string): void {
+    rmSync(this.pendingActionPath(sessionId), { force: true });
+  }
+
   // ── Message log ────────────────────────────────────────
 
   /**
@@ -992,6 +1035,14 @@ export class SessionManager {
         if (!payload) continue;
 
         switch (inner.type) {
+          case 'interrupted_turn': {
+            const draft = payload.draft;
+            return {
+              text: typeof draft === 'string' && draft ? stripMarkdownForPreview(draft) : 'Turn aborted',
+              type: 'agent',
+              timestamp: entry.ts,
+            };
+          }
           case 'agent_message': {
             const content = payload.content;
             if (typeof content === 'string' && content) {

--- a/packages/tests/src/head-tentacle.test.ts
+++ b/packages/tests/src/head-tentacle.test.ts
@@ -36,9 +36,13 @@ class MockAdapter {
   private sessionCounter = 0;
   started = false;
   sessions = new Map<string, { ended: boolean }>();
-  lastPermissionResponse: string | null = null;
-  lastQuestionResponse: string | null = null;
-  lastMessage: string | null = null;
+  lastPermissionResponse: { sessionId: string; permissionId: string; decision: string } | null = null;
+  lastQuestionResponse: {
+    sessionId: string;
+    questionId: string;
+    answer: string | { text: string; attachments?: unknown[] };
+  } | null = null;
+  lastMessage: { sessionId: string; text: string } | null = null;
   killedSessions: string[] = [];
 
   async start() { this.started = true; }
@@ -58,7 +62,7 @@ class MockAdapter {
   async respondToPermission(sid: string, pid: string, d: string) {
     this.lastPermissionResponse = { sessionId: sid, permissionId: pid, decision: d };
   }
-  async respondToQuestion(sid: string, qid: string, a: string) {
+  async respondToQuestion(sid: string, qid: string, a: string | { text: string; attachments?: unknown[] }) {
     this.lastQuestionResponse = { sessionId: sid, questionId: qid, answer: a };
   }
   async endSession(sessionId: string) {
@@ -242,7 +246,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
     await waitMs(200);
 
     expect(adapter.lastQuestionResponse).toEqual({
-      sessionId, questionId: "q_1", answer: "SQLite",
+      sessionId, questionId: "q_1", answer: { text: "SQLite", attachments: undefined },
     });
 
     app.close();


### PR DESCRIPTION
## Summary
- persist and restore pending Pi ask_user cards across daemon/process restart
- support text and image answers, including image-only answers, with recovery prompts when the original Pi request is gone
- make explicit Abort produce durable read-only interrupted-turn history and preserve it across reload/replay
- serialize session inputs until a real idle boundary and protect pending human actions from stale idle/eviction
- make Pi permission mode changes live: switching to execute/delegate auto-approves current pending permissions and removes lifecycle-bearing mode steer
- keep permission card resolution authoritative until the adapter accepts the response

## Validation
- `pnpm --filter @kraki/tentacle test` (`698/698`)
- `NODE_ENV=test pnpm --filter @kraki/arm-web test` (`350/350`)
- `pnpm --filter @kraki/protocol build`
- `pnpm --filter @kraki/crypto build`
- `pnpm --filter @kraki/tentacle build`
- `pnpm --filter @kraki/arm-web build`
- Playwright `e2e/pi-question-abort-refresh.spec.ts` (`1 passed`)
- `git diff --check`

## Known validation gap
- iOS build/test remains blocked by the existing missing `packages/arm/ios/Vendor/GRDB.swift` dependency.
- The broader Pi logical-turn generation/compaction watchdog work is intentionally separate from this PR.