### PR TITLE
chore(tentacle): bump version to 0.29.11

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.29.10",
+  "version": "0.29.11",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps @kraki/tentacle to 0.29.11 for the unified legacy interrupted-turn renderer fix merged in #164.