### PR TITLE
fix(ui): remove legacy interrupted turn card renderer

### DIFF
--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -398,8 +398,9 @@ final class MessageRouter {
             appState.sessionStore.flushDelta(sessionId)
             appState.messageProvider?.ingestTailCandidate(sessionId, json: json)
             let draft = payload?["draft"] as? String ?? ""
-            updatePreview(sessionId, text: draft.isEmpty ? "Turn aborted" : draft,
-                          type: "agent", timestamp: timestamp)
+            let failed = payload?["reason"] as? String == "process_lost"
+            updatePreview(sessionId, text: draft.isEmpty ? (failed ? "Turn failed" : "User aborted") : draft,
+                          type: failed ? "error" : "agent", timestamp: timestamp)
 
         case "agent_message_delta":
             if let content = payload?["content"] as? String {

--- a/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
@@ -258,11 +258,10 @@ struct MessageBubbleView: View {
         case "agent_message":
             agentBubble
 
-        case "turn_status":
+        case "turn_status", "interrupted_turn":
+            // Legacy interrupted_turn is normalized at the render boundary and
+            // uses the same terminal status bubble. It has no separate UI.
             turnStatusBubble
-
-        case "interrupted_turn":
-            interruptedTurnBubble
 
         case "session_created":
             sessionCreatedBanner
@@ -323,11 +322,14 @@ struct MessageBubbleView: View {
 
     private var turnStatusBubble: some View {
         let action = message.terminalAction
-        let failed = action?["type"]?.stringValue == "failed"
+        let legacyProcessLost = message.type == "interrupted_turn" && message.reason == "process_lost"
+        let failed = legacyProcessLost || action?["type"]?.stringValue == "failed"
         let label = failed ? "Turn failed" : "User aborted"
         let icon = failed ? "xmark.octagon.fill" : "stop.circle.fill"
         let tint: Color = failed ? .red : .secondary
-        let detail = failed ? action?["payload"]?.dictValue?["message"]?.stringValue : nil
+        let detail = legacyProcessLost
+            ? "Agent process was lost"
+            : (failed ? action?["payload"]?.dictValue?["message"]?.stringValue : nil)
         return HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 8) {
                 if let draft = message.interruptedDraft, !draft.isEmpty {
@@ -341,36 +343,6 @@ struct MessageBubbleView: View {
                 Label(label, systemImage: icon)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(tint)
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(Color.secondary.opacity(0.08), in: bubbleShape(isUser: false))
-            Spacer(minLength: WindowSize.width * 0.05)
-        }
-    }
-
-    // MARK: - Interrupted Turn
-
-    private var interruptedTurnBubble: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 8) {
-                if let draft = message.interruptedDraft, !draft.isEmpty {
-                    messageBody(draft, foreground: .primary.opacity(0.8))
-                }
-                if let action = message.payload["action"]?.dictValue,
-                   let actionPayload = action["payload"]?.dictValue {
-                    let summary = actionPayload["question"]?.stringValue
-                        ?? actionPayload["description"]?.stringValue
-                        ?? actionPayload["headline"]?.stringValue
-                    if let summary, !summary.isEmpty {
-                        Text(summary)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                Label("Turn aborted", systemImage: "stop.circle.fill")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)

--- a/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
+++ b/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
@@ -107,6 +107,44 @@ test.describe.serial('real-stack terminal status cards', () => {
     await page.screenshot({ path: '/tmp/kraki-terminal-abort-refreshed.png', fullPage: false });
   });
 
+  test('legacy interrupted_turn is normalized to the same frozen live bubble', async () => {
+    const legacyDraft = 'Legacy interrupted history uses the shared bubble';
+    await control('/legacyInterrupted', { sid: sessionId, draft: legacyDraft });
+
+    const legacyCard = page.locator('[data-terminal-card="user_abort"]')
+      .filter({ hasText: legacyDraft });
+    await expect(legacyCard).toBeVisible({ timeout: 10_000 });
+    await expect(legacyCard.getByText('User aborted')).toBeVisible();
+    await expect(legacyCard.getByText('npm test')).toHaveCount(0);
+    await expect(page.getByText('Turn aborted', { exact: true })).toHaveCount(0);
+
+    await page.screenshot({ path: '/tmp/kraki-terminal-legacy-normalized.png', fullPage: false });
+
+    // Legacy storage must keep using the shared renderer after a full replay.
+    await page.reload();
+    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 10_000 });
+    const replayedLegacyCard = page.locator('[data-terminal-card="user_abort"]')
+      .filter({ hasText: legacyDraft });
+    await expect(replayedLegacyCard).toBeVisible({ timeout: 10_000 });
+    await expect(replayedLegacyCard.getByText('User aborted')).toBeVisible();
+    await expect(page.getByText('Turn aborted', { exact: true })).toHaveCount(0);
+
+    const lostDraft = 'Legacy process loss uses the shared failed bubble';
+    await control('/legacyInterrupted', {
+      sid: sessionId,
+      draft: lostDraft,
+      reason: 'process_lost',
+    });
+    const lostCard = page.locator('[data-terminal-card="failed"]')
+      .filter({ hasText: lostDraft });
+    await expect(lostCard).toBeVisible({ timeout: 10_000 });
+    await expect(lostCard.getByText('Turn failed')).toBeVisible();
+    await expect(lostCard.getByText('Agent process was lost')).toBeVisible();
+    await expect(page.getByText('Turn aborted', { exact: true })).toHaveCount(0);
+
+    await page.screenshot({ path: '/tmp/kraki-terminal-legacy-process-lost.png', fullPage: false });
+  });
+
   test('backend error freezes a permanent failed card', async () => {
     await control('/idle', { sid: sessionId });
     await sendPrompt(page, 'Run the full test suite');
@@ -119,7 +157,8 @@ test.describe.serial('real-stack terminal status cards', () => {
     await control('/error', { sid: sessionId, message: '524 status code (no body)' });
     await control('/idle', { sid: sessionId });
 
-    const failedCard = page.locator('[data-terminal-card="failed"]');
+    const failedCard = page.locator('[data-terminal-card="failed"]')
+      .filter({ hasText: 'Compiling and running tests' });
     await expect(failedCard).toBeVisible({ timeout: 10_000 });
     await expect(failedCard.getByText('Turn failed')).toBeVisible();
     await expect(failedCard.getByText('524 status code (no body)')).toBeVisible();
@@ -132,7 +171,8 @@ test.describe.serial('real-stack terminal status cards', () => {
   test('failed card survives a full browser refresh', async () => {
     await page.reload();
     await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 10_000 });
-    const failedCard = page.locator('[data-terminal-card="failed"]');
+    const failedCard = page.locator('[data-terminal-card="failed"]')
+      .filter({ hasText: 'Compiling and running tests' });
     await expect(failedCard).toBeVisible({ timeout: 10_000 });
     await expect(failedCard.getByText('Turn failed')).toBeVisible();
 

--- a/packages/arm/web/src/components/actions/QuestionInput.tsx
+++ b/packages/arm/web/src/components/actions/QuestionInput.tsx
@@ -26,10 +26,10 @@ export function QuestionInput({ action, sessionId }: { action: Extract<CardActio
 
   if (cancelled) {
     return (
-      <div className="max-h-[40vh] shrink-0 overflow-y-auto border-t border-slate-500/30 bg-slate-500/5 px-3 pb-3 pt-2.5 sm:px-4 sm:pb-4">
+      <div className="max-h-[40vh] shrink-0 overflow-y-auto border-t border-violet-500/30 bg-violet-500/5 px-3 pb-3 pt-2.5 sm:px-4 sm:pb-4">
         <div className="mx-auto max-w-3xl">
           {text && <div className="text-sm text-text-primary"><Markdown>{text}</Markdown></div>}
-          <p className="mt-2 text-xs font-semibold text-text-muted">Turn aborted</p>
+          <p className="mt-2 text-xs font-semibold text-text-muted">Question cancelled</p>
         </div>
       </div>
     );

--- a/packages/arm/web/src/components/chat/MessageBubble.test.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.test.tsx
@@ -151,6 +151,34 @@ describe('MessageBubble', () => {
     });
   });
 
+  describe('terminal status compatibility', () => {
+    it('normalizes legacy interrupted_turn through the frozen LiveAgentBubble renderer', () => {
+      const { container } = render(
+        <MemoryRouter>
+          <MessageBubble
+            message={makeMsg('interrupted_turn', {
+              reason: 'user_aborted',
+              draft: 'Partial streamed answer',
+              action: { type: 'tool_start', payload: { toolName: 'bash', headline: 'npm test' } },
+              interruptedAt: '2026-03-18T12:00:00.000Z',
+              cancelled: true,
+              steps: 1,
+            })}
+            sessionId="sess-1"
+          />
+        </MemoryRouter>,
+      );
+
+      expect(container.querySelector('[data-terminal-card="user_abort"]')).toBeTruthy();
+      expect(screen.getByText('Partial streamed answer')).toBeInTheDocument();
+      expect(screen.getByText('User aborted')).toBeInTheDocument();
+      expect(screen.queryByText('Turn aborted')).not.toBeInTheDocument();
+      // The former action belongs in Steps; the terminal action owns the card slot.
+      expect(screen.queryByText('npm test')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Open steps' })).toBeInTheDocument();
+    });
+  });
+
   describe('system_message', () => {
     it('renders the default no_reply label, marked as Kraki', () => {
       renderMsg(makeMsg('system_message', { kind: 'no_reply' }));

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -1,7 +1,7 @@
 import Markdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
-import type { PermissionRequest as ProtocolPermissionRequest, QuestionRequest as ProtocolQuestionRequest, Attachment, CardActionState, ContentRef } from '@kraki/protocol';
+import type { PermissionRequest as ProtocolPermissionRequest, QuestionRequest as ProtocolQuestionRequest, Attachment, ContentRef } from '@kraki/protocol';
 import type { ChatMessage, SessionCard } from '../../types/store';
 import { formatTime, agentInfo } from '../../lib/format';
 import { stringToHue } from '../../lib/color';
@@ -92,73 +92,44 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
         </CopyableBubble>
       );
 
-    case 'turn_status': {
-      // Reuse the SAME renderer as the live status card — a frozen card looks
-      // identical to the live bubble that was on screen when the turn ended,
-      // just read-only with the action slot set to the terminal outcome.
+    case 'turn_status':
+    case 'interrupted_turn': {
+      // Legacy `interrupted_turn` remains readable on the wire, but it has no
+      // renderer of its own. Normalize it to the modern terminal action and
+      // feed both message types through the exact frozen live-card path.
       if (!sessionId) return null;
-      const payload = message.payload;
-      const card: SessionCard = { text: payload.draft ?? '', action: payload.action };
+      const legacy = message.type === 'interrupted_turn';
+      const legacyProcessLost = legacy && message.payload.reason === 'process_lost';
+      const card: SessionCard = legacy
+        ? {
+            text: message.payload.draft ?? '',
+            action: legacyProcessLost
+              ? {
+                  type: 'failed',
+                  payload: {
+                    message: 'Agent process was lost',
+                    source: 'process',
+                    failedAt: message.payload.interruptedAt,
+                  },
+                }
+              : {
+                  type: 'user_abort',
+                  payload: { abortedAt: message.payload.interruptedAt },
+                },
+          }
+        : { text: message.payload.draft ?? '', action: message.payload.action };
+      const finishedAt = legacy ? message.payload.interruptedAt : message.payload.finishedAt;
       return (
         <LiveAgentBubble
           sessionId={sessionId}
           agent={agent}
           card={card}
           frozen={{
-            timestamp: message.timestamp ?? payload.finishedAt ?? new Date().toISOString(),
+            timestamp: message.timestamp ?? finishedAt ?? new Date().toISOString(),
             bubbleSeq: typeof message.seq === 'number' ? message.seq : 0,
-            stepHint: payload.steps,
+            stepHint: message.payload.steps,
           }}
         />
-      );
-    }
-
-    case 'interrupted_turn': {
-      const payload = message.payload;
-      const action = payload.action as CardActionState | null;
-      const actionText = action?.type === 'question'
-        ? action.payload.question
-        : action?.type === 'permission'
-          ? action.payload.description
-          : action?.type === 'tool_start' || action?.type === 'tool_complete'
-            ? action.payload.headline
-            : action?.type === 'tool_batch'
-              ? `${action.payload.running} tools were running`
-              : '';
-      return (
-        <div className="flex gap-2">
-          <div className="mt-0.5 shrink-0">
-            <AgentAvatar agent={agent ?? ''} sessionId={sessionId} size="sm" />
-          </div>
-          <div className="min-w-0 max-w-[85%] overflow-hidden rounded-2xl rounded-bl-md border border-slate-500/30 bg-slate-500/5 shadow-sm sm:max-w-[70%]">
-            {payload.draft && (
-              <div className="markdown-content px-4 py-2.5 text-sm leading-relaxed text-text-primary opacity-80">
-                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
-                  {payload.draft}
-                </Markdown>
-              </div>
-            )}
-            {(actionText || !payload.draft) && (
-              <div className="border-t border-slate-500/20 bg-slate-500/10 px-4 py-2.5">
-                {actionText && <p className="text-sm text-text-secondary">{actionText}</p>}
-                <p className="mt-1 flex items-center gap-1 text-xs font-medium text-text-muted">
-                  <CircleStop className="h-3.5 w-3.5" /> Turn aborted
-                </p>
-              </div>
-            )}
-            <div className="flex items-center gap-2 px-4 pb-2">
-              {!actionText && payload.draft && (
-                <p className="flex items-center gap-1 text-xs font-medium text-text-muted">
-                  <CircleStop className="h-3.5 w-3.5" /> Turn aborted
-                </p>
-              )}
-              <p className="text-[10px] text-text-muted">{formatTime(message.timestamp)}</p>
-              {sessionId && typeof message.seq === 'number' && message.seq > 0 && (
-                <StepsButton sessionId={sessionId} bubbleSeq={message.seq} agent={agent} stepHint={payload.steps} />
-              )}
-            </div>
-          </div>
-        </div>
       );
     }
 

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -76,7 +76,12 @@ function rebuildPreview(sessionId: string): void {
     }
     if (m.type === 'interrupted_turn' && payload) {
       const draft = typeof payload.draft === 'string' ? payload.draft : '';
-      preview = { text: stripMarkdown(draft || 'Turn aborted').slice(0, PREVIEW_MAX), type: 'agent', timestamp: ts };
+      const failed = payload.reason === 'process_lost';
+      preview = {
+        text: stripMarkdown(draft || (failed ? 'Turn failed' : 'User aborted')).slice(0, PREVIEW_MAX),
+        type: failed ? 'error' : 'agent',
+        timestamp: ts,
+      };
       break;
     }
     if (m.type === 'agent_message' && payload) {

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -227,9 +227,10 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
     case 'interrupted_turn': {
       store.appendMessage(sid, msg);
       const draft = typeof msg.payload.draft === 'string' ? msg.payload.draft : '';
+      const failed = msg.payload.reason === 'process_lost';
       updatePreview(sid, {
-        text: truncPreview(draft || 'Turn aborted'),
-        type: 'agent',
+        text: truncPreview(draft || (failed ? 'Turn failed' : 'User aborted')),
+        type: failed ? 'error' : 'agent',
         timestamp: msg.timestamp,
       }, !replaying);
       break;

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -289,6 +289,30 @@ async function main(): Promise<void> {
         case '/toolComplete': adapter.toolComplete(q.get('sid')!, q.get('tool') ?? 'bash', q.get('result') ?? 'done'); return json(200, { ok: true });
         case '/idle': adapter.idle(q.get('sid')!); return json(200, { ok: true });
         case '/error': adapter.error(q.get('sid')!, q.get('message') ?? 'error'); return json(200, { ok: true });
+        // Legacy-history compatibility: inject the old durable Abort message
+        // through RelayClient's real persistence + pulse broadcast path. The UI
+        // must normalize it to the modern frozen LiveAgentBubble renderer.
+        case '/legacyInterrupted': {
+          const sid = q.get('sid')!;
+          const interruptedAt = new Date().toISOString();
+          const reason = q.get('reason') === 'process_lost' ? 'process_lost' : 'user_aborted';
+          (relay as unknown as { send: (msg: Record<string, unknown>) => void }).send({
+            type: 'interrupted_turn',
+            sessionId: sid,
+            payload: {
+              reason,
+              draft: q.get('draft') ?? 'Legacy streamed draft',
+              action: {
+                type: 'tool_start',
+                payload: { toolName: 'bash', headline: 'npm test', toolCallId: 'legacy-tool-1' },
+              },
+              interruptedAt,
+              cancelled: true,
+              steps: 1,
+            },
+          });
+          return json(200, { ok: true });
+        }
         // ── debug: what does the tentacle see? ──
         case '/debug': {
           const r = relay as unknown as { consumerKeys?: Map<string, string>; onlineConsumers?: Set<string> };


### PR DESCRIPTION
## Summary

Completely removes the legacy `interrupted_turn` card renderer. Legacy protocol messages remain readable as data, but they are normalized at the render boundary and use the exact same frozen status-bubble path as modern `turn_status` messages.

## Changes

- Web `MessageBubble` combines `turn_status` and `interrupted_turn` into one `LiveAgentBubble` render path.
- Legacy `user_aborted` maps to modern `user_abort`.
- Legacy `process_lost` maps to modern `failed { source: 'process' }`.
- Deletes the old Web slate/bordered interrupted card JSX and `Turn aborted` copy.
- Deletes the separate iOS `interruptedTurnBubble`; legacy messages use the unified terminal status view.
- Normalizes Web/iOS session previews to `User aborted` / `Turn failed`.
- Changes cancelled question action copy from `Turn aborted` to `Question cancelled`.
- Keeps legacy protocol/storage/router support so existing history is not lost.

## Verification

- Web production build passes.
- Biome lint passes.
- `git diff --check` passes.
- Real-stack Playwright: 5/5 passed through real Head + Tentacle + Pulse + browser.
  - modern user abort
  - abort refresh replay
  - legacy `user_aborted` + refresh replay
  - legacy `process_lost`
  - modern backend failure + refresh replay
- Production source scan has no `Turn aborted`, `interruptedTurnBubble`, or legacy slate terminal-card styles.

## Screenshot evidence

- `/tmp/kraki-terminal-legacy-normalized.png`
- `/tmp/kraki-terminal-legacy-process-lost.png`

The default Web component-test runner remains blocked by the repository's existing React 19 `React.act is not a function` environment issue; the real-stack browser workflow covers the changed renderer end to end.
