### PR TITLE
fix(pi): state-aware prompt ACK watchdog, no false timeout during compaction

### DIFF
--- a/packages/arm/web/src/components/chat/LiveAgentBubble.test.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.test.tsx
@@ -94,6 +94,13 @@ describe('LiveAgentBubble action section', () => {
     expect(screen.queryByText('Working…')).not.toBeInTheDocument();
   });
 
+  it('renders compaction as transient runtime activity, not a fake tool', () => {
+    renderLive({ text: '', action: { type: 'compaction', payload: { phase: 'running', reason: 'threshold' } } });
+    expect(screen.getByText('Compacting context…')).toBeInTheDocument();
+    expect(screen.queryByText('bash')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Open steps' })).not.toBeInTheDocument();
+  });
+
   it('renders a running tool in the action section', () => {
     renderLive({
       text: 'working on it',

--- a/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
@@ -64,7 +64,8 @@ export function LiveAgentBubble({ sessionId, agent, card }: LiveAgentBubbleProps
   // completed tool). The input components render their own resolved read-only view.
   const permission = a?.type === 'permission' ? a : null;
   const question = a?.type === 'question' ? a : null;
-  const hasAction = !!tool || batchRunning > 0 || !!permission || !!question;
+  const compaction = a?.type === 'compaction' ? a : null;
+  const hasAction = !!tool || batchRunning > 0 || !!permission || !!question || !!compaction;
 
   const { steps, targetSeq } = useTurnSteps(sessionId, true);
 
@@ -131,6 +132,13 @@ export function LiveAgentBubble({ sessionId, agent, card }: LiveAgentBubbleProps
               <div className="flex items-center gap-2 rounded-lg border border-border-primary bg-surface-primary/40 px-3 py-2 text-xs text-text-secondary">
                 <span className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-ocean-500" />
                 <span>{batchRunning} 个工具并行运行中…</span>
+              </div>
+            )}
+
+            {compaction && (
+              <div className="flex items-center gap-2 rounded-lg border border-border-primary bg-surface-primary/40 px-3 py-2 text-xs text-text-secondary">
+                <span className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-ocean-500" />
+                <span>Compacting context…</span>
               </div>
             )}
 

--- a/packages/arm/web/src/lib/session-status.ts
+++ b/packages/arm/web/src/lib/session-status.ts
@@ -33,6 +33,8 @@ export function cardActionKey(a: CardActionState | null): string {
       return `perm:${a.payload.id}:${a.payload.decision ?? 'pending'}`;
     case 'question':
       return `q:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer === undefined ? 'pending' : 'answered'}`;
+    case 'compaction':
+      return `compaction:${a.payload.reason ?? 'unknown'}`;
   }
 }
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -380,7 +380,16 @@ export type CardActionState =
       };
     }
   | Pick<PermissionRequest, 'type' | 'payload'>
-  | Pick<QuestionRequest, 'type' | 'payload'>;
+  | Pick<QuestionRequest, 'type' | 'payload'>
+  | {
+      /** Transient Pi runtime activity. Never persisted to the conversation or
+       *  trace; it only occupies the server-owned live status-card slot. */
+      type: 'compaction';
+      payload: {
+        phase: 'running';
+        reason?: 'manual' | 'threshold' | 'overflow';
+      };
+    };
 
 /**
  * The ACTION part of the server-owned status card — the single active

--- a/packages/tentacle/src/__tests__/card-manager.test.ts
+++ b/packages/tentacle/src/__tests__/card-manager.test.ts
@@ -316,6 +316,52 @@ describe('CardManager action part', () => {
     card.onToolStart('s1', tool('tc1', 't'));
     expect(actions(sent)).toHaveLength(1);
   });
+
+  it('surfaces compaction transiently and includes it in reconnect snapshots', () => {
+    const { card, sent } = setup();
+    card.onCompactionStart('s1', 'threshold');
+    card.onCompactionStart('s1', 'threshold');
+    expect(actions(sent)).toEqual([
+      { type: 'compaction', payload: { phase: 'running', reason: 'threshold' } },
+    ]);
+    expect((card.snapshot('s1')[1].payload as { action: unknown }).action)
+      .toEqual({ type: 'compaction', payload: { phase: 'running', reason: 'threshold' } });
+    expect(card.activeSessions()).toEqual(['s1']);
+  });
+
+  it('does not let compaction hide a pending human prompt', () => {
+    const { card, sent } = setup();
+    card.onPrompt('s1', question('q1', 'choose?'));
+    sent.length = 0;
+    card.onCompactionStart('s1', 'threshold');
+    expect(actions(sent)).toEqual([]);
+    expect((card.snapshot('s1')[1].payload as { action: unknown }).action)
+      .toMatchObject({ type: 'question', payload: { id: 'q1' } });
+  });
+
+  it('late compaction end cannot clear a newer tool action', () => {
+    const { card, sent } = setup();
+    card.onCompactionStart('s1', 'threshold');
+    card.onToolStart('s1', tool('tc1', 'new work'));
+    sent.length = 0;
+    card.onCompactionEnd('s1');
+    expect(actions(sent)).toEqual([]);
+    expect((card.snapshot('s1')[1].payload as { action: unknown }).action)
+      .toMatchObject({ type: 'tool_start', payload: { toolCallId: 'tc1' } });
+  });
+
+  it('clears compaction when it still owns the slot or narration resumes', () => {
+    const { card, sent } = setup();
+    card.onCompactionStart('s1');
+    sent.length = 0;
+    card.onCompactionEnd('s1');
+    expect(actions(sent)).toEqual([null]);
+
+    card.onCompactionStart('s1', 'overflow');
+    sent.length = 0;
+    card.onDelta('s1', 'continuing');
+    expect(actions(sent)).toEqual([null]);
+  });
 });
 
 describe('CardManager lifecycle', () => {

--- a/packages/tentacle/src/__tests__/multi-adapter-wiring.test.ts
+++ b/packages/tentacle/src/__tests__/multi-adapter-wiring.test.ts
@@ -29,6 +29,7 @@ describe('MultiAgentAdapter.wireCallbacks forwards sub-adapter callbacks', () =>
       onIdle: null,
       onFlushComplete: null,
       onError: null,
+      onCompaction: null,
       onSessionEnded: null,
       onSessionEvicted: null,
       onTitleChanged: null,
@@ -70,6 +71,18 @@ describe('MultiAgentAdapter.wireCallbacks forwards sub-adapter callbacks', () =>
     stub.onFinalizeDelta?.('s1', { content: '✅ done' });
 
     expect(seen).toHaveBeenCalledWith('s1', { content: '✅ done' });
+  });
+
+  it('forwards transient compaction lifecycle events', () => {
+    const multi = new MultiAgentAdapter({ agentIds: ['pi'] });
+    const stub = makeStubAdapter();
+    (multi as unknown as { wireCallbacks(id: string, a: AgentAdapter): void }).wireCallbacks('pi', stub);
+
+    const seen = vi.fn();
+    multi.onCompaction = seen;
+    stub.onCompaction?.('s1', { phase: 'start', reason: 'threshold' });
+
+    expect(seen).toHaveBeenCalledWith('s1', { phase: 'start', reason: 'threshold' });
   });
 
   it('forwards onMessageDelta and onToolStart (sanity — same wiring path)', () => {

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -33,8 +33,13 @@ interface StubProc {
   request: ReturnType<typeof vi.fn>;
 }
 
-function makeAdapter() {
-  const adapter = new PiAdapter({ cliPath: '/bin/true' });
+function makeAdapter(promptWatchdog?: {
+  ackGraceMs?: number;
+  intervalMs?: number;
+  probeFailureLimit?: number;
+  idleStallMs?: number;
+}) {
+  const adapter = new PiAdapter({ cliPath: '/bin/true', promptWatchdog });
   const sid = 's1';
   const proc: StubProc = {
     alive: true,
@@ -49,6 +54,7 @@ function makeAdapter() {
     mode: 'execute',
     usage: {},
     lastActivity: Date.now(),
+    exitObserved: false,
     pendingPerms: new Map<string, string>(),
     pendingQuestions: new Map<string, string>(),
     narrationSegments: 0,
@@ -270,6 +276,117 @@ describe('pi model switching', () => {
 });
 
 describe('pi prompt recovery', () => {
+  it('keeps one delayed prompt alive through compaction without false error or idle', async () => {
+    const { adapter, proc } = makeAdapter({ ackGraceMs: 1, intervalMs: 1, idleStallMs: 100 });
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    const onCompaction = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    adapter.onCompaction = onCompaction;
+
+    let acknowledge!: () => void;
+    const ack = new Promise<void>((resolve) => { acknowledge = resolve; });
+    proc.request.mockImplementation((type: string) => {
+      if (type === 'prompt') return ack;
+      if (type === 'get_state') return Promise.resolve({ isCompacting: true, isStreaming: false });
+      return Promise.resolve({});
+    });
+
+    const sending = adapter.sendMessage('s1', 'compact me');
+    await vi.waitFor(() => expect(proc.request.mock.calls.some(call => call[0] === 'get_state')).toBe(true));
+    expect(proc.request.mock.calls.filter(call => call[0] === 'prompt')).toHaveLength(1);
+    expect(onCompaction).toHaveBeenCalledTimes(1);
+    expect(onCompaction).toHaveBeenCalledWith('s1', { phase: 'start' });
+    expect(onError).not.toHaveBeenCalled();
+    expect(onIdle).not.toHaveBeenCalled();
+
+    acknowledge();
+    await sending;
+    expect(proc.request.mock.calls.filter(call => call[0] === 'prompt')).toHaveLength(1);
+  });
+
+  it('treats isStreaming as accepted while retaining the late ACK cleanup', async () => {
+    const { adapter, proc } = makeAdapter({ ackGraceMs: 1, intervalMs: 1 });
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+
+    let rejectAck!: (error: Error) => void;
+    const ack = new Promise<void>((_resolve, reject) => { rejectAck = reject; });
+    proc.request.mockImplementation((type: string) => {
+      if (type === 'prompt') return ack;
+      if (type === 'get_state') return Promise.resolve({ isStreaming: true, isCompacting: false });
+      return Promise.resolve({});
+    });
+
+    await adapter.sendMessage('s1', 'run once');
+    expect(proc.request.mock.calls.filter(call => call[0] === 'prompt')).toHaveLength(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onIdle).not.toHaveBeenCalled();
+    // A late transport rejection is observed by ackOutcome, not left unhandled.
+    rejectAck(new Error('late response after process exit'));
+    await Promise.resolve();
+  });
+
+  it('does not duplicate idle when process exit already owns the terminal transition', async () => {
+    const { adapter, proc, session } = makeAdapter();
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    proc.request.mockImplementation((type: string) => {
+      if (type !== 'prompt') return Promise.resolve({});
+      session.exitObserved = true;
+      onIdle('s1'); // mirrors PiRpcProcess.onExit ordering
+      return Promise.reject(new Error('pi process exited'));
+    });
+
+    await adapter.sendMessage('s1', 'will exit');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails once after repeated state-probe failures without resending', async () => {
+    const { adapter, proc } = makeAdapter({ ackGraceMs: 1, intervalMs: 1, probeFailureLimit: 2 });
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    proc.request.mockImplementation((type: string) => {
+      if (type === 'prompt') return new Promise(() => undefined);
+      if (type === 'get_state') return Promise.reject(new Error('state channel wedged'));
+      return Promise.resolve({});
+    });
+
+    await adapter.sendMessage('s1', 'one delivery');
+    expect(proc.request.mock.calls.filter(call => call[0] === 'prompt')).toHaveLength(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[1].message).toContain('could not be reconciled');
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps native compaction events once and never forwards summary content', () => {
+    const { adapter, emit } = makeAdapter();
+    const onCompaction = vi.fn();
+    adapter.onCompaction = onCompaction;
+
+    emit({ type: 'compaction_start', reason: 'threshold' });
+    emit({ type: 'compaction_start', reason: 'threshold' });
+    emit({
+      type: 'compaction_end', reason: 'threshold', aborted: false, willRetry: true,
+      result: { summary: 'private conversation summary' },
+    });
+
+    expect(onCompaction).toHaveBeenCalledTimes(2);
+    expect(onCompaction).toHaveBeenNthCalledWith(1, 's1', { phase: 'start', reason: 'threshold' });
+    expect(onCompaction).toHaveBeenNthCalledWith(2, 's1', {
+      phase: 'end', reason: 'threshold', aborted: false, willRetry: true, errorMessage: undefined,
+    });
+    expect(JSON.stringify(onCompaction.mock.calls)).not.toContain('private conversation summary');
+  });
+
   it('awaits abort and idle reconciliation before retrying the prompt', async () => {
     const { adapter, proc } = makeAdapter();
     let releaseAbort!: () => void;
@@ -285,8 +402,10 @@ describe('pi prompt recovery', () => {
       .mockResolvedValueOnce({});
 
     const sending = adapter.sendMessage('s1', 'retry me');
-    await Promise.resolve();
-    expect(proc.request.mock.calls.map(call => call[0])).toEqual(['prompt', 'abort']);
+    await vi.waitFor(() => {
+      expect(proc.request.mock.calls.map(call => call[0])).toEqual(['prompt', 'abort']);
+    });
+    expect(proc.request.mock.calls[0]?.[2]).toEqual({ timeoutMs: null });
     releaseAbort();
     await sending;
     expect(proc.request.mock.calls.map(call => call[0])).toEqual(['prompt', 'abort', 'get_state', 'prompt']);
@@ -310,13 +429,13 @@ describe('pi inbound images (sendMessage → RPC prompt.images)', () => {
     expect(proc.request).toHaveBeenCalledWith('prompt', {
       message: 'what is this?',
       images: [{ type: 'image', data: 'QUJD', mimeType: 'image/png' }],
-    });
+    }, { timeoutMs: null });
   });
 
   it('omits the images field entirely when there are no image attachments', async () => {
     const { adapter, proc } = makeAdapter();
     await adapter.sendMessage('s1', 'plain text');
-    expect(proc.request).toHaveBeenCalledWith('prompt', { message: 'plain text' });
+    expect(proc.request).toHaveBeenCalledWith('prompt', { message: 'plain text' }, { timeoutMs: null });
   });
 
   it('drops non-image (ContentRef) attachments — they cannot be inlined', async () => {
@@ -324,7 +443,7 @@ describe('pi inbound images (sendMessage → RPC prompt.images)', () => {
     await adapter.sendMessage('s1', 'hi', [
       { type: 'content_ref', id: 'abc', mimeType: 'image/png', size: 10 },
     ]);
-    expect(proc.request).toHaveBeenCalledWith('prompt', { message: 'hi' });
+    expect(proc.request).toHaveBeenCalledWith('prompt', { message: 'hi' }, { timeoutMs: null });
   });
 });
 

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -127,6 +127,7 @@ function createAdapter(): Record<string, unknown> {
     onToolComplete: null,
     onIdle: null,
     onError: null,
+    onCompaction: null,
     onSessionEnded: null,
     onTitleChanged: null,
     onUsageUpdate: null,
@@ -1835,6 +1836,35 @@ describe('RelayClient trace mirroring (off-spine)', () => {
     })));
     return { adapter, sm, ws: sockets[0], cleanup: () => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ } } };
   }
+
+  it('keeps compaction transient: card_action only, never spine or trace', () => {
+    const { adapter, sm, ws, cleanup } = buildClient();
+    try {
+      const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+      ws.sent.length = 0;
+      (adapter.onCompaction as (sid: string, e: Record<string, unknown>) => void)('sess_1', {
+        phase: 'start', reason: 'threshold',
+      });
+
+      expect(smMock.appendMessage).not.toHaveBeenCalled();
+      expect(smMock.appendTrace).not.toHaveBeenCalled();
+      const messages = decodePulseSends(ws.sent);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        type: 'card_action',
+        sessionId: 'sess_1',
+        payload: { action: { type: 'compaction', payload: { phase: 'running', reason: 'threshold' } } },
+      });
+
+      ws.sent.length = 0;
+      (adapter.onCompaction as (sid: string, e: Record<string, unknown>) => void)('sess_1', { phase: 'end' });
+      expect(decodePulseSends(ws.sent)[0]).toMatchObject({
+        type: 'card_action', payload: { action: null },
+      });
+      expect(smMock.appendMessage).not.toHaveBeenCalled();
+      expect(smMock.appendTrace).not.toHaveBeenCalled();
+    } finally { cleanup(); }
+  });
 
   it('mirrors tool_start/tool_complete to appendTrace (off-spine), broadcasts card_action not raw tool events', () => {
     const { adapter, sm, ws, cleanup } = buildClient();

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -69,6 +69,16 @@ export interface ErrorEvent {
   message: string;
 }
 
+export type CompactionReason = 'manual' | 'threshold' | 'overflow';
+
+export interface CompactionEvent {
+  phase: 'start' | 'end';
+  reason?: CompactionReason;
+  aborted?: boolean;
+  willRetry?: boolean;
+  errorMessage?: string;
+}
+
 /** A Kraki-originated system notice (not the agent's words). See
  *  protocol `SystemMessage`. First use: `kind: 'no_reply'`. */
 export interface SystemMessageEvent {
@@ -159,6 +169,9 @@ export abstract class AgentAdapter {
    *  after a turn completes. Used by EventsWatcher to safely resume watching. */
   onFlushComplete: ((sessionId: string) => void) | null = null;
   onError: ((sessionId: string, event: ErrorEvent) => void) | null = null;
+  /** Transient agent-runtime compaction activity. Never persisted to the spine
+   *  or TRACE; RelayClient maps it to the server-owned status-card slot. */
+  onCompaction: ((sessionId: string, event: CompactionEvent) => void) | null = null;
   /** Called when Kraki itself needs to leave a spine notice (not the agent's
    *  words) — e.g. `kind: 'no_reply'` when a turn ends without any reply.
    *  Rendered as a system-marked bubble that still anchors the turn's Steps. */

--- a/packages/tentacle/src/adapters/multi.ts
+++ b/packages/tentacle/src/adapters/multi.ts
@@ -402,6 +402,7 @@ export class MultiAgentAdapter extends AgentAdapter {
     adapter.onIdle = (sid) => this.onIdle?.(sid);
     adapter.onFlushComplete = (sid) => this.onFlushComplete?.(sid);
     adapter.onError = (sid, e) => this.onError?.(sid, e);
+    adapter.onCompaction = (sid, e) => this.onCompaction?.(sid, e);
     adapter.onSystemMessage = (sid, e) => this.onSystemMessage?.(sid, e);
     adapter.onSessionEnded = (sid, e) => {
       this.sessionAgent.delete(sid);

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -55,7 +55,14 @@ export interface PiRpcEvent {
 interface Pending {
   resolve: (data: unknown) => void;
   reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+interface RequestOptions {
+  /** Omitted = normal bounded control-command timeout; null = wait until the
+   *  response or process exit. Prompt ACKs use null because preflight may spend
+   *  minutes compacting after the frame has already been delivered. */
+  timeoutMs?: number | null;
 }
 
 export interface PiRpcOptions {
@@ -78,8 +85,12 @@ export interface PiRpcOptions {
   env?: NodeJS.ProcessEnv;
 }
 
-/** Bounds short control commands; prompts run fire-and-forget. */
+/** Bounds short control commands. Prompt acceptance has its own watchdog. */
 const CMD_TIMEOUT_MS = 30_000;
+const PROMPT_ACK_GRACE_MS = 30_000;
+const PROMPT_WATCHDOG_INTERVAL_MS = 5_000;
+const PROMPT_PROBE_FAILURE_LIMIT = 3;
+const PROMPT_IDLE_STALL_MS = 120_000;
 
 class PiRpcProcess {
   private child: ChildProcessWithoutNullStreams | null = null;
@@ -130,7 +141,7 @@ class PiRpcProcess {
     this.child.on('exit', (code) => {
       const detail = this.lastStderr ? `: ${this.lastStderr}` : '';
       for (const p of this.pending.values()) {
-        clearTimeout(p.timer);
+        if (p.timer) clearTimeout(p.timer);
         p.reject(new Error(`pi process exited${detail}`));
       }
       this.pending.clear();
@@ -152,7 +163,7 @@ class PiRpcProcess {
     if (msg.type === 'response' && typeof msg.id === 'string') {
       const p = this.pending.get(msg.id);
       if (p) {
-        clearTimeout(p.timer);
+        if (p.timer) clearTimeout(p.timer);
         this.pending.delete(msg.id);
         if (msg.success) p.resolve(msg.data);
         else p.reject(new Error(String(msg.error ?? 'pi command failed')));
@@ -162,18 +173,25 @@ class PiRpcProcess {
     this.onEvent?.(msg as PiRpcEvent);
   }
 
-  /** Send a command and await its response. */
-  request<T = unknown>(type: string, payload: Record<string, unknown> = {}): Promise<T> {
+  /** Send a command and await its response. Short control commands are bounded;
+   *  callers may disable the wall-clock timer for commands whose response is
+   *  legitimately delayed after delivery (notably prompt preflight/compaction). */
+  request<T = unknown>(
+    type: string,
+    payload: Record<string, unknown> = {},
+    options: RequestOptions = {},
+  ): Promise<T> {
     const id = `c${++this.seq}`;
     const frame = JSON.stringify({ id, type, ...payload });
     return new Promise<T>((resolve, reject) => {
-      const timer = setTimeout(() => {
+      const timeoutMs = options.timeoutMs === undefined ? CMD_TIMEOUT_MS : options.timeoutMs;
+      const timer = timeoutMs === null ? null : setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`pi command '${type}' timed out`));
-      }, CMD_TIMEOUT_MS);
+      }, timeoutMs);
       this.pending.set(id, { resolve: resolve as (d: unknown) => void, reject, timer });
       if (!this.child?.stdin.writable) {
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
         this.pending.delete(id);
         reject(new Error('pi stdin not writable'));
         return;
@@ -307,6 +325,9 @@ interface PiSession {
   sessionFile?: string;
   usage: SessionUsage;
   lastActivity: number;
+  /** Set before the process-exit callback publishes idle, so an in-flight
+   *  prompt rejection cannot publish the same terminal idle a second time. */
+  exitObserved: boolean;
   /** Outstanding per-call permission requests (permissionId → pi's UI request
    *  id). Cleared when answered or when the child is killed/respawned so the
    *  arm's card doesn't dangle. */
@@ -480,10 +501,19 @@ function finalizePrompt(draft: string): string {
   );
 }
 
+interface PromptWatchdogOptions {
+  ackGraceMs: number;
+  intervalMs: number;
+  probeFailureLimit: number;
+  idleStallMs: number;
+}
+
 export class PiAdapter extends AgentAdapter {
   private cliPath: string;
   private readonly attachmentStore?: import('../attachment-store.js').AttachmentStore;
+  private readonly promptWatchdog: PromptWatchdogOptions;
   private sessions = new Map<string, PiSession>();
+  private compactingSessions = new Set<string>();
   private evictTimer: ReturnType<typeof setInterval> | null = null;
   /** Lazily-materialized path to the always-loaded Kraki tools extension. */
   private toolsExtPath: string | null = null;
@@ -492,10 +522,21 @@ export class PiAdapter extends AgentAdapter {
    *  message (the meta sidecar / kraki_get_mode stays the source of truth). */
   private pendingModeSignals = new Map<string, Mode>();
 
-  constructor(opts: { cliPath: string; attachmentStore?: import('../attachment-store.js').AttachmentStore }) {
+  constructor(opts: {
+    cliPath: string;
+    attachmentStore?: import('../attachment-store.js').AttachmentStore;
+    /** Test-only timing override; production uses conservative defaults. */
+    promptWatchdog?: Partial<PromptWatchdogOptions>;
+  }) {
     super();
     this.cliPath = opts.cliPath;
     this.attachmentStore = opts.attachmentStore;
+    this.promptWatchdog = {
+      ackGraceMs: opts.promptWatchdog?.ackGraceMs ?? PROMPT_ACK_GRACE_MS,
+      intervalMs: opts.promptWatchdog?.intervalMs ?? PROMPT_WATCHDOG_INTERVAL_MS,
+      probeFailureLimit: opts.promptWatchdog?.probeFailureLimit ?? PROMPT_PROBE_FAILURE_LIMIT,
+      idleStallMs: opts.promptWatchdog?.idleStallMs ?? PROMPT_IDLE_STALL_MS,
+    };
   }
 
   /** Write the embedded Kraki tools extension to a stable on-disk path and
@@ -596,6 +637,7 @@ export class PiAdapter extends AgentAdapter {
     if (this.evictTimer) clearInterval(this.evictTimer);
     for (const s of this.sessions.values()) s.proc.kill();
     this.sessions.clear();
+    this.compactingSessions.clear();
   }
 
   private blankUsage(): SessionUsage {
@@ -621,13 +663,14 @@ export class PiAdapter extends AgentAdapter {
       extensionPath: this.ensureToolsExtension(),
       env,
     });
-    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingNarration: '', aborting: false, finalizing: false, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
+    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), exitObserved: false, pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingNarration: '', aborting: false, finalizing: false, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
     proc.onEvent = (e) => this.handleEvent(sessionId, e);
     proc.onExit = () => {
       // Process gone (crash/kill) → no agent_end will arrive. Permissions cannot
       // be reconstructed, but ask_user is durable at RelayClient/CardManager:
       // keep its id/card so the next answer can transparently use a recovery
       // prompt after lazy resume.
+      sess.exitObserved = true;
       this.clearPendingPerms(sessionId);
       this.pendingModeSignals.delete(sessionId);
       this.onIdle?.(sessionId);
@@ -678,13 +721,119 @@ export class PiAdapter extends AgentAdapter {
     }
   }
 
+  private setCompacting(
+    sessionId: string,
+    active: boolean,
+    event: Omit<import('./base.js').CompactionEvent, 'phase'> = {},
+  ): void {
+    if (active) {
+      if (this.compactingSessions.has(sessionId)) return;
+      this.compactingSessions.add(sessionId);
+      this.onCompaction?.(sessionId, { phase: 'start', ...event });
+      return;
+    }
+    if (!this.compactingSessions.delete(sessionId)) return;
+    this.onCompaction?.(sessionId, { phase: 'end', ...event });
+  }
+
+  private normalizeCompactionReason(value: unknown): import('./base.js').CompactionReason | undefined {
+    return value === 'manual' || value === 'threshold' || value === 'overflow' ? value : undefined;
+  }
+
+  /** Wait for the ORIGINAL prompt's preflight ACK without ever resending it.
+   *  After the normal 30s grace, bounded get_state probes distinguish healthy
+   *  compaction/streaming from a dead RPC channel or a genuinely idle stall. */
+  private async awaitPromptAcceptance(
+    sessionId: string,
+    s: PiSession,
+    promptPayload: Record<string, unknown>,
+  ): Promise<void> {
+    const ack = s.proc.request('prompt', promptPayload, { timeoutMs: null });
+    // Attach exactly one terminal observer so returning early on authoritative
+    // isStreaming cannot produce an unhandled rejection when the late ACK lands.
+    const ackOutcome = ack.then(
+      () => ({ kind: 'ack' as const }),
+      (error: unknown) => ({ kind: 'error' as const, error: error as Error }),
+    );
+    let delayMs = this.promptWatchdog.ackGraceMs;
+    let idleSince: number | null = null;
+    let consecutiveProbeFailures = 0;
+
+    while (true) {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const tick = new Promise<{ kind: 'tick' }>((resolve) => {
+        timer = setTimeout(() => resolve({ kind: 'tick' }), delayMs);
+      });
+      const outcome = await Promise.race([ackOutcome, tick]);
+      if (timer) clearTimeout(timer);
+      if (outcome.kind === 'ack') return;
+      if (outcome.kind === 'error') throw outcome.error;
+      if (!s.proc.alive) throw new Error('pi process exited before prompt acceptance');
+
+      delayMs = this.promptWatchdog.intervalMs;
+      try {
+        const state = await s.proc.request<{
+          isStreaming?: boolean;
+          isCompacting?: boolean;
+        }>('get_state');
+        consecutiveProbeFailures = 0;
+
+        if (state.isCompacting) {
+          idleSince = null;
+          this.setCompacting(sessionId, true);
+          logger.debug({ sessionId }, 'pi prompt ACK delayed by compaction; continuing to wait');
+          continue;
+        }
+
+        // A missed native compaction_end must not leave stale UI once Pi reports
+        // real streaming or a settled non-compacting state.
+        this.setCompacting(sessionId, false);
+        if (state.isStreaming) {
+          logger.debug({ sessionId }, 'pi prompt accepted before ACK; watchdog reconciled active state');
+          return;
+        }
+
+        idleSince ??= Date.now();
+        if (Date.now() - idleSince >= this.promptWatchdog.idleStallMs) {
+          throw new Error('pi prompt was not acknowledged and pi reported neither streaming nor compaction');
+        }
+      } catch (err) {
+        const message = (err as Error).message;
+        if (message === 'pi prompt was not acknowledged and pi reported neither streaming nor compaction') throw err;
+        consecutiveProbeFailures += 1;
+        logger.warn({ sessionId, err: message, consecutiveProbeFailures }, 'pi prompt watchdog state probe failed');
+        if (!s.proc.alive || consecutiveProbeFailures >= this.promptWatchdog.probeFailureLimit) {
+          throw new Error(`pi prompt acknowledgement could not be reconciled: ${message}`);
+        }
+      }
+    }
+  }
+
   // ── Event mapping: pi session.subscribe → Kraki callbacks ──
   private async handleEvent(sessionId: string, e: { type: string; [k: string]: unknown }): Promise<void> {
     this.touch(sessionId);
     switch (e.type) {
+      case 'compaction_start':
+        this.setCompacting(sessionId, true, { reason: this.normalizeCompactionReason(e.reason) });
+        break;
+      case 'compaction_end':
+        this.setCompacting(sessionId, false, {
+          reason: this.normalizeCompactionReason(e.reason),
+          aborted: e.aborted === true,
+          willRetry: e.willRetry === true,
+          errorMessage: typeof e.errorMessage === 'string' ? e.errorMessage : undefined,
+        });
+        break;
       case 'agent_start':
+        // Streaming proves any preceding compaction is over even if its end
+        // event was missed during resume/reconciliation.
+        this.setCompacting(sessionId, false);
         break;
       case 'message_update': {
+        // Real model/tool activity also proves a stale compaction indicator is
+        // no longer current. Clear only the adapter-owned compaction lifecycle;
+        // CardManager independently protects newer action-slot owners.
+        this.setCompacting(sessionId, false);
         const s = this.sessions.get(sessionId);
         const am = (e as { assistantMessageEvent?: AssistantStreamEvent }).assistantMessageEvent;
         if (am?.type === 'text_delta' && typeof am.delta === 'string') {
@@ -767,6 +916,7 @@ export class PiAdapter extends AgentAdapter {
         break;
       }
       case 'tool_execution_start': {
+        this.setCompacting(sessionId, false);
         const toolName = String(e.toolName ?? 'tool');
         if (toolName === 'finalize_reply') {
           // The turn-conclusion tool — never a TRACE step. Only meaningful during
@@ -1161,14 +1311,12 @@ export class PiAdapter extends AgentAdapter {
       .filter((a): a is import('@kraki/protocol').ImageAttachment => a.type === 'image')
       .map(a => ({ type: 'image' as const, data: a.data, mimeType: a.mimeType }));
     const promptPayload: Record<string, unknown> = { message: text, ...(images.length > 0 && { images }) };
-    // The `prompt` RPC resolves as soon as pi accepts the run (it streams
-    // asynchronously and ends with agent_end); backend failures surface
-    // in-stream as message_end{stopReason:'error'} -> onError. The await here
-    // is the transport-level safety net: if the request itself is rejected
-    // (stdin closed, process gone, command timeout) there will be no agent_end,
-    // so emit error + idle to avoid hanging the session "active" forever.
+    // Submit exactly once. Pi only ACKs after prompt preflight, which may spend
+    // minutes compacting even though the frame was delivered successfully. The
+    // state-aware watchdog preserves the original request and never translates a
+    // slow ACK into a false error/idle or duplicate prompt.
     try {
-      await s.proc.request('prompt', promptPayload);
+      await this.awaitPromptAcceptance(sessionId, s, promptPayload);
     } catch (err) {
       const message = (err as Error).message;
       // pi can get into a state where the adapter has emitted idle (agent_end
@@ -1192,12 +1340,16 @@ export class PiAdapter extends AgentAdapter {
         } finally {
           s.aborting = false;
         }
-        await s.proc.request('prompt', promptPayload);
+        // The explicit rejection proves the first prompt was NOT accepted. Only
+        // this path may retry, after authoritative abort + idle reconciliation.
+        await this.awaitPromptAcceptance(sessionId, s, promptPayload);
         return;
       }
       logger.warn({ sessionId, err: message }, 'pi prompt request failed');
       this.onError?.(sessionId, { message });
-      this.onIdle?.(sessionId);
+      // Unexpected process exit owns its terminal idle in proc.onExit. Other
+      // transport/watchdog failures still need to release the active UI here.
+      if (!s.exitObserved) this.onIdle?.(sessionId);
     }
   }
 

--- a/packages/tentacle/src/card-manager.ts
+++ b/packages/tentacle/src/card-manager.ts
@@ -120,7 +120,8 @@ export class CardManager {
     }
     if (a.type === 'tool_batch') return `batch:${a.payload.running}`;
     if (a.type === 'permission') return `permission:${a.payload.id}:${a.payload.decision ?? ''}`;
-    return `question:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer !== undefined ? 'answered' : 'pending'}`;
+    if (a.type === 'question') return `question:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer !== undefined ? 'answered' : 'pending'}`;
+    return `compaction:${a.payload.reason ?? 'unknown'}`;
   }
 
   /** The action a session's live tools should occupy the slot with, derived from
@@ -153,13 +154,9 @@ export class CardManager {
   onDelta(sessionId: string, content: string): void {
     if (!content) return;
     const c = this.get(sessionId);
-    // Narration resumed → a SETTLED tail sitting in the slot is no longer the
-    // most recent activity, so retire it now. This enforces the live-action
-    // rule: the slot carries a completed tool / resolved prompt ONLY while it is
-    // the latest thing that happened (nothing narrated after it). A still-running
-    // tool (runningTools non-empty) or an UNRESOLVED prompt is left untouched —
-    // those are genuinely live and stream in parallel with the narration.
-    if (this.isSettledTail(c)) {
+    // Narration resumed → a SETTLED tail or stale compaction indicator is no
+    // longer the latest activity. Running tools and unresolved prompts remain.
+    if (this.isSettledTail(c) || c.action?.type === 'compaction') {
       c.action = null;
       this.syncAction(sessionId, c);
     }
@@ -187,10 +184,9 @@ export class CardManager {
    *  next delta to start a fresh segment (keep-last). */
   onNarrationFinal(sessionId: string, content: string): void {
     const c = this.get(sessionId);
-    // A narration segment is the latest activity now → retire a settled tail
-    // still sitting in the slot (mirrors the same rule in onDelta, for the edge
-    // where a segment finalizes without having streamed any delta).
-    if (this.isSettledTail(c)) {
+    // A narration segment is the latest activity now → retire a settled tail or
+    // stale compaction indicator (mirrors onDelta for no-stream edge cases).
+    if (this.isSettledTail(c) || c.action?.type === 'compaction') {
       c.action = null;
       this.syncAction(sessionId, c);
     }
@@ -227,6 +223,24 @@ export class CardManager {
   }
 
   // ── Action part ───────────────────────────────────────
+
+  /** Pi started compacting before prompt acceptance. Do not hide a blocking
+   *  human affordance; otherwise compaction owns the transient action slot. */
+  onCompactionStart(sessionId: string, reason?: 'manual' | 'threshold' | 'overflow'): void {
+    const c = this.get(sessionId);
+    if (this.slotBlocksTool(c)) return;
+    c.action = { type: 'compaction', payload: { phase: 'running', ...(reason && { reason }) } };
+    this.syncAction(sessionId, c);
+  }
+
+  /** Clear only if compaction still owns the slot. A newer tool/prompt action
+   *  must survive a late native compaction_end or watchdog reconciliation. */
+  onCompactionEnd(sessionId: string): void {
+    const c = this.cards.get(sessionId);
+    if (!c || c.action?.type !== 'compaction') return;
+    c.action = null;
+    this.syncAction(sessionId, c);
+  }
 
   /** A tool started — track it as in-flight and (unless a pending prompt owns the
    *  slot) show the derived tool action: the single tool, or a `tool_batch` count

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1664,6 +1664,11 @@ export class RelayClient {
       this.sessionManager.setUsage(sessionId, usage);
     };
 
+    this.adapter.onCompaction = (sessionId, event) => {
+      if (event.phase === 'start') this.card.onCompactionStart(sessionId, event.reason);
+      else this.card.onCompactionEnd(sessionId);
+    };
+
     this.adapter.onError = (sessionId, event) => {
       this.send({
         type: 'error',


### PR DESCRIPTION
## Problem

Pi only ACKs a `prompt` RPC after preflight, which can spend minutes compacting even though the frame was already delivered. The old 30s command timeout treated that slow ACK as a failure: it rejected the in-flight prompt, emitted `error + idle`, and risked a duplicate turn on retry.

Confirmed in production (`mrgg8eeb-lxbdu6qd`, `mrgg6nj1-kkreou2m`): both reported `pi command 'prompt' timed out` but Pi kept executing the original prompt to completion.

## Fix

- **`PiRpcProcess.request`** accepts `{ timeoutMs: null }` for commands whose response is legitimately delayed after delivery; control commands (`get_state`, `abort`, `set_model` …) stay bounded at 30s.
- **`awaitPromptAcceptance`** submits the prompt exactly once and races the original ACK against bounded `get_state` probes:
  - `isCompacting` → keep waiting, surface compaction
  - `isStreaming` → reconcile acceptance, stop treating missing ACK as failure
  - repeated probe failure or genuine idle stall → one terminal `error/idle`
  - process exit owns its single idle via a per-session `exitObserved` guard
- Native `compaction_start/end` events map to a deduplicated adapter callback; the summary is never forwarded.
- **Protocol** adds a transient `compaction` `CardActionState` variant.
- **CardManager** surfaces/clears compaction without hiding blocking prompts or newer tool actions; late `compaction_end` cannot clear a newer tool.
- **RelayClient** + **MultiAgentAdapter** forward `onCompaction`.
- **Web ARM** renders `Compacting context…` as runtime activity, never a fake tool/step.

Compaction state is transient: `card_action` only, never `messages.jsonl`, `trace.jsonl`, or model context.

## Verification

- Unit: tentacle 714, web 356, head 232, crypto 36 — all pass; `pnpm lint` + `pnpm build` clean.
- Real fake-Pi spawn/RPC process check: 1 prompt frame, 2 state probes, 0 error, 0 idle, correct compaction start/end.
- Regression coverage includes: delayed ACK through compaction, `isStreaming` acceptance, repeated probe failure, native compaction dedup, process-exit exactly-once idle, prompt never resent, transient-only `card_action`, reconnect snapshot, late-end ownership.

## Notes

- iOS ARM has no `card_action` support in this lineage, so it is intentionally out of scope; the watchdog fix is correct without client UI support. Unknown transient action variants degrade safely.
- No behavior change for Claude/Copilot adapters.