### PR TITLE
fix(pi): guide local HTML reports through show_html

### DIFF
--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -23,7 +23,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { PiAdapter } from '../adapters/pi.js';
+import { KRAKI_SYSTEM_PROMPT, PiAdapter } from '../adapters/pi.js';
 import { PI_KRAKI_TOOLS_SOURCE } from '../adapters/pi-kraki-tools.js';
 
 interface StubProc {
@@ -963,6 +963,14 @@ describe('pi agent_end guards', () => {
     adapter.onIdle = onIdle;
     emit({ type: 'agent_end', willRetry: true });
     expect(onIdle).not.toHaveBeenCalled();
+  });
+});
+
+describe('Pi Kraki system prompt', () => {
+  it('directs local HTML reports through show_html instead of the system browser', () => {
+    expect(KRAKI_SYSTEM_PROMPT).toContain('call show_html');
+    expect(KRAKI_SYSTEM_PROMPT).toContain('remains accessible in the producing message');
+    expect(KRAKI_SYSTEM_PROMPT).toContain('is not a substitute');
   });
 });
 

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -442,7 +442,7 @@ const IDLE_TTL_MS = 30 * 60_000;
 
 /** Describes the Kraki UI to the model so it narrates naturally instead of
  *  tagging its own messages. Appended to pi's system prompt on every spawn. */
-const KRAKI_SYSTEM_PROMPT =
+export const KRAKI_SYSTEM_PROMPT =
   'You are operating inside Kraki, a remote-control harness. Communicate with the ' +
   'human by writing ordinary assistant prose — it IS your reply and is shown to ' +
   'them directly. You do NOT need any special tool to "send" a message; just ' +
@@ -456,8 +456,11 @@ const KRAKI_SYSTEM_PROMPT =
   'yourself. To get a decision or missing information from the human, call the ' +
   'ask_user tool (it blocks and returns their answer). To visually show the human ' +
   'an image (a screenshot, diagram, chart, or generated graphic they cannot ' +
-  'already see), call the show_image tool with the file path. Do NOT call ' +
-  'finalize_reply on your own — Kraki will ask you to when it needs you to ' +
+  'already see), call the show_image tool with the file path. When the human asks you to ' +
+  'inspect, open, review, generate, or update a local HTML report, call show_html before ' +
+  'concluding so it remains accessible in the producing message; a shell command that ' +
+  'opens the system browser is not a substitute. ' +
+  'Do NOT call finalize_reply on your own — Kraki will ask you to when it needs you to ' +
   'conclude a turn.';
 
 /** Injected at the end of a turn whose intermediate narration was dropped, so


### PR DESCRIPTION
## Root cause

The existing HTML Artifact path was working, but Pi's Kraki system prompt only described `show_image`. For requests such as reviewing or opening a local HTML report, the model continued using `bash`/`open` and `view_image`, so no `text/html` attachment was emitted.

## Change

- explicitly instruct Pi to call `show_html` when inspecting, opening, reviewing, generating, or updating a local HTML report
- state that opening the system browser is not a substitute because the report must remain attached to the producing message
- add a regression test for the system prompt guidance

## Validation

- Pi adapter tests: 67 passed
- Tentacle build: passed
- `git diff --check`: passed

The affected historical message in `mrevwgym-6c35f6eb` cannot be retroactively given an attachment because its stored trace has no `show_html` call; it must be regenerated or re-requested after this fix.