### PR TITLE
test(realstack): replay mrhuha8u two failed turns + trailing success

### DIFF
--- a/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
+++ b/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
@@ -179,6 +179,70 @@ test.describe.serial('real-stack terminal status cards', () => {
     await page.keyboard.press('Escape');
   });
 
+  test('two consecutive failed turns each render exactly one bubble (mrhuha8u-tcpn1tz8 replay)', async () => {
+    // Real-session tail replay: TWO failed turns back-to-back.
+    // mrhuha8u-tcpn1tz8 seq 70-80: two turns each shaped user -> error ->
+    // agent_reply -> turn_status(failed) -> idle. Each terminal turn must be
+    // its own single bubble; backend errors never appear as standalone bubbles.
+    await control('/idle', { sid: sessionId });
+
+    // --- turn 1 ---
+    const prompt1 = 'Run the full suite again';
+    const reply1 = '已重置并重新启动，开屏动画和模式选择正在从头播放';
+    await sendPrompt(page, prompt1);
+    await control('/error', { sid: sessionId, message: '524 status code (no body)' });
+    await control('/error', { sid: sessionId, message: '524 status code (no body)' });
+    await control('/msg', { sid: sessionId, text: reply1 });
+    await control('/idle', { sid: sessionId });
+
+    const card1 = page.locator('[data-terminal-card="failed"]').filter({ hasText: reply1 });
+    await expect(card1).toBeVisible({ timeout: 10_000 });
+    await expect(card1).toHaveCount(1);
+    await expect(card1.getByText('Turn failed')).toBeVisible();
+
+    // --- turn 2 ---
+    const prompt2 = '回到原来的卡片大小 只保留卡片内容';
+    const reply2 = '已经按你的要求调整：卡片恢复到之前的尺寸';
+    await sendPrompt(page, prompt2);
+    await control('/error', { sid: sessionId, message: '524 status code (no body)' });
+    await control('/msg', { sid: sessionId, text: reply2 });
+    await control('/idle', { sid: sessionId });
+
+    const card2 = page.locator('[data-terminal-card="failed"]').filter({ hasText: reply2 });
+    await expect(card2).toBeVisible({ timeout: 10_000 });
+    await expect(card2).toHaveCount(1);
+    await expect(card2.getByText('Turn failed')).toBeVisible();
+    await expect(card2.getByText(reply2)).toBeVisible();
+
+    // Both failed turns coexist as distinct single bubbles; the reply of turn 1
+    // is still visible (not absorbed into turn 2).
+    await expect(card1.getByText(reply1)).toBeVisible();
+
+    // Backend errors never escape as standalone top-level chat bubbles: each
+    // failed card surfaces its 524 message exactly once in the action slot.
+    await expect(card1.getByText('524 status code (no body)')).toHaveCount(1);
+    await expect(card2.getByText('524 status code (no body)')).toHaveCount(1);
+
+    // --- turn 3: a SUCCESSFUL turn right after the failures ---
+    // mrhuha8u-tcpn1tz8 seq 81-83: user -> agent_message -> idle (no error,
+    // no turn_status). It must render as a normal agent bubble, NOT a terminal
+    // card, and must not absorb the preceding failed turn.
+    const prompt3 = '不是我是说加入棋盘之前的那个尺寸';
+    const reply3 = '已按你刚才的准确意思修改：卡片恢复到之前的大小';
+    await sendPrompt(page, prompt3);
+    await control('/msg', { sid: sessionId, text: reply3 });
+    await control('/idle', { sid: sessionId });
+
+    await expect(page.getByText(reply3).first()).toBeVisible({ timeout: 10_000 });
+    // The successful turn is a plain agent reply, never a terminal card.
+    await expect(page.locator('[data-terminal-card]').filter({ hasText: reply3 })).toHaveCount(0);
+    // The two failed cards are untouched.
+    await expect(card1).toHaveCount(1);
+    await expect(card2).toHaveCount(1);
+
+    await page.screenshot({ path: '/tmp/kraki-terminal-two-failed-turns.png', fullPage: false });
+  });
+
   test('failed card survives a full browser refresh', async () => {
     await page.reload();
     await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
Adds a real-stack regression test that replays the exact tail of session `mrhuha8u-tcpn1tz8`: two consecutive failed turns (each `user -> error -> agent_reply -> turn_status(failed) -> idle`) followed by a successful turn.

Asserts:
- each failed turn renders as exactly one `failed` terminal card
- the agent reply text is folded into the card (not a separate bubble)
- the 524 backend error appears exactly once per card, only in the action slot — never as a standalone top-level Error bubble
- the trailing successful turn stays a normal agent bubble, is not misclassified as a terminal card, and does not absorb the preceding failed turn

This protects the single-bubble-per-terminal-turn fix shipped in v0.29.13 (#168).