### PR TITLE
feat: add HTML report artifacts

### DIFF
--- a/docs/html-reports/generation-prompt.md
+++ b/docs/html-reports/generation-prompt.md
@@ -1,0 +1,32 @@
+# Kraki HTML Report Generation Prompt
+
+Use the attached `kraki-html-report-template.html` to generate a technical report.
+
+The template is primarily a visual and interaction template, not a fixed report form. Preserve its overall design language, responsive layout, card styles, semantic color system, SVG diagram containers, pan/zoom interactions, and print styles. Decide the report structure, number of sections, visualization types, and narrative flow freely based on the material.
+
+Write the generated report in the language currently used in this Kraki session. The template and this prompt are intentionally written in English, but the final report content must follow the session language.
+
+## Task
+
+Topic:
+{{TOPIC}}
+
+Supporting material:
+{{MATERIAL}}
+
+## Generation requirements
+
+- Modify the attached HTML template; do not redesign the page from scratch.
+- Keep only the sections and components that help explain this report.
+- Do not force the use of an executive summary, state machine, pipeline, ER diagram, decision matrix, timeline, or any other component.
+- Choose visualizations freely based on the material, such as architecture diagrams, flows, sequence diagrams, state machines, data pipelines, timelines, comparison tables, or other clear SVG visualizations.
+- Put complex diagrams inside the template's `data-panzoom`, `diagram-shell`, `diagram-viewport`, and `diagram-canvas` structure so they support local zooming and panning.
+- If using Mermaid as a source, convert it to inline SVG before producing the final document. Do not load the Mermaid runtime.
+- Feel free to shape the layout and narrative around the subject, while keeping the result readable in a 420–760px vertical side panel.
+- Wide tables, code blocks, or diagrams may scroll horizontally inside their own containers, but the page itself must not have horizontal overflow.
+- Base the report on the provided material. Do not present uncertain information as fact; label assumptions or open questions when necessary.
+- Do not use external CSS, JavaScript, fonts, images, CDNs, or network requests.
+- Remove all unused placeholders. The final HTML must not contain `{{...}}` placeholders.
+- Output only one complete HTML document starting with `<!doctype html>`. Do not output Markdown fences or explanatory text.
+
+Focus on helping me quickly understand the subject, its important relationships, trade-offs, and conclusions. Do not mechanically follow a fixed section order.

--- a/docs/html-reports/kraki-html-report-template.html
+++ b/docs/html-reports/kraki-html-report-template.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="{{LANGUAGE_CODE}}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{{REPORT_TITLE}}</title>
+<style>
+/*
+  KRAKI HTML REPORT TEMPLATE
+  - Designed for a 420–760px vertical side panel
+  - Self-contained: no external resources
+  - Delete unused components and sections
+  - Keep semantic color meanings consistent
+*/
+:root{
+  --bg:#f4f6fa;--paper:#fff;--ink:#172033;--muted:#667085;--line:#d9dee8;
+  --brand:#f05b44;--brand-soft:#fff0ec;
+  --blue:#2878ff;--blue-soft:#eaf2ff;
+  --green:#169b62;--green-soft:#e8f7f0;
+  --amber:#d98200;--amber-soft:#fff5df;
+  --purple:#7857d8;--purple-soft:#f0ecff;
+  --red:#d83b4c;--red-soft:#ffebee;
+  --shadow:0 8px 28px rgba(23,32,51,.08);--radius:16px;
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif}
+button{font:inherit}
+.report{max-width:760px;margin:0 auto;min-height:100vh}
+
+/* Reading progress */
+.progress{position:fixed;z-index:40;top:0;left:0;height:2px;background:linear-gradient(90deg,var(--brand),#ff9f7d);width:0}
+
+/* Compact report title */
+.report-title{padding:16px 14px 8px}.report-title h1{font-size:22px;line-height:1.3;margin:0 0 3px}.report-title p{margin:0;color:var(--muted);font-size:11px}.report-title .eyebrow{color:var(--brand);font-size:10px;letter-spacing:.12em;font-weight:800}
+
+/* Navigation and sections */
+.quicknav{display:flex;gap:7px;overflow:auto;padding:0 14px 5px;scrollbar-width:none}.quicknav::-webkit-scrollbar{display:none}.quicknav a{flex:none;padding:6px 10px;border-radius:999px;background:#fff;border:1px solid var(--line);color:var(--muted);text-decoration:none;font-size:11px}.quicknav a:hover{border-color:var(--brand);color:var(--brand)}
+main{padding:0 14px 50px}.section{scroll-margin-top:64px;margin-top:18px}.section-head{display:flex;align-items:flex-start;gap:10px;margin:0 2px 9px}.num{display:grid;place-items:center;flex:none;width:27px;height:27px;border-radius:9px;background:#172033;color:#fff;font-size:11px;font-weight:800}.section-head h2{font-size:17px;line-height:1.3;margin:1px 0 2px}.section-head p{margin:0;color:var(--muted);font-size:11px}
+.card{background:var(--paper);border:1px solid var(--line);border-radius:var(--radius);box-shadow:0 3px 14px rgba(23,32,51,.045);padding:15px;margin-bottom:10px}.card h3{font-size:14px;margin:0 0 5px}.card>p{margin:0 0 12px;color:var(--muted);font-size:12px}
+
+/* Metrics and callouts */
+.summary-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px}.metric{border-radius:13px;padding:13px;border:1px solid}.metric strong{display:block;font-size:21px;line-height:1.1}.metric span{font-size:10px;color:var(--muted)}
+.metric.blue{background:var(--blue-soft);border-color:#c6d9ff}.metric.green{background:var(--green-soft);border-color:#bde8d3}.metric.amber{background:var(--amber-soft);border-color:#f5db9e}.metric.purple{background:var(--purple-soft);border-color:#d8ceff}.metric.red{background:var(--red-soft);border-color:#ffc7ce}
+.callout{display:flex;gap:10px;padding:12px;border-radius:12px;border:1px solid #b8d5ff;background:#eff6ff;margin-bottom:10px}.callout .glyph{font-size:17px}.callout strong{display:block;font-size:12px}.callout p{margin:2px 0 0;color:#38547c;font-size:11px}
+.callout.warning{border-color:#f0d28c;background:var(--amber-soft)}.callout.warning p{color:#76501a}.callout.risk{border-color:#f2a9b2;background:var(--red-soft)}.callout.risk p{color:#7c3540}.callout.success{border-color:#a9dfc5;background:var(--green-soft)}.callout.success p{color:#276147}
+
+/* Interactive SVG diagram */
+.diagram-shell{border:1px solid var(--line);border-radius:14px;overflow:hidden;background:#fbfcfe;margin-top:10px}.diagram-bar{display:flex;align-items:center;gap:6px;padding:7px 8px;border-bottom:1px solid var(--line);background:#fff}.diagram-bar strong{flex:1;font-size:11px}.diagram-bar span{color:var(--muted);font-size:9px}.zoom-btn{min-width:27px;height:25px;display:grid;place-items:center;padding:0 6px;font-size:12px}.diagram-viewport{height:420px;overflow:hidden;position:relative;touch-action:none;cursor:grab;background-image:radial-gradient(#dfe5ef 1px,transparent 1px);background-size:18px 18px}.diagram-viewport.dragging{cursor:grabbing}.diagram-canvas{width:100%;height:100%;transform-origin:0 0;will-change:transform}.diagram-canvas svg{display:block;width:100%;height:100%}.diagram-note{padding:8px 9px;border-top:1px solid var(--line);background:#fff;color:var(--muted);font-size:11px}
+
+/* State flow */
+.state-flow{display:grid;grid-template-columns:1fr;gap:9px}.state{position:relative;border:1.5px solid;border-radius:12px;padding:12px 13px}.state strong{font-size:12px}.state p{font-size:11px;color:var(--muted);margin:2px 0}.state:after{content:"↓";position:absolute;left:50%;bottom:-21px;transform:translateX(-50%);color:#98a2b3;font-size:15px}.state:last-child:after{display:none}.state.neutral{border-color:#aab4c3;background:#f8fafc}.state.active{border-color:#5891ee;background:var(--blue-soft)}.state.waiting{border-color:#e1a542;background:var(--amber-soft)}.state.done{border-color:#45ad7d;background:var(--green-soft)}.state.error{border-color:#e16b78;background:var(--red-soft)}.branch{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:5px 0}.branch .state:after{display:none}
+
+/* Pipeline */
+.pipeline{display:grid;gap:8px}.pipe-stage{display:grid;grid-template-columns:35px 1fr auto;align-items:center;gap:9px;padding:10px;border:1px solid var(--line);border-radius:12px}.pipe-icon{display:grid;place-items:center;width:35px;height:35px;border-radius:10px;font-size:16px}.pipe-stage strong{font-size:11px;display:block}.pipe-stage small{font-size:9px;color:var(--muted)}.badge{font-size:9px;padding:3px 6px;border-radius:999px;background:#f0f2f5;color:var(--muted)}.connector{text-align:center;height:11px;color:#98a2b3;font-size:12px;line-height:11px}
+
+/* Entity cards */
+.entity-grid{display:grid;grid-template-columns:1fr 1fr;gap:9px}.entity{border:1px solid var(--line);border-radius:11px;overflow:hidden}.entity h4{margin:0;padding:8px 10px;background:#172033;color:#fff;font-size:11px}.entity ul{list-style:none;margin:0;padding:6px 9px}.entity li{display:flex;justify-content:space-between;gap:8px;border-bottom:1px solid #edf0f4;padding:5px 0;font-size:9px}.entity li:last-child{border:0}.entity code{color:var(--muted)}.relation-note{margin-top:9px;padding:8px;border-left:3px solid var(--purple);background:var(--purple-soft);font-size:10px}
+
+/* Tables and decision matrices */
+.table-wrap{overflow:auto;border:1px solid var(--line);border-radius:11px}.matrix{width:100%;min-width:480px;border-collapse:separate;border-spacing:0;font-size:10px}.matrix th,.matrix td{padding:8px;border-right:1px solid var(--line);border-bottom:1px solid var(--line);text-align:center}.matrix th:first-child,.matrix td:first-child{text-align:left;font-weight:700}.matrix th{background:#f7f9fc}.matrix tr:last-child td{border-bottom:0}.matrix th:last-child,.matrix td:last-child{border-right:0}.score{display:inline-grid;place-items:center;min-width:22px;height:22px;padding:0 5px;border-radius:7px;font-weight:800}.score.good{background:var(--green-soft);color:var(--green)}.score.mid{background:var(--amber-soft);color:var(--amber)}.score.bad{background:var(--red-soft);color:var(--red)}
+
+/* Timeline */
+.timeline{position:relative;margin-left:8px;padding-left:22px;border-left:2px solid #d9dee8}.event{position:relative;padding:0 0 17px}.event:last-child{padding-bottom:2px}.event:before{content:"";position:absolute;left:-29px;top:3px;width:11px;height:11px;border-radius:50%;background:#fff;border:3px solid var(--blue)}.event.done:before{border-color:var(--green);background:var(--green)}.event.next:before{border-color:var(--amber)}.event.blocked:before{border-color:var(--red)}.event strong{display:block;font-size:11px}.event time{font-size:9px;color:var(--muted)}.event p{font-size:10px;color:var(--muted);margin:3px 0}
+
+/* Lists and code */
+.key-list{margin:0;padding-left:20px}.key-list li{padding:4px 0;font-size:12px}.codeblock{background:#111827;color:#d8dee9;border-radius:12px;padding:13px;overflow:auto;font:10px/1.6 SFMono-Regular,Consolas,monospace;white-space:pre}.footer{text-align:center;color:var(--muted);font-size:9px;padding:18px 5px}
+
+@media(min-width:680px){.summary-grid{grid-template-columns:repeat(4,1fr)}.diagram-viewport{height:470px}}
+@media(max-width:420px){.card{padding:12px}.entity-grid{grid-template-columns:1fr}.diagram-viewport{height:390px}.diagram-bar span{display:none}}
+@media print{.quicknav,.progress,.diagram-bar{display:none}.report{max-width:none}.card{break-inside:avoid;box-shadow:none}.diagram-viewport{height:auto;overflow:visible;background:none}.diagram-canvas{transform:none!important}.diagram-canvas svg{height:auto}.section{page-break-inside:avoid}}
+</style>
+</head>
+<body>
+<div class="progress" id="progress"></div>
+<div class="report">
+
+<header class="report-title">
+  <div class="eyebrow">{{REPORT_CATEGORY}} · {{REPORT_DATE_OR_VERSION}}</div>
+  <h1>{{REPORT_TITLE}}</h1>
+  <p>{{REPORT_SUBTITLE_OR_EXECUTIVE_SUMMARY}}</p>
+</header>
+
+<!-- Keep only links for sections that exist. -->
+<nav class="quicknav" aria-label="Report sections">
+  <a href="#summary">Summary</a>
+  <a href="#overview">Overview</a>
+  <a href="#details">Analysis</a>
+  <a href="#decision">Decision</a>
+  <a href="#risks">Risks</a>
+  <a href="#next">Next steps</a>
+</nav>
+
+<main>
+
+<!-- REQUIRED: Executive summary -->
+<section class="section" id="summary">
+  <div class="section-head">
+    <span class="num">01</span>
+    <div><h2>Executive summary</h2><p>{{SECTION_SUMMARY}}</p></div>
+  </div>
+
+  <div class="card">
+    <!-- Keep 2–4 metrics. Replace metrics with key facts if numeric metrics do not exist. -->
+    <div class="summary-grid">
+      <div class="metric blue"><strong>{{METRIC_1_VALUE}}</strong><span>{{METRIC_1_LABEL}}</span></div>
+      <div class="metric green"><strong>{{METRIC_2_VALUE}}</strong><span>{{METRIC_2_LABEL}}</span></div>
+      <div class="metric amber"><strong>{{METRIC_3_VALUE}}</strong><span>{{METRIC_3_LABEL}}</span></div>
+      <div class="metric purple"><strong>{{METRIC_4_VALUE}}</strong><span>{{METRIC_4_LABEL}}</span></div>
+    </div>
+  </div>
+
+  <div class="callout">
+    <div class="glyph">💡</div>
+    <div><strong>Recommendation</strong><p>{{RECOMMENDATION}}</p></div>
+  </div>
+</section>
+
+<!-- REQUIRED WHEN A SYSTEM OR PROCESS CAN BE VISUALIZED -->
+<section class="section" id="overview">
+  <div class="section-head">
+    <span class="num">02</span>
+    <div><h2>{{OVERVIEW_SECTION_TITLE}}</h2><p>{{OVERVIEW_SECTION_SUBTITLE}}</p></div>
+  </div>
+
+  <div class="card">
+    <h3>{{DIAGRAM_TITLE}}</h3>
+    <p>{{DIAGRAM_INTRODUCTION_AND_READING_GUIDANCE}}</p>
+
+    <!--
+      For a complex architecture/flow diagram, keep data-panzoom.
+      Replace the sample SVG entirely. Use a meaningful viewBox.
+      Prefer top-to-bottom flow, <= 4 layers, and 3–5 nodes per layer.
+    -->
+    <div class="diagram-shell" data-panzoom>
+      <div class="diagram-bar">
+        <strong>{{DIAGRAM_SHORT_TITLE}}</strong>
+        <span>Drag to pan · Wheel to zoom</span>
+        <button class="zoom-btn" data-action="out" aria-label="Zoom out">−</button>
+        <button class="zoom-btn" data-action="reset" aria-label="Reset diagram">↺</button>
+        <button class="zoom-btn" data-action="fit" aria-label="Fit diagram">Fit</button>
+        <button class="zoom-btn" data-action="in" aria-label="Zoom in">＋</button>
+      </div>
+      <div class="diagram-viewport">
+        <div class="diagram-canvas">
+          <svg viewBox="0 0 720 720" role="img" aria-label="{{DIAGRAM_ACCESSIBLE_DESCRIPTION}}">
+            <defs>
+              <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+                <path d="M0 0L8 4L0 8Z" fill="#7b8798"/>
+              </marker>
+            </defs>
+
+            <!-- REPLACE WITH THE REPORT'S INLINE SVG DIAGRAM. -->
+            <rect x="80" y="80" width="560" height="120" rx="18" fill="#f0ecff" stroke="#c8baff"/>
+            <text x="360" y="130" text-anchor="middle" font-size="18" font-weight="700" fill="#172033">{{DIAGRAM_LAYER_OR_NODE_1}}</text>
+            <text x="360" y="158" text-anchor="middle" font-size="12" fill="#667085">{{NODE_1_DESCRIPTION}}</text>
+
+            <path d="M360 200V285" fill="none" stroke="#7b8798" stroke-width="2" marker-end="url(#arrow)"/>
+
+            <rect x="80" y="286" width="560" height="150" rx="18" fill="#eaf2ff" stroke="#b7d0ff"/>
+            <text x="360" y="345" text-anchor="middle" font-size="18" font-weight="700" fill="#172033">{{DIAGRAM_LAYER_OR_NODE_2}}</text>
+            <text x="360" y="375" text-anchor="middle" font-size="12" fill="#667085">{{NODE_2_DESCRIPTION}}</text>
+
+            <path d="M360 436V521" fill="none" stroke="#7b8798" stroke-width="2" marker-end="url(#arrow)"/>
+
+            <rect x="80" y="522" width="560" height="120" rx="18" fill="#e8f7f0" stroke="#a9dfc5"/>
+            <text x="360" y="572" text-anchor="middle" font-size="18" font-weight="700" fill="#172033">{{DIAGRAM_LAYER_OR_NODE_3}}</text>
+            <text x="360" y="600" text-anchor="middle" font-size="12" fill="#667085">{{NODE_3_DESCRIPTION}}</text>
+          </svg>
+        </div>
+      </div>
+      <div class="diagram-note">{{DIAGRAM_INTERPRETATION_OR_KEY_TAKEAWAY}}</div>
+    </div>
+  </div>
+</section>
+
+<!-- OPTIONAL: Detailed analysis. Choose useful components; do not include every type. -->
+<section class="section" id="details">
+  <div class="section-head">
+    <span class="num">03</span>
+    <div><h2>{{DETAIL_SECTION_TITLE}}</h2><p>{{DETAIL_SECTION_SUBTITLE}}</p></div>
+  </div>
+
+  <!-- Example prose/list card. -->
+  <div class="card">
+    <h3>{{ANALYSIS_CARD_TITLE}}</h3>
+    <p>{{ANALYSIS_INTRODUCTION}}</p>
+    <ul class="key-list">
+      <li><strong>{{POINT_1_TITLE}}:</strong> {{POINT_1_DETAIL}}</li>
+      <li><strong>{{POINT_2_TITLE}}:</strong> {{POINT_2_DETAIL}}</li>
+      <li><strong>{{POINT_3_TITLE}}:</strong> {{POINT_3_DETAIL}}</li>
+    </ul>
+  </div>
+
+  <!--
+    OPTIONAL STATE MACHINE COMPONENT — delete unless needed.
+    Put the happy path vertically and alternatives in .branch.
+  -->
+  <div class="card">
+    <h3>{{STATE_MACHINE_TITLE}}</h3>
+    <p>{{STATE_MACHINE_EXPLANATION}}</p>
+    <div class="state-flow">
+      <div class="state neutral"><strong>{{STATE_1}}</strong><p>{{STATE_1_CONDITION_AND_ACTION}}</p></div>
+      <div class="state active"><strong>{{STATE_2}}</strong><p>{{STATE_2_CONDITION_AND_ACTION}}</p></div>
+      <div class="branch">
+        <div class="state done"><strong>{{SUCCESS_STATE}}</strong><p>{{SUCCESS_STATE_DETAIL}}</p></div>
+        <div class="state error"><strong>{{ERROR_STATE}}</strong><p>{{ERROR_STATE_DETAIL}}</p></div>
+      </div>
+    </div>
+  </div>
+
+  <!--
+    OPTIONAL PIPELINE COMPONENT — delete unless needed.
+    Add/remove stages as required.
+  -->
+  <div class="card">
+    <h3>{{PIPELINE_TITLE}}</h3>
+    <p>{{PIPELINE_EXPLANATION}}</p>
+    <div class="pipeline">
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--blue-soft)">1</div><div><strong>{{STAGE_1}}</strong><small>{{STAGE_1_DETAIL}}</small></div><span class="badge">{{STAGE_1_MODE}}</span></div>
+      <div class="connector">↓</div>
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--purple-soft)">2</div><div><strong>{{STAGE_2}}</strong><small>{{STAGE_2_DETAIL}}</small></div><span class="badge">{{STAGE_2_MODE}}</span></div>
+      <div class="connector">↓</div>
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--green-soft)">3</div><div><strong>{{STAGE_3}}</strong><small>{{STAGE_3_DETAIL}}</small></div><span class="badge">{{STAGE_3_MODE}}</span></div>
+    </div>
+  </div>
+
+  <!--
+    OPTIONAL ENTITY COMPONENT — delete unless needed.
+    Keep only important fields. Add textual relationships below.
+  -->
+  <div class="card">
+    <h3>{{DATA_MODEL_TITLE}}</h3>
+    <p>{{DATA_MODEL_EXPLANATION}}</p>
+    <div class="entity-grid">
+      <div class="entity"><h4>{{ENTITY_1}}</h4><ul><li><strong>{{FIELD_1_PK}} 🔑</strong><code>{{TYPE}}</code></li><li><span>{{FIELD_2}}</span><code>{{TYPE}}</code></li><li><span>{{FIELD_3}}</span><code>{{TYPE}}</code></li></ul></div>
+      <div class="entity"><h4>{{ENTITY_2}}</h4><ul><li><strong>{{FIELD_1_PK}} 🔑</strong><code>{{TYPE}}</code></li><li><span>{{FIELD_2_FK}} ↗</span><code>{{TYPE}}</code></li><li><span>{{FIELD_3}}</span><code>{{TYPE}}</code></li></ul></div>
+    </div>
+    <div class="relation-note"><strong>Relationships and ownership:</strong> {{ENTITY_RELATIONSHIP_AND_OWNERSHIP}}</div>
+  </div>
+</section>
+
+<!-- REQUIRED WHEN THE REPORT SUPPORTS A DECISION -->
+<section class="section" id="decision">
+  <div class="section-head">
+    <span class="num">04</span>
+    <div><h2>Options and decision</h2><p>{{DECISION_SECTION_SUBTITLE}}</p></div>
+  </div>
+
+  <div class="card">
+    <h3>{{MATRIX_TITLE}}</h3>
+    <p>{{MATRIX_EXPLANATION}}</p>
+    <div class="table-wrap">
+      <table class="matrix">
+        <thead><tr><th>Option</th><th>{{CRITERION_1}}</th><th>{{CRITERION_2}}</th><th>{{CRITERION_3}}</th><th>{{CRITERION_4}}</th></tr></thead>
+        <tbody>
+          <tr><td>{{OPTION_1}}</td><td><span class="score good">{{SCORE}}</span></td><td><span class="score mid">{{SCORE}}</span></td><td><span class="score good">{{SCORE}}</span></td><td><span class="score bad">{{SCORE}}</span></td></tr>
+          <tr><td>{{OPTION_2}}</td><td><span class="score mid">{{SCORE}}</span></td><td><span class="score good">{{SCORE}}</span></td><td><span class="score mid">{{SCORE}}</span></td><td><span class="score good">{{SCORE}}</span></td></tr>
+          <tr><td>{{OPTION_3}}</td><td><span class="score bad">{{SCORE}}</span></td><td><span class="score mid">{{SCORE}}</span></td><td><span class="score bad">{{SCORE}}</span></td><td><span class="score mid">{{SCORE}}</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="callout success">
+    <div class="glyph">✓</div>
+    <div><strong>Decision</strong><p>{{FINAL_DECISION_AND_MAIN_TRADEOFF}}</p></div>
+  </div>
+</section>
+
+<!-- REQUIRED WHEN MATERIAL RISKS OR UNKNOWNS EXIST -->
+<section class="section" id="risks">
+  <div class="section-head">
+    <span class="num">05</span>
+    <div><h2>Risks and open questions</h2><p>{{RISKS_SECTION_SUBTITLE}}</p></div>
+  </div>
+
+  <div class="callout risk"><div class="glyph">!</div><div><strong>{{RISK_1_TITLE}}</strong><p>{{RISK_1_IMPACT_AND_MITIGATION}}</p></div></div>
+  <div class="callout warning"><div class="glyph">?</div><div><strong>{{OPEN_QUESTION_TITLE}}</strong><p>{{OPEN_QUESTION_AND_REQUIRED_EVIDENCE}}</p></div></div>
+</section>
+
+<!-- REQUIRED: Ordered next steps -->
+<section class="section" id="next">
+  <div class="section-head">
+    <span class="num">06</span>
+    <div><h2>Next steps</h2><p>{{NEXT_STEPS_SECTION_SUBTITLE}}</p></div>
+  </div>
+
+  <div class="card">
+    <div class="timeline">
+      <div class="event next"><time>{{PHASE_1_TIME}}</time><strong>{{PHASE_1_TITLE}}</strong><p>{{PHASE_1_DELIVERABLE}}</p></div>
+      <div class="event"><time>{{PHASE_2_TIME}}</time><strong>{{PHASE_2_TITLE}}</strong><p>{{PHASE_2_DELIVERABLE}}</p></div>
+      <div class="event"><time>{{PHASE_3_TIME}}</time><strong>{{PHASE_3_TITLE}}</strong><p>{{PHASE_3_DELIVERABLE}}</p></div>
+    </div>
+  </div>
+</section>
+
+<div class="footer">{{REPORT_FOOTER}}</div>
+</main>
+</div>
+
+<script>
+/* Standard Kraki report interactions. Do not modify unless necessary. */
+(() => {
+  const progress = document.getElementById('progress');
+  const updateProgress = () => {
+    const max = document.documentElement.scrollHeight - innerHeight;
+    progress.style.width = `${max > 0 ? (scrollY / max) * 100 : 0}%`;
+  };
+  addEventListener('scroll', updateProgress, { passive: true });
+  updateProgress();
+
+  document.querySelectorAll('[data-panzoom]').forEach((shell) => {
+    const viewport = shell.querySelector('.diagram-viewport');
+    const canvas = shell.querySelector('.diagram-canvas');
+    if (!viewport || !canvas) return;
+
+    let scale = 1, x = 0, y = 0, dragging = false, startX = 0, startY = 0;
+    const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+    const render = () => { canvas.style.transform = `translate(${x}px,${y}px) scale(${scale})`; };
+    const setScale = (next, cx = viewport.clientWidth / 2, cy = viewport.clientHeight / 2) => {
+      next = clamp(next, 0.55, 3.5);
+      const ratio = next / scale;
+      x = cx - (cx - x) * ratio;
+      y = cy - (cy - y) * ratio;
+      scale = next;
+      render();
+    };
+    const reset = () => { scale = 1; x = 0; y = 0; render(); };
+    const fit = () => { scale = 1; x = 0; y = 0; render(); };
+
+    shell.querySelector('[data-action="in"]')?.addEventListener('click', () => setScale(scale * 1.2));
+    shell.querySelector('[data-action="out"]')?.addEventListener('click', () => setScale(scale / 1.2));
+    shell.querySelector('[data-action="reset"]')?.addEventListener('click', reset);
+    shell.querySelector('[data-action="fit"]')?.addEventListener('click', fit);
+
+    viewport.addEventListener('wheel', (event) => {
+      event.preventDefault();
+      const rect = viewport.getBoundingClientRect();
+      setScale(scale * (event.deltaY < 0 ? 1.12 : 0.89), event.clientX - rect.left, event.clientY - rect.top);
+    }, { passive: false });
+
+    viewport.addEventListener('pointerdown', (event) => {
+      dragging = true;
+      startX = event.clientX - x;
+      startY = event.clientY - y;
+      viewport.classList.add('dragging');
+      viewport.setPointerCapture(event.pointerId);
+    });
+    viewport.addEventListener('pointermove', (event) => {
+      if (!dragging) return;
+      x = event.clientX - startX;
+      y = event.clientY - startY;
+      render();
+    });
+    const stopDragging = () => { dragging = false; viewport.classList.remove('dragging'); };
+    viewport.addEventListener('pointerup', stopDragging);
+    viewport.addEventListener('pointercancel', stopDragging);
+    render();
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/html-reports/showcase.html
+++ b/docs/html-reports/showcase.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Kraki HTML Report Template Showcase</title>
+<style>
+:root{
+  --bg:#f4f6fa;--paper:#fff;--ink:#172033;--muted:#667085;--line:#d9dee8;
+  --brand:#f05b44;--brand-soft:#fff0ec;--blue:#2878ff;--blue-soft:#eaf2ff;
+  --green:#169b62;--green-soft:#e8f7f0;--amber:#d98200;--amber-soft:#fff5df;
+  --purple:#7857d8;--purple-soft:#f0ecff;--red:#d83b4c;--red-soft:#ffebee;
+  --shadow:0 8px 28px rgba(23,32,51,.08);--radius:16px;
+}
+*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif}
+button{font:inherit}.report{max-width:760px;margin:0 auto;min-height:100vh;background:var(--bg)}
+.topbar{position:sticky;top:0;z-index:30;display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid rgba(217,222,232,.9);background:rgba(255,255,255,.92);backdrop-filter:blur(12px)}
+.mark{display:grid;place-items:center;width:30px;height:30px;border-radius:9px;background:var(--brand);color:white;font-weight:900}.title-wrap{min-width:0;flex:1}.title-wrap strong{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:13px}.title-wrap small{display:block;color:var(--muted);font-size:10px}.top-actions{display:flex;gap:5px}.icon-btn,.zoom-btn{border:1px solid var(--line);background:white;color:var(--ink);border-radius:8px;cursor:pointer}.icon-btn{padding:5px 8px;font-size:11px}.icon-btn:hover,.zoom-btn:hover{background:#f8fafc}
+.progress{position:fixed;z-index:40;top:50px;left:0;height:2px;background:linear-gradient(90deg,var(--brand),#ff9f7d);width:0}
+.hero{margin:14px;padding:22px;border-radius:20px;color:white;background:linear-gradient(135deg,#111827 0%,#273449 58%,#3b4960 100%);box-shadow:var(--shadow);overflow:hidden;position:relative}.hero:after{content:"";position:absolute;width:180px;height:180px;border-radius:50%;right:-70px;top:-80px;background:rgba(255,255,255,.06)}
+.eyebrow{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:#ffad9f;font-weight:800}.hero h1{font-size:25px;line-height:1.22;margin:8px 0}.hero p{margin:0;color:#d8deea;font-size:13px;max-width:600px}.meta{display:flex;flex-wrap:wrap;gap:7px;margin-top:16px}.meta span{padding:4px 8px;border:1px solid rgba(255,255,255,.17);border-radius:999px;background:rgba(255,255,255,.06);font-size:10px}
+.quicknav{display:flex;gap:7px;overflow:auto;padding:0 14px 5px;scrollbar-width:none}.quicknav::-webkit-scrollbar{display:none}.quicknav a{flex:none;padding:6px 10px;border-radius:999px;background:white;border:1px solid var(--line);color:var(--muted);text-decoration:none;font-size:11px}.quicknav a:hover{border-color:var(--brand);color:var(--brand)}
+main{padding:0 14px 50px}.section{scroll-margin-top:64px;margin-top:18px}.section-head{display:flex;align-items:flex-start;gap:10px;margin:0 2px 9px}.num{display:grid;place-items:center;flex:none;width:27px;height:27px;border-radius:9px;background:#172033;color:white;font-size:11px;font-weight:800}.section-head h2{font-size:17px;line-height:1.3;margin:1px 0 2px}.section-head p{margin:0;color:var(--muted);font-size:11px}
+.card{background:var(--paper);border:1px solid var(--line);border-radius:var(--radius);box-shadow:0 3px 14px rgba(23,32,51,.045);padding:15px;margin-bottom:10px}.card h3{font-size:14px;margin:0 0 5px}.card>p{margin:0 0 12px;color:var(--muted);font-size:12px}
+.summary-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px}.metric{border-radius:13px;padding:13px;border:1px solid}.metric strong{display:block;font-size:21px;line-height:1.1}.metric span{font-size:10px;color:var(--muted)}.metric.blue{background:var(--blue-soft);border-color:#c6d9ff}.metric.green{background:var(--green-soft);border-color:#bde8d3}.metric.amber{background:var(--amber-soft);border-color:#f5db9e}.metric.purple{background:var(--purple-soft);border-color:#d8ceff}
+.callout{display:flex;gap:10px;padding:12px;border-radius:12px;border:1px solid #b8d5ff;background:#eff6ff}.callout .glyph{font-size:17px}.callout strong{display:block;font-size:12px}.callout p{margin:2px 0 0;color:#38547c;font-size:11px}
+.diagram-shell{border:1px solid var(--line);border-radius:14px;overflow:hidden;background:#fbfcfe}.diagram-bar{display:flex;align-items:center;gap:6px;padding:7px 8px;border-bottom:1px solid var(--line);background:white}.diagram-bar strong{flex:1;font-size:11px}.diagram-bar span{color:var(--muted);font-size:9px}.zoom-btn{width:27px;height:25px;display:grid;place-items:center;font-size:12px}.diagram-viewport{height:420px;overflow:hidden;position:relative;touch-action:none;cursor:grab;background-image:radial-gradient(#dfe5ef 1px,transparent 1px);background-size:18px 18px}.diagram-viewport.dragging{cursor:grabbing}.diagram-canvas{width:100%;height:100%;transform-origin:0 0;will-change:transform}.diagram-canvas svg{display:block;width:100%;height:100%}.diagram-note{padding:7px 9px;border-top:1px solid var(--line);background:white;color:var(--muted);font-size:9px}
+.flow-node rect,.flow-node path{stroke-width:2}.flow-node text{font-family:inherit;fill:var(--ink)}.edge{fill:none;stroke:#7b8798;stroke-width:2;marker-end:url(#arrow)}.edge.dashed{stroke-dasharray:7 5}.edge-label{font-size:10px;fill:#667085}
+.sequence{overflow:auto;padding-bottom:3px}.sequence-grid{min-width:580px;display:grid;grid-template-columns:repeat(4,1fr);position:relative;padding:0 5px 12px}.actor{text-align:center;font-weight:700;font-size:11px;padding:8px 4px;border-radius:9px;margin:0 5px}.actor.user{background:var(--purple-soft);color:#5c3fb1}.actor.web{background:var(--blue-soft);color:#1857ba}.actor.api{background:var(--green-soft);color:#08794a}.actor.db{background:var(--amber-soft);color:#9a5d00}.lifeline{height:270px;border-left:1px dashed #b8c1d0;margin:0 auto;width:1px}.messages{position:absolute;inset:46px 0 0}.message{position:absolute;height:22px;border-top:1.5px solid;color:var(--ink);font-size:9px;padding-top:2px}.message:after{content:"";position:absolute;right:-1px;top:-4px;border-left:7px solid currentColor;border-top:3px solid transparent;border-bottom:3px solid transparent}.message.return:after{right:auto;left:-1px;border-left:0;border-right:7px solid currentColor}.message.return{border-top-style:dashed;color:#7b8798;text-align:right}.activation{position:absolute;width:7px;border:1px solid #71b492;background:#bde8d3;border-radius:3px}.sequence-caption{color:var(--muted);font-size:9px;margin-top:7px}
+.state-flow{display:grid;grid-template-columns:1fr;gap:9px}.state{position:relative;border:1.5px solid;border-radius:12px;padding:12px 13px}.state strong{font-size:12px}.state p{font-size:10px;color:var(--muted);margin:2px 0}.state:after{content:"↓";position:absolute;left:50%;bottom:-21px;transform:translateX(-50%);color:#98a2b3;font-size:15px}.state:last-child:after{display:none}.state.idle{border-color:#aab4c3;background:#f8fafc}.state.active{border-color:#5891ee;background:var(--blue-soft)}.state.review{border-color:#e1a542;background:var(--amber-soft)}.state.done{border-color:#45ad7d;background:var(--green-soft)}.state.error{border-color:#e16b78;background:var(--red-soft)}.branch{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:5px 0}.branch .state:after{display:none}
+.pipeline{display:grid;gap:8px}.pipe-stage{display:grid;grid-template-columns:35px 1fr auto;align-items:center;gap:9px;padding:10px;border:1px solid var(--line);border-radius:12px}.pipe-icon{display:grid;place-items:center;width:35px;height:35px;border-radius:10px;font-size:16px}.pipe-stage strong{font-size:11px;display:block}.pipe-stage small{font-size:9px;color:var(--muted)}.badge{font-size:9px;padding:3px 6px;border-radius:999px;background:#f0f2f5;color:var(--muted)}.connector{text-align:center;height:11px;color:#98a2b3;font-size:12px;line-height:11px}
+.entity-grid{display:grid;grid-template-columns:1fr 1fr;gap:9px}.entity{border:1px solid var(--line);border-radius:11px;overflow:hidden}.entity h4{margin:0;padding:8px 10px;background:#172033;color:white;font-size:11px}.entity ul{list-style:none;margin:0;padding:6px 9px}.entity li{display:flex;justify-content:space-between;gap:8px;border-bottom:1px solid #edf0f4;padding:5px 0;font-size:9px}.entity li:last-child{border:0}.entity code{color:var(--muted)}.relation-note{margin-top:9px;padding:8px;border-left:3px solid var(--purple);background:var(--purple-soft);font-size:10px}
+.matrix{width:100%;border-collapse:separate;border-spacing:0;font-size:10px;overflow:hidden;border:1px solid var(--line);border-radius:11px}.matrix th,.matrix td{padding:8px;border-right:1px solid var(--line);border-bottom:1px solid var(--line);text-align:center}.matrix th:first-child,.matrix td:first-child{text-align:left;font-weight:700}.matrix th{background:#f7f9fc}.matrix tr:last-child td{border-bottom:0}.matrix th:last-child,.matrix td:last-child{border-right:0}.score{display:inline-grid;place-items:center;width:22px;height:22px;border-radius:7px;font-weight:800}.score.good{background:var(--green-soft);color:var(--green)}.score.mid{background:var(--amber-soft);color:var(--amber)}.score.bad{background:var(--red-soft);color:var(--red)}
+.timeline{position:relative;margin-left:8px;padding-left:22px;border-left:2px solid #d9dee8}.event{position:relative;padding:0 0 17px}.event:last-child{padding-bottom:2px}.event:before{content:"";position:absolute;left:-29px;top:3px;width:11px;height:11px;border-radius:50%;background:white;border:3px solid var(--blue)}.event.done:before{border-color:var(--green);background:var(--green)}.event.next:before{border-color:var(--amber)}.event strong{display:block;font-size:11px}.event time{font-size:9px;color:var(--muted)}.event p{font-size:10px;color:var(--muted);margin:3px 0}
+.codeblock{background:#111827;color:#d8dee9;border-radius:12px;padding:13px;overflow:auto;font:10px/1.6 SFMono-Regular,Consolas,monospace;white-space:pre}.rules{margin:0;padding:0;list-style:none;counter-reset:rule}.rules li{counter-increment:rule;position:relative;padding:8px 8px 8px 34px;border-bottom:1px solid #edf0f4;font-size:10px}.rules li:last-child{border:0}.rules li:before{content:counter(rule);position:absolute;left:2px;top:7px;display:grid;place-items:center;width:21px;height:21px;border-radius:7px;background:#172033;color:white;font-size:9px;font-weight:800}
+.footer{text-align:center;color:var(--muted);font-size:9px;padding:18px 5px}.wide-only{display:none}
+@media(min-width:680px){.summary-grid{grid-template-columns:repeat(4,1fr)}.report{padding-bottom:30px}.diagram-viewport{height:470px}.wide-only{display:inline}}
+@media(max-width:420px){.hero h1{font-size:22px}.card{padding:12px}.entity-grid{grid-template-columns:1fr}.diagram-viewport{height:390px}.top-actions .optional{display:none}}
+@media print{.topbar,.quicknav,.progress,.diagram-bar,.diagram-note{display:none}.report{max-width:none}.card,.hero{break-inside:avoid;box-shadow:none}.diagram-viewport{height:auto;overflow:visible;background:none}.diagram-canvas{transform:none!important}.diagram-canvas svg{height:auto}.section{page-break-inside:avoid}}
+</style>
+</head>
+<body>
+<div class="progress" id="progress"></div>
+<div class="report">
+<header class="topbar">
+  <div class="mark">K</div>
+  <div class="title-wrap"><strong>HTML Report Template Showcase</strong><small>Side-panel optimized · self-contained</small></div>
+  <div class="top-actions">
+    <button class="icon-btn optional" onclick="window.print()">Print</button>
+    <button class="icon-btn" onclick="document.documentElement.requestFullscreen?.()">Full</button>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="eyebrow">Kraki Artifact Standard · Draft 01</div>
+  <h1>复杂技术内容，也应该在窄侧栏里清晰可读</h1>
+  <p>这个样例同时展示固定版式、信息层级与多种图形语言。复杂图支持本地缩放和拖动，文字类内容保持纵向阅读节奏。</p>
+  <div class="meta"><span>静态单文件</span><span>无外部依赖</span><span>SVG 可交互</span><span>打印友好</span></div>
+</section>
+
+<nav class="quicknav" aria-label="Report sections">
+  <a href="#summary">摘要</a><a href="#architecture">架构 Flow</a><a href="#sequence">Sequence</a><a href="#state">状态机</a><a href="#pipeline">数据管道</a><a href="#data">ER 模型</a><a href="#decision">决策矩阵</a><a href="#roadmap">时间线</a><a href="#template">LLM 规则</a>
+</nav>
+
+<main>
+<section class="section" id="summary">
+  <div class="section-head"><span class="num">01</span><div><h2>执行摘要</h2><p>先给结论，再提供证据和细节。</p></div></div>
+  <div class="card">
+    <div class="summary-grid">
+      <div class="metric blue"><strong>4</strong><span>核心服务</span></div>
+      <div class="metric green"><strong>99.9%</strong><span>目标可用性</span></div>
+      <div class="metric amber"><strong>180ms</strong><span>P95 延迟</span></div>
+      <div class="metric purple"><strong>3</strong><span>交付阶段</span></div>
+    </div>
+  </div>
+  <div class="callout"><div class="glyph">💡</div><div><strong>推荐结论</strong><p>将报告写成纵向叙事：摘要 → 总图 → 局部流程 → 状态与数据 → 决策和行动项。避免在侧栏中并排放置大段文本。</p></div></div>
+</section>
+
+<section class="section" id="architecture">
+  <div class="section-head"><span class="num">02</span><div><h2>系统架构 Flow</h2><p>适合系统边界、服务关系和主要请求路径。</p></div></div>
+  <div class="card">
+    <h3>Marketplace Request Architecture</h3><p>这类复杂总图应使用 SVG，并提供缩放、拖动和 Fit。下方图可直接交互。</p>
+    <div class="diagram-shell" data-panzoom>
+      <div class="diagram-bar"><strong>Architecture overview</strong><span>拖动画布 · 滚轮缩放</span><button class="zoom-btn" data-action="out">−</button><button class="zoom-btn" data-action="reset">↺</button><button class="zoom-btn" data-action="fit">Fit</button><button class="zoom-btn" data-action="in">＋</button></div>
+      <div class="diagram-viewport">
+        <div class="diagram-canvas">
+          <svg viewBox="0 0 720 760" role="img" aria-label="Marketplace architecture flow diagram">
+            <defs>
+              <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#7b8798"/></marker>
+              <filter id="shadow"><feDropShadow dx="0" dy="3" stdDeviation="4" flood-opacity=".12"/></filter>
+            </defs>
+            <rect x="22" y="18" width="676" height="118" rx="18" fill="#f0ecff" stroke="#c8baff"/>
+            <text x="42" y="43" font-size="12" font-weight="800" fill="#6549b8">CLIENT LAYER</text>
+            <g class="flow-node" filter="url(#shadow)"><rect x="55" y="62" width="170" height="48" rx="12" fill="white" stroke="#7857d8"/><text x="140" y="83" text-anchor="middle" font-size="12" font-weight="700">Buyer Web</text><text x="140" y="99" text-anchor="middle" font-size="9" fill="#667085">Next.js · Search · Checkout</text></g>
+            <g class="flow-node" filter="url(#shadow)"><rect x="275" y="62" width="170" height="48" rx="12" fill="white" stroke="#7857d8"/><text x="360" y="83" text-anchor="middle" font-size="12" font-weight="700">Supplier Console</text><text x="360" y="99" text-anchor="middle" font-size="9" fill="#667085">Offers · Capacity · Payout</text></g>
+            <g class="flow-node" filter="url(#shadow)"><rect x="495" y="62" width="170" height="48" rx="12" fill="white" stroke="#7857d8"/><text x="580" y="83" text-anchor="middle" font-size="12" font-weight="700">Operations</text><text x="580" y="99" text-anchor="middle" font-size="9" fill="#667085">Risk · Pricing · Support</text></g>
+
+            <rect x="22" y="166" width="676" height="190" rx="18" fill="#eaf2ff" stroke="#b7d0ff"/>
+            <text x="42" y="191" font-size="12" font-weight="800" fill="#1857ba">CONTROL PLANE</text>
+            <g class="flow-node"><rect x="65" y="216" width="180" height="54" rx="12" fill="white" stroke="#2878ff"/><text x="155" y="239" text-anchor="middle" font-size="12" font-weight="700">API Gateway</text><text x="155" y="256" text-anchor="middle" font-size="9" fill="#667085">Auth · Rate limit · Routing</text></g>
+            <g class="flow-node"><rect x="270" y="216" width="180" height="54" rx="12" fill="white" stroke="#2878ff"/><text x="360" y="239" text-anchor="middle" font-size="12" font-weight="700">Marketplace API</text><text x="360" y="256" text-anchor="middle" font-size="9" fill="#667085">Orders · Offers · Matching</text></g>
+            <g class="flow-node"><rect x="475" y="216" width="180" height="54" rx="12" fill="white" stroke="#2878ff"/><text x="565" y="239" text-anchor="middle" font-size="12" font-weight="700">Policy Engine</text><text x="565" y="256" text-anchor="middle" font-size="9" fill="#667085">Eligibility · Risk · Price</text></g>
+            <g class="flow-node"><rect x="168" y="292" width="180" height="44" rx="12" fill="#dbe8ff" stroke="#2878ff"/><text x="258" y="318" text-anchor="middle" font-size="11" font-weight="700">Identity & RBAC</text></g>
+            <g class="flow-node"><rect x="372" y="292" width="180" height="44" rx="12" fill="#dbe8ff" stroke="#2878ff"/><text x="462" y="318" text-anchor="middle" font-size="11" font-weight="700">Audit & Metering</text></g>
+
+            <rect x="22" y="386" width="676" height="176" rx="18" fill="#e8f7f0" stroke="#a9dfc5"/>
+            <text x="42" y="411" font-size="12" font-weight="800" fill="#08794a">EXECUTION PLANE</text>
+            <g class="flow-node"><rect x="65" y="438" width="180" height="54" rx="12" fill="white" stroke="#169b62"/><text x="155" y="461" text-anchor="middle" font-size="12" font-weight="700">Matching Worker</text><text x="155" y="478" text-anchor="middle" font-size="9" fill="#667085">Rank · Reserve · Retry</text></g>
+            <g class="flow-node"><rect x="270" y="438" width="180" height="54" rx="12" fill="white" stroke="#169b62"/><text x="360" y="461" text-anchor="middle" font-size="12" font-weight="700">Provisioner</text><text x="360" y="478" text-anchor="middle" font-size="9" fill="#667085">Allocate · Start · Observe</text></g>
+            <g class="flow-node"><rect x="475" y="438" width="180" height="54" rx="12" fill="white" stroke="#169b62"/><text x="565" y="461" text-anchor="middle" font-size="12" font-weight="700">Settlement Worker</text><text x="565" y="478" text-anchor="middle" font-size="9" fill="#667085">Usage · Ledger · Payout</text></g>
+            <g class="flow-node"><rect x="168" y="512" width="180" height="34" rx="10" fill="#d9f2e6" stroke="#169b62"/><text x="258" y="533" text-anchor="middle" font-size="10" font-weight="700">Queue / Event Bus</text></g>
+            <g class="flow-node"><rect x="372" y="512" width="180" height="34" rx="10" fill="#d9f2e6" stroke="#169b62"/><text x="462" y="533" text-anchor="middle" font-size="10" font-weight="700">Scheduler / Reconciler</text></g>
+
+            <rect x="22" y="592" width="676" height="140" rx="18" fill="#fff5df" stroke="#f0d28c"/>
+            <text x="42" y="617" font-size="12" font-weight="800" fill="#9a5d00">DATA & INFRASTRUCTURE</text>
+            <g class="flow-node"><path d="M78 650Q78 638 98 638H222Q242 638 242 650V690Q242 702 222 702H98Q78 702 78 690Z" fill="white" stroke="#d98200"/><ellipse cx="160" cy="650" rx="82" ry="12" fill="#fff8ea" stroke="#d98200"/><text x="160" y="674" text-anchor="middle" font-size="11" font-weight="700">PostgreSQL</text><text x="160" y="689" text-anchor="middle" font-size="9" fill="#667085">Orders · Ledger · Audit</text></g>
+            <g class="flow-node"><path d="M278 650Q278 638 298 638H422Q442 638 442 650V690Q442 702 422 702H298Q278 702 278 690Z" fill="white" stroke="#d98200"/><ellipse cx="360" cy="650" rx="82" ry="12" fill="#fff8ea" stroke="#d98200"/><text x="360" y="674" text-anchor="middle" font-size="11" font-weight="700">Redis</text><text x="360" y="689" text-anchor="middle" font-size="9" fill="#667085">Cache · Locks · Streams</text></g>
+            <g class="flow-node"><path d="M478 650Q478 638 498 638H622Q642 638 642 650V690Q642 702 622 702H498Q478 702 478 690Z" fill="white" stroke="#d98200"/><ellipse cx="560" cy="650" rx="82" ry="12" fill="#fff8ea" stroke="#d98200"/><text x="560" y="674" text-anchor="middle" font-size="11" font-weight="700">Object Storage</text><text x="560" y="689" text-anchor="middle" font-size="9" fill="#667085">Reports · Exports · Evidence</text></g>
+
+            <path class="edge" d="M140 110V145H155V216"/><path class="edge" d="M360 110V145H155V216"/><path class="edge" d="M580 110V145H155V216"/>
+            <path class="edge" d="M245 243H270"/><path class="edge" d="M450 243H475"/><path class="edge dashed" d="M360 270V292"/><path class="edge dashed" d="M565 270V314H552"/>
+            <path class="edge" d="M360 336V370H155V438"/><path class="edge" d="M360 336V438"/><path class="edge" d="M462 336V370H565V438"/>
+            <path class="edge" d="M155 492V529H168"/><path class="edge" d="M360 492V512"/><path class="edge" d="M565 492V529H552"/>
+            <path class="edge" d="M258 546V576H160V638"/><path class="edge" d="M360 546V638"/><path class="edge" d="M462 546V576H560V638"/>
+          </svg>
+        </div>
+      </div>
+      <div class="diagram-note">建议：总图最多 4 个层级、每层 3–5 个节点；边使用单一方向；颜色表达边界，不表达装饰。</div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="sequence">
+  <div class="section-head"><span class="num">03</span><div><h2>Sequence Diagram</h2><p>适合展示跨服务时序、同步与异步边界。</p></div></div>
+  <div class="card">
+    <h3>Order placement happy path</h3><p>窄侧栏中允许局部横向滚动，不应压缩到文字不可读。</p>
+    <div class="sequence">
+      <div class="sequence-grid">
+        <div><div class="actor user">Buyer</div><div class="lifeline"></div></div>
+        <div><div class="actor web">Web App</div><div class="lifeline"></div></div>
+        <div><div class="actor api">Marketplace API</div><div class="lifeline"></div></div>
+        <div><div class="actor db">Ledger DB</div><div class="lifeline"></div></div>
+        <div class="messages">
+          <div class="message" style="left:8%;width:25%;top:12px">1. Submit order</div>
+          <div class="message" style="left:33%;width:25%;top:54px">2. Validate + reserve</div>
+          <div class="message" style="left:58%;width:25%;top:96px">3. Create hold</div>
+          <div class="message return" style="left:58%;width:25%;top:138px">4. hold_id</div>
+          <div class="message return" style="left:33%;width:25%;top:180px">5. order accepted</div>
+          <div class="message return" style="left:8%;width:25%;top:222px">6. Show confirmation</div>
+          <div class="activation" style="left:49.4%;top:45px;height:173px"></div>
+          <div class="activation" style="left:74.4%;top:88px;height:89px;background:#ffe7b5;border-color:#d9a33d"></div>
+        </div>
+      </div>
+    </div>
+    <div class="sequence-caption">虚线代表返回；激活条表示服务正在处理。失败分支应拆到独立小节，避免一张图承载所有异常。</div>
+  </div>
+</section>
+
+<section class="section" id="state">
+  <div class="section-head"><span class="num">04</span><div><h2>状态机</h2><p>适合订单、任务、审批和生命周期说明。</p></div></div>
+  <div class="card">
+    <h3>Order lifecycle</h3><p>主路径纵向排列，异常分支并排；每个状态只写进入条件和核心动作。</p>
+    <div class="state-flow">
+      <div class="state idle"><strong>Draft</strong><p>用户编辑需求，尚未占用资源。</p></div>
+      <div class="state active"><strong>Reserved</strong><p>锁定预算与候选供给，等待 provisioning。</p></div>
+      <div class="branch"><div class="state done"><strong>Running</strong><p>资源已交付，持续记录 usage。</p></div><div class="state error"><strong>Reservation Failed</strong><p>释放 hold，返回可重试原因。</p></div></div>
+      <div class="state review"><strong>Settling</strong><p>冻结最终 usage，执行双式记账。</p></div>
+      <div class="branch"><div class="state done"><strong>Completed</strong><p>结算完成，可生成 invoice。</p></div><div class="state error"><strong>Disputed</strong><p>冻结 payout，进入人工复核。</p></div></div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="pipeline">
+  <div class="section-head"><span class="num">05</span><div><h2>数据管道</h2><p>适合 ETL、事件流、模型推理和批处理。</p></div></div>
+  <div class="card">
+    <h3>Usage metering pipeline</h3><p>每阶段突出输入、动作和输出；状态 badge 只表达执行模式。</p>
+    <div class="pipeline">
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--blue-soft)">📥</div><div><strong>Ingest usage events</strong><small>API gateway + runtime agents</small></div><span class="badge">stream</span></div><div class="connector">↓</div>
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--purple-soft)">🧹</div><div><strong>Normalize & deduplicate</strong><small>schema validation · idempotency key</small></div><span class="badge">real-time</span></div><div class="connector">↓</div>
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--amber-soft)">🧮</div><div><strong>Price with snapshot</strong><small>rate card · currency · discount policy</small></div><span class="badge">deterministic</span></div><div class="connector">↓</div>
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--green-soft)">📒</div><div><strong>Post ledger entries</strong><small>debit buyer · credit supplier · fee</small></div><span class="badge">transactional</span></div><div class="connector">↓</div>
+      <div class="pipe-stage"><div class="pipe-icon" style="background:var(--red-soft)">🔎</div><div><strong>Reconcile & alert</strong><small>watermark · missing interval · anomaly</small></div><span class="badge">scheduled</span></div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="data">
+  <div class="section-head"><span class="num">06</span><div><h2>ER / 数据所有权</h2><p>适合展示关键实体、主外键和边界归属。</p></div></div>
+  <div class="card">
+    <h3>Core marketplace entities</h3><p>侧栏内优先使用实体卡片，不强求传统横向 ER 图。</p>
+    <div class="entity-grid">
+      <div class="entity"><h4>orders</h4><ul><li><strong>id 🔑</strong><code>uuid</code></li><li><span>buyer_org_id</span><code>uuid</code></li><li><span>status</span><code>enum</code></li><li><span>budget_minor</span><code>bigint</code></li></ul></div>
+      <div class="entity"><h4>allocations</h4><ul><li><strong>id 🔑</strong><code>uuid</code></li><li><span>order_id ↗</span><code>uuid</code></li><li><span>offer_id ↗</span><code>uuid</code></li><li><span>started_at</span><code>timestamptz</code></li></ul></div>
+      <div class="entity"><h4>usage_events</h4><ul><li><strong>event_id 🔑</strong><code>text</code></li><li><span>allocation_id ↗</span><code>uuid</code></li><li><span>quantity</span><code>decimal</code></li><li><span>occurred_at</span><code>timestamptz</code></li></ul></div>
+      <div class="entity"><h4>ledger_entries</h4><ul><li><strong>id 🔑</strong><code>uuid</code></li><li><span>usage_event_id ↗</span><code>text</code></li><li><span>account_id</span><code>uuid</code></li><li><span>amount_minor</span><code>bigint</code></li></ul></div>
+    </div>
+    <div class="relation-note"><strong>关系：</strong>order 1—N allocation 1—N usage_event 1—N ledger_entry。业务状态归 marketplace；账户余额归 ledger。</div>
+  </div>
+</section>
+
+<section class="section" id="decision">
+  <div class="section-head"><span class="num">07</span><div><h2>决策矩阵</h2><p>适合技术选型、方案比较和 trade-off。</p></div></div>
+  <div class="card">
+    <h3>Report delivery options</h3><p>评分只辅助决策，结论必须在表格后明确写出。</p>
+    <div style="overflow:auto"><table class="matrix"><thead><tr><th>方案</th><th>清晰度</th><th>缩放</th><th>远程</th><th>复杂度</th></tr></thead><tbody>
+      <tr><td>PNG 截图</td><td><span class="score mid">2</span></td><td><span class="score bad">1</span></td><td><span class="score good">3</span></td><td><span class="score good">3</span></td></tr>
+      <tr><td>Screencast</td><td><span class="score mid">2</span></td><td><span class="score bad">1</span></td><td><span class="score good">3</span></td><td><span class="score bad">1</span></td></tr>
+      <tr><td>HTML Artifact</td><td><span class="score good">3</span></td><td><span class="score good">3</span></td><td><span class="score good">3</span></td><td><span class="score mid">2</span></td></tr>
+    </tbody></table></div>
+    <div class="callout" style="margin-top:11px"><div class="glyph">✓</div><div><strong>Decision</strong><p>文档型内容统一使用 self-contained HTML Artifact；仅在必须操作动态 localhost 应用时考虑其他 transport。</p></div></div>
+  </div>
+</section>
+
+<section class="section" id="roadmap">
+  <div class="section-head"><span class="num">08</span><div><h2>Roadmap / 时间线</h2><p>适合实施计划、迁移步骤和里程碑。</p></div></div>
+  <div class="card">
+    <div class="timeline">
+      <div class="event done"><time>Phase 0 · Complete</time><strong>格式规范与 showcase</strong><p>确定窄侧栏布局、静态安全边界、可交互 SVG 约定。</p></div>
+      <div class="event"><time>Phase 1 · MVP</time><strong>HTML Artifact transport</strong><p>通过 attachment/content-ref 传输单文件 HTML，并在 sandbox iframe 中渲染。</p></div>
+      <div class="event next"><time>Phase 2 · UX</time><strong>Side panel reader controls</strong><p>面板宽度、全屏、页面缩放、目录、下载和更新恢复。</p></div>
+      <div class="event"><time>Phase 3 · Authoring</time><strong>LLM template and validation</strong><p>提供模板、生成提示词和静态检查器，保证报告质量。</p></div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="template">
+  <div class="section-head"><span class="num">09</span><div><h2>给 LLM 的生成规范</h2><p>固定约束比“做得漂亮”更容易得到稳定质量。</p></div></div>
+  <div class="card">
+    <h3>Required structure</h3>
+    <ol class="rules">
+      <li>输出单个 self-contained HTML 文件；禁止外部 CDN、字体、图片和网络请求。</li>
+      <li>正文按竖向 side panel 设计，目标宽度 420–760px；不要依赖桌面宽屏才能阅读。</li>
+      <li>开头必须有执行摘要、关键指标和明确结论；复杂细节放在后续章节。</li>
+      <li>Flow/Mermaid 最终必须转成内联 SVG；复杂 SVG 必须放入 <code>data-panzoom</code> 容器。</li>
+      <li>一张图只表达一个主题；总图最多 4 层，每层 3–5 个节点，避免交叉连线。</li>
+      <li>颜色用于表达领域或状态，全文保持同一语义；不要使用随机渐变和装饰色。</li>
+      <li>所有表格必须允许横向滚动；所有代码块必须可滚动，不能撑破页面。</li>
+      <li>必须包含结论、风险、未决问题或下一步，不能只给图而没有解释。</li>
+    </ol>
+  </div>
+  <div class="card">
+    <h3>Suggested prompt fragment</h3>
+    <div class="codeblock">Create a single self-contained HTML technical report.
+Target a vertical side panel between 420px and 760px wide.
+Use a clear hierarchy: executive summary, overview diagram,
+detailed flows, state/data model, decisions, risks, next steps.
+Render Mermaid to inline SVG before final output.
+Wrap complex SVG diagrams in the provided data-panzoom component.
+Do not use external scripts, styles, fonts, images, or network calls.
+Keep text selectable and diagrams locally zoomable and pannable.
+Use colors consistently to communicate domain boundaries or state.</div>
+  </div>
+</section>
+
+<div class="footer">Kraki HTML Artifact Template · self-contained reference report</div>
+</main>
+</div>
+<script>
+(() => {
+  const progress = document.getElementById('progress');
+  const updateProgress = () => {
+    const max = document.documentElement.scrollHeight - innerHeight;
+    progress.style.width = `${max > 0 ? (scrollY / max) * 100 : 0}%`;
+  };
+  addEventListener('scroll', updateProgress, { passive: true }); updateProgress();
+
+  document.querySelectorAll('[data-panzoom]').forEach((shell) => {
+    const viewport = shell.querySelector('.diagram-viewport');
+    const canvas = shell.querySelector('.diagram-canvas');
+    let scale = 1, x = 0, y = 0, dragging = false, startX = 0, startY = 0;
+    const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+    const render = () => { canvas.style.transform = `translate(${x}px,${y}px) scale(${scale})`; };
+    const setScale = (next, cx = viewport.clientWidth / 2, cy = viewport.clientHeight / 2) => {
+      next = clamp(next, .55, 3.5);
+      const ratio = next / scale;
+      x = cx - (cx - x) * ratio; y = cy - (cy - y) * ratio; scale = next; render();
+    };
+    const reset = () => { scale = 1; x = 0; y = 0; render(); };
+    const fit = () => { scale = 1; x = 0; y = 0; render(); };
+    shell.querySelector('[data-action="in"]').onclick = () => setScale(scale * 1.2);
+    shell.querySelector('[data-action="out"]').onclick = () => setScale(scale / 1.2);
+    shell.querySelector('[data-action="reset"]').onclick = reset;
+    shell.querySelector('[data-action="fit"]').onclick = fit;
+    viewport.addEventListener('wheel', (event) => {
+      event.preventDefault();
+      const rect = viewport.getBoundingClientRect();
+      setScale(scale * (event.deltaY < 0 ? 1.12 : .89), event.clientX - rect.left, event.clientY - rect.top);
+    }, { passive: false });
+    viewport.addEventListener('pointerdown', (event) => {
+      dragging = true; startX = event.clientX - x; startY = event.clientY - y;
+      viewport.classList.add('dragging'); viewport.setPointerCapture(event.pointerId);
+    });
+    viewport.addEventListener('pointermove', (event) => {
+      if (!dragging) return; x = event.clientX - startX; y = event.clientY - startY; render();
+    });
+    const stop = () => { dragging = false; viewport.classList.remove('dragging'); };
+    viewport.addEventListener('pointerup', stop); viewport.addEventListener('pointercancel', stop);
+    render();
+  });
+})();
+</script>
+</body>
+</html>

--- a/packages/arm/web/src/components/chat/ChatView.test.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { act, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { useStore } from '../../hooks/useStore';
 import { ChatView } from './ChatView';
 import type { ChatMessage } from '../../types/store';
+import type { ContentRef } from '@kraki/protocol';
 import { messageProvider } from '../../lib/message-provider';
 
 vi.mock('../../lib/ws-client', () => ({
@@ -19,12 +20,12 @@ vi.mock('../../lib/ws-client', () => ({
   },
 }));
 
-function renderChatView(sessionId?: string) {
+function renderChatView(sessionId?: string, onOpenArtifact?: (artifact: ContentRef) => void) {
   const route = sessionId ? `/session/${sessionId}` : '/session/none';
   return render(
     <MemoryRouter initialEntries={[route]}>
       <Routes>
-        <Route path="/session/:sessionId" element={<ChatView />} />
+        <Route path="/session/:sessionId" element={<ChatView onOpenArtifact={onOpenArtifact} />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -271,7 +272,74 @@ describe('ChatView', () => {
     expect(within(reply as HTMLElement).getAllByText('One image')).toHaveLength(1);
   });
 
-  it('requests the latest final bubble trace on open so images recover after reload', async () => {
+  it('renders each turn HTML report in its concluding bubble and opens the selected report', () => {
+    const onOpen = vi.fn();
+    const first = { type: 'content_ref' as const, id: 'report-1', mimeType: 'text/html', size: 2048, name: 'first.html', caption: 'First report' };
+    const second = { type: 'content_ref' as const, id: 'report-2', mimeType: 'text/html', size: 4096, name: 'second.html', caption: 'Second report' };
+    useStore.getState().setSessions([
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 4 },
+    ]);
+    const messages: ChatMessage[] = [
+      { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'First' } } as ChatMessage,
+      { type: 'tool_complete', deviceId: 'd1', seq: 1.5, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [first] } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'First reply' } } as ChatMessage,
+      { type: 'user_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { content: 'Second' } } as ChatMessage,
+      { type: 'tool_complete', deviceId: 'd1', seq: 3.5, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [second] } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1', payload: { content: 'Second reply' } } as ChatMessage,
+    ];
+    for (const message of messages) useStore.getState().appendMessage('s1', message);
+
+    renderChatView('s1', onOpen);
+
+    const firstReply = screen.getByText('First reply').closest('.rounded-2xl');
+    const secondReply = screen.getByText('Second reply').closest('.rounded-2xl');
+    expect(within(firstReply as HTMLElement).getByText('First report')).toBeInTheDocument();
+    expect(within(firstReply as HTMLElement).queryByText('Second report')).not.toBeInTheDocument();
+    expect(within(secondReply as HTMLElement).getByText('Second report')).toBeInTheDocument();
+    fireEvent.click(within(firstReply as HTMLElement).getByRole('button', { name: 'Open report First report' }));
+    expect(onOpen).toHaveBeenCalledWith(first);
+  });
+
+  it('renders an HTML report attached directly to the final agent message', () => {
+    const report = { type: 'content_ref' as const, id: 'direct-report', mimeType: 'text/html', size: 512, name: 'direct.html' };
+    useStore.getState().setSessions([
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 2 },
+    ]);
+    useStore.getState().appendMessage('s1', {
+      type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1',
+      payload: { content: 'Report' },
+    } as ChatMessage);
+    useStore.getState().appendMessage('s1', {
+      type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1',
+      payload: { content: 'Direct report', attachments: [report] },
+    } as ChatMessage);
+
+    renderChatView('s1', vi.fn());
+
+    expect(screen.getByRole('button', { name: 'Open report direct.html' })).toBeInTheDocument();
+  });
+
+  it('renders multiple HTML reports from one turn without duplicates', () => {
+    const first = { type: 'content_ref' as const, id: 'report-1', mimeType: 'text/html', size: 100, name: 'first.html' };
+    const second = { type: 'content_ref' as const, id: 'report-2', mimeType: 'text/html', size: 200, name: 'second.html' };
+    useStore.getState().setSessions([
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 2 },
+    ]);
+    const messages: ChatMessage[] = [
+      { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'Reports' } } as ChatMessage,
+      { type: 'tool_complete', deviceId: 'd1', seq: 1.2, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [first, second] } } as ChatMessage,
+      { type: 'tool_complete', deviceId: 'd1', seq: 1.4, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [first] } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'Both reports' } } as ChatMessage,
+    ];
+    for (const message of messages) useStore.getState().appendMessage('s1', message);
+
+    renderChatView('s1', vi.fn());
+
+    expect(screen.getAllByText('first.html')).toHaveLength(1);
+    expect(screen.getByText('second.html')).toBeInTheDocument();
+  });
+
+  it('requests every historical final bubble trace on open so artifacts recover after reload', async () => {
     const spy = vi.spyOn(messageProvider, 'requestTurnTrace').mockImplementation(() => {});
     useStore.getState().setDevices([
       { id: 'd1', name: 'Mac', role: 'tentacle', online: true, encryptionKey: 'key' },
@@ -279,18 +347,22 @@ describe('ChatView', () => {
     useStore.getState().setSessions([
       { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 2 },
     ]);
-    useStore.getState().appendMessage('s1', {
-      type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1',
-      payload: { content: 'Show it' },
-    } as ChatMessage);
-    useStore.getState().appendMessage('s1', {
-      type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1',
-      payload: { content: 'Final reply', steps: 1 },
-    } as ChatMessage);
+    const messages: ChatMessage[] = [
+      { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'First' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 1.5, timestamp: '', sessionId: 's1', payload: { content: 'Intermediate reply', steps: 1 } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'First reply', steps: 1 } } as ChatMessage,
+      { type: 'user_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { content: 'Second' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1', payload: { content: 'Second reply', steps: 2 } } as ChatMessage,
+    ];
+    for (const message of messages) useStore.getState().appendMessage('s1', message);
 
     renderChatView('s1');
 
-    await vi.waitFor(() => expect(spy).toHaveBeenCalledWith('s1', 2));
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledWith('s1', 2);
+      expect(spy).toHaveBeenCalledWith('s1', 4);
+      expect(spy).not.toHaveBeenCalledWith('s1', 1.5);
+    });
     spy.mockRestore();
   });
 

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -7,7 +7,7 @@ import { MessageInput } from './MessageInput';
 import { useScrollController } from '../../hooks/useScrollController';
 import { messageProvider } from '../../lib/message-provider';
 import { getSessionStatus, cardActionKey } from '../../lib/session-status';
-import type { Attachment } from '@kraki/protocol';
+import type { Attachment, ContentRef } from '@kraki/protocol';
 import type { ChatMessage } from '../../types/store';
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
@@ -30,10 +30,11 @@ function attachmentKey(attachment: Attachment): string {
 /** Images produced by show_image/tool steps in the turn concluding at
  *  `bubbleSeq`. They stay on the TRACE axis for history, but are also rendered
  *  inside that turn's final agent bubble. */
-export function collectTurnImages(
+function collectTurnAttachments(
   messages: ChatMessage[],
   bubbleSeq: number,
-  directAttachments: Attachment[] = [],
+  directAttachments: Attachment[],
+  matches: (attachment: Attachment) => boolean,
 ): Attachment[] {
   const directKeys = new Set(directAttachments.map(attachmentKey));
   const targetIdx = messages.findIndex((message) => getSeq(message) === bubbleSeq);
@@ -46,24 +47,50 @@ export function collectTurnImages(
     }
   }
   const seen = new Set<string>();
-  const images: Attachment[] = [];
+  const attachments: Attachment[] = [];
   for (let i = turnStartIdx + 1; i < targetIdx; i++) {
     const step = messages[i];
     if (step.type !== 'tool_complete') continue;
     for (const attachment of step.payload.attachments ?? []) {
-      const isImage = attachment.type === 'image' ||
-        (attachment.type === 'content_ref' && attachment.mimeType.startsWith('image/'));
-      if (!isImage) continue;
+      if (!matches(attachment)) continue;
       const key = attachmentKey(attachment);
       if (directKeys.has(key) || seen.has(key)) continue;
       seen.add(key);
-      images.push(attachment);
+      attachments.push(attachment);
     }
   }
-  return images;
+  return attachments;
 }
 
-export const ChatView = memo(function ChatView() {
+/** Images produced by tool steps in the turn concluding at `bubbleSeq`. */
+export function collectTurnImages(
+  messages: ChatMessage[],
+  bubbleSeq: number,
+  directAttachments: Attachment[] = [],
+): Attachment[] {
+  return collectTurnAttachments(messages, bubbleSeq, directAttachments, (attachment) =>
+    attachment.type === 'image' ||
+    (attachment.type === 'content_ref' && attachment.mimeType.startsWith('image/')),
+  );
+}
+
+/** HTML reports produced by show_html in the turn concluding at `bubbleSeq`. */
+export function collectTurnHtmlArtifacts(
+  messages: ChatMessage[],
+  bubbleSeq: number,
+  directAttachments: Attachment[] = [],
+): ContentRef[] {
+  const directArtifacts = directAttachments.filter(
+    (attachment): attachment is ContentRef =>
+      attachment.type === 'content_ref' && attachment.mimeType === 'text/html',
+  );
+  const tracedArtifacts = collectTurnAttachments(messages, bubbleSeq, directAttachments, (attachment) =>
+    attachment.type === 'content_ref' && attachment.mimeType === 'text/html',
+  ) as ContentRef[];
+  return [...directArtifacts, ...tracedArtifacts];
+}
+
+export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtifact?: (artifact: ContentRef) => void }) {
   const { sessionId } = useParams<{ sessionId: string }>();
   const messages = useStore((s) => sessionId ? s.messages.get(sessionId) : undefined) ?? EMPTY_MESSAGES;
   const session = useStore((s) => (sessionId ? s.sessions.get(sessionId) : undefined));
@@ -111,16 +138,19 @@ export const ChatView = memo(function ChatView() {
     if (lastAgentSeq > 0) seqs.add(lastAgentSeq);
     return seqs;
   }, [spine]);
-  const turnImagesByBubbleSeq = useMemo(() => {
-    const bySeq = new Map<number, Attachment[]>();
+  const turnAttachmentsByBubbleSeq = useMemo(() => {
+    const images = new Map<number, Attachment[]>();
+    const artifacts = new Map<number, ContentRef[]>();
     for (const msg of spine) {
       if (msg.type !== 'agent_message') continue;
       const seq = getSeq(msg);
       if (!finalAgentSeqs.has(seq)) continue;
-      const images = collectTurnImages(messages, seq, msg.payload.attachments);
-      if (images.length > 0) bySeq.set(seq, images);
+      const turnImages = collectTurnImages(messages, seq, msg.payload.attachments);
+      const turnArtifacts = collectTurnHtmlArtifacts(messages, seq, msg.payload.attachments);
+      if (turnImages.length > 0) images.set(seq, turnImages);
+      if (turnArtifacts.length > 0) artifacts.set(seq, turnArtifacts);
     }
-    return bySeq;
+    return { images, artifacts };
   }, [finalAgentSeqs, messages, spine]);
 
   // Derived human-facing status decides card visibility.
@@ -178,15 +208,13 @@ export const ChatView = memo(function ChatView() {
 
   useEffect(() => {
     if (!sessionId || !isTentacleEncryptable) return;
-    for (let i = spine.length - 1; i >= 0; i--) {
-      const msg = spine[i];
-      if (msg.type === 'agent_message') {
-        if ((msg.payload.steps ?? 0) > 0) messageProvider.requestTurnTrace(sessionId, getSeq(msg));
-        break;
+    for (const msg of spine) {
+      const seq = getSeq(msg);
+      if (msg.type === 'agent_message' && finalAgentSeqs.has(seq) && (msg.payload.steps ?? 0) > 0) {
+        messageProvider.requestTurnTrace(sessionId, seq);
       }
-      if (msg.type === 'user_message') break;
     }
-  }, [sessionId, isTentacleEncryptable, spine]);
+  }, [sessionId, isTentacleEncryptable, finalAgentSeqs, spine]);
 
   // `idle` here is the message-level marker (last spine entry is an idle
   // event), used by the scroll controller for the working→idle reposition. It
@@ -267,7 +295,9 @@ export const ChatView = memo(function ChatView() {
                   message={msg}
                   agent={session.agent}
                   sessionId={sessionId}
-                  turnImages={msg.type === 'agent_message' ? turnImagesByBubbleSeq.get(getSeq(msg)) : undefined}
+                  turnImages={msg.type === 'agent_message' ? turnAttachmentsByBubbleSeq.images.get(getSeq(msg)) : undefined}
+                  turnArtifacts={msg.type === 'agent_message' ? turnAttachmentsByBubbleSeq.artifacts.get(getSeq(msg)) : undefined}
+                  onOpenArtifact={onOpenArtifact}
                 />
               </div>
             ))}

--- a/packages/arm/web/src/components/chat/HtmlArtifactPanel.test.tsx
+++ b/packages/arm/web/src/components/chat/HtmlArtifactPanel.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { HtmlArtifactPanel } from './HtmlArtifactPanel';
+
+vi.mock('../../hooks/useAttachment', () => ({
+  useAttachmentText: () => ({ status: 'loading', text: null, error: null }),
+}));
+
+const artifact = {
+  type: 'content_ref' as const,
+  id: 'report-1',
+  mimeType: 'text/html',
+  size: 2048,
+  name: 'architecture.html',
+  caption: 'Architecture Report',
+};
+
+describe('HtmlArtifactPanel', () => {
+  it('renders the selected artifact title, requests panel fullscreen, and closes', () => {
+    const onClose = vi.fn();
+    render(<HtmlArtifactPanel artifact={artifact} sessionId="s1" onClose={onClose} />);
+
+    expect(screen.getByText('Architecture Report')).toBeInTheDocument();
+    expect(screen.getByText('Loading report…')).toBeInTheDocument();
+    const panel = screen.getByRole('complementary', { name: 'HTML report preview' });
+    const requestFullscreen = vi.fn();
+    Object.defineProperty(panel, 'requestFullscreen', { value: requestFullscreen });
+    fireEvent.click(screen.getByRole('button', { name: 'Fullscreen report' }));
+    expect(requestFullscreen).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole('button', { name: 'Close report preview' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/arm/web/src/components/chat/HtmlArtifactPanel.tsx
+++ b/packages/arm/web/src/components/chat/HtmlArtifactPanel.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ContentRef } from '@kraki/protocol';
+import { useAttachmentText } from '../../hooks/useAttachment';
+import { X, Maximize2, FileCode2, LoaderCircle, AlertTriangle } from 'lucide-react';
+
+const ATTACHMENT_PULL = (sessionId: string, id: string): void => {
+  void import('../../lib/ws-client').then(({ wsClient }) => {
+    wsClient.requestAttachment(sessionId, id);
+  });
+};
+
+function withArtifactCsp(html: string): string {
+  const csp = '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; frame-src \'none\'; form-action \'none\'; connect-src \'none\'; img-src data: blob:; style-src \'unsafe-inline\'; script-src \'unsafe-inline\'; font-src data:;">';
+  const cspPattern = /<meta[^>]+http-equiv=["']Content-Security-Policy["'][^>]*>/gi;
+  if (cspPattern.test(html)) return html.replace(cspPattern, csp);
+  if (/<head[^>]*>/i.test(html)) return html.replace(/<head[^>]*>/i, (head) => `${head}${csp}`);
+  return `${csp}${html}`;
+}
+
+function ArtifactFrame({ artifact, sessionId }: { artifact: ContentRef; sessionId: string }) {
+  const { status, text, error } = useAttachmentText(artifact, sessionId, ATTACHMENT_PULL);
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (status !== 'ready' || text === null) {
+      setUrl(null);
+      return undefined;
+    }
+    const blobUrl = URL.createObjectURL(new Blob([withArtifactCsp(text)], { type: 'text/html' }));
+    setUrl(blobUrl);
+    return () => URL.revokeObjectURL(blobUrl);
+  }, [artifact.id, status, text]);
+
+  if (status === 'error') {
+    return <div className="flex flex-1 items-center justify-center p-6 text-center text-xs text-text-secondary"><AlertTriangle className="mb-2 size-5 text-amber-500" /><p>Could not load this report.<br /><span className="text-[10px] text-text-muted">{error}</span></p></div>;
+  }
+  if (!url) {
+    return <div className="flex flex-1 items-center justify-center gap-2 text-xs text-text-secondary"><LoaderCircle className="size-4 animate-spin" />Loading report…</div>;
+  }
+  return <iframe title={artifact.caption || artifact.name || 'HTML report'} src={url} sandbox="allow-scripts" referrerPolicy="no-referrer" className="min-h-0 flex-1 border-0 bg-white" />;
+}
+
+export function HtmlArtifactPanel({ artifact, sessionId, onClose }: { artifact: ContentRef; sessionId: string; onClose: () => void }) {
+  const title = artifact.caption || artifact.name || 'HTML report';
+  const panelRef = useRef<HTMLElement>(null);
+  return (
+    <aside ref={panelRef} className="fixed inset-0 z-40 flex flex-col bg-surface-primary md:static md:h-full md:w-[min(48vw,680px)] md:shrink-0 md:border-l md:border-border-primary md:shadow-none fullscreen:h-screen fullscreen:w-screen fullscreen:max-w-none fullscreen:border-0" aria-label="HTML report preview">
+      <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border-primary px-3">
+        <FileCode2 className="size-4 shrink-0 text-kraki-500" />
+        <span className="min-w-0 flex-1 truncate text-xs font-semibold text-text-primary">{title}</span>
+        <button type="button" onClick={() => panelRef.current?.requestFullscreen?.()} className="rounded-md p-1.5 text-text-muted hover:bg-surface-tertiary hover:text-text-primary" aria-label="Fullscreen report" title="Fullscreen">
+          <Maximize2 className="size-4" />
+        </button>
+        <button type="button" onClick={onClose} className="rounded-md p-1.5 text-text-muted hover:bg-surface-tertiary hover:text-text-primary" aria-label="Close report preview" title="Close">
+          <X className="size-4" />
+        </button>
+      </div>
+      <ArtifactFrame artifact={artifact} sessionId={sessionId} />
+    </aside>
+  );
+}

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -1,13 +1,13 @@
 import Markdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
-import type { PermissionRequest as ProtocolPermissionRequest, QuestionRequest as ProtocolQuestionRequest, Attachment } from '@kraki/protocol';
+import type { PermissionRequest as ProtocolPermissionRequest, QuestionRequest as ProtocolQuestionRequest, Attachment, ContentRef } from '@kraki/protocol';
 import type { ChatMessage } from '../../types/store';
 import { formatTime, agentInfo } from '../../lib/format';
 import { stringToHue } from '../../lib/color';
 import { ToolActivity } from './ToolActivity';
 import { AgentAvatar } from '../common/AgentAvatar';
-import { Lock, Check, X, LockOpen, CircleStop, Copy, Info, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Lock, Check, X, LockOpen, CircleStop, Copy, Info, ChevronLeft, ChevronRight, FileCode2, ExternalLink } from 'lucide-react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useAttachment } from '../../hooks/useAttachment';
 import { StepsButton } from './StepsModal';
@@ -35,7 +35,7 @@ export const markdownComponents = {
   ),
 };
 
-export function MessageBubble({ message, agent, forceExpanded, turnImages, cancelled, sessionId }: { message: ChatMessage; agent?: string; forceExpanded?: boolean; turnImages?: Attachment[]; cancelled?: boolean; sessionId?: string }) {
+export function MessageBubble({ message, agent, forceExpanded, turnImages, turnArtifacts, onOpenArtifact, cancelled, sessionId }: { message: ChatMessage; agent?: string; forceExpanded?: boolean; turnImages?: Attachment[]; turnArtifacts?: ContentRef[]; onOpenArtifact?: (artifact: ContentRef) => void; cancelled?: boolean; sessionId?: string }) {
   switch (message.type) {
     case 'user_message': {
       const showUserText = message.payload.content !== IMAGE_PLACEHOLDER;
@@ -75,6 +75,9 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, cance
               </div>
               <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} sessionId={sessionId} />
               {turnImages && turnImages.length > 0 && <ImageAttachments attachments={turnImages} sessionId={sessionId} />}
+              {turnArtifacts && turnArtifacts.length > 0 && (
+                <HtmlArtifactCards artifacts={turnArtifacts} onOpen={onOpenArtifact} />
+              )}
               <div className="mt-1 flex items-center gap-2">
                 <p className="text-[10px] text-text-muted">
                   {formatTime(message.timestamp)}
@@ -404,12 +407,41 @@ function CopyableBubble({ text, children }: { text: string; children: React.Reac
   );
 }
 
+function HtmlArtifactCards({ artifacts, onOpen }: { artifacts: ContentRef[]; onOpen?: (artifact: ContentRef) => void }) {
+  return (
+    <div className="mt-2 space-y-1.5" data-html-artifacts={artifacts.length}>
+      {artifacts.map((artifact) => {
+        const title = artifact.caption || artifact.name || 'HTML report';
+        return (
+          <button
+            key={artifact.id}
+            type="button"
+            onClick={() => onOpen?.(artifact)}
+            className="group flex w-full items-center gap-3 rounded-xl border border-border-primary bg-surface-primary/80 px-3 py-2.5 text-left transition-colors hover:border-kraki-500/40 hover:bg-surface-secondary disabled:cursor-default"
+            aria-label={`Open report ${title}`}
+            disabled={!onOpen}
+          >
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-kraki-500/10 text-kraki-500">
+              <FileCode2 className="size-4.5" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-xs font-semibold text-text-primary">{title}</span>
+              <span className="mt-0.5 block text-[10px] text-text-muted">HTML Report · {formatBytes(artifact.size)}</span>
+            </span>
+            <ExternalLink className="size-3.5 shrink-0 text-text-muted transition-colors group-hover:text-kraki-500" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 function ImageAttachments({ attachments, sessionId }: { attachments?: Attachment[]; sessionId?: string }) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
   const [resolvedRefs, setResolvedRefs] = useState<Record<number, string>>({});
   const images = attachments?.filter(
     (a): a is (Attachment & { type: 'image' }) | (Attachment & { type: 'content_ref' }) =>
-      a.type === 'image' || a.type === 'content_ref',
+      a.type === 'image' || (a.type === 'content_ref' && a.mimeType.startsWith('image/')),
   ) ?? [];
   const imageCount = images.length;
   const isGallery = imageCount > 1;

--- a/packages/arm/web/src/pages/SessionPage.tsx
+++ b/packages/arm/web/src/pages/SessionPage.tsx
@@ -7,6 +7,8 @@ import { getSessionStatus, countPendingQuestions } from '../lib/session-status';
 import { AgentAvatar } from '../components/common/AgentAvatar';
 import { SessionInfoPanel } from '../components/devices/SessionInfoPanel';
 import { messageProvider } from '../lib/message-provider';
+import { HtmlArtifactPanel } from '../components/chat/HtmlArtifactPanel';
+import type { ContentRef } from '@kraki/protocol';
 
 export function SessionPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -30,6 +32,7 @@ export function SessionPage() {
   });
   const navigate = useNavigate();
   const [mobileInfoOpen, setMobileInfoOpen] = useState(false);
+  const [selectedArtifact, setSelectedArtifact] = useState<ContentRef | null>(null);
   const sessionUsage = useStore((s) => sessionId ? s.sessionUsage.get(sessionId) : undefined);
   const deviceAgentsList = useStore((s) => session ? s.deviceAgents.get(session.deviceId) : undefined);
   // Find the agent matching this session, or flatten all agents' models
@@ -51,6 +54,7 @@ export function SessionPage() {
   // Track which session is being viewed so ws-client can suppress unread for it
   useEffect(() => {
     if (sessionId) setActiveSessionId(sessionId);
+    setSelectedArtifact(null);
     return () => setActiveSessionId(null);
   }, [sessionId, setActiveSessionId]);
 
@@ -182,7 +186,14 @@ export function SessionPage() {
         </button>
       </div>
 
-      <ChatView />
+      <div className="relative flex min-h-0 flex-1">
+        <div className="relative flex min-w-0 flex-1">
+          <ChatView onOpenArtifact={setSelectedArtifact} />
+        </div>
+        {selectedArtifact && (
+          <HtmlArtifactPanel artifact={selectedArtifact} sessionId={sessionId} onClose={() => setSelectedArtifact(null)} />
+        )}
+      </div>
 
       {/* Mobile session info slide-over */}
       {mobileInfoOpen && session && (

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -340,6 +340,75 @@ describe('pi outbound images (tool result → attachment store)', () => {
     });
   });
 
+  it('stores show_html output as a text/html attachment and broadcasts its bytes', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kraki-show-html-'));
+    const htmlPath = join(dir, 'report.html');
+    writeFileSync(htmlPath, '<!doctype html><title>Report</title>');
+    try {
+      const { adapter, emit, put } = makeAdapterWithStore();
+      const onToolComplete = vi.fn();
+      const onAttachmentBytes = vi.fn();
+      adapter.onToolComplete = onToolComplete;
+      adapter.onAttachmentBytes = onAttachmentBytes;
+
+      await emit({
+        type: 'tool_execution_end',
+        toolName: 'show_html',
+        toolCallId: 'html-1',
+        isError: false,
+        result: {
+          content: [{ type: 'text', text: 'HTML report ready for preview.' }],
+          details: { htmlPath, title: 'Architecture Report', name: 'report.html' },
+        },
+      });
+
+      expect(put).toHaveBeenCalledWith(
+        's1',
+        Buffer.from('<!doctype html><title>Report</title>'),
+        'text/html',
+        { name: 'report.html', caption: 'Architecture Report' },
+      );
+      expect(onToolComplete).toHaveBeenCalledWith('s1', {
+        toolName: 'show_html',
+        result: 'HTML report ready for preview.',
+        toolCallId: 'html-1',
+        success: true,
+        attachments: [{ type: 'content_ref', id: 'ref1', mimeType: 'text/html', size: 3 }],
+      });
+      expect(onAttachmentBytes).toHaveBeenCalledWith('s1', {
+        refs: [{ type: 'content_ref', id: 'ref1', mimeType: 'text/html', size: 3 }],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores an htmlPath handle from tools other than show_html', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kraki-show-html-spoof-'));
+    const htmlPath = join(dir, 'secret.html');
+    writeFileSync(htmlPath, '<p>secret</p>');
+    try {
+      const { adapter, emit, put } = makeAdapterWithStore();
+      const onToolComplete = vi.fn();
+      adapter.onToolComplete = onToolComplete;
+
+      await emit({
+        type: 'tool_execution_end',
+        toolName: 'bash',
+        toolCallId: 'bash-1',
+        isError: false,
+        result: { content: [{ type: 'text', text: 'done' }], details: { htmlPath } },
+      });
+
+      expect(put).not.toHaveBeenCalled();
+      expect(onToolComplete).toHaveBeenCalledWith('s1', {
+        toolName: 'bash', result: 'done', toolCallId: 'bash-1', success: true,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('joins text content blocks (no images) into a clean result string', () => {
     const { adapter, emit, put } = makeAdapterWithStore();
     const onToolComplete = vi.fn();
@@ -811,6 +880,7 @@ describe('PI_KRAKI_TOOLS_SOURCE extension shape', () => {
     expect(PI_KRAKI_TOOLS_SOURCE).toContain('name: "finalize_reply"');
     expect(PI_KRAKI_TOOLS_SOURCE).toContain('name: "ask_user"');
     expect(PI_KRAKI_TOOLS_SOURCE).toContain('name: "show_image"');
+    expect(PI_KRAKI_TOOLS_SOURCE).toContain('name: "show_html"');
     expect(PI_KRAKI_TOOLS_SOURCE).not.toContain('present_to_user');
     expect(PI_KRAKI_TOOLS_SOURCE).toContain('pi.registerTool');
   });
@@ -822,9 +892,16 @@ describe('PI_KRAKI_TOOLS_SOURCE extension shape', () => {
     expect(PI_KRAKI_TOOLS_SOURCE).toContain('"show_image"');
   });
 
+  it('show_html returns a local attachment handle without returning HTML bytes to pi', () => {
+    expect(PI_KRAKI_TOOLS_SOURCE).toContain('details: { htmlPath: abs');
+    expect(PI_KRAKI_TOOLS_SOURCE).toContain('10 * 1024 * 1024');
+    expect(PI_KRAKI_TOOLS_SOURCE).not.toContain('htmlBase64');
+  });
+
   it('whitelists the capability tools from the always-on permission gate', () => {
     expect(PI_KRAKI_TOOLS_SOURCE).toContain('"finalize_reply"');
     expect(PI_KRAKI_TOOLS_SOURCE).toContain('"ask_user"');
+    expect(PI_KRAKI_TOOLS_SOURCE).toContain('"show_html"');
     // The gate is loaded in every mode (no KRAKI_PI_GATE env guard); the adapter
     // decides silent-approve vs card per its mode policy.
     expect(PI_KRAKI_TOOLS_SOURCE).not.toContain('process.env.KRAKI_PI_GATE');

--- a/packages/tentacle/src/adapters/pi-kraki-tools.ts
+++ b/packages/tentacle/src/adapters/pi-kraki-tools.ts
@@ -40,7 +40,7 @@ import { isAbsolute, join } from "node:path";
 // Capability tools never go through the permission gate — they carry their own
 // operator interaction (ask_user/show_image), settle the turn (finalize_reply),
 // or are read-only introspection (kraki_get_mode).
-const KRAKI_TOOLS = new Set(["ask_user", "finalize_reply", "show_image", "kraki_get_mode"]);
+const KRAKI_TOOLS = new Set(["ask_user", "finalize_reply", "show_image", "show_html", "kraki_get_mode"]);
 
 export default function krakiTools(pi) {
   pi.registerTool({
@@ -152,6 +152,53 @@ export default function krakiTools(pi) {
       if (caption) content.push({ type: "text", text: caption });
       content.push({ type: "image", data: bytes.toString("base64"), mimeType });
       return { content, details: { shown: abs, mimeType } };
+    },
+  });
+
+  pi.registerTool({
+    name: "show_html",
+    label: "Show HTML report",
+    description:
+      "Display a self-contained HTML report to the user in the Kraki preview panel. " +
+      "Use this for documents, architecture reports, diagrams, and technical analysis. " +
+      "The file must be a local .html or .htm file and is rendered locally in a sandbox.",
+    promptGuidelines:
+      "Use show_html when the user would benefit from reading a generated HTML report. " +
+      "Prefer a self-contained HTML file with inline CSS, inline SVG, and no external resources.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "Absolute or cwd-relative path to the HTML report." },
+        title: { type: "string", description: "Optional report title shown in the preview panel." },
+      },
+      required: ["path"],
+      additionalProperties: false,
+    },
+    async execute(_id, params) {
+      const p = String((params && params.path) || "");
+      const requestedTitle = params && params.title ? String(params.title).trim() : "";
+      if (!p) return { content: [{ type: "text", text: "show_html: no path provided" }], isError: true, details: {} };
+      const abs = isAbsolute(p) ? p : join(process.cwd(), p);
+      const lower = abs.toLowerCase();
+      if (!lower.endsWith(".html") && !lower.endsWith(".htm")) {
+        return { content: [{ type: "text", text: "show_html: path must end in .html or .htm" }], isError: true, details: {} };
+      }
+      let bytes;
+      try {
+        bytes = readFileSync(abs);
+      } catch (err) {
+        const msg = (err && err.message) || String(err);
+        return { content: [{ type: "text", text: "show_html: cannot read " + abs + " — " + msg }], isError: true, details: {} };
+      }
+      if (bytes.length > 10 * 1024 * 1024) {
+        return { content: [{ type: "text", text: "show_html: file is larger than the 10 MB limit" }], isError: true, details: {} };
+      }
+      return {
+        content: [{ type: "text", text: "HTML report ready for preview." }],
+        // The adapter consumes this local path and stores the bytes as an
+        // attachment. The HTML itself is deliberately never returned to pi.
+        details: { htmlPath: abs, title: requestedTitle, name: abs.split(/[\\/]/).pop() || "report.html" },
+      };
     },
   });
 

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -821,7 +821,7 @@ export class PiAdapter extends AgentAdapter {
         // Extract text for the trace and externalize any image blocks (e.g. from
         // the show_image tool) into the attachment store so their bytes reach
         // connected devices — mirrors the claude/copilot outbound image path.
-        const imageAttachments: import('@kraki/protocol').Attachment[] = [];
+        const outputAttachments: import('@kraki/protocol').Attachment[] = [];
         let resultText: string;
         const raw = e.result as unknown;
         const blocks =
@@ -840,8 +840,7 @@ export class PiAdapter extends AgentAdapter {
                   const bytes = Buffer.from(c.data, 'base64');
                   const mime = c.mimeType;
                   const { bytes: resized, mimeType: outMime } = await fitToMaxDimension(bytes, mime).catch(() => ({ bytes, mimeType: mime }));
-                  const ref = this.attachmentStore.put(sessionId, resized, outMime, {});
-                  imageAttachments.push(ref);
+                  outputAttachments.push(this.attachmentStore.put(sessionId, resized, outMime, {}));
                 } catch (err) {
                   logger.warn({ err, sessionId }, 'failed to store pi image attachment');
                 }
@@ -851,16 +850,33 @@ export class PiAdapter extends AgentAdapter {
         } else {
           resultText = typeof raw === 'string' ? raw : JSON.stringify(raw ?? '');
         }
-        if (imageAttachments.length > 0 && !resultText) resultText = 'Displayed image.';
+        const details = raw && typeof raw === 'object' && (raw as { details?: unknown }).details;
+        if (toolName === 'show_html' && this.attachmentStore && details && typeof details === 'object') {
+          const htmlPath = (details as { htmlPath?: unknown }).htmlPath;
+          const lowerHtmlPath = typeof htmlPath === 'string' ? htmlPath.toLowerCase() : '';
+          if (typeof htmlPath === 'string' && (lowerHtmlPath.endsWith('.html') || lowerHtmlPath.endsWith('.htm'))) {
+            try {
+              const html = readFileSync(htmlPath);
+              const title = typeof (details as { title?: unknown }).title === 'string' ? (details as { title: string }).title : undefined;
+              const name = typeof (details as { name?: unknown }).name === 'string' ? (details as { name: string }).name : 'report.html';
+              if (html.length <= 10 * 1024 * 1024) {
+                outputAttachments.push(this.attachmentStore.put(sessionId, html, 'text/html', { name, caption: title }));
+              }
+            } catch (err) {
+              logger.warn({ err, sessionId }, 'failed to store pi HTML artifact');
+            }
+          }
+        }
+        if (outputAttachments.length > 0 && !resultText) resultText = 'Output is ready.';
         this.onToolComplete?.(sessionId, {
           toolName,
           result: resultText,
           toolCallId: e.toolCallId as string | undefined,
           success: e.isError !== true,
-          ...(imageAttachments.length > 0 && { attachments: imageAttachments }),
+          ...(outputAttachments.length > 0 && { attachments: outputAttachments }),
         });
-        if (imageAttachments.length > 0) {
-          const refs = imageAttachments.filter(
+        if (outputAttachments.length > 0) {
+          const refs = outputAttachments.filter(
             (a): a is import('@kraki/protocol').ContentRef => a.type === 'content_ref',
           );
           if (refs.length > 0) this.onAttachmentBytes?.(sessionId, { refs });


### PR DESCRIPTION
## Summary

- add Pi `show_html` for self-contained `.html` / `.htm` reports up to 10 MB
- transport report bytes through the existing attachment/content-ref path without placing HTML in model context or message state
- attach reports to the producing turn's final agent bubble, including historical trace recovery after refresh
- open any selected historical report in a responsive sandboxed side panel with close and panel-scoped fullscreen controls
- add reusable report template, concise generation prompt, and visual showcase under `docs/html-reports/`

## Security

- only `show_html` tool results may provide an `htmlPath` attachment handle
- adapter revalidates the HTML extension and size before storing bytes
- iframe uses `sandbox="allow-scripts"`, `referrerPolicy="no-referrer"`, and an injected CSP that blocks network, forms, nested frames, objects, and base URL changes
- attachment Blob URLs are revoked when the preview closes or changes

## History behavior

- reports remain attached to their original final agent bubble
- multiple reports and multiple turns remain isolated and deduplicated
- reports do not auto-open
- visible final turns with Steps lazily request their authoritative trace after reload so historical report cards recover
- direct `text/html` attachments on final messages are also supported

## Validation

- Web tests: 354 passed
- Pi adapter tests: 60 passed
- Web production build
- Crypto build
- Tentacle build
- `git diff --check`
- Playwright + Google Chrome against the real local dev stack: two historical report cards survived a full page refresh; selecting the older report opened the correct 680px sandbox panel

Screenshot: `/tmp/kraki-html-artifact-history-after-refresh.png` (local verification artifact)
