### PR TITLE
feat(pulse): paced attachment pulls to eliminate cross-session HOL blocking

### DIFF
--- a/packages/arm/web/e2e/real-stack/pulse-attachment-concurrency.spec.ts
+++ b/packages/arm/web/e2e/real-stack/pulse-attachment-concurrency.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, type Page, request } from '@playwright/test';
+
+/**
+ * REAL-STACK concurrency regression for paced attachment pulls.
+ *
+ * Proves the fix for the cross-session Pulse head-of-line blocking where a
+ * multi-megabyte attachment broadcast occupied the single ordered stream and
+ * delayed an unrelated live message (the 115s abort incident).
+ *
+ * With the fix:
+ *   - the tentacle no longer broadcasts attachment bytes to every Arm;
+ *   - the browser pulls one 256 KiB chunk at a time (AttachmentPullQueue);
+ *   - a live message fired while the attachment is mid-download is NOT queued
+ *     behind the whole blob.
+ *
+ * The transport, head hub, pulse framing, E2E crypto and browser render are all
+ * REAL; only the agent is a MockAdapter driven via the control plane.
+ *
+ * Proof:
+ *   - `/attachmentReads` on the control plane records every chunk the tentacle
+ *     served. Exactly `chunkCount` reads (one per paced request_attachment)
+ *     proves the browser pulled one chunk at a time, not the whole blob.
+ *   - A live echo fired the same tick as the pull is visible before all chunks
+ *     are served — it was not blocked behind the attachment.
+ */
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB_URL = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const qs = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${qs ? `?${qs}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`control ${path} failed: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pairBrowser(page: Page): Promise<string> {
+  const { token, web, sessionId } = await control('/token');
+  await page.goto(web as string);
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  return sessionId as string;
+}
+
+test.describe.serial('real-stack pulse: paced attachment concurrency', () => {
+  let page: Page;
+  const pageErrors: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    await pairBrowser(page);
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
+  });
+
+  test('a live echo is not blocked behind a multi-chunk attachment download', async () => {
+    const sessionId = 'realstack-1';
+    await page.goto(`${WEB_URL}/session/${sessionId}`);
+    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await control('/idle', { sid: sessionId });
+
+    // 0. Send a real user message to open a turn — the tool trace is keyed to
+    //    the user_message that starts the turn, so without one readTurnTrace
+    //    returns empty and no Steps chip renders.
+    const prompt = `pull-and-check-${Date.now().toString(36)}`;
+    const input = page.getByPlaceholder('Send a message…');
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill(prompt);
+    await input.press('Enter');
+    await expect.poll(async () => {
+      const { messages } = await control('/received');
+      return (messages as Array<{ text: string }>).some((m) => m.text === prompt);
+    }, { timeout: 15_000 }).toBe(true);
+
+    // 1. Generate a 1.5 MB tool result (≈6 chunks of 256 KiB) → offloaded to a
+    //    ContentRef the browser must pull on demand.
+    const reply = `DONE-${Date.now().toString(36)}`;
+    const big = await control('/bigRef', { sid: sessionId, sizeKb: '1500', reply });
+    const chunkCount = big.chunkCount as number;
+    expect(chunkCount).toBeGreaterThan(1);
+
+    // 2. Reload so the resultRef renders from replay with no cached bytes → the
+    //    only way the bytes arrive is a paced request_attachment pull.
+    await page.reload();
+    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-chat-scroll]').getByText(reply, { exact: false }).first())
+      .toBeVisible({ timeout: 20_000 });
+
+    // 3. Expand the turn's Steps, then expand the tool step. ToolResultBody
+    //    (which fires the paced request_attachment pull) only mounts when the
+    //    individual step is expanded.
+    const stepsBtn = page.locator('[data-chat-scroll]').getByRole('button', { name: /Open steps/i }).first();
+    await expect(stepsBtn).toBeVisible({ timeout: 20_000 });
+    await stepsBtn.click();
+    const toolChip = page.locator('[data-chat-scroll]').getByRole('button', { name: /cat big\.bin/i }).first();
+    await expect(toolChip).toBeVisible({ timeout: 20_000 });
+    await toolChip.click(); // expand → ToolResultBody mounts → paced pull starts
+
+    // 4. Wait until the paced pull has actually started (≥1 chunk served) before
+    //    firing the concurrent echo — this avoids a race where the echo's idle
+    //    re-renders the panel before ToolResultBody mounts.
+    await expect.poll(async () => {
+      const { reads } = await control('/attachmentReads');
+      return (reads as unknown[]).length;
+    }, { timeout: 20_000, message: 'paced attachment pull never started' }).toBeGreaterThanOrEqual(1);
+
+    // 5. Fire a live echo CONCURRENTLY with the in-flight attachment download.
+    //    It must interleave, not wait for all chunks.
+    const echoMarker = `ECHO-${Date.now().toString(36)}`;
+    await control('/msg', { sid: sessionId, text: echoMarker });
+    await control('/idle', { sid: sessionId }); // conclude the echo's turn
+    await expect(page.locator('[data-chat-scroll]').getByText(echoMarker, { exact: false }).first())
+      .toBeVisible({ timeout: 15_000 });
+
+    // 6. The paced pull eventually serves every chunk (one request_attachment
+    //    per 256 KiB chunk). Exactly chunkCount reads proves the browser did
+    //    NOT request the whole blob at once — it advanced one chunk at a time,
+    //    even with a concurrent live echo interleaved.
+    await expect.poll(async () => {
+      const { reads } = await control('/attachmentReads');
+      return (reads as unknown[]).length;
+    }, { timeout: 30_000, message: 'paced attachment pull did not serve all chunks' }).toBe(chunkCount);
+
+    // 7. No browser errors during the concurrent download + echo.
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/packages/arm/web/e2e/real-stack/pulse-image-pull.spec.ts
+++ b/packages/arm/web/e2e/real-stack/pulse-image-pull.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type Page, request } from '@playwright/test';
+
+/**
+ * REAL-STACK image regression for paced attachment pulls.
+ *
+ * Proves a REAL PNG image produced by show_image (image ContentRef) still
+ * renders after the broadcast was removed — the browser pulls the bytes on
+ * demand via paced request_attachment (one 256 KiB chunk at a time) and
+ * reassembles them into a displayable blob.
+ *
+ * The image is > 256 KiB (noise pixels) so it spans multiple chunks, exercising
+ * the full paced reassembly path.
+ */
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB_URL = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const qs = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${qs ? `?${qs}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`control ${path} failed: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pairBrowser(page: Page): Promise<string> {
+  const { token, web, sessionId } = await control('/token');
+  await page.goto(web as string);
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  return sessionId as string;
+}
+
+test.describe.serial('real-stack pulse: image rendering via paced pull', () => {
+  let page: Page;
+  const pageErrors: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    await pairBrowser(page);
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
+  });
+
+  test('a multi-chunk PNG image renders in the chat via paced request_attachment', async () => {
+    const sessionId = 'realstack-1';
+    await page.goto(`${WEB_URL}/session/${sessionId}`);
+    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await control('/idle', { sid: sessionId });
+
+    // 1. Open a turn with a real user message (trace is keyed to user_message).
+    const prompt = `show-me-an-image-${Date.now().toString(36)}`;
+    const input = page.getByPlaceholder('Send a message…');
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill(prompt);
+    await input.press('Enter');
+    await expect.poll(async () => {
+      const { messages } = await control('/received');
+      return (messages as Array<{ text: string }>).some((m) => m.text === prompt);
+    }, { timeout: 15_000 }).toBe(true);
+
+    // 2. Produce a > 256 KiB PNG via show_image → image ContentRef (multi-chunk).
+    const reply = `IMG-${Date.now().toString(36)}`;
+    const img = await control('/imageRef', { sid: sessionId, reply });
+    const chunkCount = img.chunkCount as number;
+    expect(chunkCount).toBeGreaterThan(1);
+
+    // 3. Reload so the image ContentRef renders from replay with no cached
+    //    bytes — the only way the PNG arrives is a paced pull.
+    await page.reload();
+    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-chat-scroll]').getByText(reply, { exact: false }).first())
+      .toBeVisible({ timeout: 20_000 });
+
+    // 4. The PNG <img> loads successfully — naturalWidth > 0 proves the
+    //    browser reassembled all chunks into a valid, displayable PNG blob.
+    const imgEl = page.locator('[data-chat-scroll] img[alt="gen.png"]');
+    await expect(imgEl).toBeVisible({ timeout: 30_000 });
+    await expect.poll(async () => imgEl.evaluate((el) => (el as HTMLImageElement).naturalWidth), {
+      timeout: 30_000,
+      message: 'image never decoded (naturalWidth stayed 0)',
+    }).toBeGreaterThan(0);
+
+    // 5. The paced pull served every chunk (one request_attachment per chunk).
+    await expect.poll(async () => {
+      const { reads } = await control('/attachmentReads');
+      return (reads as unknown[]).length;
+    }, { timeout: 30_000, message: 'paced image pull did not serve all chunks' }).toBe(chunkCount);
+
+    // 6. No browser errors.
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -16,7 +16,7 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
-    "@coinfra/pulse": "^0.3.1",
+    "@coinfra/pulse": "^0.3.3",
     "@kraki/protocol": "workspace:*",
     "highlight.js": "^11.10.0",
     "idb": "^8.0.3",

--- a/packages/arm/web/src/lib/attachment-pull-queue.test.ts
+++ b/packages/arm/web/src/lib/attachment-pull-queue.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AttachmentPullQueue } from './attachment-pull-queue';
+
+describe('AttachmentPullQueue', () => {
+  it('round-robins concurrent attachments one chunk at a time', () => {
+    const sent: Array<{ sessionId: string; id: string; index: number }> = [];
+    const queue = new AttachmentPullQueue((request) => {
+      sent.push(request);
+      return true;
+    });
+
+    queue.request('session-a', 'attachment-a');
+    queue.request('session-b', 'attachment-b');
+    expect(sent).toEqual([
+      { sessionId: 'session-a', id: 'attachment-a', index: 0 },
+    ]);
+
+    queue.handleChunk({ sessionId: 'session-a', id: 'attachment-a', index: 0, total: 3, paced: true });
+    expect(sent.at(-1)).toEqual({ sessionId: 'session-b', id: 'attachment-b', index: 0 });
+
+    queue.handleChunk({ sessionId: 'session-b', id: 'attachment-b', index: 0, total: 2, paced: true });
+    expect(sent.at(-1)).toEqual({ sessionId: 'session-a', id: 'attachment-a', index: 1 });
+
+    queue.handleChunk({ sessionId: 'session-a', id: 'attachment-a', index: 1, total: 3, paced: true });
+    expect(sent.at(-1)).toEqual({ sessionId: 'session-b', id: 'attachment-b', index: 1 });
+  });
+
+  it('releases the queue when an older tentacle returns an unpaced response', () => {
+    const send = vi.fn(() => true);
+    const queue = new AttachmentPullQueue(send);
+
+    queue.request('session-a', 'legacy');
+    queue.request('session-b', 'next');
+    queue.handleChunk({ sessionId: 'session-a', id: 'legacy', index: 0, total: 3 });
+
+    expect(send).toHaveBeenNthCalledWith(2, { sessionId: 'session-b', id: 'next', index: 0 });
+  });
+
+  it('retries the in-flight chunk after reconnect', () => {
+    let connected = true;
+    const sent: Array<{ sessionId: string; id: string; index: number }> = [];
+    const queue = new AttachmentPullQueue((request) => {
+      if (!connected) return false;
+      sent.push(request);
+      return true;
+    });
+
+    queue.request('session-a', 'attachment-a');
+    queue.disconnect();
+    connected = false;
+    queue.resume();
+    expect(sent).toHaveLength(1);
+
+    connected = true;
+    queue.resume();
+    expect(sent).toEqual([
+      { sessionId: 'session-a', id: 'attachment-a', index: 0 },
+      { sessionId: 'session-a', id: 'attachment-a', index: 0 },
+    ]);
+  });
+
+  it('ignores duplicate and out-of-order chunks', () => {
+    const send = vi.fn(() => true);
+    const queue = new AttachmentPullQueue(send);
+    queue.request('session-a', 'attachment-a');
+
+    queue.handleChunk({ sessionId: 'session-a', id: 'attachment-a', index: 1, total: 3, paced: true });
+    expect(send).toHaveBeenCalledTimes(1);
+
+    queue.handleChunk({ sessionId: 'session-a', id: 'attachment-a', index: 0, total: 3, paced: true });
+    expect(send).toHaveBeenNthCalledWith(2, { sessionId: 'session-a', id: 'attachment-a', index: 1 });
+  });
+});

--- a/packages/arm/web/src/lib/attachment-pull-queue.ts
+++ b/packages/arm/web/src/lib/attachment-pull-queue.ts
@@ -1,0 +1,88 @@
+export interface AttachmentChunkProgress {
+  sessionId: string;
+  id: string;
+  index: number;
+  total: number;
+  paced?: true;
+  error?: string;
+}
+
+export interface AttachmentChunkRequest {
+  sessionId: string;
+  id: string;
+  index: number;
+}
+
+interface PullTask extends AttachmentChunkRequest {}
+
+type SendChunkRequest = (request: AttachmentChunkRequest) => boolean;
+
+/**
+ * Limits attachment traffic to one requested chunk at a time per Arm. Tasks
+ * rotate after every chunk so concurrent downloads cannot fill Pulse's ordered
+ * stream ahead of live messages.
+ */
+export class AttachmentPullQueue {
+  private readonly queued: PullTask[] = [];
+  private current: PullTask | null = null;
+
+  constructor(private readonly send: SendChunkRequest) {}
+
+  request(sessionId: string, id: string): void {
+    if (this.has(sessionId, id)) return;
+    this.queued.push({ sessionId, id, index: 0 });
+    this.pump();
+  }
+
+  handleChunk(chunk: AttachmentChunkProgress): void {
+    const current = this.current;
+    if (
+      !current
+      || current.sessionId !== chunk.sessionId
+      || current.id !== chunk.id
+      || current.index !== chunk.index
+    ) return;
+
+    this.current = null;
+
+    // An older Tentacle ignores paced mode and sends the whole attachment.
+    // Release the queue on its first response; the remaining legacy chunks are
+    // already in Pulse and need no follow-up requests.
+    if (!chunk.paced) {
+      this.pump();
+      return;
+    }
+
+    if (!chunk.error && chunk.index + 1 < chunk.total) {
+      current.index = chunk.index + 1;
+      this.queued.push(current);
+    }
+    this.pump();
+  }
+
+  disconnect(): void {
+    if (this.current) {
+      this.queued.unshift(this.current);
+      this.current = null;
+    }
+  }
+
+  resume(): void {
+    this.pump();
+  }
+
+  private has(sessionId: string, id: string): boolean {
+    if (this.current?.sessionId === sessionId && this.current.id === id) return true;
+    return this.queued.some((task) => task.sessionId === sessionId && task.id === id);
+  }
+
+  private pump(): void {
+    if (this.current || this.queued.length === 0) return;
+    const next = this.queued.shift()!;
+    this.current = next;
+    if (!this.send(next)) {
+      this.current = null;
+      this.queued.unshift(next);
+    }
+  }
+}

--- a/packages/arm/web/src/lib/attachments.ts
+++ b/packages/arm/web/src/lib/attachments.ts
@@ -153,18 +153,18 @@ export async function ingestChunk(
   mimeType: string,
   data: string,
   error?: string,
-): Promise<void> {
+): Promise<boolean> {
   if (error) {
     states.set(id, { kind: 'error', reason: error });
     clearPushTimeout(id);
     notify(id);
-    return;
+    return true;
   }
 
   let current = states.get(id);
+  if (current?.kind === 'ready') return false;
   if (!current || (current.kind !== 'awaiting-chunks' && current.kind !== 'fetching')) {
-    // Either we already have it, or a stray chunk arrived. Initialize a
-    // fresh awaiting-chunks state defensively.
+    // No active assembly exists. Initialize one defensively for a stray chunk.
     current = {
       kind: 'awaiting-chunks',
       received: new Map(),
@@ -185,6 +185,7 @@ export async function ingestChunk(
     states.set(id, current);
   }
 
+  if (current.received.has(index)) return false;
   current.received.set(index, data);
   current.total = total;
   current.mimeType = mimeType;
@@ -206,6 +207,7 @@ export async function ingestChunk(
   } else {
     notify(id);
   }
+  return true;
 }
 
 function clearPushTimeout(id: string): void {

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -50,6 +50,15 @@ export interface RouterContext {
   onSessionList?: (msg: SessionListMessage) => void;
   /** Called when tentacle sends a range-fetch batch. */
   onSessionMessagesRangeBatch?: (msg: SessionMessagesRangeBatchMessage) => void;
+  /** Advances the paced attachment queue after a chunk is safely ingested. */
+  onAttachmentChunk?: (chunk: {
+    sessionId: string;
+    id: string;
+    index: number;
+    total: number;
+    paced?: true;
+    error?: string;
+  }) => void;
 }
 
 export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
@@ -78,8 +87,18 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
   // but we route it before the session-existence check because the chunk's
   // session may not be in our store yet during early load.
   if (msg.type === 'attachment_data') {
-    const payload = (msg as { payload: { id: string; index: number; total: number; mimeType: string; data: string; error?: string } }).payload;
-    void ingestChunk(payload.id, payload.index, payload.total, payload.mimeType, payload.data, payload.error);
+    const payload = (msg as { payload: { id: string; index: number; total: number; mimeType: string; data: string; paced?: true; error?: string } }).payload;
+    void ingestChunk(payload.id, payload.index, payload.total, payload.mimeType, payload.data, payload.error).then((accepted) => {
+      if (!accepted) return;
+      ctx.onAttachmentChunk?.({
+        sessionId: msg.sessionId,
+        id: payload.id,
+        index: payload.index,
+        total: payload.total,
+        paced: payload.paced,
+        error: payload.error,
+      });
+    });
     return;
   }
 

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -13,6 +13,7 @@ import * as commands from './commands';
 import { createLogger, setLogBroadcast } from './logger';
 import { ArmPulse } from './arm-pulse';
 import { traceEvent } from './trace';
+import { AttachmentPullQueue } from './attachment-pull-queue';
 
 const logger = createLogger('ws-client');
 
@@ -24,6 +25,17 @@ export class KrakiWSClient {
   private handlers: MessageHandler[] = [];
   private pulse: ArmPulse;
   private pulseTick: ReturnType<typeof setInterval> | null = null;
+  private attachmentPulls = new AttachmentPullQueue(({ sessionId, id, index }) => {
+    if (getStore().status !== 'connected') return false;
+    const deviceId = getStore().deviceId;
+    this.sendEncrypted({
+      type: 'request_attachment',
+      deviceId,
+      sessionId,
+      payload: { id, sessionId, mode: 'paced', index },
+    });
+    return true;
+  });
 
   get url(): string { return this.transport.url; }
 
@@ -56,7 +68,11 @@ export class KrakiWSClient {
           this.handleMessage(msg);
           this.handlers.forEach((h) => h(msg));
         },
-        onClose: () => { this.clearReplayTracking(); this.pulse.onDisconnected(); },
+        onClose: () => {
+          this.clearReplayTracking();
+          this.attachmentPulls.disconnect();
+          this.pulse.onDisconnected();
+        },
       },
       url,
     );
@@ -151,6 +167,7 @@ export class KrakiWSClient {
       sendEncrypted: (m) => this.sendEncrypted(m),
       onSessionList: (m) => this.handleSessionList(m),
       onSessionMessagesRangeBatch: (m) => this.handleRangeBatch(m),
+      onAttachmentChunk: (chunk) => this.attachmentPulls.handleChunk(chunk),
     });
     this.handlers.forEach((h) => h(inner as unknown as Message));
   }
@@ -219,13 +236,7 @@ export class KrakiWSClient {
    *     which session dir to read from.
    */
   requestAttachment(sessionId: string, attachmentId: string) {
-    const deviceId = getStore().deviceId;
-    this.sendEncrypted({
-      type: 'request_attachment',
-      deviceId,
-      sessionId,
-      payload: { id: attachmentId, sessionId },
-    });
+    this.attachmentPulls.request(sessionId, attachmentId);
   }
 
   approve(permissionId: string, sessionId: string) {
@@ -693,6 +704,7 @@ export class KrakiWSClient {
         // Bring up the pulse endpoint + start the tick loop.
         this.pulse.onConnected();
         this.startPulseTick();
+        this.attachmentPulls.resume();
         break;
 
       case 'auth_challenge':

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -785,10 +785,9 @@ export interface LocalSessionsListMessage extends BaseEnvelope {
   };
 }
 
-/** Chunk of attachment bytes — flows either as a broadcast (live, immediately
- *  after the message that referenced the attachment) or as a unicast response
- *  to `request_attachment`. The relay never sees the bytes; payload is inside
- *  the encrypted blob like any other message. */
+/** Chunk of attachment bytes returned as a unicast response to
+ *  `request_attachment`. The relay never sees the bytes; payload is inside the
+ *  encrypted blob like any other message. */
 export interface AttachmentDataMessage extends BaseEnvelope {
   type: 'attachment_data';
   payload: {
@@ -802,6 +801,8 @@ export interface AttachmentDataMessage extends BaseEnvelope {
     mimeType: string;
     /** base64 of this chunk's bytes. Empty when `error` is set. */
     data: string;
+    /** Set by tentacles that support one-chunk-at-a-time attachment pulls. */
+    paced?: true;
     /** When set, this chunk carries an error instead of bytes (index/total
      *  should be 0/0). */
     error?: 'not_found' | 'unauthorized' | 'too_large';
@@ -1060,6 +1061,10 @@ export interface RequestAttachmentMessage extends BaseEnvelope {
     id: string;
     /** Session the attachment belongs to (used for AttachmentStore scoping). */
     sessionId: string;
+    /** Opt into one-chunk-at-a-time delivery. Older tentacles ignore this. */
+    mode?: 'paced';
+    /** Chunk requested in paced mode. Defaults to the first chunk. */
+    index?: number;
   };
 }
 

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.156",
-    "@coinfra/pulse": "^0.3.1",
+    "@coinfra/pulse": "^0.3.3",
     "@earendil-works/pi-coding-agent": "0.80.2",
     "@github/copilot-sdk": "^1.0.1",
     "@inquirer/prompts": "^8.3.2",

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -1129,7 +1129,7 @@ describe('RelayClient tool message lazy-load shape', () => {
     } finally { cleanup(); }
   });
 
-  it('tool_complete pushes attachment_data chunks for resultRef', () => {
+  it('tool_complete publishes a resultRef without broadcasting its bytes', () => {
     const { adapter, ws, cleanup } = buildClientWithStore();
     try {
       ws.sent.length = 0;
@@ -1139,17 +1139,59 @@ describe('RelayClient tool message lazy-load shape', () => {
         toolCallId: 'tc1',
       });
       const sent = decodePulseSends(ws.sent);
-      // The tool no longer broadcasts a tool_complete — it surfaces via
-      // card_action — but its result bytes still stream as attachment_data.
-      const cardIdx = sent.findIndex(m => m.type === 'card_action');
-      const chunkIdx = sent.findIndex(m => m.type === 'attachment_data');
-      expect(cardIdx).toBeGreaterThanOrEqual(0);
-      expect(chunkIdx).toBeGreaterThanOrEqual(0);
-      // Chunks ride after the card_action in send order
-      expect(chunkIdx).toBeGreaterThan(cardIdx);
-      const chunk = sent[chunkIdx];
-      expect(chunk.payload.mimeType).toBe('text/plain');
-      expect(Buffer.from(chunk.payload.data, 'base64').toString('utf-8')).toBe('hello world');
+      expect(sent.some(m => m.type === 'card_action')).toBe(true);
+      expect(sent.some(m => m.type === 'attachment_data')).toBe(false);
+    } finally { cleanup(); }
+  });
+
+  it('serves paced attachment requests one 256 KiB chunk at a time', () => {
+    const { ws, store, cleanup } = buildClientWithStore();
+    try {
+      const bytes = Buffer.alloc(600 * 1024, 0x61);
+      const ref = store.put('sess_1', bytes, 'application/octet-stream');
+      ws.sent.length = 0;
+
+      ws.emit('message', Buffer.from(JSON.stringify({
+        type: 'request_attachment',
+        deviceId: 'consumer-dev',
+        sessionId: 'sess_1',
+        payload: { id: ref.id, sessionId: 'sess_1', mode: 'paced', index: 0 },
+      })));
+
+      let chunks = decodePulseSends(ws.sent).filter(m => m.type === 'attachment_data');
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].payload).toMatchObject({ id: ref.id, index: 0, total: 3, paced: true });
+      expect(Buffer.from(chunks[0].payload.data, 'base64')).toHaveLength(256 * 1024);
+
+      ws.sent.length = 0;
+      ws.emit('message', Buffer.from(JSON.stringify({
+        type: 'request_attachment',
+        deviceId: 'consumer-dev',
+        sessionId: 'sess_1',
+        payload: { id: ref.id, sessionId: 'sess_1', mode: 'paced', index: 2 },
+      })));
+      chunks = decodePulseSends(ws.sent).filter(m => m.type === 'attachment_data');
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].payload).toMatchObject({ index: 2, total: 3, paced: true });
+      expect(Buffer.from(chunks[0].payload.data, 'base64')).toHaveLength(88 * 1024);
+    } finally { cleanup(); }
+  });
+
+  it('keeps complete attachment responses for legacy Arm requests', () => {
+    const { ws, store, cleanup } = buildClientWithStore();
+    try {
+      const ref = store.put('sess_1', Buffer.alloc(600 * 1024, 0x62), 'application/octet-stream');
+      ws.sent.length = 0;
+      ws.emit('message', Buffer.from(JSON.stringify({
+        type: 'request_attachment',
+        deviceId: 'consumer-dev',
+        sessionId: 'sess_1',
+        payload: { id: ref.id, sessionId: 'sess_1' },
+      })));
+      const chunks = decodePulseSends(ws.sent).filter(m => m.type === 'attachment_data');
+      expect(chunks).toHaveLength(3);
+      expect(chunks.map(c => c.payload.index)).toEqual([0, 1, 2]);
+      expect(chunks.every(c => c.payload.paced === undefined)).toBe(true);
     } finally { cleanup(); }
   });
 
@@ -1166,7 +1208,7 @@ describe('RelayClient tool message lazy-load shape', () => {
     } finally { cleanup(); }
   });
 
-  it('purges lastArgs* + broadcastedAttachmentIds when a session ends with in-flight tool calls', () => {
+  it('purges in-flight tool argument state when a session ends', () => {
     const { adapter, client, cleanup } = buildClientWithStore();
     try {
       const bigArgs = { command: 'echo ' + 'x'.repeat(400) };
@@ -1182,12 +1224,10 @@ describe('RelayClient tool message lazy-load shape', () => {
         lastArgsByToolCallId: Map<string, unknown>;
         lastArgsRefByToolCallId: Map<string, unknown>;
         sessionToolCallIds: Map<string, Set<string>>;
-        broadcastedAttachmentIds: Map<string, Set<string>>;
       };
       expect(c.lastArgsByToolCallId.size).toBe(2);
       expect(c.lastArgsRefByToolCallId.size).toBe(2);
       expect(c.sessionToolCallIds.get('sess_1')?.size).toBe(2);
-      expect(c.broadcastedAttachmentIds.has('sess_1')).toBe(true);
 
       // Session ends.
       (adapter.onSessionEnded as ((sid: string, e: { reason: string }) => void))('sess_1', { reason: 'killed' });
@@ -1195,7 +1235,6 @@ describe('RelayClient tool message lazy-load shape', () => {
       expect(c.lastArgsByToolCallId.size).toBe(0);
       expect(c.lastArgsRefByToolCallId.size).toBe(0);
       expect(c.sessionToolCallIds.has('sess_1')).toBe(false);
-      expect(c.broadcastedAttachmentIds.has('sess_1')).toBe(false);
     } finally { cleanup(); }
   });
 });

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -322,12 +322,6 @@ export class RelayClient {
 
   private readonly attachmentStore?: import('./attachment-store.js').AttachmentStore;
 
-  /** Track attachment ids already broadcast per session — prevents double-push
-   *  if the agent calls show_image twice with the same image bytes. The
-   *  receiving devices still see the ref each time (so the chat history is
-   *  correct); they just don't get a redundant byte broadcast. */
-  private broadcastedAttachmentIds = new Map<string, Set<string>>();
-
   /** Inline floor for offloading args. Below this we don't bother creating
    *  a ContentRef + chunk push — the round-trip overhead would exceed the
    *  bytes saved. Above it we always offload. */
@@ -1128,7 +1122,6 @@ export class RelayClient {
           this.sessionManager.deleteSession(sessionId);
           this.lastAgentContent.delete(sessionId);
           this.purgeSessionToolState(sessionId);
-          this.broadcastedAttachmentIds.delete(sessionId);
           this.send({ type: 'session_deleted', sessionId, payload: {} });
           this.eventsWatcher?.unwatch(sessionId);
           this.adapter.killSession(sessionId)
@@ -1700,11 +1693,6 @@ export class RelayClient {
           toolCallId: event.toolCallId,
         },
       });
-      if (argsRef) {
-        this.broadcastAttachmentBytes(sessionId, argsRef).catch((err) => {
-          logger.warn({ err, sessionId, attachmentId: argsRef.id }, 'failed to broadcast args bytes');
-        });
-      }
       // Track key files from tool usage
       if (event.toolName === 'read_file' || event.toolName === 'write_file' || event.toolName === 'view' ||
           event.toolName === 'edit' || event.toolName === 'create') {
@@ -1765,24 +1753,12 @@ export class RelayClient {
           ...(event.attachments?.length && { attachments: event.attachments }),
         },
       });
-      if (resultRef) {
-        this.broadcastAttachmentBytes(sessionId, resultRef).catch((err) => {
-          logger.warn({ err, sessionId, attachmentId: resultRef.id }, 'failed to broadcast result bytes');
-        });
-      }
     };
 
-    this.adapter.onAttachmentBytes = (sessionId, event) => {
-      // Fire-and-forget — chunks are streamed from disk and pushed via the
-      // normal broadcast queue. We deliberately don't block onToolComplete
-      // on chunk delivery; both events ride the same WS queue so ordering
-      // (ref-first, chunks-after) is preserved naturally.
-      for (const ref of event.refs) {
-        this.broadcastAttachmentBytes(sessionId, ref).catch((err) => {
-          logger.warn({ err, sessionId, attachmentId: ref.id }, 'failed to broadcast attachment bytes');
-        });
-      }
-    };
+    // Bytes remain in AttachmentStore until an Arm actually renders the
+    // ContentRef. Broadcasting large results to every Arm blocked unrelated
+    // control and live messages in Pulse's ordered stream.
+    this.adapter.onAttachmentBytes = () => {};
 
     this.adapter.onIdle = (sessionId) => {
       if (this.steerAcceptanceInFlight.has(sessionId)) {
@@ -1840,7 +1816,6 @@ export class RelayClient {
       this.titleGenerationInFlight.delete(sessionId);
       this.lastAgentContent.delete(sessionId);
       this.purgeSessionToolState(sessionId);
-      this.broadcastedAttachmentIds.delete(sessionId);
       this.steerAcceptanceInFlight.delete(sessionId);
       this.idleDuringSteerAcceptance.delete(sessionId);
       this.resolveTurnIdle(sessionId);
@@ -2356,60 +2331,9 @@ export class RelayClient {
     }
   }
 
-  /** Plaintext chunk budget for `attachment_data` envelopes.
-   *  Stays under the relay's 10 MB frame cap after base64 + envelope. */
-  private static readonly ATTACHMENT_CHUNK_BYTES = 2 * 1024 * 1024;
-
-  /**
-   * Stream an attachment's bytes to all connected consumers as
-   * `attachment_data` chunks. Called immediately after the producer fires
-   * a `tool_complete` carrying the matching `ContentRef`. Skipped if
-   * we've already broadcast this id within the session.
-   */
-  private async broadcastAttachmentBytes(
-    sessionId: string,
-    ref: import('@kraki/protocol').ContentRef,
-  ): Promise<void> {
-    if (!this.attachmentStore) {
-      logger.warn({ sessionId, attachmentId: ref.id }, 'no attachment store — skipping broadcast');
-      return;
-    }
-    let seen = this.broadcastedAttachmentIds.get(sessionId);
-    if (!seen) {
-      seen = new Set();
-      this.broadcastedAttachmentIds.set(sessionId, seen);
-    }
-    if (seen.has(ref.id)) return;
-    seen.add(ref.id);
-
-    const total = Math.max(1, Math.ceil(ref.size / RelayClient.ATTACHMENT_CHUNK_BYTES));
-    let index = 0;
-    for (const chunk of this.attachmentStore.stream(sessionId, ref.id, RelayClient.ATTACHMENT_CHUNK_BYTES)) {
-      this.send({
-        type: 'attachment_data',
-        sessionId,
-        payload: {
-          id: ref.id,
-          index,
-          total,
-          mimeType: ref.mimeType,
-          data: chunk.toString('base64'),
-        },
-      });
-      index += 1;
-    }
-    if (index === 0) {
-      // The ref was emitted but bytes are no longer on disk — odd state, but
-      // notify consumers with a structured error so they don't sit on a
-      // pending placeholder forever.
-      logger.warn({ sessionId, attachmentId: ref.id }, 'no bytes on disk for ref, sending error chunk');
-      this.send({
-        type: 'attachment_data',
-        sessionId,
-        payload: { id: ref.id, index: 0, total: 0, mimeType: ref.mimeType, data: '', error: 'not_found' },
-      });
-    }
-  }
+  /** Keep encrypted frames small so control messages can interleave between
+   *  attachment chunks. */
+  private static readonly ATTACHMENT_CHUNK_BYTES = 256 * 1024;
 
   /**
    * Serve a `request_attachment` from a consumer device. Reads from the
@@ -2434,7 +2358,15 @@ export class RelayClient {
       return;
     }
     const total = Math.max(1, Math.ceil(got.bytes.length / RelayClient.ATTACHMENT_CHUNK_BYTES));
-    for (let i = 0; i < total; i++) {
+    const paced = msg.payload.mode === 'paced';
+    const requestedIndex = paced ? Math.floor(msg.payload.index ?? 0) : 0;
+    if (paced && (requestedIndex < 0 || requestedIndex >= total)) {
+      this.unicastAttachmentError(requesterDeviceId, requesterKey, sessionId, id, 'not_found');
+      return;
+    }
+    const first = paced ? requestedIndex : 0;
+    const end = paced ? requestedIndex + 1 : total;
+    for (let i = first; i < end; i++) {
       const slice = got.bytes.subarray(
         i * RelayClient.ATTACHMENT_CHUNK_BYTES,
         Math.min((i + 1) * RelayClient.ATTACHMENT_CHUNK_BYTES, got.bytes.length),
@@ -2451,6 +2383,7 @@ export class RelayClient {
           total,
           mimeType: got.meta.mimeType,
           data: slice.toString('base64'),
+          ...(paced && { paced: true as const }),
         },
       };
       this.sendReliableUnicastTo(requesterDeviceId, requesterKey, chunkMsg);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   packages/arm/web:
     dependencies:
       '@coinfra/pulse':
-        specifier: ^0.3.1
-        version: 0.3.2
+        specifier: ^0.3.3
+        version: 0.3.3
       '@kraki/protocol':
         specifier: workspace:*
         version: link:../../protocol
@@ -197,8 +197,8 @@ importers:
         specifier: ^0.3.156
         version: 0.3.156(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@coinfra/pulse':
-        specifier: ^0.3.1
-        version: 0.3.2
+        specifier: ^0.3.3
+        version: 0.3.3
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.2
         version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -103,8 +103,8 @@ class MockAdapter extends AgentAdapter {
   toolStart(sid: string, tool: string, args: Record<string, unknown> = {}, toolCallId?: string) {
     this.onToolStart?.(sid, { toolName: tool, args, ...(toolCallId && { toolCallId }) });
   }
-  toolComplete(sid: string, tool: string, result: string, toolCallId?: string) {
-    this.onToolComplete?.(sid, { toolName: tool, result, ...(toolCallId && { toolCallId }) });
+  toolComplete(sid: string, tool: string, result: string, toolCallId?: string, attachments?: unknown[]) {
+    this.onToolComplete?.(sid, { toolName: tool, result, ...(toolCallId && { toolCallId }), ...(attachments && { attachments }) });
   }
   idle(sid: string) { this.onIdle?.(sid); }
   error(sid: string, message: string) { this.onError?.(sid, { message }); }
@@ -121,6 +121,17 @@ function fail(msg: string): never {
   console.error(`❌ ${msg}`);
   cleanup();
   process.exit(1);
+}
+
+/** Build a PNG chunk: [length][type][data][crc]. */
+function pngChunk(type: string, data: Buffer, crc32: (b: Buffer) => number): Buffer {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const typeBuf = Buffer.from(type, 'ascii');
+  const crcVal = crc32(Buffer.concat([typeBuf, data])) >>> 0;
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crcVal, 0);
+  return Buffer.concat([len, typeBuf, data, crc]);
 }
 
 function cleanup() {
@@ -231,6 +242,15 @@ async function main(): Promise<void> {
   // args) to a ContentRef the browser pulls on demand — this is what exercises
   // the request_attachment pulse path in the browser (Stage 4).
   const attachmentStore = new AttachmentStore(mkdtempSync(join(tmpdir(), 'kraki-realstack-att-')));
+  /** Records every paced attachment read so the concurrency spec can prove the
+   *  browser pulls one 256 KiB chunk at a time (not the whole blob at once). */
+  const attachmentReads: Array<{ ts: number; id: string }> = [];
+  const origRead = attachmentStore.read.bind(attachmentStore);
+  attachmentStore.read = (sid: string, id: string) => {
+    const r = origRead(sid, id);
+    if (r) attachmentReads.push({ ts: Date.now(), id });
+    return r;
+  };
   relay = new RelayClient(adapter as unknown as AgentAdapter, sm, {
     relayUrl: RELAY_URL,
     device: { name: 'RealStack Tentacle', role: 'tentacle', kind: 'desktop' },
@@ -376,6 +396,54 @@ async function main(): Promise<void> {
         case '/permResponses': return json(200, { responses: adapter.permissionResponses });
         case '/answers': return json(200, { answers: adapter.questionAnswers });
         case '/killed': return json(200, { killed: adapter.killed });
+        // ── generate a large (multi-chunk) tool result so the browser exercises
+        //    paced attachment pulls (one 256 KiB chunk per request_attachment). ──
+        case '/bigRef': {
+          const sid = q.get('sid')!;
+          const sizeKb = Number(q.get('sizeKb') ?? '1500');
+          const marker = q.get('marker') ?? `BIG-${Date.now().toString(36)}`;
+          const body = `${marker}\n${'x'.repeat(sizeKb * 1024)}`;
+          const tcid = `tc-big-${sid}-${marker}`;
+          attachmentReads.length = 0;
+          adapter.toolStart(sid, q.get('tool') ?? 'bash', { command: 'cat big.bin' }, tcid);
+          adapter.toolComplete(sid, q.get('tool') ?? 'bash', body, tcid);
+          // Concluding agent_message anchors the turn so its tool step renders as
+          // a chip on reload (the trace is keyed to the concluding bubble).
+          adapter.msg(sid, q.get('reply') ?? 'Done — open the step to see the result.');
+          adapter.idle(sid);
+          return json(200, { ok: true, marker, sizeKb, chunkCount: Math.ceil((body.length) / (256 * 1024)) });
+        }
+        case '/attachmentReads': return json(200, { reads: attachmentReads });
+        // ── generate a REAL multi-chunk PNG image (show_image path) so the spec
+        //    proves image ContentRefs render via paced request_attachment pulls.
+        //    Noise pixels keep the PNG > 256 KiB (multiple chunks) after compression. ──
+        case '/imageRef': {
+          const sid = q.get('sid')!;
+          const W = 700, H = 500;
+          const { deflateSync, crc32 } = await import('node:zlib');
+          const { randomFillSync } = await import('node:crypto');
+          // Build a valid PNG: signature + IHDR + IDAT(zlib of scanlines) + IEND.
+          const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+          const ihdrData = Buffer.alloc(13);
+          ihdrData.writeUInt32BE(W, 0); ihdrData.writeUInt32BE(H, 4);
+          ihdrData[8] = 8;   // bit depth
+          ihdrData[9] = 2;   // color type RGB
+          const ihdr = pngChunk('IHDR', ihdrData, crc32);
+          const raw = Buffer.alloc(H * (1 + W * 3)); // filter byte per scanline
+          randomFillSync(raw);
+          for (let y = 0; y < H; y++) raw[y * (1 + W * 3)] = 0; // filter = none
+          const idat = pngChunk('IDAT', deflateSync(raw), crc32);
+          const iend = pngChunk('IEND', Buffer.alloc(0), crc32);
+          const png = Buffer.concat([sig, ihdr, idat, iend]);
+          const ref = attachmentStore.put(sid, png, 'image/png', { name: 'gen.png' });
+          attachmentReads.length = 0;
+          const tcid = `tc-img-${sid}-${Date.now().toString(36)}`;
+          adapter.toolStart(sid, 'show_image', {}, tcid);
+          adapter.toolComplete(sid, 'show_image', '', tcid, [ref]);
+          adapter.msg(sid, q.get('reply') ?? 'Here is the generated image.');
+          adapter.idle(sid);
+          return json(200, { ok: true, id: ref.id, sizeKb: Math.round(png.length / 1024), chunkCount: Math.ceil(png.length / (256 * 1024)) });
+        }
         case '/shutdown': json(200, { ok: true }); cleanup(); process.exit(0); return;
         default: return json(404, { error: 'unknown control endpoint' });
       }


### PR DESCRIPTION
## Summary

Fixes the cross-session Pulse head-of-line blocking where a multi-megabyte attachment broadcast (e.g. a 4 MB `show_image` image) occupied the single ordered stream and delayed unrelated live/control messages — the root cause of the ~115 s abort incident (abort completed at Pi in <0.5 s, but took ~115 s to surface in Arm behind two ~5 MB attachment frames).

## Changes

**Tentacle** (`@kraki/tentacle`):
- **Stop broadcasting attachment bytes** to every connected Arm. Bytes stay in `AttachmentStore` until an Arm that renders the `ContentRef` requests them.
- Shrink chunk budget `2 MiB → 256 KiB`.
- `request_attachment` supports **paced mode**: return ONE chunk per request. Legacy requests still get the full attachment (old Arm ↔ new Tentacle compatible).

**Arm** (`@kraki/arm-web`):
- New `AttachmentPullQueue` limits attachment traffic to **one chunk in flight globally**; concurrent downloads round-robin per chunk (`A0→B0→A1→B1…`). So the most a live message can be queued behind is one 256 KiB chunk, not a whole blob.
- `request_attachment` opts into paced mode.
- Duplicate chunk ingest rejected (reconnect re-sends) without stalling.

**Protocol** (`@kraki/protocol`):
- Optional fields: `request_attachment.mode/index`, `attachment_data.paced`. Old clients/tentacles ignore them.

**Both arm-web and tentacle** bumped `@coinfra/pulse` `^0.3.1 → ^0.3.3`.

## Backward compatibility

All protocol fields are optional. Four upgrade combinations work:
- new Arm + new Tentacle → paced one-chunk-at-a-time (the fix)
- old Arm + new Tentacle → full attachment per request (unchanged)
- new Arm + old Tentacle → Arm sees no `paced` flag, releases queue on first response
- old Arm + old Tentacle → unchanged

## Verification

- Arm unit tests: **361/361**
- Tentacle unit tests: **717/717** (incl. paced single-chunk + legacy full-response regressions)
- `AttachmentPullQueue` unit tests: round-robin, legacy compat, reconnect retry, out-of-order dedup
- Real-stack Playwright (real browser ⇄ real head ⇄ real tentacle, real E2E crypto):
  - `pulse-attachment-concurrency`: 1.5 MB (6-chunk) result pulled paced while a live echo fires concurrently — echo renders before all chunks served, exactly 6 reads recorded.
  - `pulse-image-pull`: >256 KiB PNG via `show_image` renders (`naturalWidth > 0`) through paced reassembly.
- Both specs stable across 3 consecutive runs.

## Test plan

- [x] `pnpm validate` (lint + build + test) passes locally
- [x] CI `Validate` job
- [ ] After merge: cut `@kraki/tentacle` and `@kraki/arm-web` releases
