### PR TITLE
chore(tentacle): bump version to 0.29.13

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.29.12",
+  "version": "0.29.13",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps @kraki/tentacle to 0.29.13 for the single-terminal-turn-bubble fix merged in #168.