### PR TITLE
chore(release): v0.29.15

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.29.14",
+  "version": "0.29.15",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Publishes the compaction runtime-state protocol and clients merged in #171.

- `@kraki/protocol`: `0.18.0` → `0.19.0`
- `@kraki/tentacle`: `0.29.14` → `0.29.15`

## Review

The diff contains only the two package version fields. No blocking findings.

## Validation

- #171 `Validate`: passed
- post-merge main `Validate`: passed
- `@kraki/protocol` build: passed
- `@kraki/tentacle` build: passed
- `git diff --check`: passed

## Operational note

Publishing this release does **not** update or restart the currently running Tentacle. No local/production self-update command will be run.
