### PR TITLE
fix(turn): collapse terminal errors into one bubble

### DIFF
--- a/packages/arm/ios/Kraki/Core/Storage/IncrementalGrouper.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/IncrementalGrouper.swift
@@ -526,7 +526,9 @@ struct SessionGrouperCache {
         } else {
             var lastAgentIdx = -1
             for i in stride(from: state.currentThinking.count - 1, through: 0, by: -1) {
-                if state.currentThinking[i].type == "agent_message" {
+                if state.currentThinking[i].type == "agent_message"
+                    || state.currentThinking[i].type == "interrupted_turn"
+                    || state.currentThinking[i].type == "turn_status" {
                     lastAgentIdx = i
                     break
                 }
@@ -542,10 +544,37 @@ struct SessionGrouperCache {
                     isActive: false
                 ))
             } else {
-                let thinking = state.currentThinking.enumerated()
+                var thinking = state.currentThinking.enumerated()
                     .filter { $0.offset != lastAgentIdx }
                     .map(\.element)
-                let finalMsg = state.currentThinking[lastAgentIdx]
+                var finalMsg = state.currentThinking[lastAgentIdx]
+
+                if finalMsg.type == "turn_status" || finalMsg.type == "interrupted_turn" {
+                    let existingDraft = finalMsg.payload["draft"]?.stringValue ?? ""
+                    let hasTerminalAttachments = finalMsg.payload["attachments"] != nil
+                    if let replyIdx = thinking.lastIndex(where: {
+                        $0.type == "agent_message"
+                            && (!($0.content ?? "").isEmpty || $0.payload["attachments"] != nil)
+                    }) {
+                        var payload = finalMsg.payload
+                        if existingDraft.isEmpty {
+                            payload["draft"] = AnyCodable(thinking[replyIdx].content ?? "")
+                        }
+                        if !hasTerminalAttachments,
+                           let attachments = thinking[replyIdx].payload["attachments"] {
+                            payload["attachments"] = attachments
+                        }
+                        finalMsg = ChatMessage(
+                            type: finalMsg.type,
+                            seq: finalMsg.seq,
+                            sessionId: finalMsg.sessionId,
+                            deviceId: finalMsg.deviceId,
+                            timestamp: finalMsg.timestamp,
+                            payload: payload
+                        )
+                        thinking.remove(at: replyIdx)
+                    }
+                }
                 closed.append(ActivityBlock(
                     id: blockId,
                     initiator: initiator,

--- a/packages/arm/ios/Kraki/Core/Storage/TurnGrouper.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/TurnGrouper.swift
@@ -342,10 +342,42 @@ func groupMessagesIntoTurns(
                     isActive: false
                 )))
             } else {
-                let thinking = currentThinking.enumerated()
+                var thinking = currentThinking.enumerated()
                     .filter { $0.offset != lastAgentIdx }
                     .map(\.element)
-                let finalMsg = currentThinking[lastAgentIdx]
+                var finalMsg = currentThinking[lastAgentIdx]
+
+                // A terminal status may arrive after Pi has already emitted its
+                // final agent_message, so CardManager's draft is empty. Fold
+                // that reply into the terminal bubble and remove it from Steps:
+                // one turn must render as one bubble, with errors/tools retained
+                // only in thinkingHistory.
+                if finalMsg.type == "turn_status" || finalMsg.type == "interrupted_turn" {
+                    let existingDraft = finalMsg.payload["draft"]?.stringValue ?? ""
+                    let hasTerminalAttachments = finalMsg.payload["attachments"] != nil
+                    if let replyIdx = thinking.lastIndex(where: {
+                        $0.type == "agent_message"
+                            && (!($0.content ?? "").isEmpty || $0.payload["attachments"] != nil)
+                    }) {
+                        var payload = finalMsg.payload
+                        if existingDraft.isEmpty {
+                            payload["draft"] = AnyCodable(thinking[replyIdx].content ?? "")
+                        }
+                        if !hasTerminalAttachments,
+                           let attachments = thinking[replyIdx].payload["attachments"] {
+                            payload["attachments"] = attachments
+                        }
+                        finalMsg = ChatMessage(
+                            type: finalMsg.type,
+                            seq: finalMsg.seq,
+                            sessionId: finalMsg.sessionId,
+                            deviceId: finalMsg.deviceId,
+                            timestamp: finalMsg.timestamp,
+                            payload: payload
+                        )
+                        thinking.remove(at: replyIdx)
+                    }
+                }
                 result.append(.block(ActivityBlock(
                     id: blockId,
                     initiator: initiator,

--- a/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageBubbleView.swift
@@ -335,6 +335,7 @@ struct MessageBubbleView: View {
                 if let draft = message.interruptedDraft, !draft.isEmpty {
                     messageBody(draft, foreground: .primary.opacity(0.8))
                 }
+                imageGrid(attachments: message.attachments)
                 if let detail, !detail.isEmpty {
                     Text(detail)
                         .font(.subheadline)

--- a/packages/arm/ios/KrakiTests/IncrementalGrouperTests.swift
+++ b/packages/arm/ios/KrakiTests/IncrementalGrouperTests.swift
@@ -71,6 +71,29 @@ final class IncrementalGrouperTests: XCTestCase {
         )
     }
 
+    private func terminalStatus(seq: Int, draft: String = "") -> ChatMessage {
+        ChatMessage(
+            type: "turn_status", seq: seq,
+            sessionId: "s", deviceId: "d", timestamp: "2024-01-01T00:00:00Z",
+            payload: [
+                "draft": AnyCodable(draft),
+                "action": AnyCodable([
+                    "type": "failed",
+                    "payload": ["message": "524 status code (no body)"]
+                ]),
+                "finishedAt": AnyCodable("2026-07-14T00:00:00Z")
+            ]
+        )
+    }
+
+    private func errorMsg(seq: Int) -> ChatMessage {
+        ChatMessage(
+            type: "error", seq: seq,
+            sessionId: "s", deviceId: "d", timestamp: "2024-01-01T00:00:00Z",
+            payload: ["message": AnyCodable("524 status code (no body)")]
+        )
+    }
+
     /// Convenience: extract blocks from a TurnItem array, skipping
     /// standalones.
     private func blocks(_ items: [TurnItem]) -> [ActivityBlock] {
@@ -78,6 +101,25 @@ final class IncrementalGrouperTests: XCTestCase {
     }
 
     // MARK: - Single-island, append-only
+
+    func testTerminalStatusFoldsReplyAndKeepsErrorsInThinking() {
+        var cache = SessionGrouperCache()
+        cache.ingest([
+            userMsg(seq: 70, text: "retry"),
+            errorMsg(seq: 71),
+            errorMsg(seq: 72),
+            agentMsg(seq: 73, text: "Restarted successfully"),
+            terminalStatus(seq: 74),
+            idle(seq: 75),
+        ])
+
+        let grouped = blocks(cache.items(streamingContent: nil))
+        XCTAssertEqual(grouped.count, 1)
+        XCTAssertEqual(grouped[0].finalMessage?.type, "turn_status")
+        XCTAssertEqual(grouped[0].finalMessage?.payload["draft"]?.stringValue, "Restarted successfully")
+        XCTAssertEqual(grouped[0].thinkingMessages.filter { $0.type == "error" }.count, 2)
+        XCTAssertFalse(grouped[0].thinkingMessages.contains { $0.type == "agent_message" })
+    }
 
     /// New cache + a complete turn arriving as one batch produces
     /// the same output as the non-incremental grouper.

--- a/packages/arm/ios/KrakiTests/TurnGrouperTests.swift
+++ b/packages/arm/ios/KrakiTests/TurnGrouperTests.swift
@@ -317,6 +317,34 @@ final class TurnGrouperTests: XCTestCase {
         } else { XCTFail() }
     }
 
+    func testFailedStatusFoldsFinalReplyIntoOneTerminalBlock() {
+        let msgs = [
+            makeMsg(type: "user_message", seq: 70, payload: ["content": AnyCodable("retry")]),
+            makeMsg(type: "error", seq: 71, payload: ["message": AnyCodable("524 status code (no body)")]),
+            makeMsg(type: "error", seq: 72, payload: ["message": AnyCodable("524 status code (no body)")]),
+            makeMsg(type: "agent_message", seq: 73, payload: ["content": AnyCodable("Restarted successfully")]),
+            makeMsg(type: "turn_status", seq: 74, payload: [
+                "draft": AnyCodable(""),
+                "action": AnyCodable([
+                    "type": "failed",
+                    "payload": ["message": "524 status code (no body)"]
+                ]),
+                "finishedAt": AnyCodable("2026-07-14T00:00:00Z")
+            ]),
+            makeMsg(type: "idle", seq: 75),
+        ]
+
+        let result = groupMessagesIntoTurns(msgs)
+        XCTAssertEqual(result.count, 1)
+        guard case .block(let block) = result[0] else {
+            return XCTFail("Expected one activity block")
+        }
+        XCTAssertEqual(block.finalMessage?.type, "turn_status")
+        XCTAssertEqual(block.finalMessage?.payload["draft"]?.stringValue, "Restarted successfully")
+        XCTAssertEqual(block.thinkingMessages.filter { $0.type == "error" }.count, 2)
+        XCTAssertFalse(block.thinkingMessages.contains { $0.type == "agent_message" })
+    }
+
     // MARK: - System Messages
 
     func testSessionCreatedStandalone() {

--- a/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
+++ b/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
@@ -145,37 +145,50 @@ test.describe.serial('real-stack terminal status cards', () => {
     await page.screenshot({ path: '/tmp/kraki-terminal-legacy-process-lost.png', fullPage: false });
   });
 
-  test('backend error freezes a permanent failed card', async () => {
+  test('backend errors and final reply collapse into one permanent failed bubble', async () => {
     await control('/idle', { sid: sessionId });
     await sendPrompt(page, 'Run the full test suite');
 
-    // Active streaming draft.
-    await control('/delta', { sid: sessionId, text: 'Compiling and running tests' });
     await control('/toolStart', { sid: sessionId, tool: 'bash', cmd: 'npm test' });
 
-    // A terminal backend error arrives, then idle freezes it as `failed`.
+    // Reproduce mrhuha8u-tcpn1tz8: repeated backend errors, then a final Pi
+    // reply, then idle freezes the terminal status with an empty card draft.
     await control('/error', { sid: sessionId, message: '524 status code (no body)' });
+    await control('/error', { sid: sessionId, message: '524 status code (no body)' });
+    await control('/msg', { sid: sessionId, text: 'Restarted successfully after the backend errors' });
     await control('/idle', { sid: sessionId });
 
     const failedCard = page.locator('[data-terminal-card="failed"]')
-      .filter({ hasText: 'Compiling and running tests' });
+      .filter({ hasText: 'Restarted successfully after the backend errors' });
     await expect(failedCard).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-terminal-card="failed"]')
+      .filter({ hasText: 'Restarted successfully after the backend errors' })).toHaveCount(1);
     await expect(failedCard.getByText('Turn failed')).toBeVisible();
     await expect(failedCard.getByText('524 status code (no body)')).toBeVisible();
-    // The streaming draft is preserved inside the frozen card.
-    await expect(failedCard.getByText('Compiling and running tests')).toBeVisible();
+    await expect(failedCard.getByText('Restarted successfully after the backend errors')).toBeVisible();
+    // Error wire records are turn details, never top-level chat bubbles.
+    await expect(page.getByText('Error', { exact: true })).toHaveCount(0);
 
-    await page.screenshot({ path: '/tmp/kraki-terminal-failed.png', fullPage: false });
+    await page.screenshot({ path: '/tmp/kraki-terminal-single-failed-bubble.png', fullPage: false });
+
+    // Both backend errors remain available inside Steps.
+    await failedCard.getByRole('button', { name: 'Open steps' }).click();
+    await expect(page.getByText('Error', { exact: true })).toHaveCount(2);
+    await expect(page.getByText('524 status code (no body)', { exact: true })).toHaveCount(3);
+    await page.screenshot({ path: '/tmp/kraki-terminal-single-failed-bubble-steps.png', fullPage: false });
+    await page.keyboard.press('Escape');
   });
 
   test('failed card survives a full browser refresh', async () => {
     await page.reload();
     await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 10_000 });
     const failedCard = page.locator('[data-terminal-card="failed"]')
-      .filter({ hasText: 'Compiling and running tests' });
+      .filter({ hasText: 'Restarted successfully after the backend errors' });
     await expect(failedCard).toBeVisible({ timeout: 10_000 });
+    await expect(failedCard).toHaveCount(1);
     await expect(failedCard.getByText('Turn failed')).toBeVisible();
+    await expect(page.getByText('Error', { exact: true })).toHaveCount(0);
 
-    await page.screenshot({ path: '/tmp/kraki-terminal-failed-refreshed.png', fullPage: false });
+    await page.screenshot({ path: '/tmp/kraki-terminal-single-failed-bubble-refreshed.png', fullPage: false });
   });
 });

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -9,12 +9,9 @@ import { messageProvider } from '../../lib/message-provider';
 import { getSessionStatus, cardActionKey } from '../../lib/session-status';
 import type { Attachment, ContentRef } from '@kraki/protocol';
 import type { ChatMessage } from '../../types/store';
+import { projectSpineMessages } from '../../lib/turn-projection';
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
-
-/** TRACE / transient activity types — never on the spine; they live in the
- *  live bubble (live) or the Steps modal (pulled history). */
-const TRACE_TYPES = new Set(['tool_start', 'tool_complete', 'agent_narration', 'active']);
 
 /** Extract seq from a message, returning 0 for non-sequenced messages. */
 function getSeq(m: ChatMessage): number {
@@ -38,7 +35,7 @@ function collectTurnAttachments(
 ): Attachment[] {
   const directKeys = new Set(directAttachments.map(attachmentKey));
   const targetIdx = messages.findIndex((message) => getSeq(message) === bubbleSeq);
-  if (targetIdx < 0 || messages[targetIdx].type !== 'agent_message') return [];
+  if (targetIdx < 0 || !['agent_message', 'turn_status', 'interrupted_turn'].includes(messages[targetIdx].type)) return [];
   let turnStartIdx = -1;
   for (let i = targetIdx - 1; i >= 0; i--) {
     if (messages[i].type === 'user_message') {
@@ -118,13 +115,7 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
   // Persistent, replayed bubbles rendered directly in seq order. Excludes the
   // transient TRACE/activity axis (tool_start/tool_complete/agent_narration/
   // active), which is shown only from the Steps popover.
-  const spine = useMemo(
-    () => messages.filter((msg) => {
-      if (TRACE_TYPES.has(msg.type)) return false;
-      return true;
-    }),
-    [messages],
-  );
+  const spine = useMemo(() => projectSpineMessages(messages), [messages]);
   const finalAgentSeqs = useMemo(() => {
     const seqs = new Set<number>();
     let lastAgentSeq = 0;
@@ -143,11 +134,13 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
     const images = new Map<number, Attachment[]>();
     const artifacts = new Map<number, ContentRef[]>();
     for (const msg of spine) {
-      if (msg.type !== 'agent_message') continue;
+      const terminal = msg.type === 'turn_status' || msg.type === 'interrupted_turn';
+      if (msg.type !== 'agent_message' && !terminal) continue;
       const seq = getSeq(msg);
-      if (!finalAgentSeqs.has(seq)) continue;
-      const turnImages = collectTurnImages(messages, seq, msg.payload.attachments);
-      const turnArtifacts = collectTurnHtmlArtifacts(messages, seq, msg.payload.attachments);
+      if (msg.type === 'agent_message' && !finalAgentSeqs.has(seq)) continue;
+      const directAttachments = (msg.payload as { attachments?: Attachment[] }).attachments ?? [];
+      const turnImages = collectTurnImages(messages, seq, directAttachments);
+      const turnArtifacts = collectTurnHtmlArtifacts(messages, seq, directAttachments);
       if (turnImages.length > 0) images.set(seq, turnImages);
       if (turnArtifacts.length > 0) artifacts.set(seq, turnArtifacts);
     }
@@ -297,8 +290,8 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
                   message={msg}
                   agent={session.agent}
                   sessionId={sessionId}
-                  turnImages={msg.type === 'agent_message' ? turnAttachmentsByBubbleSeq.images.get(getSeq(msg)) : undefined}
-                  turnArtifacts={msg.type === 'agent_message' ? turnAttachmentsByBubbleSeq.artifacts.get(getSeq(msg)) : undefined}
+                  turnImages={turnAttachmentsByBubbleSeq.images.get(getSeq(msg))}
+                  turnArtifacts={turnAttachmentsByBubbleSeq.artifacts.get(getSeq(msg))}
                   onOpenArtifact={onOpenArtifact}
                 />
               </div>

--- a/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
@@ -8,11 +8,12 @@ import { PermissionInput } from '../actions/PermissionInput';
 import { QuestionInput } from '../actions/QuestionInput';
 import { ToolActivity } from './ToolActivity';
 import { StepsButton, useTurnSteps } from './StepsModal';
-import { markdownComponents } from './MessageBubble';
+import { markdownComponents, ImageAttachments, HtmlArtifactCards } from './MessageBubble';
 import { messageProvider } from '../../lib/message-provider';
 import { formatTime } from '../../lib/format';
 import { cardActionKey } from '../../lib/session-status';
 import type { SessionCard } from '../../types/store';
+import type { Attachment, ContentRef } from '@kraki/protocol';
 
 /** Lazy attachment pull for tool args/result refs rendered in the status
  *  section (mirrors MessageBubble's ATTACHMENT_PULL). */
@@ -37,6 +38,9 @@ interface LiveAgentBubbleProps {
     timestamp: string;
     bubbleSeq: number;
     stepHint?: number;
+    attachments?: Attachment[];
+    artifacts?: ContentRef[];
+    onOpenArtifact?: (artifact: ContentRef) => void;
   };
 }
 
@@ -69,6 +73,8 @@ export function LiveAgentBubble({ sessionId, agent, card, frozen }: LiveAgentBub
   const live = !frozen;
   const draft = card.text ?? '';
   const hasContent = draft.length > 0;
+  const hasFrozenArtifacts = !!frozen?.attachments?.length || !!frozen?.artifacts?.length;
+  const showContentSection = hasContent || hasFrozenArtifacts;
   const a = card.action;
 
   const runningTool = a?.type === 'tool_start' ? a : null;
@@ -114,13 +120,19 @@ export function LiveAgentBubble({ sessionId, agent, card, frozen }: LiveAgentBub
         <AgentAvatar agent={agent ?? ''} sessionId={sessionId} size="sm" />
       </div>
       <div className="min-w-0 max-w-[85%] overflow-hidden rounded-2xl rounded-bl-md bg-ocean-500/5 shadow-sm sm:max-w-[70%]">
-        {hasContent && (
+        {showContentSection && (
           <div className="overflow-x-auto px-4 py-2.5">
-            <div className="markdown-content text-sm leading-relaxed text-text-primary">
-              <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
-                {draft}
-              </Markdown>
-            </div>
+            {hasContent && (
+              <div className="markdown-content text-sm leading-relaxed text-text-primary">
+                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
+                  {draft}
+                </Markdown>
+              </div>
+            )}
+            <ImageAttachments attachments={frozen?.attachments} sessionId={sessionId} />
+            {frozen?.artifacts && frozen.artifacts.length > 0 && (
+              <HtmlArtifactCards artifacts={frozen.artifacts} onOpen={frozen.onOpenArtifact} />
+            )}
             {/* Settled tail (no live action): render a footer BYTE-IDENTICAL to
                the concluded agent bubble (MessageBubble's agent_message) — same
                `mt-1` row, same timestamp (HH:MM of ~now, which matches the
@@ -138,7 +150,7 @@ export function LiveAgentBubble({ sessionId, agent, card, frozen }: LiveAgentBub
         )}
 
         {hasAction && (
-          <div className={`bg-surface-tertiary/40 px-3 py-2 ${hasContent ? 'border-t border-border-primary/50' : ''}`}>
+          <div className={`bg-surface-tertiary/40 px-3 py-2 ${showContentSection ? 'border-t border-border-primary/50' : ''}`}>
             {tool && (
               <ToolActivity
                 type={runningTool ? 'start' : 'complete'}

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -119,6 +119,10 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
           }
         : { text: message.payload.draft ?? '', action: message.payload.action };
       const finishedAt = legacy ? message.payload.interruptedAt : message.payload.finishedAt;
+      const directImages = ((message.payload as { attachments?: Attachment[] }).attachments ?? []).filter(
+        (attachment) => attachment.type === 'image' ||
+          (attachment.type === 'content_ref' && attachment.mimeType.startsWith('image/')),
+      );
       return (
         <LiveAgentBubble
           sessionId={sessionId}
@@ -128,6 +132,9 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
             timestamp: message.timestamp ?? finishedAt ?? new Date().toISOString(),
             bubbleSeq: typeof message.seq === 'number' ? message.seq : 0,
             stepHint: message.payload.steps,
+            attachments: [...directImages, ...(turnImages ?? [])],
+            artifacts: turnArtifacts,
+            onOpenArtifact,
           }}
         />
       );
@@ -468,7 +475,7 @@ function CopyableBubble({ text, children }: { text: string; children: React.Reac
   );
 }
 
-function HtmlArtifactCards({ artifacts, onOpen }: { artifacts: ContentRef[]; onOpen?: (artifact: ContentRef) => void }) {
+export function HtmlArtifactCards({ artifacts, onOpen }: { artifacts: ContentRef[]; onOpen?: (artifact: ContentRef) => void }) {
   return (
     <div className="mt-2 space-y-1.5" data-html-artifacts={artifacts.length}>
       {artifacts.map((artifact) => {
@@ -497,7 +504,7 @@ function HtmlArtifactCards({ artifacts, onOpen }: { artifacts: ContentRef[]; onO
   );
 }
 
-function ImageAttachments({ attachments, sessionId }: { attachments?: Attachment[]; sessionId?: string }) {
+export function ImageAttachments({ attachments, sessionId }: { attachments?: Attachment[]; sessionId?: string }) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
   const [resolvedRefs, setResolvedRefs] = useState<Record<number, string>>({});
   const images = attachments?.filter(

--- a/packages/arm/web/src/components/chat/StepsModal.tsx
+++ b/packages/arm/web/src/components/chat/StepsModal.tsx
@@ -5,7 +5,9 @@ import { useStore } from '../../hooks/useStore';
 import { messageProvider } from '../../lib/message-provider';
 import { StepsList } from './StepsList';
 
-const isTrace = (t: string) => t === 'tool_start' || t === 'tool_complete' || t === 'agent_narration' || t === 'permission' || t === 'question';
+const isTrace = (t: string) =>
+  t === 'tool_start' || t === 'tool_complete' || t === 'agent_narration' ||
+  t === 'permission' || t === 'question' || t === 'error';
 
 /**
  * Collect the TRACE steps (narration + tool chips) belonging to one turn,

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -462,8 +462,23 @@ export const useStore = create<Store>()(persist((set) => ({
       );
       if (bubbleIdx < 0) return state; // bubble not loaded — nothing to attach to
 
+      // A final agent_message can briefly become the visible turn anchor before
+      // a following turn_status arrives. Its async trace pull may then complete
+      // after the terminal pull and re-inject the entire turn a second time.
+      // Once a terminal record exists later in the same user-bounded turn, that
+      // record exclusively owns Steps; discard stale agent-anchor responses.
+      if (existing[bubbleIdx].type === 'agent_message') {
+        for (let i = bubbleIdx + 1; i < existing.length; i++) {
+          const next = existing[i];
+          if (next.type === 'user_message' || next.type === 'send_input') break;
+          if (next.type === 'turn_status' || next.type === 'interrupted_turn') return state;
+        }
+      }
+
+      const replaceErrors = entries.some((entry) => entry.type === 'error');
       const isTrace = (t: string) =>
-        t === 'tool_start' || t === 'tool_complete' || t === 'agent_narration';
+        t === 'tool_start' || t === 'tool_complete' || t === 'agent_narration' ||
+        t === 'permission' || t === 'question' || (replaceErrors && t === 'error');
 
       // The target bubble is either the concluding agent_message (a concluded
       // turn — steps go BEFORE it) or the leading user_message of an in-progress

--- a/packages/arm/web/src/hooks/useStore.turnSteps.test.ts
+++ b/packages/arm/web/src/hooks/useStore.turnSteps.test.ts
@@ -136,6 +136,25 @@ describe('setTurnSteps', () => {
     expect(tools).toHaveLength(2);
   });
 
+  it('rejects a stale final-agent trace response once terminal status owns the turn', () => {
+    const store = useStore.getState();
+    store.appendMessage('s1', m('user_message', 1));
+    store.appendMessage('s1', m('agent_message', 2, { content: 'done' }));
+    store.appendMessage('s1', m('turn_status', 3, {
+      draft: '',
+      action: { type: 'failed', payload: { message: '524', source: 'backend', failedAt: '' } },
+      finishedAt: '',
+    }));
+
+    const terminalTrace = [traceEntry('tool_start', 'tc1'), traceEntry('tool_complete', 'tc1')];
+    store.setTurnSteps('s1', 3, terminalTrace);
+    store.setTurnSteps('s1', 2, terminalTrace); // stale response races in later
+
+    const list = useStore.getState().messages.get('s1')!;
+    expect(list.filter(x => x.type === 'tool_start')).toHaveLength(1);
+    expect(list.filter(x => x.type === 'tool_complete')).toHaveLength(1);
+  });
+
   it('does not persist injected trace to IDB', async () => {
     const store = useStore.getState();
     store.appendMessage('s1', m('user_message', 1));

--- a/packages/arm/web/src/lib/turn-projection.test.ts
+++ b/packages/arm/web/src/lib/turn-projection.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatMessage } from '../types/store';
+import { projectSpineMessages } from './turn-projection';
+
+describe('projectSpineMessages', () => {
+  it('folds error + final agent reply + failed status into one terminal bubble', () => {
+    const messages: ChatMessage[] = [
+      { type: 'user_message', deviceId: 'd1', seq: 70, timestamp: '', sessionId: 's1', payload: { content: 'retry' } } as ChatMessage,
+      { type: 'error', deviceId: 'd1', seq: 71, timestamp: '', sessionId: 's1', payload: { message: '524 status code (no body)' } } as ChatMessage,
+      { type: 'error', deviceId: 'd1', seq: 72, timestamp: '', sessionId: 's1', payload: { message: '524 status code (no body)' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 73, timestamp: '', sessionId: 's1', payload: { content: 'Restarted successfully', steps: 2 } } as ChatMessage,
+      { type: 'turn_status', deviceId: 'd1', seq: 74, timestamp: '', sessionId: 's1', payload: {
+        draft: '',
+        action: { type: 'failed', payload: { message: '524 status code (no body)', source: 'backend', failedAt: '' } },
+        finishedAt: '',
+        steps: 2,
+      } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 75, timestamp: '', sessionId: 's1', payload: { reason: 'failed' } } as ChatMessage,
+    ];
+
+    const projected = projectSpineMessages(messages);
+    expect(projected.map((message) => message.type)).toEqual(['user_message', 'turn_status', 'idle']);
+    expect(projected[1].payload.draft).toBe('Restarted successfully');
+  });
+
+  it('preserves final reply attachments when folding into terminal status', () => {
+    const image = { type: 'image' as const, mimeType: 'image/png', data: 'aW1hZ2U=' };
+    const projected = projectSpineMessages([
+      { type: 'agent_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: '', attachments: [image] } } as ChatMessage,
+      { type: 'turn_status', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: {
+        draft: '',
+        action: { type: 'failed', payload: { message: 'failed', source: 'backend', failedAt: '' } },
+        finishedAt: '',
+      } } as ChatMessage,
+    ]);
+
+    expect(projected).toHaveLength(1);
+    expect((projected[0].payload as { attachments?: unknown[] }).attachments).toEqual([image]);
+  });
+
+  it('preserves an explicit terminal draft over an earlier agent reply', () => {
+    const projected = projectSpineMessages([
+      { type: 'agent_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'Earlier' } } as ChatMessage,
+      { type: 'turn_status', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: {
+        draft: 'Frozen draft',
+        action: { type: 'user_abort', payload: { abortedAt: '' } },
+        finishedAt: '',
+      } } as ChatMessage,
+    ]);
+
+    expect(projected).toHaveLength(1);
+    expect(projected[0].payload.draft).toBe('Frozen draft');
+  });
+
+  it('hides a non-terminal error from the top-level spine without dropping normal replies', () => {
+    const projected = projectSpineMessages([
+      { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'go' } } as ChatMessage,
+      { type: 'error', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { message: 'recoverable' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { content: 'continued' } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1', payload: { reason: 'completed' } } as ChatMessage,
+    ]);
+
+    expect(projected.map((message) => message.type)).toEqual(['user_message', 'agent_message', 'idle']);
+  });
+});

--- a/packages/arm/web/src/lib/turn-projection.ts
+++ b/packages/arm/web/src/lib/turn-projection.ts
@@ -1,0 +1,74 @@
+import type { Attachment } from '@kraki/protocol';
+import type { ChatMessage } from '../types/store';
+
+/** TRACE / transient activity types — never top-level chat bubbles. */
+const TRACE_TYPES = new Set(['tool_start', 'tool_complete', 'agent_narration', 'active']);
+
+/** Project durable wire/history records into visual chat bubbles.
+ *
+ * `error` is turn detail, never a top-level bubble. When a turn ends with a
+ * terminal status after already emitting its final `agent_message`, merge that
+ * reply into the terminal card's draft and render only the terminal card. The
+ * raw records remain untouched in storage and continue to feed Steps/replay. */
+export function projectSpineMessages(messages: ChatMessage[]): ChatMessage[] {
+  const projected: ChatMessage[] = [];
+  let segment: ChatMessage[] = [];
+
+  const flush = () => {
+    if (segment.length === 0) return;
+    const terminalIdx = segment.findLastIndex(
+      (msg) => msg.type === 'turn_status' || msg.type === 'interrupted_turn',
+    );
+    if (terminalIdx >= 0) {
+      const terminal = segment[terminalIdx];
+      let fallbackDraft = '';
+      let fallbackAttachments: Attachment[] | undefined;
+      for (let i = terminalIdx - 1; i >= 0; i--) {
+        const candidate = segment[i];
+        if (candidate.type === 'agent_message') {
+          const attachments = candidate.payload.attachments;
+          if (candidate.payload.content || attachments?.length) {
+            fallbackDraft = candidate.payload.content ?? '';
+            fallbackAttachments = attachments;
+            break;
+          }
+        }
+      }
+      const ownDraft = terminal.payload.draft ?? '';
+      const terminalAttachments = (terminal.payload as { attachments?: Attachment[] }).attachments;
+      const hasFallback = !!fallbackDraft || !!fallbackAttachments?.length;
+      const needsMerge = hasFallback && (!ownDraft || (!terminalAttachments?.length && !!fallbackAttachments?.length));
+      const normalizedTerminal = !needsMerge
+        ? terminal
+        : ({
+            ...terminal,
+            payload: {
+              ...terminal.payload,
+              draft: ownDraft || fallbackDraft,
+              ...(!terminalAttachments?.length && fallbackAttachments?.length
+                ? { attachments: fallbackAttachments }
+                : {}),
+            },
+          } as ChatMessage);
+
+      for (let i = 0; i < segment.length; i++) {
+        const msg = segment[i];
+        if (msg.type === 'error' || msg.type === 'agent_message') continue;
+        projected.push(i === terminalIdx ? normalizedTerminal : msg);
+      }
+    } else {
+      for (const msg of segment) {
+        if (msg.type !== 'error') projected.push(msg);
+      }
+    }
+    segment = [];
+  };
+
+  for (const msg of messages) {
+    if (TRACE_TYPES.has(msg.type)) continue;
+    segment.push(msg);
+    if (msg.type === 'idle') flush();
+  }
+  flush();
+  return projected;
+}

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2330,7 +2330,11 @@ describe('RelayClient pending-question digest', () => {
     expect(status.payload).toMatchObject({
       action: { type: 'failed', payload: { message: '524 status code (no body)', source: 'backend' } },
     });
-    expect(status.payload.steps).toBe(1);
+    expect(status.payload.steps).toBe(2);
+    const tracedError = (sm.appendTrace as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) => JSON.parse(call[2]) as { type: string; payload: Record<string, unknown> })
+      .find((entry) => entry.type === 'error' && entry.payload.message === '524 status code (no body)');
+    expect(tracedError).toBeDefined();
     // The running tool was closed as interrupted, not left dangling.
     const interruptedTool = (sm.appendTrace as ReturnType<typeof vi.fn>).mock.calls
       .map((call) => JSON.parse(call[2]) as { type: string; payload: Record<string, unknown> })

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1790,6 +1790,11 @@ export class RelayClient {
         message: event.message,
         source: 'backend',
       });
+      this.recordTrace({
+        type: 'error',
+        sessionId,
+        payload: { message: event.message },
+      });
       this.send({
         type: 'error',
         sessionId,
@@ -2288,7 +2293,10 @@ export class RelayClient {
     // agent_message / system_message stamps this running total as payload.steps
     // (see send()), letting a concluded bubble show its "Steps" affordance from
     // replay alone — WITHOUT first pulling the transient trace.
-    if (msg.type === 'tool_start' || msg.type === 'agent_narration' || msg.type === 'permission' || msg.type === 'question') {
+    if (
+      msg.type === 'tool_start' || msg.type === 'agent_narration' ||
+      msg.type === 'permission' || msg.type === 'question' || msg.type === 'error'
+    ) {
       this.turnStepCounts.set(msg.sessionId, (this.turnStepCounts.get(msg.sessionId) ?? 0) + 1);
     }
     const enriched = { ...msg, timestamp: new Date().toISOString() };


### PR DESCRIPTION
## Summary

Fixes terminal turns rendering as multiple chat bubbles. A turn is now always one visual bubble: final agent content is folded into the terminal status card, the `failed` / `user_abort` outcome occupies its action slot, and backend errors remain available only inside Steps.

This directly fixes session `mrhuha8u-tcpn1tz8`, whose raw order is:

`user_message → error → error → agent_message → turn_status → idle`

The visual projection is now:

`user_message → one turn_status bubble → idle`

## Changes

- Add an idle-bounded Web turn projection that:
  - removes top-level error bubbles;
  - folds the final `agent_message` into a following terminal status;
  - preserves final text, images, content refs, and HTML artifacts;
  - leaves raw durable history untouched.
- Treat errors as Steps entries.
- Record adapter/backend errors in trace and include them in terminal step hints.
- Reject stale final-agent trace responses after a terminal status becomes the authoritative Steps anchor, fixing duplicate tool/error groups caused by an async trace-pull race.
- Apply the same terminal fold to both iOS full and incremental groupers.
- Preserve image attachments in iOS terminal bubbles.

## Verification

- Real session `mrhuha8u-tcpn1tz8` projected from its actual `messages.jsonl`: exactly one terminal record, zero top-level errors, zero separate agent replies.
- Web production build passed.
- Protocol, crypto, and Tentacle builds passed.
- Web focused tests: 14/14 passed.
- Tentacle focused tests: 78/78 passed.
- Real-stack terminal-card Playwright: 5/5 passed.
  - repeated 524 errors
  - final agent reply
  - one failed terminal bubble
  - exactly two errors inside Steps
  - no duplicate trace group
  - full browser refresh remains one bubble
- Biome lint and `git diff --check` passed.

## Notes

The repository's existing React 19 component-test environment still fails all render tests with `React.act is not a function`; pure projection/store tests and real-browser Playwright cover this change. iOS full build remains blocked by the existing missing `packages/arm/ios/Vendor/GRDB.swift`, but both full and incremental groupers have matching XCTest regression cases.
