### PR TITLE
feat(turn): unified terminal status cards for abort and backend failure

### DIFF
--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -97,6 +97,7 @@ final class MessageRouter {
         "session_created",
         "agent_message",
         "interrupted_turn",
+        "turn_status",
         "user_message",
         "permission",
         "permission_resolved",
@@ -117,7 +118,7 @@ final class MessageRouter {
     /// `updatePreview` flips the card to the agent's final reply (or
     /// to permission / question / error text).
     private static let notifyWorthyTypes: Set<String> = [
-        "idle", "error", "permission", "question"
+        "idle", "error", "permission", "question", "turn_status"
     ]
 
     // MARK: Init
@@ -383,6 +384,15 @@ final class MessageRouter {
             if let content = payload?["content"] as? String {
                 appState.sessionStore.setAgentTextActivity(sessionId, text: content)
             }
+
+        case "turn_status":
+            appState.sessionStore.flushDelta(sessionId)
+            appState.messageProvider?.ingestTailCandidate(sessionId, json: json)
+            let draft = payload?["draft"] as? String ?? ""
+            let action = payload?["action"] as? [String: Any]
+            let failed = action?["type"] as? String == "failed"
+            updatePreview(sessionId, text: draft.isEmpty ? (failed ? "Turn failed" : "User aborted") : draft,
+                          type: failed ? "error" : "agent", timestamp: timestamp)
 
         case "interrupted_turn":
             appState.sessionStore.flushDelta(sessionId)

--- a/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
@@ -143,6 +143,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Sendable {
 
     var content: String? { payload["content"]?.stringValue }
     var interruptedDraft: String? { payload["draft"]?.stringValue }
+    var terminalAction: [String: AnyCodable]? { payload["action"]?.dictValue }
     var toolName: String? { payload["toolName"]?.stringValue }
     var toolCallId: String? { payload["toolCallId"]?.stringValue }
     var result: String? { payload["result"]?.stringValue }
@@ -235,7 +236,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Sendable {
     /// True for message types that should be rendered in the chat.
     var isRenderable: Bool {
         switch type {
-        case "user_message", "agent_message", "interrupted_turn", "pending_input", "send_input",
+        case "user_message", "agent_message", "interrupted_turn", "turn_status", "pending_input", "send_input",
              "permission", "question", "tool_start", "tool_complete",
              "idle", "active", "error", "session_created", "session_ended",
              "session_deleted", "kill_session", "answer",

--- a/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
@@ -78,6 +78,7 @@ final class MessageStore {
         "session_created",
         "agent_message",
         "interrupted_turn",
+        "turn_status",
         "user_message",
         "permission",
         "permission_resolved",

--- a/packages/arm/ios/Kraki/Core/Storage/TurnGrouper.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/TurnGrouper.swift
@@ -188,6 +188,7 @@ private let thinkingTypes: Set<String> = [
     "tool_complete",
     "agent_message",
     "interrupted_turn",
+    "turn_status",
     "permission",
     "permission_resolved",
     "question",
@@ -324,7 +325,7 @@ func groupMessagesIntoTurns(
             // block) leave finalMessage nil.
             var lastAgentIdx = -1
             for i in stride(from: currentThinking.count - 1, through: 0, by: -1) {
-                if currentThinking[i].type == "agent_message" || currentThinking[i].type == "interrupted_turn" {
+                if currentThinking[i].type == "agent_message" || currentThinking[i].type == "interrupted_turn" || currentThinking[i].type == "turn_status" {
                     lastAgentIdx = i
                     break
                 }

--- a/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
@@ -258,6 +258,9 @@ struct MessageBubbleView: View {
         case "agent_message":
             agentBubble
 
+        case "turn_status":
+            turnStatusBubble
+
         case "interrupted_turn":
             interruptedTurnBubble
 
@@ -313,6 +316,36 @@ struct MessageBubbleView: View {
 
         default:
             EmptyView()
+        }
+    }
+
+    // MARK: - Terminal Turn Status
+
+    private var turnStatusBubble: some View {
+        let action = message.terminalAction
+        let failed = action?["type"]?.stringValue == "failed"
+        let label = failed ? "Turn failed" : "User aborted"
+        let icon = failed ? "xmark.octagon.fill" : "stop.circle.fill"
+        let tint: Color = failed ? .red : .secondary
+        let detail = failed ? action?["payload"]?.dictValue?["message"]?.stringValue : nil
+        return HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 8) {
+                if let draft = message.interruptedDraft, !draft.isEmpty {
+                    messageBody(draft, foreground: .primary.opacity(0.8))
+                }
+                if let detail, !detail.isEmpty {
+                    Text(detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Label(label, systemImage: icon)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(tint)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color.secondary.opacity(0.08), in: bubbleShape(isUser: false))
+            Spacer(minLength: WindowSize.width * 0.05)
         }
     }
 

--- a/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
+++ b/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type Page, request } from '@playwright/test';
+
+/**
+ * REAL-STACK terminal-card verification — proves the unified `turn_status`
+ * protocol renders a permanent, read-only status card for BOTH terminal
+ * outcomes (user_abort + failed), survives a full browser refresh, and that
+ * unfinished tool steps are preserved in the Steps trace with the correct
+ * cancelled/interrupted outcome.
+ *
+ * Transport, head hub, SQLite durable outbox, pulse framing, E2E crypto and
+ * browser render are all REAL. The tentacle is a MockAdapter driven via the
+ * orchestrator's HTTP control plane.
+ */
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB_URL = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const qs = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${qs ? `?${qs}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`control ${path} failed: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pairBrowser(page: Page): Promise<string> {
+  const { token, web, sessionId } = await control('/token');
+  await page.goto(web as string);
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  return sessionId as string;
+}
+
+async function openSessionChat(page: Page, sessionId: string): Promise<void> {
+  await expect(page.getByRole('button', { name: /Mock-agent/ }).first())
+    .toBeVisible({ timeout: 15_000 });
+  await page.goto(`${WEB_URL}/session/${sessionId}`);
+  await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 10_000 });
+}
+
+async function sendPrompt(page: Page, text: string): Promise<void> {
+  const input = page.getByPlaceholder('Send a message…');
+  await expect(input).toBeVisible({ timeout: 10_000 });
+  await input.fill(text);
+  await input.press('Enter');
+  await expect(page.locator('[data-chat-scroll]').getByText(text)).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe.serial('real-stack terminal status cards', () => {
+  let sessionId: string;
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    sessionId = await pairBrowser(page);
+    await openSessionChat(page, sessionId);
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
+  });
+
+  test('user abort freezes a permanent user_abort card with draft + cancelled step', async () => {
+    await control('/idle', { sid: sessionId });
+    await sendPrompt(page, 'Refactor the auth module');
+
+    // Make the card active: streaming draft + a running tool.
+    await control('/delta', { sid: sessionId, text: 'Analyzing the auth module structure' });
+    await control('/toolStart', { sid: sessionId, tool: 'read_file', cmd: 'src/auth.ts' });
+
+    // The Stop button is only interactive while the session is active (not idle).
+    const stopBtn = page.locator('button[aria-label="Stop"]');
+    await expect(stopBtn).toBeVisible({ timeout: 10_000 });
+    await stopBtn.click();
+
+    // turn_status with user_abort arrives over pulse and renders as a terminal card.
+    const abortCard = page.locator('[data-terminal-card="user_abort"]');
+    await expect(abortCard).toBeVisible({ timeout: 10_000 });
+    await expect(abortCard.getByText('User aborted')).toBeVisible();
+    // The streaming draft is preserved inside the frozen card.
+    await expect(abortCard.getByText('Analyzing the auth module structure')).toBeVisible();
+
+    await page.screenshot({ path: '/tmp/kraki-terminal-abort.png', fullPage: false });
+
+    // The cancelled tool step survives in the Steps trace.
+    const stepsBtn = abortCard.getByRole('button', { name: /Steps/i });
+    if (await stepsBtn.isVisible()) {
+      await stepsBtn.click();
+      await expect(page.getByText(/Cancelled.*read_file|read_file.*Cancelled/i).or(page.getByText(/Cancelled/i))).toBeVisible({ timeout: 5_000 });
+      await page.screenshot({ path: '/tmp/kraki-terminal-abort-steps.png', fullPage: false });
+      await page.keyboard.press('Escape');
+    }
+  });
+
+  test('user_abort card survives a full browser refresh', async () => {
+    await page.reload();
+    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 10_000 });
+    const abortCard = page.locator('[data-terminal-card="user_abort"]');
+    await expect(abortCard).toBeVisible({ timeout: 10_000 });
+    await expect(abortCard.getByText('User aborted')).toBeVisible();
+    await expect(abortCard.getByText('Analyzing the auth module structure')).toBeVisible();
+
+    await page.screenshot({ path: '/tmp/kraki-terminal-abort-refreshed.png', fullPage: false });
+  });
+
+  test('backend error freezes a permanent failed card', async () => {
+    await control('/idle', { sid: sessionId });
+    await sendPrompt(page, 'Run the full test suite');
+
+    // Active streaming draft.
+    await control('/delta', { sid: sessionId, text: 'Compiling and running tests' });
+    await control('/toolStart', { sid: sessionId, tool: 'bash', cmd: 'npm test' });
+
+    // A terminal backend error arrives, then idle freezes it as `failed`.
+    await control('/error', { sid: sessionId, message: '524 status code (no body)' });
+    await control('/idle', { sid: sessionId });
+
+    const failedCard = page.locator('[data-terminal-card="failed"]');
+    await expect(failedCard).toBeVisible({ timeout: 10_000 });
+    await expect(failedCard.getByText('Turn failed')).toBeVisible();
+    await expect(failedCard.getByText('524 status code (no body)')).toBeVisible();
+    // The streaming draft is preserved inside the frozen card.
+    await expect(failedCard.getByText('Compiling and running tests')).toBeVisible();
+
+    await page.screenshot({ path: '/tmp/kraki-terminal-failed.png', fullPage: false });
+  });
+
+  test('failed card survives a full browser refresh', async () => {
+    await page.reload();
+    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 10_000 });
+    const failedCard = page.locator('[data-terminal-card="failed"]');
+    await expect(failedCard).toBeVisible({ timeout: 10_000 });
+    await expect(failedCard.getByText('Turn failed')).toBeVisible();
+
+    await page.screenshot({ path: '/tmp/kraki-terminal-failed-refreshed.png', fullPage: false });
+  });
+});

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -212,7 +212,7 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
     for (const msg of spine) {
       const seq = getSeq(msg);
       const isFinalAgent = msg.type === 'agent_message' && finalAgentSeqs.has(seq);
-      if ((isFinalAgent || msg.type === 'interrupted_turn') && (msg.payload.steps ?? 0) > 0) {
+      if ((isFinalAgent || msg.type === 'interrupted_turn' || msg.type === 'turn_status') && (msg.payload.steps ?? 0) > 0) {
         messageProvider.requestTurnTrace(sessionId, seq);
       }
     }
@@ -236,7 +236,7 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
       }
     }
     for (let i = spine.length - 1; i >= 0; i--) {
-      if (spine[i].type === 'agent_message' || spine[i].type === 'interrupted_turn') return i;
+      if (spine[i].type === 'agent_message' || spine[i].type === 'interrupted_turn' || spine[i].type === 'turn_status') return i;
     }
     return -1;
   }, [spine, sessionIdle]);

--- a/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react';
 import Markdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
+import { CircleStop, OctagonX } from 'lucide-react';
 import { AgentAvatar } from '../common/AgentAvatar';
 import { PermissionInput } from '../actions/PermissionInput';
 import { QuestionInput } from '../actions/QuestionInput';
@@ -26,6 +27,17 @@ interface LiveAgentBubbleProps {
   sessionId: string;
   agent?: string;
   card: SessionCard;
+  /** Render as a permanent read-only card rebuilt from a persisted
+   *  `turn_status` message. Uses the supplied timestamp/bubbleSeq instead of
+   *  the live "now" clock, skips the proactive live trace-pull, and always
+   *  shows a bottom footer (timestamp + Steps). The action slot carries the
+   *  terminal outcome (`user_abort` | `failed`) rendered with the SAME action
+   *  section the live card uses — there is no separate terminal-card chrome. */
+  frozen?: {
+    timestamp: string;
+    bubbleSeq: number;
+    stepHint?: number;
+  };
 }
 
 /**
@@ -47,8 +59,14 @@ interface LiveAgentBubbleProps {
  * When the concluding agent_message lands on the spine (and the draft + action
  * clear), ChatView stops rendering this bubble — the concluded spine bubble
  * takes over in place with no visible change.
+ *
+ * Frozen mode: a persisted `turn_status` (user abort / terminal backend error)
+ * reuses this EXACT rendering with the action slot set to the terminal outcome.
+ * It looks identical to the live card that was on screen the instant the turn
+ * ended — just frozen read-only with a permanent footer.
  */
-export function LiveAgentBubble({ sessionId, agent, card }: LiveAgentBubbleProps) {
+export function LiveAgentBubble({ sessionId, agent, card, frozen }: LiveAgentBubbleProps) {
+  const live = !frozen;
   const draft = card.text ?? '';
   const hasContent = draft.length > 0;
   const a = card.action;
@@ -65,9 +83,11 @@ export function LiveAgentBubble({ sessionId, agent, card }: LiveAgentBubbleProps
   const permission = a?.type === 'permission' ? a : null;
   const question = a?.type === 'question' ? a : null;
   const compaction = a?.type === 'compaction' ? a : null;
-  const hasAction = !!tool || batchRunning > 0 || !!permission || !!question || !!compaction;
+  const userAbort = a?.type === 'user_abort' ? a : null;
+  const failed = a?.type === 'failed' ? a : null;
+  const hasAction = !!tool || batchRunning > 0 || !!permission || !!question || !!compaction || !!userAbort || !!failed;
 
-  const { steps, targetSeq } = useTurnSteps(sessionId, true);
+  const { steps, targetSeq } = useTurnSteps(sessionId, live, frozen?.bubbleSeq);
 
   // TRACE steps are NOT broadcast live (Phase-10: retired from the wire) — they
   // only enter the store via a request_turn_trace pull. So proactively pull the
@@ -76,16 +96,20 @@ export function LiveAgentBubble({ sessionId, agent, card }: LiveAgentBubbleProps
   // reality and the Steps footer self-hides only while the turn genuinely has no
   // steps yet. Keyed off the action identity — NOT card.text — so a narration
   // token stream doesn't spam pulls. The Steps modal re-pulls fresh on open.
+  // Frozen cards skip this — their trace is already persisted and the Steps
+  // button pulls it lazily on open (same as any concluded bubble).
   const actionKey = useMemo(() => cardActionKey(card.action), [card.action]);
   useEffect(() => {
+    if (!live) return;
     if (targetSeq < 0) return;
     messageProvider.invalidateTurnTrace(sessionId, targetSeq);
     messageProvider.requestTurnTrace(sessionId, targetSeq);
-  }, [sessionId, targetSeq, actionKey]);
+  }, [sessionId, targetSeq, actionKey, live]);
 
+  const terminalKind = userAbort ? 'user_abort' : failed ? 'failed' : undefined;
 
   return (
-    <div className="flex gap-2" data-live-bubble>
+    <div className="flex gap-2" data-live-bubble={live || undefined} data-terminal-card={terminalKind}>
       <div className="mt-0.5 shrink-0">
         <AgentAvatar agent={agent ?? ''} sessionId={sessionId} size="sm" />
       </div>
@@ -104,7 +128,7 @@ export function LiveAgentBubble({ sessionId, agent, card }: LiveAgentBubbleProps
                So when this live bubble crystallizes into the spine agent_message,
                the DOM swap repaints the SAME pixels → zero visible flicker. The
                Steps button self-hides while the turn has no steps yet. */}
-            {!hasAction && (
+            {live && !hasAction && (
               <div className="mt-1 flex items-center gap-2">
                 <p className="text-[10px] text-text-muted">{formatTime(new Date().toISOString())}</p>
                 <StepsButton sessionId={sessionId} agent={agent} live />
@@ -145,16 +169,47 @@ export function LiveAgentBubble({ sessionId, agent, card }: LiveAgentBubbleProps
             {permission && <PermissionInput action={permission} sessionId={sessionId} />}
 
             {question && <QuestionInput action={question} sessionId={sessionId} />}
+
+            {/* Terminal outcomes live in the SAME action section as tools /
+               prompts — a read-only status row, no separate card chrome. A
+               frozen card therefore looks exactly like the live card that was
+               on screen when the turn ended, just stopped. */}
+            {userAbort && (
+              <div className="flex items-center gap-2 rounded-lg border border-border-primary bg-surface-primary/40 px-3 py-2 text-xs text-text-secondary">
+                <CircleStop className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+                <span className="font-medium">User aborted</span>
+              </div>
+            )}
+
+            {failed && (
+              <div className="flex items-center gap-2 rounded-lg border border-border-primary bg-surface-primary/40 px-3 py-2 text-xs">
+                <OctagonX className="h-3.5 w-3.5 shrink-0 text-red-500" />
+                <span className="font-medium text-red-600 dark:text-red-400">Turn failed</span>
+                {failed.payload.message && (
+                  <span className="truncate text-text-muted">{failed.payload.message}</span>
+                )}
+              </div>
+            )}
           </div>
         )}
 
-        {/* Mid-turn only (an action occupies the slot): the subtle bottom-right
-           Steps entry. At the settled tail the inline footer above owns Steps so
-           it aligns with the concluded bubble. */}
-        {hasAction && steps.length > 0 && (
-          <div className="flex justify-end px-2 pb-1 pt-0.5">
-            <StepsButton sessionId={sessionId} agent={agent} live />
+        {/* Frozen terminal card: always a permanent bottom footer (real
+           timestamp + Steps) — the same footer a concluded agent_message owns,
+           so the aborted/failed turn anchors its Steps history like any other. */}
+        {frozen ? (
+          <div className="flex items-center gap-2 px-4 py-2">
+            <p className="text-[10px] text-text-muted">{formatTime(frozen.timestamp)}</p>
+            <StepsButton sessionId={sessionId} agent={agent} bubbleSeq={frozen.bubbleSeq} stepHint={frozen.stepHint} />
           </div>
+        ) : (
+          /* Mid-turn only (an action occupies the slot): the subtle bottom-right
+             Steps entry. At the settled tail the inline footer above owns Steps
+             so it aligns with the concluded bubble. */
+          hasAction && steps.length > 0 && (
+            <div className="flex justify-end px-2 pb-1 pt-0.5">
+              <StepsButton sessionId={sessionId} agent={agent} live />
+            </div>
+          )
         )}
       </div>
     </div>

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -2,15 +2,16 @@ import Markdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
 import type { PermissionRequest as ProtocolPermissionRequest, QuestionRequest as ProtocolQuestionRequest, Attachment, CardActionState, ContentRef } from '@kraki/protocol';
-import type { ChatMessage } from '../../types/store';
+import type { ChatMessage, SessionCard } from '../../types/store';
 import { formatTime, agentInfo } from '../../lib/format';
 import { stringToHue } from '../../lib/color';
 import { ToolActivity } from './ToolActivity';
 import { AgentAvatar } from '../common/AgentAvatar';
-import { Lock, Check, X, LockOpen, CircleStop, Copy, Info, ChevronLeft, ChevronRight, FileCode2, ExternalLink, OctagonX } from 'lucide-react';
+import { Lock, Check, X, LockOpen, CircleStop, Copy, Info, ChevronLeft, ChevronRight, FileCode2, ExternalLink } from 'lucide-react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useAttachment } from '../../hooks/useAttachment';
 import { StepsButton } from './StepsModal';
+import { LiveAgentBubble } from './LiveAgentBubble';
 
 const ID_DISPLAY_LENGTH = 8;
 const IMAGE_PLACEHOLDER = '[image]';
@@ -92,39 +93,23 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
       );
 
     case 'turn_status': {
+      // Reuse the SAME renderer as the live status card — a frozen card looks
+      // identical to the live bubble that was on screen when the turn ended,
+      // just read-only with the action slot set to the terminal outcome.
+      if (!sessionId) return null;
       const payload = message.payload;
-      const action = payload.action as Extract<CardActionState, { type: 'user_abort' | 'failed' }>;
-      const failed = action.type === 'failed';
-      const Icon = failed ? OctagonX : CircleStop;
-      const label = failed ? 'Turn failed' : 'User aborted';
-      const detail = failed ? action.payload.message : undefined;
+      const card: SessionCard = { text: payload.draft ?? '', action: payload.action };
       return (
-        <div className="flex gap-2" data-terminal-card={action.type}>
-          <div className="mt-0.5 shrink-0">
-            <AgentAvatar agent={agent ?? ''} sessionId={sessionId} size="sm" />
-          </div>
-          <div className={`min-w-0 max-w-[85%] overflow-hidden rounded-2xl rounded-bl-md border shadow-sm sm:max-w-[70%] ${failed ? 'border-red-500/30 bg-red-500/5' : 'border-slate-500/30 bg-slate-500/5'}`}>
-            {payload.draft && (
-              <div className="markdown-content px-4 py-2.5 text-sm leading-relaxed text-text-primary opacity-80">
-                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
-                  {payload.draft}
-                </Markdown>
-              </div>
-            )}
-            <div className={`px-4 py-2.5 ${payload.draft ? 'border-t' : ''} ${failed ? 'border-red-500/20 bg-red-500/10' : 'border-slate-500/20 bg-slate-500/10'}`}>
-              <p className={`flex items-center gap-1 text-xs font-semibold ${failed ? 'text-red-600 dark:text-red-400' : 'text-text-muted'}`}>
-                <Icon className="h-3.5 w-3.5" /> {label}
-              </p>
-              {detail && <p className="mt-1 text-sm text-text-secondary">{detail}</p>}
-            </div>
-            <div className="flex items-center gap-2 px-4 py-2">
-              <p className="text-[10px] text-text-muted">{formatTime(message.timestamp)}</p>
-              {sessionId && typeof message.seq === 'number' && message.seq > 0 && (
-                <StepsButton sessionId={sessionId} bubbleSeq={message.seq} agent={agent} stepHint={payload.steps} />
-              )}
-            </div>
-          </div>
-        </div>
+        <LiveAgentBubble
+          sessionId={sessionId}
+          agent={agent}
+          card={card}
+          frozen={{
+            timestamp: message.timestamp ?? payload.finishedAt ?? new Date().toISOString(),
+            bubbleSeq: typeof message.seq === 'number' ? message.seq : 0,
+            stepHint: payload.steps,
+          }}
+        />
       );
     }
 

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -7,7 +7,7 @@ import { formatTime, agentInfo } from '../../lib/format';
 import { stringToHue } from '../../lib/color';
 import { ToolActivity } from './ToolActivity';
 import { AgentAvatar } from '../common/AgentAvatar';
-import { Lock, Check, X, LockOpen, CircleStop, Copy, Info, ChevronLeft, ChevronRight, FileCode2, ExternalLink } from 'lucide-react';
+import { Lock, Check, X, LockOpen, CircleStop, Copy, Info, ChevronLeft, ChevronRight, FileCode2, ExternalLink, OctagonX } from 'lucide-react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useAttachment } from '../../hooks/useAttachment';
 import { StepsButton } from './StepsModal';
@@ -90,6 +90,43 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
           </div>
         </CopyableBubble>
       );
+
+    case 'turn_status': {
+      const payload = message.payload;
+      const action = payload.action as Extract<CardActionState, { type: 'user_abort' | 'failed' }>;
+      const failed = action.type === 'failed';
+      const Icon = failed ? OctagonX : CircleStop;
+      const label = failed ? 'Turn failed' : 'User aborted';
+      const detail = failed ? action.payload.message : undefined;
+      return (
+        <div className="flex gap-2" data-terminal-card={action.type}>
+          <div className="mt-0.5 shrink-0">
+            <AgentAvatar agent={agent ?? ''} sessionId={sessionId} size="sm" />
+          </div>
+          <div className={`min-w-0 max-w-[85%] overflow-hidden rounded-2xl rounded-bl-md border shadow-sm sm:max-w-[70%] ${failed ? 'border-red-500/30 bg-red-500/5' : 'border-slate-500/30 bg-slate-500/5'}`}>
+            {payload.draft && (
+              <div className="markdown-content px-4 py-2.5 text-sm leading-relaxed text-text-primary opacity-80">
+                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
+                  {payload.draft}
+                </Markdown>
+              </div>
+            )}
+            <div className={`px-4 py-2.5 ${payload.draft ? 'border-t' : ''} ${failed ? 'border-red-500/20 bg-red-500/10' : 'border-slate-500/20 bg-slate-500/10'}`}>
+              <p className={`flex items-center gap-1 text-xs font-semibold ${failed ? 'text-red-600 dark:text-red-400' : 'text-text-muted'}`}>
+                <Icon className="h-3.5 w-3.5" /> {label}
+              </p>
+              {detail && <p className="mt-1 text-sm text-text-secondary">{detail}</p>}
+            </div>
+            <div className="flex items-center gap-2 px-4 py-2">
+              <p className="text-[10px] text-text-muted">{formatTime(message.timestamp)}</p>
+              {sessionId && typeof message.seq === 'number' && message.seq > 0 && (
+                <StepsButton sessionId={sessionId} bubbleSeq={message.seq} agent={agent} stepHint={payload.steps} />
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     case 'interrupted_turn': {
       const payload = message.payload;
@@ -211,6 +248,7 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
             sessionId={sessionId ?? ''}
             requestPull={ATTACHMENT_PULL}
             success={message.payload.success}
+            termination={message.payload.termination}
             forceExpanded={forceExpanded}
           />
           <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} sessionId={sessionId} />
@@ -247,7 +285,13 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
       const args = message.payload.args as Record<string, unknown> | undefined;
       const argsSummary = args ? getPermissionArgsSummary(toolName, args) : '';
       const desc = message.payload.description;
-      const resolution = (message.payload as ProtocolPermissionRequest['payload'] & { resolution?: 'approved' | 'denied' | 'always_allowed' | 'cancelled' }).resolution;
+      const permissionPayload = message.payload as ProtocolPermissionRequest['payload'] & { resolution?: 'approved' | 'denied' | 'always_allowed' | 'cancelled' };
+      const resolution = permissionPayload.cancelled ? 'cancelled' : permissionPayload.resolution ?? (
+        permissionPayload.decision === 'approve' ? 'approved'
+          : permissionPayload.decision === 'always_allow' ? 'always_allowed'
+            : permissionPayload.decision === 'deny' ? 'denied'
+              : undefined
+      );
       // Build a meaningful description
       const displayDesc = desc && desc !== 'Run:' && desc !== `Run: `
         ? desc
@@ -305,7 +349,19 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
     }
 
     case 'question': {
-      const answer = (message.payload as ProtocolQuestionRequest['payload'] & { answer?: string }).answer;
+      const questionPayload = message.payload as ProtocolQuestionRequest['payload'];
+      const answer = questionPayload.answer;
+      if (questionPayload.cancelled) {
+        return (
+          <div className="flex gap-2">
+            <CircleStop className="mt-1 h-4 w-4 shrink-0 text-text-muted" />
+            <div className="min-w-0 max-w-[85%] rounded-2xl rounded-bl-md bg-slate-500/10 px-4 py-2.5 shadow-sm sm:max-w-[70%]">
+              <p className="text-xs font-medium text-text-muted">Question cancelled</p>
+              <p className="mt-0.5 text-sm text-text-secondary">{questionPayload.question || 'The turn ended before this question was answered.'}</p>
+            </div>
+          </div>
+        );
+      }
       return (
         <>
           <div className="flex gap-2">

--- a/packages/arm/web/src/components/chat/StepsList.tsx
+++ b/packages/arm/web/src/components/chat/StepsList.tsx
@@ -31,16 +31,30 @@ export function StepsList({ messages, agent, sessionId, streamingText, allExpand
   // renders as a single "done" chip instead of a duplicate "Running…" + "done"
   // pair. In-flight tools (no matching tool_complete) keep their tool_start.
   const completedToolIds = new Set<string>();
+  const resolvedPromptIds = new Set<string>();
   for (const msg of messages) {
     if (msg.type === 'tool_complete') {
       const id = (msg.payload as { toolCallId?: string }).toolCallId;
       if (id) completedToolIds.add(id);
+    } else if (msg.type === 'permission') {
+      const p = msg.payload as { id?: string; decision?: string; cancelled?: boolean };
+      if (p.id && (p.decision || p.cancelled)) resolvedPromptIds.add(`permission:${p.id}`);
+    } else if (msg.type === 'question') {
+      const p = msg.payload as { id?: string; answer?: string; cancelled?: boolean };
+      if (p.id && (p.answer !== undefined || p.cancelled)) resolvedPromptIds.add(`question:${p.id}`);
     }
   }
   const visible = messages.filter((msg) => {
-    if (msg.type !== 'tool_start') return true;
-    const id = (msg.payload as { toolCallId?: string }).toolCallId;
-    return !(id && completedToolIds.has(id));
+    if (msg.type === 'tool_start') {
+      const id = (msg.payload as { toolCallId?: string }).toolCallId;
+      return !(id && completedToolIds.has(id));
+    }
+    if (msg.type === 'permission' || msg.type === 'question') {
+      const p = msg.payload as { id?: string; decision?: string; answer?: string; cancelled?: boolean };
+      const resolved = !!p.decision || p.answer !== undefined || !!p.cancelled;
+      return resolved || !p.id || !resolvedPromptIds.has(`${msg.type}:${p.id}`);
+    }
+    return true;
   });
 
   return (

--- a/packages/arm/web/src/components/chat/StepsModal.tsx
+++ b/packages/arm/web/src/components/chat/StepsModal.tsx
@@ -5,7 +5,7 @@ import { useStore } from '../../hooks/useStore';
 import { messageProvider } from '../../lib/message-provider';
 import { StepsList } from './StepsList';
 
-const isTrace = (t: string) => t === 'tool_start' || t === 'tool_complete' || t === 'agent_narration';
+const isTrace = (t: string) => t === 'tool_start' || t === 'tool_complete' || t === 'agent_narration' || t === 'permission' || t === 'question';
 
 /**
  * Collect the TRACE steps (narration + tool chips) belonging to one turn,

--- a/packages/arm/web/src/components/chat/ToolActivity.tsx
+++ b/packages/arm/web/src/components/chat/ToolActivity.tsx
@@ -21,6 +21,7 @@ interface ToolActivityProps {
   /** Fired with a sessionId/id when the cache misses and we need to pull. */
   requestPull: (sessionId: string, id: string) => void;
   success?: boolean;
+  termination?: 'cancelled' | 'interrupted';
   cancelled?: boolean;
   forceExpanded?: boolean;
 }
@@ -28,7 +29,7 @@ interface ToolActivityProps {
 export function ToolActivity({
   type, toolName, headline, argsRef, resultRef,
   sessionId, requestPull,
-  success, cancelled, forceExpanded,
+  success, termination, cancelled, forceExpanded,
 }: ToolActivityProps) {
   const [expanded, setExpanded] = useState(false);
   const isExpanded = forceExpanded ?? expanded;
@@ -46,13 +47,15 @@ export function ToolActivity({
           ? (cancelled
             ? <CircleSlash className="h-3.5 w-3.5 shrink-0 text-amber-500" />
             : <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-text-muted" />)
-          : (success === false
-            ? <XCircle className="h-3.5 w-3.5 shrink-0 text-red-500" />
-            : <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-500" />)
+          : termination
+            ? <CircleSlash className={`h-3.5 w-3.5 shrink-0 ${termination === 'cancelled' ? 'text-amber-500' : 'text-red-500'}`} />
+            : (success === false
+              ? <XCircle className="h-3.5 w-3.5 shrink-0 text-red-500" />
+              : <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-500" />)
         }
         <ToolIcon className="h-3.5 w-3.5 shrink-0 text-text-muted opacity-0" aria-hidden="true" />
         <span className="shrink-0 text-xs font-medium text-text-secondary">
-          {isStart && 'Running '}
+          {isStart ? 'Running ' : termination === 'cancelled' ? 'Cancelled ' : termination === 'interrupted' ? 'Interrupted ' : ''}
           <span className="font-mono text-ocean-600 dark:text-ocean-400">{toolName}</span>
         </span>
         {headline && (

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -67,6 +67,13 @@ function rebuildPreview(sessionId: string): void {
       preview = { text: stripMarkdown(msg).slice(0, PREVIEW_MAX), type: 'error', timestamp: ts };
       break;
     }
+    if (m.type === 'turn_status' && payload) {
+      const draft = typeof payload.draft === 'string' ? payload.draft : '';
+      const action = payload.action && typeof payload.action === 'object' ? payload.action as Record<string, unknown> : null;
+      const kind = action && action.type === 'failed' ? 'Turn failed' : 'User aborted';
+      preview = { text: stripMarkdown(draft || kind).slice(0, PREVIEW_MAX), type: action?.type === 'failed' ? 'error' : 'agent', timestamp: ts };
+      break;
+    }
     if (m.type === 'interrupted_turn' && payload) {
       const draft = typeof payload.draft === 'string' ? payload.draft : '';
       preview = { text: stripMarkdown(draft || 'Turn aborted').slice(0, PREVIEW_MAX), type: 'agent', timestamp: ts };

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -212,6 +212,18 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
       }, !replaying);
       break;
 
+    case 'turn_status': {
+      store.appendMessage(sid, msg);
+      const draft = typeof msg.payload.draft === 'string' ? msg.payload.draft : '';
+      const failed = msg.payload.action?.type === 'failed';
+      updatePreview(sid, {
+        text: truncPreview(draft || (failed ? 'Turn failed' : 'User aborted')),
+        type: failed ? 'error' : 'agent',
+        timestamp: msg.timestamp,
+      }, !replaying);
+      break;
+    }
+
     case 'interrupted_turn': {
       store.appendMessage(sid, msg);
       const draft = typeof msg.payload.draft === 'string' ? msg.payload.draft : '';

--- a/packages/arm/web/src/lib/session-status.ts
+++ b/packages/arm/web/src/lib/session-status.ts
@@ -35,6 +35,10 @@ export function cardActionKey(a: CardActionState | null): string {
       return `q:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer === undefined ? 'pending' : 'answered'}`;
     case 'compaction':
       return `compaction:${a.payload.reason ?? 'unknown'}`;
+    case 'user_abort':
+      return `user_abort:${a.payload.abortedAt}`;
+    case 'failed':
+      return `failed:${a.payload.failedAt}:${a.payload.code ?? ''}:${a.payload.message}`;
   }
 }
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -247,6 +247,8 @@ export interface PermissionRequest extends BaseEnvelope {
      *  sole live home is the {@link CardActionState} slot. Absent on old-session
      *  spine records. */
     decision?: 'approve' | 'deny' | 'always_allow';
+    /** Trace/history-only terminal state when the turn ended before a decision. */
+    cancelled?: boolean;
   };
 }
 
@@ -314,8 +316,12 @@ export interface ToolCompleteMessage extends BaseEnvelope {
     argsRef?: ContentRef;
     /** Unique ID matching the tool_start */
     toolCallId?: string;
-    /** Whether the tool execution succeeded (default true if absent) */
+    /** Whether the tool execution succeeded (default true if absent). */
     success?: boolean;
+    /** Synthetic terminal outcome when the turn ended before this tool returned.
+     *  `cancelled` means the user aborted; `interrupted` means the turn failed
+     *  elsewhere (backend/process/model) and the tool result is unknown. */
+    termination?: 'cancelled' | 'interrupted';
     /** Images produced by the tool (e.g. from `kraki-show_image`).
      *  Separate from `resultRef` because images render as a grid below
      *  the chip rather than as an expandable text body. */
@@ -389,6 +395,21 @@ export type CardActionState =
         phase: 'running';
         reason?: 'manual' | 'threshold' | 'overflow';
       };
+    }
+  | {
+      type: 'user_abort';
+      payload: {
+        abortedAt: string;
+      };
+    }
+  | {
+      type: 'failed';
+      payload: {
+        message: string;
+        code?: string;
+        source?: 'adapter' | 'backend' | 'process';
+        failedAt: string;
+      };
     };
 
 /**
@@ -412,7 +433,7 @@ export interface IdleMessage extends BaseEnvelope {
     /** Cumulative session token usage (present when tracked by adapter) */
     usage?: import('./sessions.js').SessionUsage;
     /** Why the session went idle */
-    reason?: 'completed' | 'aborted';
+    reason?: 'completed' | 'aborted' | 'failed';
   };
 }
 
@@ -467,6 +488,23 @@ export interface InterruptedTurnMessage extends BaseEnvelope {
     /** Running tool actions are frozen as cancelled in history. */
     cancelled: true;
     /** Trace-step count accumulated before interruption. */
+    steps?: number;
+  };
+}
+
+/**
+ * Durable terminal status-card snapshot. The card's action is itself the turn
+ * outcome (`user_abort` or `failed`); unfinished work remains in TRACE with a
+ * cancelled/interrupted resolution. This is UI history only and is never added
+ * to the model transcript. `interrupted_turn` remains readable for legacy
+ * history, while new terminal turns use this generic card container.
+ */
+export interface TurnStatusMessage extends BaseEnvelope {
+  type: 'turn_status';
+  payload: {
+    draft: string;
+    action: Extract<CardActionState, { type: 'user_abort' | 'failed' }>;
+    finishedAt: string;
     steps?: number;
   };
 }
@@ -626,7 +664,12 @@ export interface SessionMessagesRangeBatchMessage extends BaseEnvelope {
 /** One recorded step in a turn's trace. These are exactly the live tool
  *  broadcast messages, stored verbatim in `trace.jsonl`, so the client
  *  merges them by `toolCallId` with the SAME code path it uses live. */
-export type TraceEntry = ToolStartMessage | ToolCompleteMessage | AgentNarrationMessage;
+export type TraceEntry =
+  | ToolStartMessage
+  | ToolCompleteMessage
+  | AgentNarrationMessage
+  | PermissionRequest
+  | QuestionRequest;
 
 /**
  * app → tentacle: pull the tool trace for one turn from `trace.jsonl`.
@@ -784,6 +827,7 @@ export type ProducerMessage =
   | ErrorMessage
   | SystemMessage
   | InterruptedTurnMessage
+  | TurnStatusMessage
   | SessionModeSetMessage
   | SessionTitleUpdatedMessage
   | SessionModelSetMessage

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2091,7 +2091,7 @@ describe('RelayClient pending-question digest', () => {
     expect(adapter.sendMessage).not.toHaveBeenCalled();
   });
 
-  it('does not persist interrupted history when explicit abort sees an empty card', async () => {
+  it('does not persist terminal history when explicit abort sees an empty card', async () => {
     const { adapter, ws, sm } = buildClient();
     ws.emit('message', Buffer.from(JSON.stringify({
       type: 'abort_session', sessionId: 'sess_1', deviceId: 'app-x', seq: 507,
@@ -2099,10 +2099,10 @@ describe('RelayClient pending-question digest', () => {
     })));
     await vi.runAllTimersAsync();
     expect(adapter.abortSession).toHaveBeenCalledWith('sess_1');
-    expect((sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.some((call) => call[1] === 'interrupted_turn')).toBe(false);
+    expect((sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.some((call) => call[1] === 'turn_status')).toBe(false);
   });
 
-  it('persists the full visible card as interrupted_turn on explicit abort', async () => {
+  it('persists the full visible card as turn_status on explicit abort and cancels its question step', async () => {
     const { adapter, askQ, ws, sm } = buildClient();
     askQ('q1');
     ws.sent.length = 0;
@@ -2112,16 +2112,34 @@ describe('RelayClient pending-question digest', () => {
     })));
     await Promise.resolve();
     await Promise.resolve();
-    const interruptedCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls
-      .find((call) => call[1] === 'interrupted_turn');
-    expect(interruptedCall).toBeDefined();
-    const interrupted = JSON.parse(interruptedCall![2]) as { payload: Record<string, unknown> };
-    expect(interrupted.payload).toMatchObject({
-      reason: 'user_aborted',
-      cancelled: true,
-      action: { type: 'question', payload: { id: 'q1', question: 'Q q1', cancelled: true } },
+    const statusCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls
+      .find((call) => call[1] === 'turn_status');
+    expect(statusCall).toBeDefined();
+    const status = JSON.parse(statusCall![2]) as { payload: Record<string, unknown> };
+    expect(status.payload).toMatchObject({
+      action: { type: 'user_abort' },
     });
+    const cancelledQuestion = (sm.appendTrace as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) => JSON.parse(call[2]) as { type: string; payload: Record<string, unknown> })
+      .find((entry) => entry.type === 'question' && entry.payload.id === 'q1' && entry.payload.cancelled === true);
+    expect(cancelledQuestion).toBeDefined();
     expect(sm.clearPendingHumanAction).toHaveBeenCalledWith('sess_1');
+  });
+
+  it('freezes an adapter error as failed only when the turn reaches idle', async () => {
+    const { adapter, askQ, sm } = buildClient();
+    askQ('q1');
+    (adapter.onError as (sid: string, event: { message: string }) => void)('sess_1', { message: '524 status code (no body)' });
+    expect((sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.some((call) => call[1] === 'turn_status')).toBe(false);
+
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    const statusCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls
+      .find((call) => call[1] === 'turn_status');
+    expect(statusCall).toBeDefined();
+    const status = JSON.parse(statusCall![2]) as { payload: Record<string, unknown> };
+    expect(status.payload).toMatchObject({
+      action: { type: 'failed', payload: { message: '524 status code (no body)', source: 'backend' } },
+    });
   });
 
   it('pushes the active card snapshot to a freshly-joined device', () => {

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2126,9 +2126,10 @@ describe('RelayClient pending-question digest', () => {
     expect(sm.clearPendingHumanAction).toHaveBeenCalledWith('sess_1');
   });
 
-  it('freezes an adapter error as failed only when the turn reaches idle', async () => {
-    const { adapter, askQ, sm } = buildClient();
-    askQ('q1');
+  it('freezes an adapter error as failed only when the turn reaches idle and stamps step count', async () => {
+    const { adapter, sm } = buildClient();
+    // Drive a tool_start so the turn has a chip-producing step before failing.
+    (adapter.onToolStart as (sid: string, e: Record<string, unknown>) => void)('sess_1', { toolName: 'bash', args: { command: 'npm test' }, toolCallId: 'tc-1' });
     (adapter.onError as (sid: string, event: { message: string }) => void)('sess_1', { message: '524 status code (no body)' });
     expect((sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.some((call) => call[1] === 'turn_status')).toBe(false);
 
@@ -2140,6 +2141,12 @@ describe('RelayClient pending-question digest', () => {
     expect(status.payload).toMatchObject({
       action: { type: 'failed', payload: { message: '524 status code (no body)', source: 'backend' } },
     });
+    expect(status.payload.steps).toBe(1);
+    // The running tool was closed as interrupted, not left dangling.
+    const interruptedTool = (sm.appendTrace as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) => JSON.parse(call[2]) as { type: string; payload: Record<string, unknown> })
+      .find((e) => e.type === 'tool_complete' && e.payload.toolCallId === 'tc-1' && e.payload.termination === 'interrupted');
+    expect(interruptedTool).toBeDefined();
   });
 
   it('pushes the active card snapshot to a freshly-joined device', () => {

--- a/packages/tentacle/src/card-manager.ts
+++ b/packages/tentacle/src/card-manager.ts
@@ -6,6 +6,7 @@ type RunningTool = Extract<CardActionState, { type: 'tool_start' }>;
 type CompletedTool = Extract<CardActionState, { type: 'tool_complete' }>;
 /** A prompt step (permission or question). */
 type PromptAction = Extract<CardActionState, { type: 'permission' | 'question' }>;
+type TerminalAction = Extract<CardActionState, { type: 'user_abort' | 'failed' }>;
 
 /** Stable per-tool key: the tool call id, falling back to its headline when the
  *  adapter didn't supply one. */
@@ -119,9 +120,11 @@ export class CardManager {
       return `${a.type}:${a.payload.toolCallId ?? a.payload.headline}`;
     }
     if (a.type === 'tool_batch') return `batch:${a.payload.running}`;
-    if (a.type === 'permission') return `permission:${a.payload.id}:${a.payload.decision ?? ''}`;
+    if (a.type === 'permission') return `permission:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.decision ?? ''}`;
     if (a.type === 'question') return `question:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer !== undefined ? 'answered' : 'pending'}`;
-    return `compaction:${a.payload.reason ?? 'unknown'}`;
+    if (a.type === 'compaction') return `compaction:${a.payload.reason ?? 'unknown'}`;
+    if (a.type === 'user_abort') return `user_abort:${a.payload.abortedAt}`;
+    return `failed:${a.payload.failedAt}:${a.payload.code ?? ''}:${a.payload.message}`;
   }
 
   /** The action a session's live tools should occupy the slot with, derived from
@@ -294,7 +297,26 @@ export class CardManager {
     this.syncAction(sessionId, c);
   }
 
-  /** Authoritative full state used for durable pending and abort history. */
+  /** Replace the live action with a terminal turn outcome and return everything
+   *  that was still unfinished so RelayClient can close those TRACE steps. */
+  terminate(sessionId: string, action: TerminalAction): {
+    draft: string;
+    previousAction: CardActionState | null;
+    runningTools: RunningTool[];
+  } {
+    const c = this.get(sessionId);
+    const snapshot = {
+      draft: c.draftText,
+      previousAction: c.action,
+      runningTools: [...c.runningTools.values()],
+    };
+    c.runningTools.clear();
+    c.action = action;
+    this.syncAction(sessionId, c);
+    return snapshot;
+  }
+
+  /** Authoritative full state used for durable pending and terminal history. */
   state(sessionId: string): { draft: string; action: CardActionState | null } {
     const c = this.cards.get(sessionId);
     return { draft: c?.draftText ?? '', action: c?.action ?? null };

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -486,10 +486,11 @@ export class RelayClient {
     }
 
     const finishedAt = action.type === 'user_abort' ? action.payload.abortedAt : action.payload.failedAt;
+    const steps = this.turnStepCounts.get(sessionId) ?? 0;
     this.send({
       type: 'turn_status',
       sessionId,
-      payload: { draft: snapshot.draft, action, finishedAt },
+      payload: { draft: snapshot.draft, action, finishedAt, steps },
     });
     this.clearOpenQuestions(sessionId);
     this.card.clear(sessionId);
@@ -1735,9 +1736,18 @@ export class RelayClient {
     };
 
     this.adapter.onError = (sessionId, event) => {
+      // Stage as the terminal outcome so idle freezes it as a `failed` card,
+      // AND broadcast the error immediately so apps surface it without waiting
+      // for the turn to settle. A recoverable error that never reaches idle just
+      // shows the transient notice — no frozen card.
       this.pendingTerminalErrors.set(sessionId, {
         message: event.message,
         source: 'backend',
+      });
+      this.send({
+        type: 'error',
+        sessionId,
+        payload: { message: event.message },
       });
     };
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -119,6 +119,7 @@ export class RelayClient {
     'error',
     'system_message',
     'interrupted_turn',
+    'turn_status',
     'session_ended',
     'idle',
   ]);
@@ -161,6 +162,9 @@ export class RelayClient {
    *  preceding turn reaches a real idle boundary. */
   private inputChains = new Map<string, Promise<void>>();
   private turnIdleWaiters = new Map<string, { promise: Promise<void>; resolve: () => void }>();
+  /** Adapter errors become terminal only when the same logical turn reaches
+   *  idle. Keeping them pending avoids freezing recoverable tool failures. */
+  private pendingTerminalErrors = new Map<string, { message: string; code?: string; source: 'adapter' | 'backend' | 'process' }>();
 
   private waitForTurnIdle(sessionId: string): Promise<void> {
     const existing = this.turnIdleWaiters.get(sessionId);
@@ -381,6 +385,7 @@ export class RelayClient {
 
     this.removeOpenQuestion(sessionId, pending.questionId);
     this.card.resolvePrompt(sessionId, pending.questionId, { answer: answer.text || 'Answered with image' });
+    this.recordTrace({ type: 'question', sessionId, payload: { id: pending.questionId, question: pending.question, answer: answer.text || 'Answered with image' } });
     this.send({
       type: 'question_resolved',
       sessionId,
@@ -437,6 +442,57 @@ export class RelayClient {
       logger.warn({ err, sessionId, toolName }, 'failed to offload result');
       return undefined;
     }
+  }
+
+  /** Freeze the live card into a durable terminal status and close every
+   *  unfinished TRACE action with the appropriate non-success outcome. */
+  private finishTurnWithStatus(
+    sessionId: string,
+    action: Extract<CardActionState, { type: 'user_abort' | 'failed' }>,
+  ): void {
+    const termination = action.type === 'user_abort' ? 'cancelled' : 'interrupted';
+    const snapshot = this.card.terminate(sessionId, action);
+
+    for (const tool of snapshot.runningTools) {
+      this.recordTrace({
+        type: 'tool_complete',
+        sessionId,
+        payload: { ...tool.payload, success: false, termination },
+      });
+      const id = tool.payload.toolCallId;
+      if (id) {
+        this.lastArgsByToolCallId.delete(id);
+        this.lastArgsRefByToolCallId.delete(id);
+      }
+    }
+    this.sessionToolCallIds.delete(sessionId);
+
+    if (snapshot.previousAction?.type === 'permission' && !snapshot.previousAction.payload.decision) {
+      this.recordTrace({
+        type: 'permission',
+        sessionId,
+        payload: { ...snapshot.previousAction.payload, cancelled: true },
+      });
+    } else if (
+      snapshot.previousAction?.type === 'question' &&
+      snapshot.previousAction.payload.answer === undefined &&
+      !snapshot.previousAction.payload.cancelled
+    ) {
+      this.recordTrace({
+        type: 'question',
+        sessionId,
+        payload: { ...snapshot.previousAction.payload, cancelled: true },
+      });
+    }
+
+    const finishedAt = action.type === 'user_abort' ? action.payload.abortedAt : action.payload.failedAt;
+    this.send({
+      type: 'turn_status',
+      sessionId,
+      payload: { draft: snapshot.draft, action, finishedAt },
+    });
+    this.clearOpenQuestions(sessionId);
+    this.card.clear(sessionId);
   }
 
   /** Drop any in-flight toolCallId state for a session — called when a
@@ -899,6 +955,7 @@ export class RelayClient {
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'approve')
             .then(() => {
               this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'approve' });
+              this.recordTrace({ type: 'permission', sessionId, payload: { id: msg.payload.permissionId, description: '', toolName: '', args: {}, decision: 'approve' } });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'approved' } });
             })
             .catch((err) => {
@@ -910,6 +967,7 @@ export class RelayClient {
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'deny')
             .then(() => {
               this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'deny' });
+              this.recordTrace({ type: 'permission', sessionId, payload: { id: msg.payload.permissionId, description: '', toolName: '', args: {}, decision: 'deny' } });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'denied' } });
             })
             .catch((err) => {
@@ -921,6 +979,7 @@ export class RelayClient {
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'always_allow')
             .then(() => {
               this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'always_allow' });
+              this.recordTrace({ type: 'permission', sessionId, payload: { id: msg.payload.permissionId, description: '', toolName: '', args: {}, decision: 'always_allow' } });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'always_allowed' } });
             })
             .catch((err) => {
@@ -951,24 +1010,16 @@ export class RelayClient {
           const snapshot = this.card.state(sessionId);
           this.adapter.abortSession(sessionId)
             .then(() => {
-              const frozenAction = snapshot.action?.type === 'question'
-                ? { ...snapshot.action, payload: { ...snapshot.action.payload, cancelled: true } }
-                : snapshot.action;
-              if (snapshot.draft || frozenAction) {
-                this.send({
-                  type: 'interrupted_turn',
-                  sessionId,
-                  payload: {
-                    reason: 'user_aborted',
-                    draft: snapshot.draft,
-                    action: frozenAction,
-                    interruptedAt: new Date().toISOString(),
-                    cancelled: true,
-                  },
+              if (snapshot.draft || snapshot.action) {
+                this.finishTurnWithStatus(sessionId, {
+                  type: 'user_abort',
+                  payload: { abortedAt: new Date().toISOString() },
                 });
+              } else {
+                this.clearOpenQuestions(sessionId);
+                this.card.clear(sessionId);
               }
-              this.clearOpenQuestions(sessionId);
-              this.card.clear(sessionId);
+              this.pendingTerminalErrors.delete(sessionId);
               this.resolveTurnIdle(sessionId);
               this.sessionManager.markIdle(sessionId);
               this.send({ type: 'idle', sessionId, payload: { reason: 'aborted' } });
@@ -1475,24 +1526,25 @@ export class RelayClient {
     };
 
     this.adapter.onPermissionRequest = (sessionId, event) => {
-      // Permission args stay inline (they're what the human is approving — a
-      // command, a path — and must render without a lazy round-trip). The card
-      // slot IS the permission message (type + payload), minus the envelope.
-      this.card.onPrompt(sessionId, {
-        type: 'permission',
+      const action = {
+        type: 'permission' as const,
         payload: { ...event.toolArgs, id: event.id, description: event.description },
-      });
+      };
+      this.card.onPrompt(sessionId, action);
+      this.recordTrace({ type: 'permission', sessionId, payload: action.payload });
     };
 
     // Auto-resolved (e.g. by an Always Allow rule) — mark the slot approved.
     this.adapter.onPermissionAutoResolved = (sessionId, permissionId) => {
       this.card.resolvePrompt(sessionId, permissionId, { decision: 'approve' });
+      this.recordTrace({ type: 'permission', sessionId, payload: { id: permissionId, description: '', toolName: '', args: {}, decision: 'approve' } });
     };
 
     // Auto-resolved (e.g. cancelled/aborted) — no answer, clear the slot.
     this.adapter.onQuestionAutoResolved = (sessionId, questionId) => {
       this.removeOpenQuestion(sessionId, questionId);
       this.card.resolvePrompt(sessionId, questionId);
+      this.recordTrace({ type: 'question', sessionId, payload: { id: questionId, question: '', cancelled: true } });
     };
 
     this.adapter.onQuestionRequest = (sessionId, event) => {
@@ -1506,6 +1558,7 @@ export class RelayClient {
         },
       };
       this.card.onPrompt(sessionId, action);
+      this.recordTrace({ type: 'question', sessionId, payload: action.payload });
       const snapshot = this.card.state(sessionId);
       this.addOpenQuestion(sessionId, {
         version: 1,
@@ -1646,13 +1699,25 @@ export class RelayClient {
       // Idle carries no run/turn identity. Never let a late idle callback erase
       // a newer card. Permanent bubble boundaries retire settled card state;
       // explicit abort owns its own freeze+clear path; pending questions stay.
-      if (this.soleOpenQuestion(sessionId)) return;
-      this.clearOpenQuestions(sessionId);
+      const terminalError = this.pendingTerminalErrors.get(sessionId);
+      if (this.soleOpenQuestion(sessionId) && !terminalError) return;
+      if (terminalError) {
+        this.pendingTerminalErrors.delete(sessionId);
+        this.finishTurnWithStatus(sessionId, {
+          type: 'failed',
+          payload: {
+            ...terminalError,
+            failedAt: new Date().toISOString(),
+          },
+        });
+      } else {
+        this.clearOpenQuestions(sessionId);
+      }
       this.resolveTurnIdle(sessionId);
       this.sessionManager.markIdle(sessionId);
       const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
       if (usage) this.sessionManager.setUsage(sessionId, usage);
-      this.send({ type: 'idle', sessionId, payload: { usage } });
+      this.send({ type: 'idle', sessionId, payload: { usage, ...(terminalError && { reason: 'failed' as const }) } });
       this.maybeGenerateTitle(sessionId);
     };
 
@@ -1670,10 +1735,9 @@ export class RelayClient {
     };
 
     this.adapter.onError = (sessionId, event) => {
-      this.send({
-        type: 'error',
-        sessionId,
-        payload: { message: event.message },
+      this.pendingTerminalErrors.set(sessionId, {
+        message: event.message,
+        source: 'backend',
       });
     };
 
@@ -2167,7 +2231,7 @@ export class RelayClient {
     // agent_message / system_message stamps this running total as payload.steps
     // (see send()), letting a concluded bubble show its "Steps" affordance from
     // replay alone — WITHOUT first pulling the transient trace.
-    if (msg.type === 'tool_start' || msg.type === 'agent_narration') {
+    if (msg.type === 'tool_start' || msg.type === 'agent_narration' || msg.type === 'permission' || msg.type === 'question') {
       this.turnStepCounts.set(msg.sessionId, (this.turnStepCounts.get(msg.sessionId) ?? 0) + 1);
     }
     const enriched = { ...msg, timestamp: new Date().toISOString() };
@@ -2422,7 +2486,7 @@ export class RelayClient {
     if (sessionId) {
       if (type === 'user_message') {
         this.turnStepCounts.set(sessionId, 0);
-      } else if (type === 'agent_message' || type === 'system_message' || type === 'interrupted_turn') {
+      } else if (type === 'agent_message' || type === 'system_message' || type === 'interrupted_turn' || type === 'turn_status') {
         const p = enriched.payload as Record<string, unknown> | undefined;
         if (p && typeof p === 'object') p.steps = this.turnStepCounts.get(sessionId) ?? 0;
       }


### PR DESCRIPTION
## Summary

Replaces the incremental `interrupted_turn` Abort-only protocol with a unified `turn_status` wire message whose card action IS the turn outcome (`user_abort` | `failed`). A frozen terminal card renders with the **exact same** `LiveAgentBubble` component as the live streaming card — no separate terminal-card chrome.

## Architecture

- **Card action IS the turn outcome**: `user_abort` and `failed` are first-class `CardActionState` variants. The frozen card's action slot carries the final outcome, not the former live tool/permission/question action.
- **Single termination path**: `RelayClient.finishTurnWithStatus()` is the single helper called from both the explicit-abort path and the adapter-error path. It replaces the live action, closes unfinished tools with synthetic `cancelled`/`interrupted` completions in the trace, cancels unresolved permission/question steps, broadcasts `turn_status`, and clears live state.
- **Adapter errors are staged, not immediately terminal**: `adapter.onError` broadcasts the error immediately (apps surface it) AND stages it as a pending terminal outcome. Only when the same logical turn reaches `onIdle` does it freeze as a `failed` card. A recoverable tool failure (`success:false`) never terminates the turn — the agent can continue.
- **Frozen cards reuse `LiveAgentBubble`**: `turn_status` in `MessageBubble` rebuilds a `SessionCard { text: draft, action }` and passes it to `LiveAgentBubble` in a frozen mode. The terminal outcome lives in the SAME action section as tools/prompts — a read-only status row using the identical visual container.
- **`interrupted_turn` is legacy-only**: existing history remains readable; new terminal turns exclusively use `turn_status`.

## Protocol changes
- `TurnStatusMessage { type: 'turn_status', payload: { draft, action: user_abort|failed, finishedAt, steps? } }`
- `CardActionState` gains `user_abort` and `failed`
- `ToolCompleteMessage.payload.termination?: 'cancelled' | 'interrupted'`
- `TraceEntry` now includes `PermissionRequest` and `QuestionRequest`
- `IdleMessage.payload.reason` gains `'failed'`

## Test plan
- [x] Tentacle unit: 715/715 (new tests: empty-card abort, abort→turn_status with question cancellation + step count, error→idle→failed freezing)
- [x] Integration (head+tentacle+app): 44/44
- [x] Web build OK
- [x] Real-stack Playwright (real head ⇄ real tentacle ⇄ real browser arm): 4/4 — abort card, abort refresh persistence, failed card, failed refresh persistence
- [x] `git diff --check`, `pnpm lint` clean

## Screenshots
Real devstack (real pulse transport, real head hub, real browser):
- User abort card: draft + "User aborted" action row + Steps — identical ocean-bubble container as live streaming
- Failed card: draft + red "Turn failed" + "524 status code (no body)" inline in action row
- Both survive full browser refresh as permanent read-only cards
- Cancelled tool steps visible in Steps trace (amber icon)
