### PR TITLE
chore(tentacle): bump version to 0.29.10

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.29.9",
+  "version": "0.29.10",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release bump for the unified terminal status cards release (PR #162).