### PR TITLE
feat(compaction): model runtime compaction as session state

### DIFF
--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -534,7 +534,12 @@ final class MessageRouter {
             }
 
         case "active":
-            appState.sessionStore.updateState(sessionId, state: "active")
+            // Active may be reasserted during steer acceptance while Pi is still
+            // compacting. Only compacting-end, idle, or session_list may leave
+            // the independent compacting state.
+            if appState.sessionStore.sessions[sessionId]?.state != .compacting {
+                appState.sessionStore.updateState(sessionId, state: "active")
+            }
             // NOTE: We deliberately do NOT call `messageStore.append`
             // here. `active` is a TRANSIENT envelope (see the comment at
             // L297) whose `seq` field comes from the relay's GLOBAL event
@@ -546,6 +551,16 @@ final class MessageRouter {
             // after reconnect. Compounding fact: `MessageBubbleView`
             // explicitly filters out `active` from rendering anyway, so
             // persisting it had zero UI value.
+
+        case "compacting":
+            if payload?["phase"] as? String == "start" {
+                appState.sessionStore.setTransientState(sessionId, .compacting)
+            } else {
+                let nextState = SessionState(rawValue: payload?["nextState"] as? String ?? "active") ?? .active
+                appState.sessionStore.setState(sessionId, nextState)
+            }
+            // Deliberately no MessageStore/MessageProvider ingestion: this is a
+            // transient session state, not spine, TRACE, or a chat cell.
 
         case "error":
             appState.sessionStore.flushDelta(sessionId)

--- a/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
@@ -340,6 +340,12 @@ struct IdlePayload: Codable, Sendable {
     var usage: SessionUsage?
 }
 
+struct CompactingPayload: Codable, Sendable {
+    let phase: String
+    var reason: String?
+    var nextState: SessionState?
+}
+
 struct ErrorPayload: Codable, Sendable {
     let message: String
 }
@@ -433,6 +439,7 @@ enum ProducerMessage: Sendable {
     // State
     case idle(IdlePayload)
     case active
+    case compacting(CompactingPayload)
     case error(ErrorPayload)
 
     // Session metadata
@@ -466,6 +473,7 @@ enum ProducerMessage: Sendable {
         case .toolComplete:         return "tool_complete"
         case .idle:                 return "idle"
         case .active:               return "active"
+        case .compacting:           return "compacting"
         case .error:                return "error"
         case .sessionModeSet:       return "session_mode_set"
         case .sessionModelSet:      return "session_model_set"
@@ -525,6 +533,8 @@ extension ProducerMessage: Codable {
             return .idle(try container.decode(IdlePayload.self, forKey: .payload))
         case "active":
             return .active
+        case "compacting":
+            return .compacting(try container.decode(CompactingPayload.self, forKey: .payload))
         case "error":
             return .error(try container.decode(ErrorPayload.self, forKey: .payload))
         case "session_mode_set":
@@ -570,6 +580,7 @@ extension ProducerMessage: Codable {
         case .toolComplete(let p):         try container.encode(p, forKey: .payload)
         case .idle(let p):                 try container.encode(p, forKey: .payload)
         case .active:                      try container.encode([String: String](), forKey: .payload)
+        case .compacting(let p):           try container.encode(p, forKey: .payload)
         case .error(let p):                try container.encode(p, forKey: .payload)
         case .sessionModeSet(let p):       try container.encode(p, forKey: .payload)
         case .sessionModelSet(let p):      try container.encode(p, forKey: .payload)

--- a/packages/arm/ios/Kraki/Core/Protocol/ProtocolTypes.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/ProtocolTypes.swift
@@ -138,6 +138,7 @@ extension AnyCodable: ExpressibleByNilLiteral {
 enum SessionState: String, Codable, Sendable {
     case active
     case idle
+    case compacting
 }
 
 enum SessionMode: String, Codable, Sendable {

--- a/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
@@ -243,7 +243,16 @@ final class SessionStore {
     /// disk. Called after any mutation that changes a card-visible field.
     /// Safe to call frequently — the cache coalesces.
     fileprivate func scheduleSave() {
-        pendingSnapshot = Snapshot(sessions: sessions, previews: sessionPreviews)
+        // Compacting is runtime-only. Persist the underlying working fallback
+        // so a cold launch cannot resurrect stale compaction before the next
+        // authoritative session_list arrives.
+        let persistedSessions = sessions.mapValues { session in
+            guard session.state == .compacting else { return session }
+            var normalized = session
+            normalized.state = .active
+            return normalized
+        }
+        pendingSnapshot = Snapshot(sessions: persistedSessions, previews: sessionPreviews)
         let wasScheduled = saveTask != nil
         saveTask?.cancel()
         let task = DispatchWorkItem { [weak self] in self?.flushCache() }
@@ -558,6 +567,18 @@ final class SessionStore {
     }
 
     func setState(_ id: String, _ state: SessionState) {
+        applyState(id, state)
+        scheduleSave()
+    }
+
+    /// Apply a live state transition without persisting the metadata snapshot.
+    /// `active`, `idle`, and `compacting` envelopes carry a global transport seq
+    /// and are reconciled authoritatively by session_list after reconnect.
+    func setTransientState(_ id: String, _ state: SessionState) {
+        applyState(id, state)
+    }
+
+    private func applyState(_ id: String, _ state: SessionState) {
         sessions[id]?.state = state
         // Idle clears any lingering tool-in-flight marker AND the
         // activity snapshot — at idle, the session-card row falls back
@@ -567,7 +588,6 @@ final class SessionStore {
             sessions[id]?.currentToolHeadline = nil
             sessions[id]?.activity = .none
         }
-        scheduleSave()
     }
 
     /// Record the tool whose `tool_start` event just arrived. The icon

--- a/packages/arm/ios/Kraki/Features/Chat/ChatView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatView.swift
@@ -107,7 +107,7 @@ struct ChatView: View {
                         // mid-typing on every reconnect would be far
                         // more disruptive than queueing for a few
                         // hundred ms.
-                        if isDeviceOnline {
+                        if isDeviceOnline || session?.state == .compacting {
                             bottomInputArea
                                 // Measure the rendered height so we
                                 // can mirror it into the collection
@@ -351,18 +351,42 @@ struct ChatView: View {
 
     @ViewBuilder
     private var bottomInputArea: some View {
-        // Pure floating liquid-glass capsule. The capsule itself owns
-        // its glass background (see `inputBoxGlassBackground` in
-        // MessageInputView); we deliberately do NOT add a band of
-        // material under the home-indicator strip — the chat
-        // collection view scrolls behind the input so messages blur
-        // through the capsule and the home-indicator area shows the
-        // underlying content directly, matching the web composer.
-        MessageInputView(
-            sessionId: sessionId,
-            pendingPermission: permissions.first,
-            pendingQuestion: permissions.isEmpty ? questions.first : nil
-        )
+        VStack(spacing: 0) {
+            // Session runtime chrome, independent from the UICollectionView and
+            // its chat cells. Compacting never becomes a bubble, TRACE row, or
+            // card action; it only occupies this lightweight page-level band.
+            if session?.state == .compacting {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .tint(Color(hex: 0x06B6D4))
+                    Text("Compacting context…")
+                        .font(.caption)
+                        .foregroundStyle(Color.textSecondary)
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Color.surfaceSecondary.opacity(0.78))
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Compacting context")
+            }
+
+            // Pure floating liquid-glass capsule. The capsule itself owns
+            // its glass background (see `inputBoxGlassBackground` in
+            // MessageInputView); we deliberately do NOT add a band of
+            // material under the home-indicator strip — the chat
+            // collection view scrolls behind the input so messages blur
+            // through the capsule and the home-indicator area shows the
+            // underlying content directly, matching the web composer.
+            if isDeviceOnline {
+                MessageInputView(
+                    sessionId: sessionId,
+                    pendingPermission: permissions.first,
+                    pendingQuestion: permissions.isEmpty ? questions.first : nil
+                )
+            }
+        }
     }
 }
 #endif

--- a/packages/arm/ios/Kraki/Features/Chat/MessageInputView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageInputView.swift
@@ -154,7 +154,9 @@ struct MessageInputView: View {
 
     private var sessionStore: SessionStore { appState.sessionStore }
     private var session: SessionInfo? { sessionStore.sessions[sessionId] }
-    private var sessionActive: Bool { session?.state == .active }
+    private var sessionActive: Bool {
+        session?.state == .active || session?.state == .compacting
+    }
     private var text: String { sessionStore.drafts[sessionId] ?? "" }
     private var isIdle: Bool { !sessionActive && !awaitingActive }
     private var hasText: Bool { !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionCardView.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionCardView.swift
@@ -218,7 +218,18 @@ private struct SessionCardBody: View {
     /// now reads as the description of what's being asked.
     @ViewBuilder
     private var activityOrPreview: some View {
-        if session.state == .active && !hasPendingPermission && !hasPendingQuestion {
+        if session.state == .compacting && !hasPendingPermission && !hasPendingQuestion {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.mini)
+                    .tint(Color(hex: 0x06B6D4))
+                Text("Compacting context…")
+                    .font(.caption)
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else if session.state == .active && !hasPendingPermission && !hasPendingQuestion {
             ActivityRow(
                 activity: session.activity,
                 lastUserMessage: appState.messageProvider?.lastUserMessageContent(session.id)

--- a/packages/arm/ios/Kraki/Shared/AgentAvatar.swift
+++ b/packages/arm/ios/Kraki/Shared/AgentAvatar.swift
@@ -135,17 +135,16 @@ struct AgentAvatar: View {
                            color: Color(hex: 0xF97316))
                     .offset(x: 4, y: -1)
                     .transition(.opacity)
-            } else if status == .active {
-                // Active-turn spinner. The default `krakiPrimary`
-                // adaptively shifts to `kraki300` in dark mode, which
-                // washes out the spinner strokes against the avatar's
-                // pale-pastel hue. Pin a more solid blue for the
-                // dark case so the spinner reads as a confident
-                // affordance in both themes.
+            } else if status == .active || status == .compacting {
+                // Active and compacting are peer runtime states. Use a distinct
+                // cyan tint for compaction while keeping the same stable badge
+                // dimensions as the active-turn spinner.
                 ProgressView()
                     .controlSize(.mini)
-                    .tint(Color(light: UIColor(Color.kraki500),
-                                dark:  UIColor(Color.kraki400)))
+                    .tint(status == .compacting
+                          ? Color(hex: 0x06B6D4)
+                          : Color(light: UIColor(Color.kraki500),
+                                  dark: UIColor(Color.kraki400)))
                     .offset(x: 4, y: -1)
                     .transition(.opacity)
             }

--- a/packages/arm/ios/KrakiTests/MessagesTests.swift
+++ b/packages/arm/ios/KrakiTests/MessagesTests.swift
@@ -586,6 +586,47 @@ final class ProducerMessageCodableTests: XCTestCase {
         XCTAssertEqual(decoded.message.typeString, "agent_message")
     }
 
+    func testCompactingEnvelopeRoundtrip() throws {
+        let start = ProducerEnvelope(
+            deviceId: "dev-1",
+            seq: 6,
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "sess-1",
+            message: .compacting(CompactingPayload(
+                phase: "start", reason: "threshold", nextState: nil
+            ))
+        )
+        let startDecoded = try JSONDecoder().decode(
+            ProducerEnvelope.self,
+            from: JSONEncoder().encode(start)
+        )
+        guard case .compacting(let startPayload) = startDecoded.message else {
+            return XCTFail("Expected compacting start")
+        }
+        XCTAssertEqual(startPayload.phase, "start")
+        XCTAssertEqual(startPayload.reason, "threshold")
+        XCTAssertNil(startPayload.nextState)
+
+        let end = ProducerEnvelope(
+            deviceId: "dev-1",
+            seq: 7,
+            timestamp: "2024-01-01T00:00:01Z",
+            sessionId: "sess-1",
+            message: .compacting(CompactingPayload(
+                phase: "end", reason: nil, nextState: .idle
+            ))
+        )
+        let endDecoded = try JSONDecoder().decode(
+            ProducerEnvelope.self,
+            from: JSONEncoder().encode(end)
+        )
+        guard case .compacting(let endPayload) = endDecoded.message else {
+            return XCTFail("Expected compacting end")
+        }
+        XCTAssertEqual(endPayload.phase, "end")
+        XCTAssertEqual(endPayload.nextState, .idle)
+    }
+
     func testConsumerEnvelopeRoundtrip() throws {
         let envelope = ConsumerEnvelope(
             deviceId: "dev-1",

--- a/packages/arm/ios/KrakiTests/ProtocolTypesTests.swift
+++ b/packages/arm/ios/KrakiTests/ProtocolTypesTests.swift
@@ -170,8 +170,10 @@ final class ProtocolEnumTests: XCTestCase {
     func testSessionStateRawValues() {
         XCTAssertEqual(SessionState.active.rawValue, "active")
         XCTAssertEqual(SessionState.idle.rawValue, "idle")
+        XCTAssertEqual(SessionState.compacting.rawValue, "compacting")
         XCTAssertEqual(SessionState(rawValue: "active"), .active)
         XCTAssertEqual(SessionState(rawValue: "idle"), .idle)
+        XCTAssertEqual(SessionState(rawValue: "compacting"), .compacting)
         XCTAssertNil(SessionState(rawValue: "unknown"))
     }
 

--- a/packages/arm/web/src/components/chat/ChatView.test.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.test.tsx
@@ -65,6 +65,17 @@ describe('ChatView', () => {
     expect(screen.getByText('Streaming text...')).toBeInTheDocument();
   });
 
+  it('renders compacting as page runtime state without creating a live bubble', () => {
+    useStore.getState().setSessions([
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'compacting', messageCount: 0 },
+    ]);
+    useStore.getState().setDevices([{ id: 'd1', name: 'Mac', role: 'tentacle', online: true }]);
+    const { container } = renderChatView('s1');
+    expect(screen.getByRole('status')).toHaveTextContent('Compacting context…');
+    expect(container.querySelector('[data-session-runtime-status="compacting"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-live-bubble]')).toBeNull();
+  });
+
   it('renders inline permission card', () => {
     useStore.getState().setSessions([
       { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'copilot', messageCount: 0 },

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -182,7 +182,11 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
   // this bubble drops and the concluded spine bubble takes over in place, so
   // there is no card↔bubble morph and no lingering "answered" card.
   const draft = card?.text ?? '';
-  const cardEligible = status === 'working' || status === 'pending';
+  // Compacting is page/session chrome, not a card owner. It must not make an
+  // empty card eligible or create a live bubble by itself. Existing real card
+  // content/actions may continue rendering independently while compacting.
+  const cardEligible = status === 'working' || status === 'pending' || status === 'compacting';
+  const shouldSeedCard = status === 'working' || status === 'pending';
   const showLive = cardEligible && !!card && (draft.length > 0 || actionLive);
 
   // First seq for prepend tracking (passed to scroll controller)
@@ -195,10 +199,10 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
   // opening a non-idle session without local card state. Gated on the tentacle
   // being encryptable (its key may arrive after mount) and re-runs when it does.
   useEffect(() => {
-    if (!sessionId || !cardEligible || card) return;
+    if (!sessionId || !shouldSeedCard || card) return;
     if (!isConnected || !isTentacleEncryptable) return;
     messageProvider.requestCard(sessionId);
-  }, [sessionId, cardEligible, card, isConnected, isTentacleEncryptable]);
+  }, [sessionId, shouldSeedCard, card, isConnected, isTentacleEncryptable]);
 
   useEffect(() => {
     if (!sessionId || !isTentacleEncryptable) return;
@@ -323,6 +327,18 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
         )}
       </div>
 
+      {session.state === 'compacting' && (
+        <div
+          className="border-t border-border-primary bg-surface-secondary/70 px-3 py-2 sm:px-6"
+          data-session-runtime-status="compacting"
+          role="status"
+        >
+          <div className="mx-auto flex max-w-3xl items-center gap-2 text-xs text-text-secondary">
+            <span className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-cyan-500" />
+            <span>Compacting context…</span>
+          </div>
+        </div>
+      )}
       {isDeviceOnline && <MessageInput sessionId={sessionId} />}
     </div>
   );

--- a/packages/arm/web/src/components/chat/LiveAgentBubble.test.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.test.tsx
@@ -94,13 +94,6 @@ describe('LiveAgentBubble action section', () => {
     expect(screen.queryByText('Working…')).not.toBeInTheDocument();
   });
 
-  it('renders compaction as transient runtime activity, not a fake tool', () => {
-    renderLive({ text: '', action: { type: 'compaction', payload: { phase: 'running', reason: 'threshold' } } });
-    expect(screen.getByText('Compacting context…')).toBeInTheDocument();
-    expect(screen.queryByText('bash')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Open steps' })).not.toBeInTheDocument();
-  });
-
   it('renders a running tool in the action section', () => {
     renderLive({
       text: 'working on it',

--- a/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
@@ -88,10 +88,9 @@ export function LiveAgentBubble({ sessionId, agent, card, frozen }: LiveAgentBub
   // completed tool). The input components render their own resolved read-only view.
   const permission = a?.type === 'permission' ? a : null;
   const question = a?.type === 'question' ? a : null;
-  const compaction = a?.type === 'compaction' ? a : null;
   const userAbort = a?.type === 'user_abort' ? a : null;
   const failed = a?.type === 'failed' ? a : null;
-  const hasAction = !!tool || batchRunning > 0 || !!permission || !!question || !!compaction || !!userAbort || !!failed;
+  const hasAction = !!tool || batchRunning > 0 || !!permission || !!question || !!userAbort || !!failed;
 
   const { steps, targetSeq } = useTurnSteps(sessionId, live, frozen?.bubbleSeq);
 
@@ -168,13 +167,6 @@ export function LiveAgentBubble({ sessionId, agent, card, frozen }: LiveAgentBub
               <div className="flex items-center gap-2 rounded-lg border border-border-primary bg-surface-primary/40 px-3 py-2 text-xs text-text-secondary">
                 <span className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-ocean-500" />
                 <span>{batchRunning} 个工具并行运行中…</span>
-              </div>
-            )}
-
-            {compaction && (
-              <div className="flex items-center gap-2 rounded-lg border border-border-primary bg-surface-primary/40 px-3 py-2 text-xs text-text-secondary">
-                <span className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-ocean-500" />
-                <span>Compacting context…</span>
               </div>
             )}
 

--- a/packages/arm/web/src/components/chat/MessageInput.tsx
+++ b/packages/arm/web/src/components/chat/MessageInput.tsx
@@ -23,7 +23,7 @@ export function MessageInput({ sessionId }: { sessionId: string }) {
   const setDraft = useStore((s) => s.setDraft);
   const sessionMode = useStore((s) => s.sessionModes.get(sessionId) ?? 'discuss') as typeof MODES[number];
   const session = useStore((s) => s.sessions.get(sessionId));
-  const sessionActive = session?.state === 'active';
+  const sessionActive = session?.state === 'active' || session?.state === 'compacting';
   const [awaitingActive, setAwaitingActive] = useState(false);
   const isIdle = !sessionActive && !awaitingActive;
 

--- a/packages/arm/web/src/components/common/AgentAvatar.tsx
+++ b/packages/arm/web/src/components/common/AgentAvatar.tsx
@@ -1,11 +1,12 @@
 import { stringToHue } from '../../lib/color';
 import { ShieldQuestion, MessageCircleQuestion } from 'lucide-react';
+import type { SessionState } from '@kraki/protocol';
 
 interface AgentAvatarProps {
   agent: string;
   sessionId?: string;
   size?: 'sm' | 'md';
-  status?: 'active' | 'idle';
+  status?: SessionState;
   badge?: 'question' | 'permission';
   pinned?: boolean;
 }

--- a/packages/arm/web/src/components/sessions/SessionCard.tsx
+++ b/packages/arm/web/src/components/sessions/SessionCard.tsx
@@ -100,7 +100,7 @@ export function SessionCard({ session, pinned, openSwipeId, setOpenSwipeId }: Se
         }`}
       >
         <div className="relative self-start shrink-0">
-          <AgentAvatar agent={session.agent} sessionId={session.id} status={session.state as 'active' | 'idle'} badge={avatarBadge} pinned={pinned} />
+          <AgentAvatar agent={session.agent} sessionId={session.id} status={session.state} badge={avatarBadge} pinned={pinned} />
           {unreadCount > 0 && (
             <span className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-kraki-500 ring-2 ring-surface-secondary" />
           )}
@@ -125,6 +125,7 @@ export function SessionCard({ session, pinned, openSwipeId, setOpenSwipeId }: Se
                   className={`h-1.5 w-1.5 shrink-0 rounded-full ${
                     !isDeviceOnline ? 'bg-slate-400'
                     : status === 'pending' ? 'bg-amber-400 animate-pulse'
+                    : status === 'compacting' ? 'bg-cyan-500 animate-pulse'
                     : status === 'working' ? 'bg-blue-400 animate-pulse'
                     : 'bg-emerald-400'
                   }`}
@@ -133,6 +134,11 @@ export function SessionCard({ session, pinned, openSwipeId, setOpenSwipeId }: Se
                 {isDeviceOnline && status === 'pending' && (
                   <span className="shrink-0 rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-medium text-amber-600 dark:text-amber-400">
                     waiting{livePending > 1 ? ` ·${livePending}` : ''}
+                  </span>
+                )}
+                {isDeviceOnline && status === 'compacting' && (
+                  <span className="shrink-0 rounded-full bg-cyan-500/15 px-1.5 py-0.5 text-[9px] font-medium text-cyan-700 dark:text-cyan-300">
+                    compacting
                   </span>
                 )}
               </>

--- a/packages/arm/web/src/hooks/useStore.test.ts
+++ b/packages/arm/web/src/hooks/useStore.test.ts
@@ -217,6 +217,33 @@ describe('useStore', () => {
       expect((msgs![0] as typeof mockMessage).payload.content).toBe('updated content');
     });
 
+    it('range batches replace a stale transient row at the same session seq', () => {
+      useStore.getState().appendMessage('sess-1', {
+        type: 'active',
+        deviceId: 'dev-1',
+        seq: 495,
+        timestamp: '',
+        sessionId: 'sess-1',
+        payload: {},
+      } as ChatMessage);
+
+      useStore.getState().prependMessages('sess-1', [{
+        type: 'agent_message',
+        deviceId: 'dev-1',
+        seq: 495,
+        timestamp: '',
+        sessionId: 'sess-1',
+        payload: { content: 'recovered reply' },
+      } as ChatMessage]);
+
+      const messages = useStore.getState().messages.get('sess-1');
+      expect(messages).toHaveLength(1);
+      expect(messages?.[0].type).toBe('agent_message');
+      expect(messages?.[0] && 'payload' in messages[0] ? messages[0].payload : undefined).toMatchObject({
+        content: 'recovered reply',
+      });
+    });
+
     it('appendMessage does NOT dedup pending_input (seq=0)', () => {
       const pendingA = {
         type: 'pending_input' as const,

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -159,7 +159,9 @@ export const useStore = create<Store>()(persist((set) => ({
     const isTransient = message.type === 'pending_input'
       || message.type === 'tool_start'
       || message.type === 'tool_complete'
-      || message.type === 'agent_narration';
+      || message.type === 'agent_narration'
+      || message.type === 'active'
+      || message.type === 'compacting';
     if (!isTransient) {
       // Write to IndexedDB (async, fire-and-forget — idempotent by [sessionId, seq])
       import('../lib/message-db').then(db => db.putMessage(sessionId, message)).catch((e) => { console.error('[Kraki:idb]', e); });
@@ -425,23 +427,31 @@ export const useStore = create<Store>()(persist((set) => ({
   setLocalSessionsLoading: (loading) => set({ localSessionsLoading: loading }),
 
   prependMessages: (sessionId, older) => {
-    // Write to IndexedDB (idempotent by [sessionId, seq] key)
+    // Range batches are authoritative for their session seqs. Besides normal
+    // deduplication, they must replace stale rows written by older clients
+    // (for example a transient `active` row occupying an agent reply's seq).
     import('../lib/message-db').then(db => db.putMessages(sessionId, older)).catch((e) => { console.error('[Kraki:idb]', e); });
     set((state) => {
       const existing = state.messages.get(sessionId) ?? [];
-      // Deduplicate by seq
-      const existingSeqs = new Set<number>();
-      for (const m of existing) {
-        const seq = 'seq' in m ? (m as { seq?: number }).seq : undefined;
-        if (typeof seq === 'number') existingSeqs.add(seq);
-      }
-      const unique = older.filter(m => {
-        const seq = 'seq' in m ? (m as { seq?: number }).seq : undefined;
-        return typeof seq === 'number' && !existingSeqs.has(seq);
+      const incomingSeqs = new Set<number>();
+      const incoming = older.filter((message) => {
+        const seq = 'seq' in message ? (message as { seq?: number }).seq : undefined;
+        if (typeof seq !== 'number' || seq <= 0 || incomingSeqs.has(seq)) return false;
+        incomingSeqs.add(seq);
+        return true;
       });
-      if (unique.length === 0) return state;
-      const merged = [...unique, ...existing];
+      if (incoming.length === 0) return state;
+
+      const retained = existing.filter((message) => {
+        const seq = 'seq' in message ? (message as { seq?: number }).seq : undefined;
+        return typeof seq !== 'number' || !incomingSeqs.has(seq);
+      });
+      const merged = [...incoming, ...retained];
       merged.sort((a, b) => {
+        const pendingA = a.type === 'pending_input';
+        const pendingB = b.type === 'pending_input';
+        if (pendingA && !pendingB) return 1;
+        if (!pendingA && pendingB) return -1;
         const seqA = 'seq' in a ? (a as { seq?: number }).seq ?? 0 : 0;
         const seqB = 'seq' in b ? (b as { seq?: number }).seq ?? 0 : 0;
         return seqA - seqB;
@@ -582,7 +592,13 @@ export const useStore = create<Store>()(persist((set) => ({
     reviver,
   }),
   partialize: (state) => ({
-    sessions: state.sessions,
+    // Compacting is runtime-only. Persist the underlying working fallback so a
+    // cold launch cannot resurrect a stale compacting state before session_list
+    // delivers the authoritative live snapshot.
+    sessions: new Map([...state.sessions].map(([id, session]) => [
+      id,
+      session.state === 'compacting' ? { ...session, state: 'active' as const } : session,
+    ])),
     devices: state.devices,
     unreadCount: state.unreadCount,
     pinnedSessions: state.pinnedSessions,

--- a/packages/arm/web/src/lib/message-provider.test.tsx
+++ b/packages/arm/web/src/lib/message-provider.test.tsx
@@ -1,4 +1,21 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { getMessagesInRange } = vi.hoisted(() => ({
+  getMessagesInRange: vi.fn(async () => [] as unknown[]),
+}));
+
+vi.mock('./message-db', () => ({
+  putMessage: async () => {},
+  putMessages: async () => {},
+  getMessages: async () => [],
+  getAllMessages: async () => new Map(),
+  getLastSeq: async () => 0,
+  getMessagesInRange,
+  deleteSessionMessages: async () => {},
+  updateSessionMessages: async () => {},
+  clearAllMessages: async () => {},
+}));
+
 import { useStore } from '../hooks/useStore';
 import { messageProvider } from './message-provider';
 
@@ -20,6 +37,8 @@ function setupSession() {
 beforeEach(() => {
   useStore.getState().reset();
   messageProvider.clear();
+  getMessagesInRange.mockReset();
+  getMessagesInRange.mockResolvedValue([]);
 });
 
 describe('message-provider: requestCard', () => {
@@ -97,11 +116,12 @@ describe('message-provider: ensureLoaded', () => {
     spy.mockRestore();
   });
 
-  it('does not fetch when store already has messages', () => {
+  it('reconciles the authoritative tail when store already has messages', () => {
     setupSession();
     messageProvider.setTentacleInfo('s1', 100, 'd1');
 
-    // Put a message into the store
+    // Existing messages do not prove the tail is complete: a live broadcast
+    // immediately before idle may have been missed.
     useStore.getState().appendMessage('s1', {
       type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 99, timestamp: '',
       payload: { content: 'hello' },
@@ -110,7 +130,19 @@ describe('message-provider: ensureLoaded', () => {
     const spy = vi.spyOn(messageProvider, 'fetchRange');
     messageProvider.ensureLoaded('s1');
 
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('s1', 51, 100, { initial: true });
+    spy.mockRestore();
+  });
+
+  it('does not let an older idle move the authoritative tail backward', () => {
+    setupSession();
+    messageProvider.setTentacleInfo('s1', 500, 'd1');
+    messageProvider.setTentacleInfo('s1', 496, 'd1');
+
+    const spy = vi.spyOn(messageProvider, 'fetchRange');
+    messageProvider.ensureLoaded('s1');
+
+    expect(spy).toHaveBeenCalledWith('s1', 451, 500, { initial: true });
     spy.mockRestore();
   });
 
@@ -157,6 +189,91 @@ describe('message-provider: range-fetch protocol', () => {
     await vi.waitFor(() => {
       expect(messageProvider.isLoading('s1')).toBe(false);
     });
+  });
+
+  it('repairs a cached tail where a legacy transient row hides the reply seq', async () => {
+    setupSession();
+    messageProvider.setTentacleInfo('s1', 496, 'd1');
+    const sent: Record<string, unknown>[] = [];
+    messageProvider.setSend((m) => sent.push(m));
+
+    const cached = Array.from({ length: 50 }, (_, index) => {
+      const seq = 447 + index;
+      if (seq === 495) {
+        return { type: 'active', sessionId: 's1', deviceId: 'd1', seq, timestamp: '', payload: {} };
+      }
+      return {
+        type: seq === 496 ? 'idle' : 'agent_message',
+        sessionId: 's1', deviceId: 'd1', seq, timestamp: '',
+        payload: seq === 496 ? { reason: 'completed' } : { content: `message ${seq}` },
+      };
+    });
+    getMessagesInRange.mockResolvedValue(cached);
+
+    const pending = messageProvider.fetchRange('s1', 447, 496, { initial: true });
+    await vi.waitFor(() => {
+      expect(sent.find(m => m.type === 'request_session_messages_range')).toBeDefined();
+    });
+
+    const request = sent.find(m => m.type === 'request_session_messages_range')!;
+    expect(request.payload).toMatchObject({ sessionId: 's1', fromSeq: 495, toSeq: 496 });
+
+    messageProvider.handleRangeBatch('s1', [
+      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 495, timestamp: '',
+        payload: { content: 'recovered reply' } },
+      { type: 'idle', sessionId: 's1', deviceId: 'd1', seq: 496, timestamp: '',
+        payload: { reason: 'completed' } },
+    ], 495, 496, false);
+    await pending;
+
+    const recovered = useStore.getState().messages.get('s1')?.find((message) =>
+      'seq' in message && message.seq === 495,
+    );
+    expect(recovered?.type).toBe('agent_message');
+    expect(recovered && 'payload' in recovered ? recovered.payload : undefined).toMatchObject({
+      content: 'recovered reply',
+    });
+  });
+
+  it('does not let an older timeout cancel a newer tail request', async () => {
+    vi.useFakeTimers();
+    try {
+      setupSession();
+      messageProvider.setTentacleInfo('s1', 2, 'd1');
+      const sent: Record<string, unknown>[] = [];
+      messageProvider.setSend((m) => sent.push(m));
+
+      const first = messageProvider.fetchRange('s1', 1, 1);
+      await vi.waitFor(() => {
+        expect(sent.filter((message) => message.type === 'request_session_messages_range')).toHaveLength(1);
+      });
+      messageProvider.handleRangeBatch('s1', [
+        { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 1, timestamp: '',
+          payload: { content: 'first' } },
+      ], 1, 1, false);
+      await first;
+
+      await vi.advanceTimersByTimeAsync(100);
+      const second = messageProvider.fetchRange('s1', 2, 2);
+      await vi.waitFor(() => {
+        expect(sent.filter((message) => message.type === 'request_session_messages_range')).toHaveLength(2);
+      });
+
+      // Fire only the first request's 10s timer. The second request was armed
+      // 100ms later and must remain pending for its real range batch.
+      await vi.advanceTimersByTimeAsync(10_000 - 100);
+      messageProvider.handleRangeBatch('s1', [
+        { type: 'idle', sessionId: 's1', deviceId: 'd1', seq: 2, timestamp: '', payload: {} },
+      ], 2, 2, false);
+      await second;
+
+      expect(useStore.getState().messages.get('s1')?.some((message) =>
+        'seq' in message && message.seq === 2,
+      )).toBe(true);
+    } finally {
+      messageProvider.clear();
+      vi.useRealTimers();
+    }
   });
 
   it('handleRangeBatch resolves the pending request and persists messages', async () => {

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -15,6 +15,29 @@ const logger = createLogger('msg-provider');
 const PREVIEW_MAX = 80;
 const BATCH_TIMEOUT_MS = 10_000;
 
+// Rows written by older web clients before runtime/TRACE state was separated
+// from the persistent conversation spine. They must never count toward cache
+// range coverage, or a stale `active` row can hide a missing agent reply at the
+// same session seq.
+const NON_SPINE_CACHE_TYPES = new Set([
+  'pending_input',
+  'active',
+  'compacting',
+  'agent_message_delta',
+  'card_action',
+  'agent_narration',
+  'tool_start',
+  'tool_complete',
+  'permission',
+  'question',
+  'permission_resolved',
+  'question_resolved',
+]);
+
+function isSpineCacheMessage(message: ChatMessage): boolean {
+  return !NON_SPINE_CACHE_TYPES.has(message.type);
+}
+
 /** Strip common markdown syntax for clean preview display. */
 function stripMarkdown(text: string): string {
   return text
@@ -123,6 +146,10 @@ class MessageProvider {
   private pendingRequests = new Map<string, PendingRequest>();
   /** Sessions currently loading */
   private loadingSessions = new Set<string>();
+  /** Highest seq covered by each in-flight fetch. */
+  private loadingThroughSeq = new Map<string, number>();
+  /** Latest tail reconciliation requested beyond an in-flight range. */
+  private pendingTailReconciles = new Map<string, number>();
   /** Turn-trace pulls already issued, keyed `${sessionId}:${bubbleSeq}`.
    *  Prevents re-pulling the same concluded turn's TRACE on every render. */
   private tracePulled = new Set<string>();
@@ -133,7 +160,8 @@ class MessageProvider {
   }
 
   setTentacleInfo(sessionId: string, lastSeq: number, deviceId: string): void {
-    this.tentacleLastSeq.set(sessionId, lastSeq);
+    const currentLastSeq = this.tentacleLastSeq.get(sessionId) ?? 0;
+    this.tentacleLastSeq.set(sessionId, Math.max(currentLastSeq, lastSeq));
     this.tentacleDeviceMap.set(sessionId, deviceId);
   }
 
@@ -143,22 +171,45 @@ class MessageProvider {
   }
 
   /**
-   * Ensure a session's messages are loaded — called when user opens a session.
-   * If store already has messages, this is a no-op.
-   * Otherwise, fetches the last 50 messages (IDB first, then tentacle).
+   * Ensure a session's latest messages are loaded — called when user opens a
+   * session. Existing in-memory messages do not prove that the tail is complete:
+   * a client can receive the closing idle while missing the agent message just
+   * before it. Always reconcile the authoritative last-50 window from the
+   * session digest (IDB first, then tentacle).
    */
   ensureLoaded(sessionId: string): void {
-    const store = getStore();
-    const existing = store.messages.get(sessionId);
-    if (existing && existing.length > 0) return;
-    if (this.loadingSessions.has(sessionId)) return;
-
     const lastSeq = this.tentacleLastSeq.get(sessionId);
     if (!lastSeq || lastSeq <= 0) return;
 
-    const fromSeq = Math.max(1, lastSeq - 49);
-    logger.info('ensureLoaded: triggering on-demand fetch', { sessionId, fromSeq, lastSeq });
-    this.fetchRange(sessionId, fromSeq, lastSeq, { initial: true });
+    this.reconcileTail(sessionId, lastSeq);
+  }
+
+  /**
+   * Reconcile the latest persistent spine window against an authoritative
+   * session seq. Used both on session open and when a closing idle arrives.
+   */
+  reconcileTail(sessionId: string, lastSeq: number): void {
+    if (lastSeq <= 0) return;
+
+    const authoritativeLastSeq = Math.max(this.tentacleLastSeq.get(sessionId) ?? 0, lastSeq);
+    this.tentacleLastSeq.set(sessionId, authoritativeLastSeq);
+
+    if (this.loadingSessions.has(sessionId)) {
+      const loadingThrough = this.loadingThroughSeq.get(sessionId) ?? 0;
+      if (authoritativeLastSeq > loadingThrough) {
+        const pending = this.pendingTailReconciles.get(sessionId) ?? 0;
+        this.pendingTailReconciles.set(sessionId, Math.max(pending, authoritativeLastSeq));
+      }
+      return;
+    }
+
+    const fromSeq = Math.max(1, authoritativeLastSeq - 49);
+    logger.info('reconcileTail: checking authoritative tail', {
+      sessionId,
+      fromSeq,
+      lastSeq: authoritativeLastSeq,
+    });
+    void this.fetchRange(sessionId, fromSeq, authoritativeLastSeq, { initial: true });
   }
 
   /**
@@ -177,6 +228,7 @@ class MessageProvider {
     logger.info('fetchRange', { sessionId, fromSeq: clampedFrom, toSeq, initial: options?.initial });
 
     this.loadingSessions.add(sessionId);
+    this.loadingThroughSeq.set(sessionId, toSeq);
     if (options?.initial) {
       getStore().setSessionLoading(sessionId, true);
     }
@@ -186,8 +238,16 @@ class MessageProvider {
       let idbMessages: ChatMessage[] = [];
       try {
         const db = await import('./message-db');
-        idbMessages = await db.getMessagesInRange(sessionId, clampedFrom, toSeq);
-        logger.info('IDB range query', { sessionId, fromSeq: clampedFrom, toSeq, found: idbMessages.length, expected: toSeq - clampedFrom + 1 });
+        const cached = await db.getMessagesInRange(sessionId, clampedFrom, toSeq);
+        idbMessages = cached.filter(isSpineCacheMessage);
+        logger.info('IDB range query', {
+          sessionId,
+          fromSeq: clampedFrom,
+          toSeq,
+          found: idbMessages.length,
+          ignoredTransient: cached.length - idbMessages.length,
+          expected: toSeq - clampedFrom + 1,
+        });
       } catch {
         // IDB unavailable
       }
@@ -244,7 +304,13 @@ class MessageProvider {
       logger.error('fetchRange failed', { sessionId, error: (err as Error).message });
     } finally {
       this.loadingSessions.delete(sessionId);
+      this.loadingThroughSeq.delete(sessionId);
       getStore().setSessionLoading(sessionId, false);
+      const pendingLastSeq = this.pendingTailReconciles.get(sessionId);
+      if (pendingLastSeq !== undefined) {
+        this.pendingTailReconciles.delete(sessionId);
+        this.reconcileTail(sessionId, pendingLastSeq);
+      }
     }
   }
 
@@ -301,6 +367,8 @@ class MessageProvider {
     this.tentacleLastSeq.clear();
     this.tentacleDeviceMap.clear();
     this.loadingSessions.clear();
+    this.loadingThroughSeq.clear();
+    this.pendingTailReconciles.clear();
     this.tracePulled.clear();
     this.cardRequested.clear();
   }
@@ -416,7 +484,8 @@ class MessageProvider {
     if (toSeq < fromSeq) return Promise.resolve([]);
 
     return new Promise<ChatMessage[]>((resolve) => {
-      this.pendingRequests.set(sessionId, { sessionId, resolve });
+      const pending: PendingRequest = { sessionId, resolve };
+      this.pendingRequests.set(sessionId, pending);
 
       const store = getStore();
       this.sendFn!({
@@ -429,7 +498,9 @@ class MessageProvider {
 
       // Safety timeout — resolve with empty if tentacle never responds
       setTimeout(() => {
-        if (this.pendingRequests.has(sessionId)) {
+        // A later tail reconcile may already have installed a new request for
+        // this session. Only the request that armed this timer may time out.
+        if (this.pendingRequests.get(sessionId) === pending) {
           logger.warn('tentacle range request timed out', { sessionId, fromSeq, toSeq });
           this.pendingRequests.delete(sessionId);
           resolve([]);

--- a/packages/arm/web/src/lib/message-router.narration.test.ts
+++ b/packages/arm/web/src/lib/message-router.narration.test.ts
@@ -18,6 +18,7 @@ vi.mock('./message-db', () => ({
 
 import { useStore } from '../hooks/useStore';
 import { CommandState } from './commands';
+import { messageProvider } from './message-provider';
 import { handleDataMessage } from './message-router';
 import type { InnerMessage } from '@kraki/protocol';
 
@@ -88,6 +89,69 @@ describe('handleDataMessage card messages', () => {
       cmdState: new CommandState(),
     });
     expect(useStore.getState().cards.get('s1')?.action?.type).toBe('question');
+  });
+
+  it('routes compacting start/end through session state without touching the card or IndexedDB', async () => {
+    seedSession('runtime-s1');
+    useStore.getState().setCardAction('runtime-s1', {
+      type: 'question',
+      payload: { id: 'q1', question: 'Proceed?' },
+    });
+
+    handleDataMessage({
+      type: 'compacting', deviceId: 'dev-tentacle', seq: 8,
+      timestamp: new Date().toISOString(), sessionId: 'runtime-s1',
+      payload: { phase: 'start', reason: 'threshold' },
+    } as unknown as InnerMessage, { cmdState: new CommandState() });
+
+    expect(useStore.getState().sessions.get('runtime-s1')?.state).toBe('compacting');
+    expect(useStore.getState().cards.get('runtime-s1')?.action?.type).toBe('question');
+
+    handleDataMessage({
+      type: 'compacting', deviceId: 'dev-tentacle', seq: 9,
+      timestamp: new Date().toISOString(), sessionId: 'runtime-s1',
+      payload: { phase: 'end', nextState: 'idle' },
+    } as unknown as InnerMessage, { cmdState: new CommandState() });
+
+    expect(useStore.getState().sessions.get('runtime-s1')?.state).toBe('idle');
+    expect(useStore.getState().cards.get('runtime-s1')?.action?.type).toBe('question');
+    await new Promise((r) => setTimeout(r, 5));
+    expect(putMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not let real card or active updates end new-protocol compacting state', () => {
+    seedSession('mixed-s1');
+    handleDataMessage({
+      type: 'compacting', deviceId: 'dev-tentacle', seq: 12,
+      timestamp: new Date().toISOString(), sessionId: 'mixed-s1',
+      payload: { phase: 'start' },
+    } as unknown as InnerMessage, { cmdState: new CommandState() });
+    handleDataMessage({
+      type: 'card_action', deviceId: 'dev-tentacle', seq: 13,
+      timestamp: new Date().toISOString(), sessionId: 'mixed-s1',
+      payload: { action: { type: 'tool_start', payload: { toolName: 'bash', headline: 'test' } } },
+    } as unknown as InnerMessage, { cmdState: new CommandState() });
+    handleDataMessage({
+      type: 'active', deviceId: 'dev-tentacle', seq: 14,
+      timestamp: new Date().toISOString(), sessionId: 'mixed-s1', payload: {},
+    } as unknown as InnerMessage, { cmdState: new CommandState() });
+
+    expect(useStore.getState().sessions.get('mixed-s1')?.state).toBe('compacting');
+    expect(useStore.getState().cards.get('mixed-s1')?.action?.type).toBe('tool_start');
+  });
+
+  it('reconciles the persistent tail when idle arrives after a missed reply', () => {
+    seedSession('gap-s1');
+    const reconcile = vi.spyOn(messageProvider, 'reconcileTail').mockImplementation(() => {});
+
+    handleDataMessage({
+      type: 'idle', deviceId: 'dev-tentacle', seq: 496,
+      timestamp: new Date().toISOString(), sessionId: 'gap-s1',
+      payload: { reason: 'completed' },
+    } as unknown as InnerMessage, { cmdState: new CommandState() });
+
+    expect(reconcile).toHaveBeenCalledWith('gap-s1', 496);
+    reconcile.mockRestore();
   });
 
   it('keeps card updates out of IndexedDB', async () => {

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -1,4 +1,4 @@
-import type { InnerMessage, SessionListMessage, SessionMessagesRangeBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, ProducerMessage, AgentMessageDelta, CardAction } from '@kraki/protocol';
+import type { InnerMessage, SessionListMessage, SessionMessagesRangeBatchMessage, DeviceGreetingMessage, SessionModeSetMessage, SessionModelSetMessage, SessionTitleUpdatedMessage, SessionPinnedMessage, SessionReadMessage, IdleMessage, ProducerMessage, AgentMessageDelta, CardAction, CompactingMessage, SessionState } from '@kraki/protocol';
 import { getStore } from './store-adapter';
 import { isViewingSession } from './replay';
 import { createLogger } from './logger';
@@ -271,6 +271,11 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
       const idled = store.sessions.get(sid);
       if (idled) store.upsertSession({ ...idled, state: 'idle' });
       store.appendMessage(sid, msg);
+      // A closing idle can arrive even if the immediately preceding agent
+      // message was dropped in transit. Reconcile the authoritative spine tail
+      // so the gap is recovered instead of leaving an idle session with no reply.
+      messageProvider.setTentacleInfo(sid, msg.seq, msg.deviceId);
+      messageProvider.reconcileTail(sid, msg.seq);
       // Extract usage from idle payload
       const idlePayload = (msg as IdleMessage).payload;
       const idleUsage = idlePayload?.usage;
@@ -321,8 +326,28 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
 
     case 'active': {
       const activated = store.sessions.get(sid);
-      if (activated) store.upsertSession({ ...activated, state: 'active' });
+      // Active can be reasserted during steer acceptance while Pi is still
+      // compacting. Only compacting-end, idle, or session_list may leave the
+      // independent compacting state.
+      if (activated && activated.state !== 'compacting') {
+        store.upsertSession({ ...activated, state: 'active' });
+      }
       store.appendMessage(sid, msg);
+      break;
+    }
+
+    case 'compacting': {
+      const compactingMsg = msg as CompactingMessage;
+      const session = store.sessions.get(sid);
+      if (session) {
+        // `compacting` is a peer of active/idle on the session-state axis. On
+        // `phase: 'start'` the session enters compacting; `end.nextState` is the
+        // authoritative state to restore. Never persists, never creates a bubble.
+        const next: SessionState = compactingMsg.payload.phase === 'start'
+          ? 'compacting'
+          : compactingMsg.payload.nextState;
+        store.upsertSession({ ...session, state: next });
+      }
       break;
     }
 

--- a/packages/arm/web/src/lib/session-status.test.ts
+++ b/packages/arm/web/src/lib/session-status.test.ts
@@ -44,6 +44,15 @@ describe('getSessionStatus', () => {
     expect(getSessionStatus(session({ state: 'active' }), 0)).toBe('working');
   });
 
+  it('compacting when compacting and no human action is pending', () => {
+    expect(getSessionStatus(session({ state: 'compacting' }), 0)).toBe('compacting');
+  });
+
+  it('pending human action takes priority over compacting', () => {
+    expect(getSessionStatus(session({ state: 'compacting' }), 1)).toBe('pending');
+    expect(getSessionStatus(session({ state: 'compacting' }), 0, 'question')).toBe('pending');
+  });
+
   it('pending when there is a live open question (even while active)', () => {
     expect(getSessionStatus(session({ state: 'active' }), 1)).toBe('pending');
   });

--- a/packages/arm/web/src/lib/session-status.ts
+++ b/packages/arm/web/src/lib/session-status.ts
@@ -16,7 +16,7 @@ import type { SessionCard } from '../types/store';
  * entry — so `previewType === 'question'` seeds the pending status until the
  * live card arrives.
  */
-export type SessionStatus = 'idle' | 'working' | 'pending' | 'ended';
+export type SessionStatus = 'idle' | 'working' | 'compacting' | 'pending' | 'ended';
 
 /** A stable identity for a card action — changes when the slot's meaningful
  *  state changes (tool start/complete, prompt open/resolve, batch count). Used
@@ -33,8 +33,6 @@ export function cardActionKey(a: CardActionState | null): string {
       return `perm:${a.payload.id}:${a.payload.decision ?? 'pending'}`;
     case 'question':
       return `q:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer === undefined ? 'pending' : 'answered'}`;
-    case 'compaction':
-      return `compaction:${a.payload.reason ?? 'unknown'}`;
     case 'user_abort':
       return `user_abort:${a.payload.abortedAt}`;
     case 'failed':
@@ -58,6 +56,9 @@ export function getSessionStatus(
 ): SessionStatus {
   if ((session.state as string) === 'ended') return 'ended';
   if (session.state === 'idle') return 'idle';
+  // A blocking human affordance remains the highest-priority visible status;
+  // compacting is independent and must not displace it.
   if (livePendingCount > 0 || previewType === 'question') return 'pending';
+  if (session.state === 'compacting') return 'compacting';
   return 'working';
 }

--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { decodeFrame } from '@coinfra/pulse';
 import { KrakiWSClient } from '../lib/ws-client';
 import { useStore } from '../hooks/useStore';
+import { messageProvider } from './message-provider';
 
 /** Recover the inner producer message from a captured wire send. Reliable
  *  consumer messages now ride pulse: the arm emits a `unicast` envelope whose
@@ -84,6 +85,7 @@ const OriginalWebSocket = globalThis.WebSocket;
 
 beforeEach(() => {
   useStore.getState().reset();
+  messageProvider.clear();
   // Wrap WebSocket to capture instances
   globalThis.WebSocket = class extends OriginalWebSocket {
     constructor(url: string) {

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -1,4 +1,4 @@
-import type { InnerMessage, SessionListMessage, AuthOkMessage, AuthInfoResponse, ServerErrorMessage, AuthChallengeMessage, DeviceJoinedMessage, DeviceLeftMessage, RelayEnvelope, Message } from '@kraki/protocol';
+import type { InnerMessage, SessionListMessage, AuthOkMessage, AuthInfoResponse, ServerErrorMessage, AuthChallengeMessage, DeviceJoinedMessage, DeviceLeftMessage, RelayEnvelope, Message, SessionState } from '@kraki/protocol';
 import { HEAD_PULSE_TARGET } from '@kraki/protocol';
 import { createAppKeyStore } from './e2e';
 import { KrakiTransport, type MessageHandler } from './transport';
@@ -430,7 +430,7 @@ export class KrakiWSClient {
         model: ts.model,
         title: ts.title,
         autoTitle: ts.autoTitle,
-        state: ts.state as 'active' | 'idle',
+        state: ts.state as SessionState,
         messageCount: ts.messageCount,
       });
 
@@ -535,7 +535,7 @@ export class KrakiWSClient {
       const previewTs = preview?.timestamp ? new Date(preview.timestamp).getTime() : 0;
 
       const entry: WarmupEntry = { id: ts.id, lastSeq: ts.lastSeq, previewTs };
-      const isEager = ts.state === 'active' || pinnedIds.has(ts.id) || (previewTs > 0 && now - previewTs < WARMUP_RECENCY_MS);
+      const isEager = ts.state === 'active' || ts.state === 'compacting' || pinnedIds.has(ts.id) || (previewTs > 0 && now - previewTs < WARMUP_RECENCY_MS);
 
       if (isEager) {
         eager.push(entry);

--- a/packages/arm/web/src/pages/SessionPage.tsx
+++ b/packages/arm/web/src/pages/SessionPage.tsx
@@ -128,7 +128,7 @@ export function SessionPage() {
           )}
         </button>
         <div className="relative">
-          <AgentAvatar agent={session.agent} sessionId={sessionId} size="sm" status={session.state as 'active' | 'idle'} />
+          <AgentAvatar agent={session.agent} sessionId={sessionId} size="sm" status={session.state} />
           {isReconnecting && (
             <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/30">
               <div className="h-3 w-3 animate-spin rounded-full border-[1.5px] border-amber-400 border-t-transparent" />
@@ -151,6 +151,7 @@ export function SessionPage() {
                   className={`h-1.5 w-1.5 shrink-0 rounded-full ${
                     !isDeviceOnline ? 'bg-slate-400'
                     : sessionStatus === 'pending' ? 'bg-amber-400 animate-pulse'
+                    : sessionStatus === 'compacting' ? 'bg-cyan-500 animate-pulse'
                     : sessionStatus === 'working' ? 'bg-blue-400 animate-pulse'
                     : 'bg-emerald-400'
                   }`}
@@ -161,6 +162,11 @@ export function SessionPage() {
             {isDeviceOnline && sessionStatus === 'pending' && (
               <span className="shrink-0 rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-medium text-amber-600 dark:text-amber-400">
                 waiting for you{livePending > 1 ? ` · ${livePending}` : ''}
+              </span>
+            )}
+            {isDeviceOnline && sessionStatus === 'compacting' && (
+              <span className="shrink-0 rounded-full bg-cyan-500/15 px-1.5 py-0.5 text-[9px] font-medium text-cyan-700 dark:text-cyan-300">
+                compacting
               </span>
             )}
             {session.deviceName && session.model && (

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -388,15 +388,6 @@ export type CardActionState =
   | Pick<PermissionRequest, 'type' | 'payload'>
   | Pick<QuestionRequest, 'type' | 'payload'>
   | {
-      /** Transient Pi runtime activity. Never persisted to the conversation or
-       *  trace; it only occupies the server-owned live status-card slot. */
-      type: 'compaction';
-      payload: {
-        phase: 'running';
-        reason?: 'manual' | 'threshold' | 'overflow';
-      };
-    }
-  | {
       type: 'user_abort';
       payload: {
         abortedAt: string;
@@ -425,6 +416,32 @@ export interface CardAction extends BaseEnvelope {
   payload: {
     action: CardActionState | null;
   };
+}
+
+/**
+ * The agent runtime is compacting its context. This is a peer of
+ * {@link ActiveMessage} / {@link IdleMessage} on the session-state axis: it is
+ * transient (never persisted to the spine or trace, never replayed) and may
+ * occur before streaming starts (prompt preflight) or after output completes
+ * (finalize / auto-retry continuation), so it is NOT a subset of `active`.
+ *
+ * `phase: 'start'` enters the compacting state; `phase: 'end'` carries the
+ * authoritative state to restore. The session's current compacting state is
+ * also reflected in {@link SessionState} (carried by the session-list digest)
+ * so reconnects recover it authoritatively.
+ */
+export interface CompactingMessage extends BaseEnvelope {
+  type: 'compacting';
+  sessionId: string;
+  payload:
+    | {
+        phase: 'start';
+        reason?: 'manual' | 'threshold' | 'overflow';
+      }
+    | {
+        phase: 'end';
+        nextState: 'active' | 'idle';
+      };
 }
 
 export interface IdleMessage extends BaseEnvelope {
@@ -822,6 +839,7 @@ export type ProducerMessage =
   | ToolCompleteMessage
   | AgentNarrationMessage
   | CardAction
+  | CompactingMessage
   | TurnTraceBatchMessage
   | IdleMessage
   | ActiveMessage

--- a/packages/protocol/src/sessions.ts
+++ b/packages/protocol/src/sessions.ts
@@ -2,7 +2,7 @@
 // Session types — managed by tentacle and frontend, not relay
 // ------------------------------------------------------------
 
-export type SessionState = 'active' | 'idle';
+export type SessionState = 'active' | 'idle' | 'compacting';
 
 /** Permission mode that controls how the agent's tool usage and questions are handled. */
 export type SessionMode = 'safe' | 'discuss' | 'execute' | 'delegate';

--- a/packages/tentacle/src/__tests__/card-manager.test.ts
+++ b/packages/tentacle/src/__tests__/card-manager.test.ts
@@ -317,51 +317,6 @@ describe('CardManager action part', () => {
     expect(actions(sent)).toHaveLength(1);
   });
 
-  it('surfaces compaction transiently and includes it in reconnect snapshots', () => {
-    const { card, sent } = setup();
-    card.onCompactionStart('s1', 'threshold');
-    card.onCompactionStart('s1', 'threshold');
-    expect(actions(sent)).toEqual([
-      { type: 'compaction', payload: { phase: 'running', reason: 'threshold' } },
-    ]);
-    expect((card.snapshot('s1')[1].payload as { action: unknown }).action)
-      .toEqual({ type: 'compaction', payload: { phase: 'running', reason: 'threshold' } });
-    expect(card.activeSessions()).toEqual(['s1']);
-  });
-
-  it('does not let compaction hide a pending human prompt', () => {
-    const { card, sent } = setup();
-    card.onPrompt('s1', question('q1', 'choose?'));
-    sent.length = 0;
-    card.onCompactionStart('s1', 'threshold');
-    expect(actions(sent)).toEqual([]);
-    expect((card.snapshot('s1')[1].payload as { action: unknown }).action)
-      .toMatchObject({ type: 'question', payload: { id: 'q1' } });
-  });
-
-  it('late compaction end cannot clear a newer tool action', () => {
-    const { card, sent } = setup();
-    card.onCompactionStart('s1', 'threshold');
-    card.onToolStart('s1', tool('tc1', 'new work'));
-    sent.length = 0;
-    card.onCompactionEnd('s1');
-    expect(actions(sent)).toEqual([]);
-    expect((card.snapshot('s1')[1].payload as { action: unknown }).action)
-      .toMatchObject({ type: 'tool_start', payload: { toolCallId: 'tc1' } });
-  });
-
-  it('clears compaction when it still owns the slot or narration resumes', () => {
-    const { card, sent } = setup();
-    card.onCompactionStart('s1');
-    sent.length = 0;
-    card.onCompactionEnd('s1');
-    expect(actions(sent)).toEqual([null]);
-
-    card.onCompactionStart('s1', 'overflow');
-    sent.length = 0;
-    card.onDelta('s1', 'continuing');
-    expect(actions(sent)).toEqual([null]);
-  });
 });
 
 describe('CardManager lifecycle', () => {

--- a/packages/tentacle/src/__tests__/coalesce-queue.test.ts
+++ b/packages/tentacle/src/__tests__/coalesce-queue.test.ts
@@ -38,6 +38,11 @@ describe('coalesceKeyFor: state-covering messages are keyed, events are not', ()
     expect(coalesceKeyFor({ type: 'card_action', sessionId: 'sess1' })).toBe('card_action:sess1');
   });
 
+  it('keys compacting runtime state by session', () => {
+    expect(coalesceKeyFor({ type: 'compacting', sessionId: 'sess1' })).toBe('compacting:sess1');
+    expect(coalesceKeyFor({ type: 'compacting' })).toBeUndefined();
+  });
+
   it('leaves durable/event messages un-keyed so pulse retains each', () => {
     for (const type of ['agent_message', 'user_message', 'tool_start', 'tool_complete',
       'session_list', 'attachment_data', 'idle', 'active', 'error'] as const) {
@@ -72,6 +77,19 @@ describe('queue dedup: same-key sends collapse to the latest', () => {
     expect(q).toHaveLength(6);
     expect(q.filter((m) => m.type === 'agent_message_delta')).toHaveLength(1);
     expect(q.filter((m) => m.type === 'user_message')).toHaveLength(5);
+  });
+
+  it('compacting phases collapse to the latest state per session', () => {
+    const q = simulateQueue([
+      { type: 'compacting', sessionId: 'a', payload: { phase: 'start' } },
+      { type: 'compacting', sessionId: 'b', payload: { phase: 'start' } },
+      { type: 'compacting', sessionId: 'a', payload: { phase: 'end', nextState: 'idle' } },
+    ]);
+    expect(q).toHaveLength(2);
+    expect(q.find((message) => message.sessionId === 'a')?.payload).toEqual({
+      phase: 'end',
+      nextState: 'idle',
+    });
   });
 
   it('distinct sessions do not coalesce each other', () => {

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -1876,7 +1876,7 @@ describe('RelayClient trace mirroring (off-spine)', () => {
     return { adapter, sm, ws: sockets[0], cleanup: () => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ } } };
   }
 
-  it('keeps compaction transient: card_action only, never spine or trace', () => {
+  it('keeps compaction transient: compacting message only, never spine or trace', () => {
     const { adapter, sm, ws, cleanup } = buildClient();
     try {
       const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
@@ -1890,15 +1890,16 @@ describe('RelayClient trace mirroring (off-spine)', () => {
       const messages = decodePulseSends(ws.sent);
       expect(messages).toHaveLength(1);
       expect(messages[0]).toMatchObject({
-        type: 'card_action',
+        type: 'compacting',
         sessionId: 'sess_1',
-        payload: { action: { type: 'compaction', payload: { phase: 'running', reason: 'threshold' } } },
+        payload: { phase: 'start', reason: 'threshold' },
       });
 
       ws.sent.length = 0;
+      smMock.getMeta.mockReturnValue({ id: 'sess_1', state: 'active' });
       (adapter.onCompaction as (sid: string, e: Record<string, unknown>) => void)('sess_1', { phase: 'end' });
       expect(decodePulseSends(ws.sent)[0]).toMatchObject({
-        type: 'card_action', payload: { action: null },
+        type: 'compacting', payload: { phase: 'end', nextState: 'active' },
       });
       expect(smMock.appendMessage).not.toHaveBeenCalled();
       expect(smMock.appendTrace).not.toHaveBeenCalled();
@@ -1950,6 +1951,7 @@ describe('RelayClient pending-question digest', () => {
     const adapter = createAdapter();
     const sm = {
       ...createSessionManager(),
+      getMeta: vi.fn(() => ({ id: 'sess_1', state: 'active' })),
       getSessionList: vi.fn(() => [{
         id: 'sess_1', agent: 'pi', state: 'active', mode: 'execute',
         lastSeq: 1, readSeq: 0, messageCount: 1, createdAt: '2024-01-01T00:00:00Z',
@@ -1991,8 +1993,18 @@ describe('RelayClient pending-question digest', () => {
       return undefined;
     };
     const preview = () => digest()?.preview as { type: string; text: string } | undefined;
-    return { adapter, sm, ws, askQ, answerQ, preview };
+    return { adapter, sm, ws, askQ, answerQ, digest, preview };
   }
+
+  it('restores compacting from session_list state without replaying runtime events', () => {
+    const { adapter, ws, digest } = buildClient();
+    (adapter.onCompaction as (sid: string, e: Record<string, unknown>) => void)('sess_1', {
+      phase: 'start', reason: 'threshold',
+    });
+
+    expect(digest()?.state).toBe('compacting');
+    expect(decodePulseSends(ws.sent).some((message) => message.type === 'compacting')).toBe(false);
+  });
 
   it('overrides the digest preview with the open question while it is pending', () => {
     const { askQ, preview } = buildClient();

--- a/packages/tentacle/src/card-manager.ts
+++ b/packages/tentacle/src/card-manager.ts
@@ -122,7 +122,6 @@ export class CardManager {
     if (a.type === 'tool_batch') return `batch:${a.payload.running}`;
     if (a.type === 'permission') return `permission:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.decision ?? ''}`;
     if (a.type === 'question') return `question:${a.payload.id}:${a.payload.cancelled ? 'cancelled' : a.payload.answer !== undefined ? 'answered' : 'pending'}`;
-    if (a.type === 'compaction') return `compaction:${a.payload.reason ?? 'unknown'}`;
     if (a.type === 'user_abort') return `user_abort:${a.payload.abortedAt}`;
     return `failed:${a.payload.failedAt}:${a.payload.code ?? ''}:${a.payload.message}`;
   }
@@ -157,9 +156,10 @@ export class CardManager {
   onDelta(sessionId: string, content: string): void {
     if (!content) return;
     const c = this.get(sessionId);
-    // Narration resumed → a SETTLED tail or stale compaction indicator is no
-    // longer the latest activity. Running tools and unresolved prompts remain.
-    if (this.isSettledTail(c) || c.action?.type === 'compaction') {
+    // Narration resumed → a SETTLED tail is no longer the latest activity.
+    // Running tools and unresolved prompts remain. (Compaction is no longer a
+    // card action - it lives in the separate compacting session-state.)
+    if (this.isSettledTail(c)) {
       c.action = null;
       this.syncAction(sessionId, c);
     }
@@ -187,9 +187,9 @@ export class CardManager {
    *  next delta to start a fresh segment (keep-last). */
   onNarrationFinal(sessionId: string, content: string): void {
     const c = this.get(sessionId);
-    // A narration segment is the latest activity now → retire a settled tail or
-    // stale compaction indicator (mirrors onDelta for no-stream edge cases).
-    if (this.isSettledTail(c) || c.action?.type === 'compaction') {
+    // A narration segment is the latest activity now → retire a settled tail
+    // (mirrors onDelta for no-stream edge cases).
+    if (this.isSettledTail(c)) {
       c.action = null;
       this.syncAction(sessionId, c);
     }
@@ -226,24 +226,6 @@ export class CardManager {
   }
 
   // ── Action part ───────────────────────────────────────
-
-  /** Pi started compacting before prompt acceptance. Do not hide a blocking
-   *  human affordance; otherwise compaction owns the transient action slot. */
-  onCompactionStart(sessionId: string, reason?: 'manual' | 'threshold' | 'overflow'): void {
-    const c = this.get(sessionId);
-    if (this.slotBlocksTool(c)) return;
-    c.action = { type: 'compaction', payload: { phase: 'running', ...(reason && { reason }) } };
-    this.syncAction(sessionId, c);
-  }
-
-  /** Clear only if compaction still owns the slot. A newer tool/prompt action
-   *  must survive a late native compaction_end or watchdog reconciliation. */
-  onCompactionEnd(sessionId: string): void {
-    const c = this.cards.get(sessionId);
-    if (!c || c.action?.type !== 'compaction') return;
-    c.action = null;
-    this.syncAction(sessionId, c);
-  }
 
   /** A tool started — track it as in-flight and (unless a pending prompt owns the
    *  slot) show the derived tool action: the single tool, or a `tool_batch` count

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -69,11 +69,12 @@ export type RelayClientState = 'disconnected' | 'connecting' | 'authenticating' 
  * a burst of stale frames.
  *
  * Only state-covering messages get a key:
- *   - `agent_message_delta` — streaming tokens; only the latest chunk matters.
- *   - `card_action` — the current status-card state; stale actions are noise.
+ *   - `agent_message_delta` - streaming tokens; only the latest chunk matters.
+ *   - `card_action` - the current status-card state; stale actions are noise.
+ *   - `compacting` - the current runtime state; stale phases are noise.
  *
  * Event messages (`agent_message`, `user_message`, `tool_start`, etc.) return
- * `undefined` — every event must be delivered.
+ * `undefined` - every event must be delivered.
  */
 export function coalesceKeyFor(msg: Partial<ProducerMessage>): string | undefined {
   if (msg.type === 'agent_message_delta' && msg.sessionId) {
@@ -81,6 +82,9 @@ export function coalesceKeyFor(msg: Partial<ProducerMessage>): string | undefine
   }
   if (msg.type === 'card_action' && msg.sessionId) {
     return `card_action:${msg.sessionId}`;
+  }
+  if (msg.type === 'compacting' && msg.sessionId) {
+    return `compacting:${msg.sessionId}`;
   }
   return undefined;
 }
@@ -227,6 +231,9 @@ export class RelayClient {
     }
     this.resolveTurnIdle(sessionId);
     this.sessionManager.markIdle(sessionId);
+    // Idle ends the turn: any in-flight compaction is over. Clear before idle
+    // so clients never show compacting once idle lands.
+    this.clearCompacting(sessionId);
     const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
     if (usage) this.sessionManager.setUsage(sessionId, usage);
     this.send({ type: 'idle', sessionId, payload: { usage, ...(terminalError && { reason: 'failed' as const }) } });
@@ -269,6 +276,37 @@ export class RelayClient {
    *  verbatim. Broadcasts route back through {@link send} (which coalesces the
    *  `agent_message_delta` text deltas). */
   private card = new CardManager((msg) => this.send(msg as Partial<ProducerMessage>));
+
+  /** Sessions whose agent runtime is currently compacting context. This is the
+   *  single in-memory source of truth for the compacting session-state (a peer
+   *  of active/idle). It is NEVER written to meta.json - a tentacle restart
+   *  means the compacting process is gone, so no stale disk state survives.
+   *  {@link getSessionList} overlays it onto the digest `state`. */
+  private compactingSessions = new Set<string>();
+
+  /** Enter/leave the compacting session-state. Broadcasts a transient
+   *  `compacting` message (peer of active/idle) so clients update the runtime
+   *  indicator without it ever touching the card action slot, TRACE, or spine. */
+  private setCompacting(sessionId: string, active: boolean, reason?: 'manual' | 'threshold' | 'overflow'): void {
+    if (active) {
+      if (!this.compactingSessions.has(sessionId)) {
+        this.compactingSessions.add(sessionId);
+        this.send({ type: 'compacting', sessionId, payload: { phase: 'start', ...(reason && { reason }) } });
+      }
+    } else {
+      if (this.compactingSessions.delete(sessionId)) {
+        const metaState = this.sessionManager.getMeta(sessionId)?.state;
+        const nextState = metaState === 'active' ? 'active' : 'idle';
+        this.send({ type: 'compacting', sessionId, payload: { phase: 'end', nextState } });
+      }
+    }
+  }
+
+  /** Clear stale compacting for a session (idle / active turn start / end /
+   *  process loss). Safe no-op when not compacting. */
+  private clearCompacting(sessionId: string): void {
+    this.setCompacting(sessionId, false);
+  }
 
   // Stale connection detection — tracks last incoming message to detect sleep/network changes
   private lastActivityAt = 0;
@@ -1105,6 +1143,7 @@ export class RelayClient {
               this.pendingTerminalErrors.delete(sessionId);
               this.resolveTurnIdle(sessionId);
               this.sessionManager.markIdle(sessionId);
+              this.clearCompacting(sessionId);
               this.send({ type: 'idle', sessionId, payload: { reason: 'aborted' } });
             })
             .catch((err) => {
@@ -1777,8 +1816,8 @@ export class RelayClient {
     };
 
     this.adapter.onCompaction = (sessionId, event) => {
-      if (event.phase === 'start') this.card.onCompactionStart(sessionId, event.reason);
-      else this.card.onCompactionEnd(sessionId);
+      if (event.phase === 'start') this.setCompacting(sessionId, true, event.reason);
+      else this.setCompacting(sessionId, false);
     };
 
     this.adapter.onError = (sessionId, event) => {
@@ -1824,6 +1863,7 @@ export class RelayClient {
       this.steerAcceptanceInFlight.delete(sessionId);
       this.idleDuringSteerAcceptance.delete(sessionId);
       this.resolveTurnIdle(sessionId);
+      this.clearCompacting(sessionId);
       this.card.delete(sessionId);
       this.send({
         type: 'session_ended',
@@ -1991,22 +2031,31 @@ export class RelayClient {
   }
 
   /** Override each digest's `preview` with the live open question (if any) so a
-   *  reloading arm can render the "pending" status — the question no longer
+   *  reloading arm can render the "pending" status - the question no longer
    *  persists to the spine, so the file-based preview can't surface it. Sessions
-   *  without an open question keep their file-derived preview untouched. */
-  private enrichSessionList<T extends { id: string; preview?: import('@kraki/protocol').SessionPreviewDigest }>(
-    sessions: T[],
-  ): T[] {
+   *  without an open question keep their file-derived preview untouched.
+   *
+   *  Also overlays the in-memory compacting state onto `state`: a session whose
+   *  agent runtime is currently compacting reports `state: 'compacting'`
+   *  (a peer of active/idle) regardless of the disk meta, so a reconnecting
+   *  arm recovers the runtime indicator from the session list alone. */
+  private enrichSessionList<
+    T extends { id: string; state: import('@kraki/protocol').SessionState; preview?: import('@kraki/protocol').SessionPreviewDigest },
+  >(sessions: T[]): T[] {
     return sessions.map((s) => {
+      const compacting = this.compactingSessions.has(s.id);
       const question = this.latestOpenQuestion(s.id);
-      if (question === undefined) return s;
+      if (!compacting && question === undefined) return s;
       return {
         ...s,
-        preview: {
-          type: 'question' as const,
-          text: question.slice(0, 200),
-          timestamp: new Date().toISOString(),
-        },
+        ...(compacting && { state: 'compacting' as const }),
+        ...(question !== undefined && {
+          preview: {
+            type: 'question' as const,
+            text: question.slice(0, 200),
+            timestamp: new Date().toISOString(),
+          },
+        }),
       };
     });
   }
@@ -2324,7 +2373,8 @@ export class RelayClient {
 
   /** Push the current card snapshot for every session with active card state to
    *  a freshly-joined consumer. Called from `device_joined` (fresh key in hand)
-   *  so a reconnecting arm re-seeds its status card without a pull round-trip. */
+   *  so a reconnecting arm re-seeds its status card without a pull round-trip.
+   *  Runtime state is carried independently by the preceding session_list. */
   private sendCardSnapshotsTo(deviceId: string, key: string): void {
     for (const sessionId of this.card.activeSessions()) {
       for (const snap of this.card.snapshot(sessionId)) {
@@ -2530,8 +2580,9 @@ export class RelayClient {
     }
 
     if (this.consumerKeys.size === 0) {
-      // No consumer keys at all — queue until a device registers
-      this.queuePendingE2e(msg);
+      // Runtime state is recovered authoritatively from session_list.state when
+      // a device joins. Never queue compacting start/end events for later replay.
+      if (type !== 'compacting') this.queuePendingE2e(msg);
       return;
     }
 
@@ -2540,8 +2591,10 @@ export class RelayClient {
     // always present; daemon-worker constructs one unconditionally).
     this.sendEncrypted(msg);
 
-    // Also queue if no online consumers, so new devices get it on connect
-    if (this.onlineConsumers.size === 0) {
+    // Also queue if no online consumers, so new devices get it on connect.
+    // Compacting is a current state, not an event backlog; session_list is its
+    // sole reconnect authority.
+    if (this.onlineConsumers.size === 0 && type !== 'compacting') {
       this.queuePendingE2e(msg);
     }
   }


### PR DESCRIPTION
## Summary

- promote context compaction to an ephemeral `SessionState` peer of `active` / `idle`
- broadcast focused `compacting` start/end messages while using `session_list.state` as reconnect authority
- keep compaction out of conversation persistence, TRACE, cards, bubbles, replay, and terminal outcomes
- adapt Web and iOS session/page/composer presentation without creating chat content
- repair Web tail reconciliation so a persisted reply missed immediately before `idle` is recovered automatically, including caches polluted by legacy transient rows

## Protocol and lifecycle

- `SessionState = 'active' | 'idle' | 'compacting'`
- `CompactingMessage` has `start` and `end`; end carries authoritative `nextState`
- Tentacle keeps compacting source state in memory and overlays it onto session digests
- Pulse coalesces transient compacting state per session
- `request_card` remains card-only; reconnect restoration is digest-only
- legacy `card_action.compaction` is intentionally unsupported

## Web missing-reply recovery

Opening a session now reconciles the authoritative last-50 spine window even when local messages already exist. Receiving `idle` also reconciles its tail, covering the observed `494 user -> missing 495 agent reply -> 496 idle` sequence.

Legacy transient rows no longer count toward IndexedDB range completeness, and authoritative range batches replace stale same-seq in-memory rows. Tail seq tracking is monotonic and overlapping reconciliations are coalesced safely.

## Review

Reviewed the full protocol, Tentacle, Web, and iOS diff. No blocking findings.

Static audit confirms compaction does not enter:
- `messages.jsonl` / conversation seq
- SQLite / IndexedDB message persistence
- TRACE / Steps
- `CardActionState` or card snapshots
- live or concluded bubbles
- terminal outcomes

## Validation

- Web: **376/376**
- Tentacle: **728/728**
- Protocol, Tentacle, and Web production builds: passed
- workspace lint: passed (`140` files)
- `git diff --check`: passed
- iOS `build-for-testing`: passed
- iOS: **213/213** excluding one unchanged baseline failure

The sole full iOS-suite failure is `IncrementalGrouperTests.testTerminalStatusFoldsReplyAndKeepsErrorsInThinking` (3 assertions). The exact same failure reproduces in a clean detached worktree at base `origin/main@b2fc4727`, so it is not introduced by this PR.

## Operational note

This PR does not update, restart, or deploy any running Tentacle process.
