### PR TITLE
feat(web): steer active agent turns from composer

### DIFF
--- a/packages/arm/web/e2e/features.spec.ts
+++ b/packages/arm/web/e2e/features.spec.ts
@@ -57,7 +57,7 @@ async function setupAndOpenSession(
 ): Promise<WebSocket> {
   await gotoWithRelay(page, server);
   const ws = await authenticateClient(server);
-  const sessionCard = page.getByText('Copilot').first();
+  const sessionCard = page.getByText('Copilot').filter({ visible: true }).first();
   await expect(sessionCard).toBeVisible({ timeout: 5000 });
   await sessionCard.click();
   await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 3000 });
@@ -121,4 +121,32 @@ test.describe('Feature fixes', () => {
     const approveButtons = chatArea(page).getByRole('button', { name: 'Approve' });
     await expect(approveButtons).toHaveCount(2);
   });
+
+  for (const viewport of [
+    { name: 'desktop', width: 1280, height: 800 },
+    { name: 'mobile', width: 375, height: 667 },
+  ]) {
+    test(`active composer controls remain usable without overlap on ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await setupAndOpenSession(page, server);
+      const input = page.getByPlaceholder('Send a message…');
+      const stop = page.getByRole('button', { name: 'Stop' });
+      const steer = page.getByRole('button', { name: 'Steer agent' });
+
+      await expect(input).toBeEditable();
+      await expect(stop).toBeVisible();
+      await expect(steer).toBeVisible();
+      await input.fill('change direction');
+
+      const boxes = await Promise.all([input, stop, steer].map(locator => locator.boundingBox()));
+      expect(boxes.every(Boolean)).toBe(true);
+      const [inputBox, stopBox, steerBox] = boxes as NonNullable<typeof boxes[number]>[];
+      expect(inputBox.x + inputBox.width).toBeLessThanOrEqual(stopBox.x);
+      expect(stopBox.x + stopBox.width).toBeLessThanOrEqual(steerBox.x);
+      expect(steerBox.x + steerBox.width).toBeLessThanOrEqual(viewport.width);
+
+      await steer.click();
+      await expect(input).toHaveValue('');
+    });
+  }
 });

--- a/packages/arm/web/src/components/chat/MessageInput.tsx
+++ b/packages/arm/web/src/components/chat/MessageInput.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react
 import { wsClient } from '../../lib/ws-client';
 import { useStore } from '../../hooks/useStore';
 import { shouldAutoFocusTextInput } from '../../lib/mobile-input';
-import { X, ImagePlus, Square } from 'lucide-react';
+import { ArrowRight, X, ImagePlus, Square } from 'lucide-react';
 import type { Attachment } from '@kraki/protocol';
 
 const MAX_INPUT_HEIGHT = 160;
@@ -218,16 +218,19 @@ export function MessageInput({ sessionId }: { sessionId: string }) {
   }, [text]);
 
   const handleSend = () => {
-    if (!isIdle) return;
     const trimmed = text.trim();
     if (!trimmed && !imageAttachment) return;
     const attachments = imageAttachment ? [imageAttachment] : undefined;
-    wsClient.sendInput(sessionId, trimmed || '[image]', attachments);
+    if (isIdle) {
+      wsClient.sendInput(sessionId, trimmed || '[image]', attachments);
+      setAwaitingActive(true);
+    } else {
+      wsClient.sendInput(sessionId, trimmed || '[image]', attachments, 'steer');
+    }
     setDraft(sessionId, '');
     clearImage();
-    setAwaitingActive(true);
     if (shouldAutoFocus) {
-      // Keep focus on desktop so user can type follow-up immediately
+      // Keep focus on desktop so user can type another correction immediately.
       requestAnimationFrame(() => textareaRef.current?.focus());
     } else {
       textareaRef.current?.blur();
@@ -352,32 +355,33 @@ export function MessageInput({ sessionId }: { sessionId: string }) {
             enterKeyHint="send"
             className="min-w-0 flex-1 cursor-text resize-none overflow-hidden rounded-xl border border-border-primary bg-surface-secondary px-4 pt-[7px] pb-[9px] pr-9 text-base text-text-primary placeholder-text-muted focus:border-kraki-500 focus:outline-none focus:ring-1 focus:ring-kraki-500 disabled:cursor-not-allowed disabled:opacity-60 sm:text-sm"
           />
-          {isIdle && text && (
+          {text && (
             <button
               onClick={() => { setDraft(sessionId, ''); textareaRef.current?.focus(); }}
               aria-label="Clear input"
-              className="absolute right-[3.75rem] top-1/2 -translate-y-1/2 rounded-full p-0.5 text-text-muted transition-colors hover:bg-surface-tertiary hover:text-text-primary"
+              className={`absolute top-1/2 -translate-y-1/2 rounded-full p-0.5 text-text-muted transition-colors hover:bg-surface-tertiary hover:text-text-primary ${isIdle ? 'right-[3.75rem]' : 'right-[6.5rem]'}`}
             >
               <X className="h-4 w-4" />
             </button>
           )}
-          <button
-            onClick={isIdle ? handleSend : () => wsClient.abortSession(sessionId)}
-            disabled={isIdle && !text.trim() && !imageAttachment}
-            aria-label={isIdle ? 'Send message' : 'Stop'}
-            className={`relative flex h-9 w-9 shrink-0 items-center justify-center self-center rounded-xl text-white transition-all duration-500 active:scale-95 ${
-              isIdle
-                ? 'bg-kraki-500 hover:bg-kraki-600 active:bg-kraki-700 disabled:opacity-40 disabled:hover:bg-kraki-500 disabled:active:scale-100'
-                : 'animate-pulse-subtle bg-kraki-500 hover:bg-kraki-600'
-            }`}
-          >
-            <svg
-              className={`absolute h-4 w-4 transition-all duration-500 ${isIdle ? 'scale-100 opacity-100' : 'scale-0 opacity-0'}`}
-              fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          {!isIdle && (
+            <button
+              onClick={() => wsClient.abortSession(sessionId)}
+              aria-label="Stop"
+              title="Stop current turn"
+              className="flex h-9 w-9 shrink-0 items-center justify-center self-center rounded-xl border border-border-primary bg-surface-secondary text-red-500 transition-colors hover:bg-red-500/10 active:scale-95"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14M12 5l7 7-7 7" />
-            </svg>
-            <Square className={`absolute h-3.5 w-3.5 fill-current transition-all duration-500 ${isIdle ? 'scale-0 opacity-0' : 'scale-100 opacity-100'}`} />
+              <Square className="h-3.5 w-3.5 fill-current" />
+            </button>
+          )}
+          <button
+            onClick={handleSend}
+            disabled={!text.trim() && !imageAttachment}
+            aria-label={isIdle ? 'Send message' : 'Steer agent'}
+            title={isIdle ? 'Send message' : 'Steer active turn'}
+            className="flex h-9 w-9 shrink-0 items-center justify-center self-center rounded-xl bg-kraki-500 text-white transition-colors hover:bg-kraki-600 active:scale-95 active:bg-kraki-700 disabled:opacity-40 disabled:hover:bg-kraki-500 disabled:active:scale-100"
+          >
+            <ArrowRight className="h-4 w-4" />
           </button>
         </div>
       </div>

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -84,11 +84,12 @@ export function sendInput(
   text: string,
   send: (msg: Record<string, unknown>) => void,
   attachments?: import('@kraki/protocol').Attachment[],
+  delivery?: 'prompt' | 'steer',
 ): void {
   const store = getStore();
   const timestamp = new Date().toISOString();
   const clientId = generateClientId();
-  traceEvent({ comp: 'arm', evt: 'USER-SEND-INPUT', sessionId, clientId, textLen: text.length, hasAttachments: !!attachments?.length });
+  traceEvent({ comp: 'arm', evt: 'USER-SEND-INPUT', sessionId, clientId, textLen: text.length, hasAttachments: !!attachments?.length, delivery: delivery ?? 'prompt' });
   store.appendMessage(sessionId, {
     type: 'pending_input',
     id: clientId,
@@ -103,7 +104,7 @@ export function sendInput(
   send({
     type: 'send_input',
     sessionId,
-    payload: { text, clientId, ...(attachments?.length && { attachments }) },
+    payload: { text, clientId, ...(attachments?.length && { attachments }), ...(delivery === 'steer' && { delivery }) },
   });
 }
 

--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -513,6 +513,18 @@ describe('KrakiWSClient', () => {
       expect(sent.payload.text).toBe('Hello agent');
     });
 
+    it('sendInput carries active-turn steer delivery', async () => {
+      const client = await setupClient();
+      client.sendInput('sess-1', 'Change direction', undefined, 'steer');
+
+      const sent = await waitForDecodedSend(lastWsInstance);
+      expect(sent).toMatchObject({
+        type: 'send_input',
+        sessionId: 'sess-1',
+        payload: { text: 'Change direction', delivery: 'steer' },
+      });
+    });
+
     it('approve sends correct message', async () => {
       const client = await setupClient();
 

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -194,8 +194,13 @@ export class KrakiWSClient {
     });
   }
 
-  sendInput(sessionId: string, text: string, attachments?: import('@kraki/protocol').Attachment[]) {
-    commands.sendInput(sessionId, text, (msg) => this.sendEncrypted(msg), attachments);
+  sendInput(
+    sessionId: string,
+    text: string,
+    attachments?: import('@kraki/protocol').Attachment[],
+    delivery?: 'prompt' | 'steer',
+  ) {
+    commands.sendInput(sessionId, text, (msg) => this.sendEncrypted(msg), attachments, delivery);
   }
 
   /**

--- a/packages/arm/web/src/pages/pages.test.tsx
+++ b/packages/arm/web/src/pages/pages.test.tsx
@@ -395,18 +395,23 @@ describe('MessageInput', () => {
     expect(screen.getByLabelText('Send message')).toBeDisabled();
   });
 
-  it('renders stop button when session is active', async () => {
+  it('keeps send and stop as separate controls while the session is active', async () => {
     const user = userEvent.setup();
-    // Set session to active state
-    const { useStore } = await import('../hooks/useStore');
     useStore.getState().upsertSession({ id: 'sess-1', deviceId: 'd1', deviceName: 'Test', agent: 'copilot', state: 'active', messageCount: 0 });
     render(
       <MemoryRouter>
         <MessageInput sessionId="sess-1" />
       </MemoryRouter>,
     );
+
+    const input = screen.getByPlaceholderText('Send a message…');
+    await user.type(input, 'change direction{Enter}');
+    expect(wsClient.sendInput).toHaveBeenCalledWith(
+      'sess-1', 'change direction', undefined, 'steer',
+    );
+
     const stopBtn = screen.getByLabelText('Stop');
-    expect(stopBtn).toBeInTheDocument();
+    expect(screen.getByLabelText('Steer agent')).toBeInTheDocument();
     await user.click(stopBtn);
     expect(wsClient.abortSession).toHaveBeenCalledWith('sess-1');
   });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -859,6 +859,10 @@ export interface SendInputMessage extends BaseEnvelope {
      *  reconnects, or multi-device scenarios. Optional for back-compat
      *  with older clients. */
     clientId?: string;
+    /** Delivery intent chosen by the app from its observed session state.
+     *  `steer` interjects into the current active turn; omitted/`prompt`
+     *  preserves the normal idle-session prompt behavior. */
+    delivery?: 'prompt' | 'steer';
   };
 }
 

--- a/packages/tentacle/src/__tests__/claude-askuserquestion.test.ts
+++ b/packages/tentacle/src/__tests__/claude-askuserquestion.test.ts
@@ -9,7 +9,7 @@
  * and every user answer was silently dropped.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ClaudeAdapter } from '../adapters/claude.js';
 
 type CapturedResult = {
@@ -33,6 +33,30 @@ const asSessions = (a: ClaudeAdapter) =>
   (a as unknown as { sessions: Map<string, EntryLike> }).sessions;
 const asModes = (a: ClaudeAdapter) =>
   (a as unknown as { sessionModes: Map<string, string> }).sessionModes;
+
+describe('Claude streaming input', () => {
+  it('pushes an active-turn steer without clearing the current draft', async () => {
+    const adapter = new ClaudeAdapter();
+    const push = vi.fn();
+    const entry = {
+      query: {},
+      inputChannel: { push, end: vi.fn() },
+      pendingPermissions: new Map(),
+      pendingQuestions: new Map(),
+      pendingText: 'working draft',
+    };
+    (adapter as unknown as { sessions: Map<string, typeof entry> }).sessions.set('s1', entry);
+
+    await adapter.sendMessage('s1', 'change direction', undefined, { delivery: 'steer' });
+
+    expect(push).toHaveBeenCalledWith({
+      type: 'user',
+      message: { role: 'user', content: 'change direction' },
+      parent_tool_use_id: null,
+    });
+    expect(entry.pendingText).toBe('working draft');
+  });
+});
 
 describe('Claude AskUserQuestion answers key', () => {
   it('respondToQuestion keys the answer by the question TEXT (not "answer")', async () => {

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -306,6 +306,21 @@ describe('pi prompt recovery', () => {
     expect(proc.request.mock.calls.filter(call => call[0] === 'prompt')).toHaveLength(1);
   });
 
+  it('uses race-safe prompt steering without resetting the active turn', async () => {
+    const { adapter, proc, session } = makeAdapter();
+    session.narrationSegments = 2;
+    session.lastNarration = 'working';
+
+    await adapter.sendMessage('s1', 'check the other file', undefined, { delivery: 'steer' });
+
+    expect(proc.request).toHaveBeenCalledWith('prompt', {
+      message: 'check the other file',
+      streamingBehavior: 'steer',
+    }, { timeoutMs: null });
+    expect(session.narrationSegments).toBe(2);
+    expect(session.lastNarration).toBe('working');
+  });
+
   it('treats isStreaming as accepted while retaining the late ACK cleanup', async () => {
     const { adapter, proc } = makeAdapter({ ackGraceMs: 1, intervalMs: 1 });
     const onError = vi.fn();

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2014,6 +2014,156 @@ describe('RelayClient pending-question digest', () => {
     expect(adapter.sendMessage).toHaveBeenNthCalledWith(2, 'sess_1', 'second', undefined);
   });
 
+  it('dispatches active-turn steer immediately without waiting for idle', async () => {
+    const { adapter, ws } = buildClient();
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 610,
+      timestamp: new Date().toISOString(), payload: { text: 'first' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 611,
+      timestamp: new Date().toISOString(), payload: { text: 'change direction', delivery: 'steer' },
+    })));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+    expect(adapter.sendMessage).toHaveBeenNthCalledWith(
+      2, 'sess_1', 'change direction', undefined, { delivery: 'steer' },
+    );
+  });
+
+  it('reasserts active after steer acceptance when the preceding work idles during its ACK', async () => {
+    const { adapter, ws, sm } = buildClient();
+    let accept!: () => void;
+    (adapter.sendMessage as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise<void>((resolve) => { accept = resolve; }),
+    );
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 612,
+      timestamp: new Date().toISOString(), payload: { text: 'change direction', delivery: 'steer' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    expect(sm.markIdle).not.toHaveBeenCalled();
+    accept();
+    await vi.waitFor(() => expect(sm.markActive).toHaveBeenCalledTimes(2));
+    expect(sm.markIdle).not.toHaveBeenCalled();
+
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    expect(sm.markIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not release the normal prompt queue for an idle racing steer acceptance', async () => {
+    const { adapter, ws } = buildClient();
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 613,
+      timestamp: new Date().toISOString(), payload: { text: 'first' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+
+    let accept!: () => void;
+    (adapter.sendMessage as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise<void>((resolve) => { accept = resolve; }),
+    );
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 614,
+      timestamp: new Date().toISOString(), payload: { text: 'change direction', delivery: 'steer' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 615,
+      timestamp: new Date().toISOString(), payload: { text: 'next prompt' },
+    })));
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    accept();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(adapter.sendMessage).toHaveBeenCalledTimes(2);
+
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(3));
+    expect(adapter.sendMessage).toHaveBeenNthCalledWith(3, 'sess_1', 'next prompt', undefined);
+  });
+
+  it('releases the normal prompt queue when a racing steer is rejected', async () => {
+    const { adapter, ws } = buildClient();
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 616,
+      timestamp: new Date().toISOString(), payload: { text: 'first' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+
+    let reject!: (error: Error) => void;
+    (adapter.sendMessage as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise<void>((_resolve, fail) => { reject = fail; }),
+    );
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 617,
+      timestamp: new Date().toISOString(), payload: { text: 'change direction', delivery: 'steer' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 618,
+      timestamp: new Date().toISOString(), payload: { text: 'next prompt' },
+    })));
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    reject(new Error('steer rejected'));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(3));
+    expect(adapter.sendMessage).toHaveBeenNthCalledWith(3, 'sess_1', 'next prompt', undefined);
+  });
+
+  it('scopes idle ownership to each rapid steer submission', async () => {
+    const { adapter, ws, sm } = buildClient();
+    let acceptFirst!: () => void;
+    let rejectSecond!: (error: Error) => void;
+    (adapter.sendMessage as ReturnType<typeof vi.fn>)
+      .mockImplementationOnce(() => new Promise<void>((resolve) => { acceptFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => { rejectSecond = reject; }));
+
+    for (const [seq, text] of [[619, 'first steer'], [620, 'second steer']] as const) {
+      ws.emit('message', Buffer.from(JSON.stringify({
+        type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq,
+        timestamp: new Date().toISOString(), payload: { text, delivery: 'steer' },
+      })));
+    }
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    expect(sm.markIdle).not.toHaveBeenCalled();
+
+    acceptFirst();
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    rejectSecond(new Error('second steer rejected'));
+
+    await vi.waitFor(() => expect(sm.markIdle).toHaveBeenCalledTimes(1));
+    expect(adapter.sendMessage).toHaveBeenNthCalledWith(
+      2, 'sess_1', 'second steer', undefined, { delivery: 'steer' },
+    );
+  });
+
+  it('preserves adapter acceptance order for a prompt immediately followed by steer', async () => {
+    const { adapter, ws } = buildClient();
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 621,
+      timestamp: new Date().toISOString(), payload: { text: 'first' },
+    })));
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 622,
+      timestamp: new Date().toISOString(), payload: { text: 'change direction', delivery: 'steer' },
+    })));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+    expect(adapter.sendMessage.mock.calls).toEqual([
+      ['sess_1', 'first', undefined],
+      ['sess_1', 'change direction', undefined, { delivery: 'steer' }],
+    ]);
+  });
+
   it('routes ordinary composer input to the sole pending question', async () => {
     const { adapter, askQ, ws, sm } = buildClient();
     askQ('q1');

--- a/packages/tentacle/src/adapters/__tests__/copilot.test.ts
+++ b/packages/tentacle/src/adapters/__tests__/copilot.test.ts
@@ -515,6 +515,18 @@ describe('CopilotAdapter', () => {
       expect(mockSessions[0].send).toHaveBeenCalledWith({ prompt: 'hello world' });
     });
 
+    it('uses immediate delivery to interject into an active turn', async () => {
+      await adapter.start();
+      const { sessionId } = await adapter.createSession({});
+
+      await adapter.sendMessage(sessionId, 'change direction', undefined, { delivery: 'steer' });
+
+      expect(mockSessions[0].send).toHaveBeenCalledWith({
+        prompt: 'change direction',
+        mode: 'immediate',
+      });
+    });
+
     it('includes attachments when provided', async () => {
       await adapter.start();
       const { sessionId } = await adapter.createSession({});

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -122,6 +122,11 @@ export interface QuestionAnswer {
   attachments?: import('@kraki/protocol').Attachment[];
 }
 
+export interface SendMessageOptions {
+  /** Normal prompt starts a turn; steer interjects into the active turn. */
+  delivery?: 'prompt' | 'steer';
+}
+
 export type QuestionResponseResult = 'accepted' | 'not_found' | 'session_gone';
 
 // ── The adapter interface ───────────────────────────────
@@ -210,8 +215,13 @@ export abstract class AgentAdapter {
   /** Resume a previously created session with recovery context. */
   abstract resumeSession(sessionId: string, context?: SessionContext): Promise<{ sessionId: string }>;
 
-  /** Send a user message to a session. */
-  abstract sendMessage(sessionId: string, text: string, attachments?: import('@kraki/protocol').Attachment[]): Promise<void>;
+  /** Send a user message to a session, optionally steering an active turn. */
+  abstract sendMessage(
+    sessionId: string,
+    text: string,
+    attachments?: import('@kraki/protocol').Attachment[],
+    options?: SendMessageOptions,
+  ): Promise<void>;
 
   /** Respond to a pending permission request. */
   abstract respondToPermission(

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -20,6 +20,7 @@ import {
   type PermissionDecision,
   type QuestionAnswer,
   type QuestionResponseResult,
+  type SendMessageOptions,
 } from './base.js';
 import type { SessionContext } from '../session-manager.js';
 import { createLogger } from '../logger.js';
@@ -703,15 +704,22 @@ export class ClaudeAdapter extends AgentAdapter {
     return { sessionId: newSessionId };
   }
 
-  async sendMessage(sessionId: string, text: string, _attachments?: Attachment[]): Promise<void> {
+  async sendMessage(
+    sessionId: string,
+    text: string,
+    _attachments?: Attachment[],
+    options?: SendMessageOptions,
+  ): Promise<void> {
     const entry = this.sessions.get(sessionId);
     if (!entry) {
       logger.warn({ sessionId }, 'sendMessage: session not found');
       throw new Error(`Session not found: ${sessionId}`);
     }
 
-    // Reset the draft-bubble prose buffer for the new turn.
-    entry.pendingText = '';
+    // Streaming input accepts another user message while the query is running.
+    // Keep the active draft for an interjection; only a normal prompt opens a
+    // fresh turn and resets the draft-bubble prose buffer.
+    if (options?.delivery !== 'steer') entry.pendingText = '';
 
     // Prepend mode-switch signal if mode changed since last message
     const pendingMode = this.pendingModeSignals.get(sessionId);

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -40,6 +40,7 @@ import {
   type PermissionDecision,
   type QuestionAnswer,
   type QuestionResponseResult,
+  type SendMessageOptions,
 } from './base.js';
 import { parsePermission } from '../parse-permission.js';
 import { createLogger } from '../logger.js';
@@ -1029,12 +1030,20 @@ export class CopilotAdapter extends AgentAdapter {
     return { sessionId: newSessionId };
   }
 
-  async sendMessage(sessionId: string, text: string, attachments?: import('@kraki/protocol').Attachment[]): Promise<void> {
-    // Reset per-cycle tracking — a new user message starts a fresh cycle
-    this.cycleHasOutput.set(sessionId, false);
-    this.turnErrorReported.set(sessionId, false);
-    this.cycleUserAborted.delete(sessionId);
-    this.pendingNarration.delete(sessionId);
+  async sendMessage(
+    sessionId: string,
+    text: string,
+    attachments?: import('@kraki/protocol').Attachment[],
+    options?: SendMessageOptions,
+  ): Promise<void> {
+    if (options?.delivery !== 'steer') {
+      // A normal prompt starts a fresh cycle. An immediate interjection remains
+      // part of the active cycle and must not reset its output/error tracking.
+      this.cycleHasOutput.set(sessionId, false);
+      this.turnErrorReported.set(sessionId, false);
+      this.cycleUserAborted.delete(sessionId);
+      this.pendingNarration.delete(sessionId);
+    }
     this.touchSession(sessionId);
 
     // Prepend mode-switch signal if mode changed since last message
@@ -1044,7 +1053,10 @@ export class CopilotAdapter extends AgentAdapter {
       text = `[kraki: mode changed to ${pendingMode}]\n\n${text}`;
     }
 
-    const opts: MessageOptions = { prompt: text };
+    const opts: MessageOptions = {
+      prompt: text,
+      ...(options?.delivery === 'steer' && { mode: 'immediate' as const }),
+    };
     const tempFiles: string[] = [];
 
     // Convert image attachments to files in the SDK session directory

--- a/packages/tentacle/src/adapters/multi.ts
+++ b/packages/tentacle/src/adapters/multi.ts
@@ -21,6 +21,7 @@ import {
   type PermissionDecision,
   type QuestionAnswer,
   type QuestionResponseResult,
+  type SendMessageOptions,
 } from './base.js';
 import type { SessionContext } from '../session-manager.js';
 import { createLogger } from '../logger.js';
@@ -281,8 +282,13 @@ export class MultiAgentAdapter extends AgentAdapter {
     return result;
   }
 
-  async sendMessage(sessionId: string, text: string, attachments?: Attachment[]): Promise<void> {
-    return this.getSessionAdapter(sessionId).sendMessage(sessionId, text, attachments);
+  async sendMessage(
+    sessionId: string,
+    text: string,
+    attachments?: Attachment[],
+    options?: SendMessageOptions,
+  ): Promise<void> {
+    return this.getSessionAdapter(sessionId).sendMessage(sessionId, text, attachments, options);
   }
 
   async respondToPermission(sessionId: string, permissionId: string, decision: PermissionDecision): Promise<void> {

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -25,6 +25,7 @@ import {
   type PermissionDecision,
   type QuestionAnswer,
   type QuestionResponseResult,
+  type SendMessageOptions,
 } from './base.js';
 import type { SessionContext } from '../session-manager.js';
 import type { ModelDetail, SessionUsage, ReasoningEffort, ToolArgs } from '@kraki/protocol';
@@ -1276,7 +1277,12 @@ export class PiAdapter extends AgentAdapter {
     return { sessionId };
   }
 
-  async sendMessage(sessionId: string, text: string, attachments?: import('@kraki/protocol').Attachment[]): Promise<void> {
+  async sendMessage(
+    sessionId: string,
+    text: string,
+    attachments?: import('@kraki/protocol').Attachment[],
+    options?: SendMessageOptions,
+  ): Promise<void> {
     // If the session was idle-evicted (proc killed but map entry retained) or
     // the daemon restarted, resume before sending — the proc's stdin is gone.
     const existing = this.sessions.get(sessionId);
@@ -1294,8 +1300,23 @@ export class PiAdapter extends AgentAdapter {
       this.pendingModeSignals.delete(sessionId);
       text = `[kraki: mode changed to ${pendingMode}]\n\n${text}`;
     }
-    // A new user message opens a fresh logical turn: reset the finalize/skip
-    // tracking so the skip-finalize rule and finalize round apply per user message.
+    const images = (attachments ?? [])
+      .filter((a): a is import('@kraki/protocol').ImageAttachment => a.type === 'image')
+      .map(a => ({ type: 'image' as const, data: a.data, mimeType: a.mimeType }));
+    const promptPayload: Record<string, unknown> = { message: text, ...(images.length > 0 && { images }) };
+
+    if (options?.delivery === 'steer') {
+      // `prompt + streamingBehavior: steer` is race-safe: while active it queues
+      // before the next LLM call; if Pi became idle between the app's state read
+      // and delivery, it starts a normal prompt instead of rejecting the input.
+      // It remains part of the current Kraki lifecycle, so do not reset/finalize
+      // local turn tracking or synthesize another idle.
+      await s.proc.request('prompt', { ...promptPayload, streamingBehavior: 'steer' }, { timeoutMs: null });
+      return;
+    }
+
+    // A normal prompt opens a fresh logical turn: reset the finalize/skip
+    // tracking so the skip-finalize rule and finalize round apply per user prompt.
     s.narrationSegments = 0;
     s.toolSinceLastNarration = false;
     s.lastNarration = '';
@@ -1307,10 +1328,6 @@ export class PiAdapter extends AgentAdapter {
     s.finalizeNarration = '';
     s.finalizeStreamId = undefined;
     s.finalizeStreamLen = 0;
-    const images = (attachments ?? [])
-      .filter((a): a is import('@kraki/protocol').ImageAttachment => a.type === 'image')
-      .map(a => ({ type: 'image' as const, data: a.data, mimeType: a.mimeType }));
-    const promptPayload: Record<string, unknown> = { message: text, ...(images.length > 0 && { images }) };
     // Submit exactly once. Pi only ACKs after prompt preflight, which may spend
     // minutes compacting even though the frame was delivered successfully. The
     // state-aware watchdog preserves the original request and never translates a

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -158,9 +158,16 @@ export class RelayClient {
    *  concurrent callers don't double-resume the same SDK session. */
   private resumeInFlight = new Map<string, Promise<boolean>>();
 
-  /** Per-session input chain. Distinct user sends are serialized until the
-   *  preceding turn reaches a real idle boundary. */
+  /** Normal prompts are serialized until the preceding turn reaches idle. */
   private inputChains = new Map<string, Promise<void>>();
+  /** All adapter submissions are serialized only until transport acceptance.
+   *  This lets an active-turn steer follow the original prompt ACK immediately
+   *  without waiting for the whole turn to become idle. */
+  private inputDispatches = new Map<string, Promise<void>>();
+  /** Idle has no turn identity. Hold it while a steer is awaiting adapter ACK so
+   *  pre-steer completion cannot settle the newly accepted interjection. */
+  private steerAcceptanceInFlight = new Set<string>();
+  private idleDuringSteerAcceptance = new Set<string>();
   private turnIdleWaiters = new Map<string, { promise: Promise<void>; resolve: () => void }>();
   /** Adapter errors become terminal only when the same logical turn reaches
    *  idle. Keeping them pending avoids freezing recoverable tool failures. */
@@ -180,6 +187,61 @@ export class RelayClient {
     if (!waiter) return;
     this.turnIdleWaiters.delete(sessionId);
     waiter.resolve();
+  }
+
+  private beginSteerAcceptance(sessionId: string): void {
+    this.steerAcceptanceInFlight.add(sessionId);
+  }
+
+  private finishSteerAcceptance(sessionId: string, accepted: boolean): void {
+    this.steerAcceptanceInFlight.delete(sessionId);
+    const deferredIdle = this.idleDuringSteerAcceptance.delete(sessionId);
+    if (!deferredIdle) return;
+    if (accepted) {
+      // The old provider error was already broadcast immediately. A successful
+      // interjection recovered the session, so it must not freeze as the outcome
+      // of the newer work when that work eventually idles.
+      this.pendingTerminalErrors.delete(sessionId);
+    } else {
+      this.settleAdapterIdle(sessionId);
+    }
+  }
+
+  private settleAdapterIdle(sessionId: string): void {
+    // Idle carries no run/turn identity. Never let a late idle callback erase
+    // a newer card. Permanent bubble boundaries retire settled card state;
+    // explicit abort owns its own freeze+clear path; pending questions stay.
+    const terminalError = this.pendingTerminalErrors.get(sessionId);
+    if (this.soleOpenQuestion(sessionId) && !terminalError) return;
+    if (terminalError) {
+      this.pendingTerminalErrors.delete(sessionId);
+      this.finishTurnWithStatus(sessionId, {
+        type: 'failed',
+        payload: {
+          ...terminalError,
+          failedAt: new Date().toISOString(),
+        },
+      });
+    } else {
+      this.clearOpenQuestions(sessionId);
+    }
+    this.resolveTurnIdle(sessionId);
+    this.sessionManager.markIdle(sessionId);
+    const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
+    if (usage) this.sessionManager.setUsage(sessionId, usage);
+    this.send({ type: 'idle', sessionId, payload: { usage, ...(terminalError && { reason: 'failed' as const }) } });
+    this.maybeGenerateTitle(sessionId);
+  }
+
+  private dispatchInput(sessionId: string, task: () => Promise<void>): Promise<void> {
+    const previous = this.inputDispatches.get(sessionId);
+    const next = previous ? previous.catch(() => {}).then(task) : task();
+    this.inputDispatches.set(sessionId, next);
+    const cleanup = () => {
+      if (this.inputDispatches.get(sessionId) === next) this.inputDispatches.delete(sessionId);
+    };
+    next.then(cleanup, cleanup);
+    return next;
   }
 
   // ── Push preview state ─────────────────────────────
@@ -920,24 +982,50 @@ export class RelayClient {
             break;
           }
 
-          const previous = this.inputChains.get(sessionId) ?? Promise.resolve();
-          const next = previous
-            .catch(() => {})
-            .then(async () => {
-              this.send({ type: 'active', sessionId, payload: {} });
+          if (msg.payload.delivery === 'steer') {
+            void this.dispatchInput(sessionId, async () => {
+              this.beginSteerAcceptance(sessionId);
               await this.ensureSessionResumed(sessionId);
-              traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId });
+              // Reassert active after resume so an idle/send race cannot leave a
+              // successfully accepted interjection running behind an idle UI.
+              this.send({ type: 'active', sessionId, payload: {} });
               this.sessionManager.markActive(sessionId);
-              const idle = this.waitForTurnIdle(sessionId);
-              try {
+              traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-STEER', sessionId, clientId });
+              await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'steer' });
+              // The adapter ACK is the ownership boundary for the interjection.
+              // Reassert active so an idle from the pre-steer work that raced the
+              // ACK cannot become the final visible state. A later provider idle
+              // still settles the steered work normally.
+              this.finishSteerAcceptance(sessionId, true);
+              this.send({ type: 'active', sessionId, payload: {} });
+              this.sessionManager.markActive(sessionId);
+            }).catch((err) => {
+              this.finishSteerAcceptance(sessionId, false);
+              logger.error({ err, sessionId }, 'steer input failed');
+              this.send({ type: 'error', sessionId, payload: { message: `Failed to steer agent: ${(err as Error).message}` } });
+            });
+            break;
+          }
+
+          const previous = this.inputChains.get(sessionId);
+          const deliver = async () => {
+            const idle = this.waitForTurnIdle(sessionId);
+            try {
+              await this.dispatchInput(sessionId, async () => {
+                await this.ensureSessionResumed(sessionId);
+                this.send({ type: 'active', sessionId, payload: {} });
+                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId });
+                this.sessionManager.markActive(sessionId);
                 await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
                 traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-DONE', sessionId, clientId });
-                await idle;
-              } catch (err) {
-                this.resolveTurnIdle(sessionId);
-                throw err;
-              }
-            })
+              });
+              await idle;
+            } catch (err) {
+              this.resolveTurnIdle(sessionId);
+              throw err;
+            }
+          };
+          const next = (previous ? previous.catch(() => {}).then(deliver) : deliver())
             .catch((err) => {
               logger.error({ err, sessionId }, 'send input failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver message: ${(err as Error).message}` } });
@@ -1697,29 +1785,11 @@ export class RelayClient {
     };
 
     this.adapter.onIdle = (sessionId) => {
-      // Idle carries no run/turn identity. Never let a late idle callback erase
-      // a newer card. Permanent bubble boundaries retire settled card state;
-      // explicit abort owns its own freeze+clear path; pending questions stay.
-      const terminalError = this.pendingTerminalErrors.get(sessionId);
-      if (this.soleOpenQuestion(sessionId) && !terminalError) return;
-      if (terminalError) {
-        this.pendingTerminalErrors.delete(sessionId);
-        this.finishTurnWithStatus(sessionId, {
-          type: 'failed',
-          payload: {
-            ...terminalError,
-            failedAt: new Date().toISOString(),
-          },
-        });
-      } else {
-        this.clearOpenQuestions(sessionId);
+      if (this.steerAcceptanceInFlight.has(sessionId)) {
+        this.idleDuringSteerAcceptance.add(sessionId);
+        return;
       }
-      this.resolveTurnIdle(sessionId);
-      this.sessionManager.markIdle(sessionId);
-      const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
-      if (usage) this.sessionManager.setUsage(sessionId, usage);
-      this.send({ type: 'idle', sessionId, payload: { usage, ...(terminalError && { reason: 'failed' as const }) } });
-      this.maybeGenerateTitle(sessionId);
+      this.settleAdapterIdle(sessionId);
     };
 
     this.adapter.onFlushComplete = (sessionId) => {
@@ -1771,6 +1841,8 @@ export class RelayClient {
       this.lastAgentContent.delete(sessionId);
       this.purgeSessionToolState(sessionId);
       this.broadcastedAttachmentIds.delete(sessionId);
+      this.steerAcceptanceInFlight.delete(sessionId);
+      this.idleDuringSteerAcceptance.delete(sessionId);
       this.resolveTurnIdle(sessionId);
       this.card.delete(sessionId);
       this.send({


### PR DESCRIPTION
## Summary
- keep the Web composer editable during active turns, with separate Steer and Stop controls
- carry explicit prompt/steer delivery through protocol, RelayClient, and all adapters
- map active interjections to Pi prompt steering, Copilot immediate delivery, and Claude streaming input
- serialize adapter acceptance without waiting for turn idle, including stale-idle/ACK and rapid multi-steer ownership races

## Verification
- `pnpm --filter @kraki/crypto build`
- `pnpm --filter @kraki/protocol build`
- `pnpm --filter @kraki/tentacle build`
- `pnpm --filter @kraki/arm-web build`
- `pnpm lint`
- Tentacle: 724/724 tests
- Web: 358/358 tests
- Playwright active composer desktop/mobile: 2/2
- `git diff --check`