### PR TITLE
feat(pulse): isolate live and bulk traffic with multi-stream transport

### DIFF
--- a/packages/arm/web/e2e/real-stack/pulse-multistream-reconnect.spec.ts
+++ b/packages/arm/web/e2e/real-stack/pulse-multistream-reconnect.spec.ts
@@ -1,0 +1,51 @@
+import { expect, type Page, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB_URL = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const context = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const response = await context.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await response.json();
+  await context.dispose();
+  if (!response.ok()) throw new Error(`control ${path} failed: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pairBrowser(page: Page): Promise<string> {
+  const { token, web, sessionId } = await control('/token');
+  await page.goto(web as string);
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  return sessionId as string;
+}
+
+test('multi-stream reconnect resumes downlink and subsequent uplink', async ({ page }) => {
+  const sessionId = await pairBrowser(page);
+  await page.goto(`${WEB_URL}/session/${sessionId}`);
+  await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+  await control('/idle', { sid: sessionId });
+
+  await page.context().setOffline(true);
+  const buffered = `buffered-live-${Date.now().toString(36)}`;
+  await control('/msg', { sid: sessionId, text: buffered });
+  await control('/idle', { sid: sessionId });
+  await page.waitForTimeout(1_000);
+
+  await page.context().setOffline(false);
+  await expect(page.locator('[data-chat-scroll]').getByText(buffered, { exact: false }).first())
+    .toBeVisible({ timeout: 25_000 });
+
+  const prompt = `post-reconnect-uplink-${Date.now().toString(36)}`;
+  const input = page.getByPlaceholder('Send a message…');
+  await expect(input).toBeVisible({ timeout: 10_000 });
+  await input.fill(prompt);
+  await input.press('Enter');
+  await expect.poll(async () => {
+    const { messages } = await control('/received');
+    return (messages as Array<{ text: string }>).some((message) => message.text === prompt);
+  }, { timeout: 15_000, message: 'Arm uplink did not recover after multi-stream reconnect' }).toBe(true);
+});

--- a/packages/arm/web/e2e/real-stack/pulse-trace-flood.spec.ts
+++ b/packages/arm/web/e2e/real-stack/pulse-trace-flood.spec.ts
@@ -1,0 +1,83 @@
+import { expect, type Page, request, test } from '@playwright/test';
+
+/**
+ * Production regression: reconnecting a large session caused many
+ * turn_trace_batch responses to queue on the only Pulse seq space. Live pong,
+ * echo, abort and idle frames sat behind them until Head dropped the browser.
+ *
+ * This drives the real application path:
+ *   user_message → hundreds of persisted tool trace entries → concluding bubble
+ *   → reload → request_turn_trace → turn_trace_batch (bulk stream 1), while a
+ *   concurrent agent message rides live stream 0.
+ */
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB_URL = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const context = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const response = await context.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await response.json();
+  await context.dispose();
+  if (!response.ok()) throw new Error(`control ${path} failed: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pairBrowser(page: Page): Promise<string> {
+  const { token, web, sessionId } = await control('/token');
+  await page.goto(web as string);
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  return sessionId as string;
+}
+
+test('live echo stays responsive while a large turn trace is pulled on bulk', async ({ page }) => {
+  const sessionId = await pairBrowser(page);
+  await page.goto(`${WEB_URL}/session/${sessionId}`);
+  await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+  await control('/idle', { sid: sessionId });
+
+  const prompt = `trace-flood-turn-${Date.now().toString(36)}`;
+  const input = page.getByPlaceholder('Send a message…');
+  await input.fill(prompt);
+  await input.press('Enter');
+  await expect.poll(async () => {
+    const { messages } = await control('/received');
+    return (messages as Array<{ text: string }>).some((message) => message.text === prompt);
+  }, { timeout: 15_000 }).toBe(true);
+
+  const reply = `trace-flood-done-${Date.now().toString(36)}`;
+  const flood = await control('/traceFlood', {
+    sid: sessionId,
+    n: '400',
+    reply,
+  });
+  expect(flood.entries).toBe(802);
+  await expect(page.locator('[data-chat-scroll]').getByText(reply, { exact: false }).first())
+    .toBeVisible({ timeout: 20_000 });
+
+  // Reload clears in-memory trace state. Mounting the concluded bubble issues
+  // request_turn_trace and the Tentacle returns all 800 entries on stream 1.
+  await page.reload();
+  await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+  const live = `live-during-trace-${Date.now().toString(36)}`;
+  const started = Date.now();
+  await control('/msg', { sid: sessionId, text: live });
+  await control('/idle', { sid: sessionId });
+  await expect(page.locator('[data-chat-scroll]').getByText(live, { exact: false }).first())
+    .toBeVisible({ timeout: 10_000 });
+  const liveLatencyMs = Date.now() - started;
+  expect(liveLatencyMs).toBeLessThan(5_000);
+
+  // The bulk response also completes: the concluded bubble's Steps affordance
+  // remains usable after the live message arrived.
+  const replyBubble = page.locator('[data-chat-scroll]').getByText(reply, { exact: false }).first()
+    .locator('xpath=ancestor::*[.//button[@aria-label="Open steps"]][1]');
+  const steps = replyBubble.getByRole('button', { name: /Open steps/i });
+  await expect(steps).toBeVisible({ timeout: 20_000 });
+  await steps.click();
+  await expect(page.getByRole('dialog').getByText(/echo trace-/i).first())
+    .toBeVisible({ timeout: 20_000 });
+});

--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -16,7 +16,7 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
-    "@coinfra/pulse": "^0.3.3",
+    "@coinfra/pulse": "^0.4.1",
     "@kraki/protocol": "workspace:*",
     "highlight.js": "^11.10.0",
     "idb": "^8.0.3",

--- a/packages/arm/web/src/lib/arm-pulse.test.ts
+++ b/packages/arm/web/src/lib/arm-pulse.test.ts
@@ -1,0 +1,130 @@
+import { decodeFrameWithStream, Endpoint, StreamSet, type Effect } from '@coinfra/pulse';
+import { describe, expect, it } from 'vitest';
+import { ArmPulse, type ArmPulseHost } from './arm-pulse';
+
+function b64(bytes: Uint8Array): string {
+  let text = '';
+  for (const byte of bytes) text += String.fromCharCode(byte);
+  return btoa(text);
+}
+
+function unb64(text: string): Uint8Array {
+  const binary = atob(text);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function makePeer(): StreamSet {
+  return new StreamSet([
+    new Endpoint({ epoch: 'head:live', streamId: 0, random: () => 0.5 }),
+    new Endpoint({ epoch: 'head:bulk', streamId: 1, random: () => 0.5 }),
+  ]);
+}
+
+class ArmWorld {
+  now = 0;
+  readonly sent: Array<{ bytes: Uint8Array; target: string }> = [];
+  readonly delivered: string[] = [];
+  readonly acked: bigint[] = [];
+  readonly arm: ArmPulse;
+  readonly head = makePeer();
+
+  constructor() {
+    const host: ArmPulseHost = {
+      now: () => this.now,
+      sendPulseFrame: (pulse, target) => this.sent.push({ bytes: unb64(pulse), target }),
+      onDelivered: (payload) => this.delivered.push(payload),
+      onAcked: (seq) => this.acked.push(seq),
+    };
+    this.arm = new ArmPulse(host, 'arm');
+  }
+
+  connect(): void {
+    this.arm.onConnected();
+    const armHello = this.sent.splice(0);
+    this.feedHead(this.head.onConnected(this.now));
+    for (const { bytes } of armHello) this.feedHead(this.head.onBytes(bytes, this.now));
+    this.pumpArmToHead();
+  }
+
+  pumpArmToHead(): void {
+    for (;;) {
+      const pending = this.sent.splice(0);
+      if (pending.length === 0) return;
+      for (const { bytes } of pending) this.feedHead(this.head.onBytes(bytes, this.now));
+    }
+  }
+
+  feedHead(effects: Effect[]): void {
+    for (const effect of effects) {
+      if (effect.t === 'transmit') this.arm.onFrame(b64(effect.bytes));
+    }
+  }
+}
+
+describe('ArmPulse multi-stream', () => {
+  it('sends every Arm-originated command on byte-compatible live stream 0', () => {
+    const world = new ArmWorld();
+    world.connect();
+    world.sent.length = 0;
+
+    const seq = world.arm.send('{"type":"abort"}', 'tentacle-1', true);
+    expect(seq).toBe(1n);
+    const data = world.sent.find(({ bytes }) => decodeFrameWithStream(bytes)?.frame.t === 'data');
+    expect(data).toBeDefined();
+    expect(decodeFrameWithStream(data!.bytes)?.streamId).toBe(0);
+    expect(data!.target).toBe('tentacle-1');
+  });
+
+  it('demuxes a stream-1 response into the normal delivery callback', () => {
+    const world = new ArmWorld();
+    world.connect();
+
+    const payload = '{"type":"turn_trace_batch"}';
+    world.feedHead(world.head.send(1, new TextEncoder().encode(payload)).effects);
+    expect(world.delivered).toContain(payload);
+  });
+
+  it('delivers live while bulk is stalled behind a missing sequence', () => {
+    const world = new ArmWorld();
+    world.connect();
+
+    const bulk1 = world.head.send(1, new TextEncoder().encode('bulk-1')).effects;
+    const bulk2 = world.head.send(1, new TextEncoder().encode('bulk-2')).effects;
+    // Drop bulk seq=1 and feed only seq=2. The bulk endpoint must wait.
+    world.feedHead(bulk2);
+    expect(world.delivered).not.toContain('bulk-2');
+
+    // Independent live seq=1 must deliver immediately despite the bulk hole.
+    world.feedHead(world.head.send(0, new TextEncoder().encode('live-1')).effects);
+    expect(world.delivered).toContain('live-1');
+    expect(world.delivered).not.toContain('bulk-2');
+
+    // Repairing bulk seq=1 allows the bulk stream to make progress independently.
+    world.feedHead(bulk1);
+    expect(world.delivered).toContain('bulk-1');
+  });
+
+  it('preserves the command target when an unacked live frame retransmits', () => {
+    const world = new ArmWorld();
+    world.connect();
+    world.sent.length = 0;
+
+    world.arm.send('{"type":"remove_device"}', '@head', true);
+    const first = world.sent.find(({ bytes }) => decodeFrameWithStream(bytes)?.frame.t === 'data');
+    expect(first?.target).toBe('@head');
+
+    // Drop DATA, reconnect both Pulse peers, and observe a resend outside send().
+    world.sent.length = 0;
+    world.arm.onDisconnected();
+    world.head.onDisconnected(world.now);
+    world.now += 1_000;
+    world.arm.onConnected();
+    const history = world.sent.splice(0);
+    world.feedHead(world.head.onConnected(world.now));
+    for (const { bytes } of history) world.feedHead(world.head.onBytes(bytes, world.now));
+
+    const resent = world.sent.find(({ bytes }) => decodeFrameWithStream(bytes)?.frame.t === 'data');
+    expect(resent).toBeDefined();
+    expect(resent!.target).toBe('@head');
+  });
+});

--- a/packages/arm/web/src/lib/arm-pulse.ts
+++ b/packages/arm/web/src/lib/arm-pulse.ts
@@ -1,4 +1,4 @@
-import { decodeFrame, type Effect, Endpoint } from '@coinfra/pulse';
+import { decodeFrame, type Effect, Endpoint, StreamSet } from '@coinfra/pulse';
 import type { InnerMessage } from '@kraki/protocol';
 import { createLogger } from './logger';
 import { traceEvent } from './trace';
@@ -45,7 +45,11 @@ const enc = new TextEncoder();
 const dec = new TextDecoder();
 
 export class ArmPulse {
-  private endpoint: Endpoint;
+  private streams: StreamSet;
+  /** The live endpoint (stream 0) — the one this arm SENDS on. Arm-originated
+   *  traffic (input, approvals, aborts, card pulls) is always live; only the
+   *  tentacle produces bulk (trace/range/attachment responses). */
+  private live: Endpoint;
   /** Per-send target, keyed by the DATA frame's seq. A single mutable
    *  "currentTarget" is WRONG: retransmits (from onConnected/onFrame/tick, e.g.
    *  after packet loss or reconnect) fire OUTSIDE the synchronous send() window,
@@ -61,7 +65,9 @@ export class ArmPulse {
     private readonly host: ArmPulseHost,
     epoch: string,
   ) {
-    this.endpoint = new Endpoint({ epoch, durable: { supported: false } });
+    this.live = new Endpoint({ epoch: `${epoch}:live`, durable: { supported: false }, streamId: 0 });
+    const bulk = new Endpoint({ epoch: `${epoch}:bulk`, durable: { supported: false }, streamId: 1 });
+    this.streams = new StreamSet([this.live, bulk]);
   }
 
   /** Send a reliable message (a JSON string {blob, keys}, or plaintext control
@@ -70,7 +76,7 @@ export class ArmPulse {
    *  seq so the caller can track it for rollback. */
   send(payloadJson: string, targetDeviceId: string, durable: boolean): bigint {
     const payload = enc.encode(payloadJson);
-    const { seq, effects } = this.endpoint.send(payload, { durable });
+    const { seq, effects } = this.live.send(payload, { durable });
     this.targetBySeq.set(seq, targetDeviceId);
     traceEvent({ comp: 'arm', evt: 'PULSE-SEND', seq: String(seq), len: payload.length, target: targetDeviceId, durable });
     this.run(effects);
@@ -79,20 +85,20 @@ export class ArmPulse {
 
   onConnected(): void {
     traceEvent({ comp: 'arm', evt: 'PULSE-CONNECTED' });
-    this.run(this.endpoint.onConnected(this.host.now()));
+    this.run(this.streams.onConnected(this.host.now()));
   }
   onDisconnected(): void {
     traceEvent({ comp: 'arm', evt: 'PULSE-DISCONNECTED' });
-    this.endpoint.onDisconnected(this.host.now());
+    this.streams.onDisconnected(this.host.now());
   }
   onFrame(pulseB64: string): void {
     const bytes = unb64(pulseB64);
     const frame = decodeFrame(bytes);
     traceEvent({ comp: 'arm', evt: 'PULSE-RX', seq: frame?.t === 'data' ? String(frame.seq) : '0', len: bytes.length, kind: frame?.t ?? '?' });
-    this.run(this.endpoint.onBytes(bytes, this.host.now()));
+    this.run(this.streams.onBytes(bytes, this.host.now()));
   }
   tick(): void {
-    this.run(this.endpoint.onTick(this.host.now()));
+    this.run(this.streams.onTick(this.host.now()));
   }
 
   private run(effects: Effect[]): void {

--- a/packages/arm/web/src/lib/message-provider.trace.test.ts
+++ b/packages/arm/web/src/lib/message-provider.trace.test.ts
@@ -56,11 +56,62 @@ describe('MessageProvider — TRACE axis', () => {
     expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(1);
   });
 
-  it('invalidateTurnTrace allows a fresh re-pull (idle reconciliation)', () => {
+  it('coalesces an in-flight invalidation into one refresh after the response', () => {
     messageProvider.requestTurnTrace('s1', 5);
     messageProvider.invalidateTurnTrace('s1', 5);
     messageProvider.requestTurnTrace('s1', 5);
+    expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(1);
+
+    messageProvider.handleTurnTraceBatch('s1', 5, [], true);
     expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(2);
+  });
+
+  it('allows only one cross-bubble trace pull in flight', () => {
+    messageProvider.setTentacleInfo('s2', 10, 'tentacle-dev');
+    messageProvider.setTentacleInfo('s3', 10, 'tentacle-dev');
+    messageProvider.requestTurnTrace('s1', 5);
+    messageProvider.requestTurnTrace('s2', 6);
+    messageProvider.requestTurnTrace('s3', 7);
+    expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(1);
+
+    messageProvider.handleTurnTraceBatch('s1', 5, [], true);
+    expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(2);
+    expect(sent.at(-1)?.payload).toMatchObject({ sessionId: 's2', bubbleSeq: 6 });
+
+    messageProvider.handleTurnTraceBatch('s2', 6, [], true);
+    expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(3);
+    expect(sent.at(-1)?.payload).toMatchObject({ sessionId: 's3', bubbleSeq: 7 });
+  });
+
+  it('collapses repeated in-flight invalidations to one refresh', () => {
+    messageProvider.requestTurnTrace('s1', 5);
+    for (let i = 0; i < 100; i++) {
+      messageProvider.invalidateTurnTrace('s1', 5);
+      messageProvider.requestTurnTrace('s1', 5);
+    }
+    expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(1);
+
+    messageProvider.handleTurnTraceBatch('s1', 5, [], true);
+    expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(2);
+    messageProvider.handleTurnTraceBatch('s1', 5, [], true);
+    expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(2);
+  });
+
+  it('releases the global trace window after a response timeout', () => {
+    vi.useFakeTimers();
+    try {
+      messageProvider.setTentacleInfo('s2', 10, 'tentacle-dev');
+      messageProvider.requestTurnTrace('s1', 5);
+      messageProvider.requestTurnTrace('s2', 6);
+      expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(1);
+
+      vi.advanceTimersByTime(15_000);
+      expect(sent.filter((x) => x.type === 'request_turn_trace')).toHaveLength(2);
+      expect(sent.at(-1)?.payload).toMatchObject({ sessionId: 's2', bubbleSeq: 6 });
+    } finally {
+      messageProvider.clear();
+      vi.useRealTimers();
+    }
   });
 
   it('does not send when the tentacle device is unknown', () => {

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -150,9 +150,19 @@ class MessageProvider {
   private loadingThroughSeq = new Map<string, number>();
   /** Latest tail reconciliation requested beyond an in-flight range. */
   private pendingTailReconciles = new Map<string, number>();
-  /** Turn-trace pulls already issued, keyed `${sessionId}:${bubbleSeq}`.
-   *  Prevents re-pulling the same concluded turn's TRACE on every render. */
+  /** Turn-trace pulls already completed or scheduled, keyed
+   *  `${sessionId}:${bubbleSeq}`. */
   private tracePulled = new Set<string>();
+  /** Only one potentially-large trace response may be in flight globally.
+   *  This prevents reconnect-time cross-bubble pulls from flooding Tentacle
+   *  encryption and the Head WebSocket before stream 1 can apply backpressure. */
+  private traceInFlight: string | null = null;
+  private traceQueue: Array<{ sessionId: string; bubbleSeq: number }> = [];
+  private traceQueued = new Set<string>();
+  /** Invalidations that arrived while the same key was in flight collapse into
+   *  one authoritative refresh after its response. */
+  private traceRefresh = new Set<string>();
+  private traceTimeout: ReturnType<typeof setTimeout> | null = null;
   private cardRequested = new Set<string>();
 
   setSend(fn: (msg: Record<string, unknown>) => void): void {
@@ -370,6 +380,12 @@ class MessageProvider {
     this.loadingThroughSeq.clear();
     this.pendingTailReconciles.clear();
     this.tracePulled.clear();
+    this.traceInFlight = null;
+    this.traceQueue = [];
+    this.traceQueued.clear();
+    this.traceRefresh.clear();
+    if (this.traceTimeout) clearTimeout(this.traceTimeout);
+    this.traceTimeout = null;
     this.cardRequested.clear();
   }
 
@@ -405,34 +421,69 @@ class MessageProvider {
   requestTurnTrace(sessionId: string, bubbleSeq: number): void {
     const key = `${sessionId}:${bubbleSeq}`;
     if (this.tracePulled.has(key)) return;
+    if (!this.canPullTurnTrace(sessionId, bubbleSeq)) return;
+
+    this.tracePulled.add(key);
+    if (this.traceInFlight === null) {
+      this.dispatchTurnTrace(sessionId, bubbleSeq);
+    } else if (!this.traceQueued.has(key)) {
+      this.traceQueued.add(key);
+      this.traceQueue.push({ sessionId, bubbleSeq });
+    }
+  }
+
+  private canPullTurnTrace(sessionId: string, bubbleSeq: number): boolean {
     const tentacleDeviceId = this.tentacleDeviceMap.get(sessionId);
     if (!tentacleDeviceId || !this.sendFn) {
       logger.warn('cannot request turn trace', {
         sessionId, bubbleSeq, hasSend: !!this.sendFn, hasDevice: !!tentacleDeviceId,
       });
-      return;
+      return false;
     }
-    const store = getStore();
-    // A turn-trace pull is a best-effort background reconcile. If the tentacle
-    // device has no known encryption key yet (offline / no key exchange this
-    // session), the encrypted-send path would surface a user-facing
-    // "Cannot send: target device has no encryption key" banner — wrong for a
-    // silent background operation. Skip without marking as pulled so it retries
-    // once the key arrives.
-    const targetDev = store.devices.get(tentacleDeviceId);
+    const targetDev = getStore().devices.get(tentacleDeviceId);
     if (!(targetDev?.encryptionKey ?? targetDev?.publicKey)) {
       logger.debug('skip turn trace pull — tentacle not encryptable yet', {
         sessionId, bubbleSeq, tentacleDeviceId,
       });
+      return false;
+    }
+    return true;
+  }
+
+  private dispatchTurnTrace(sessionId: string, bubbleSeq: number): void {
+    const key = `${sessionId}:${bubbleSeq}`;
+    const tentacleDeviceId = this.tentacleDeviceMap.get(sessionId);
+    if (!tentacleDeviceId || !this.sendFn || !this.canPullTurnTrace(sessionId, bubbleSeq)) {
+      this.tracePulled.delete(key);
+      this.dispatchNextTurnTrace();
       return;
     }
-    this.tracePulled.add(key);
+    this.traceInFlight = key;
     this.sendFn({
       type: 'request_turn_trace',
-      deviceId: store.deviceId ?? '',
+      deviceId: getStore().deviceId ?? '',
       payload: { sessionId, bubbleSeq, targetDeviceId: tentacleDeviceId },
     });
+    if (this.traceTimeout) clearTimeout(this.traceTimeout);
+    this.traceTimeout = setTimeout(() => {
+      if (this.traceInFlight !== key) return;
+      logger.warn('turn trace pull timed out', { sessionId, bubbleSeq });
+      this.traceInFlight = null;
+      this.traceTimeout = null;
+      this.tracePulled.delete(key);
+      this.traceRefresh.delete(key);
+      this.dispatchNextTurnTrace();
+    }, 15_000);
     logger.info('requested turn trace', { sessionId, bubbleSeq });
+  }
+
+  private dispatchNextTurnTrace(): void {
+    if (this.traceInFlight !== null) return;
+    const next = this.traceQueue.shift();
+    if (!next) return;
+    const key = `${next.sessionId}:${next.bubbleSeq}`;
+    this.traceQueued.delete(key);
+    this.dispatchTurnTrace(next.sessionId, next.bubbleSeq);
   }
 
   /**
@@ -441,7 +492,15 @@ class MessageProvider {
    * persisted list).
    */
   invalidateTurnTrace(sessionId: string, bubbleSeq: number): void {
-    this.tracePulled.delete(`${sessionId}:${bubbleSeq}`);
+    const key = `${sessionId}:${bubbleSeq}`;
+    if (this.traceInFlight === key) {
+      this.traceRefresh.add(key);
+      return;
+    }
+    // A queued request has not been sent yet, so it already observes the newest
+    // persisted trace and needs no duplicate queue entry.
+    if (this.traceQueued.has(key)) return;
+    this.tracePulled.delete(key);
   }
 
   /**
@@ -460,9 +519,20 @@ class MessageProvider {
       sessionId, bubbleSeq, count: list.length, complete,
     });
     getStore().setTurnSteps(sessionId, bubbleSeq, list);
-    if (!complete) {
-      // Turn not finished — let a subsequent pull (e.g. at idle) refresh it.
-      this.tracePulled.delete(`${sessionId}:${bubbleSeq}`);
+    const key = `${sessionId}:${bubbleSeq}`;
+    const refresh = this.traceRefresh.delete(key);
+    if (!complete || refresh) this.tracePulled.delete(key);
+
+    if (this.traceInFlight === key) {
+      this.traceInFlight = null;
+      if (this.traceTimeout) clearTimeout(this.traceTimeout);
+      this.traceTimeout = null;
+      if (refresh && this.canPullTurnTrace(sessionId, bubbleSeq)) {
+        this.tracePulled.add(key);
+        this.traceQueued.add(key);
+        this.traceQueue.push({ sessionId, bubbleSeq });
+      }
+      this.dispatchNextTurnTrace();
     }
   }
 

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@coinfra/pulse": "^0.3.3",
+    "@coinfra/pulse": "^0.4.1",
     "@kraki/crypto": "workspace:*",
     "@kraki/protocol": "workspace:*",
     "better-sqlite3": "^11.0.0",

--- a/packages/head/src/__tests__/pulse-hub-multistream.test.ts
+++ b/packages/head/src/__tests__/pulse-hub-multistream.test.ts
@@ -277,6 +277,66 @@ describe('PulseHub multi-stream persistence and forwarding', () => {
     afterRestart.hub.close();
   });
 
+  it('forgets historical v2 capability after a confirmed v1 rollback', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const sentStreams: number[] = [];
+    const hub = new PulseHub(db, {
+      now: () => 0,
+      sendPulseTo: (device, pulse) => {
+        if (device === ARM) {
+          sentStreams.push(decodeFrameWithStream(unb64(pulse))?.streamId ?? -1);
+        }
+        return false;
+      },
+      broadcastTargets: () => [],
+      onDeliverToSelf: () => undefined,
+    }, { intervalMs: 0 });
+
+    db.prepare('INSERT INTO pulse_capabilities (device, bulk) VALUES (?, 1)').run(ARM);
+    hub.close();
+
+    const restarted = new PulseHub(db, {
+      now: () => 0,
+      sendPulseTo: (device, pulse) => {
+        if (device === ARM) {
+          sentStreams.push(decodeFrameWithStream(unb64(pulse))?.streamId ?? -1);
+        }
+        return false;
+      },
+      broadcastTargets: () => [],
+      onDeliverToSelf: () => undefined,
+    }, { intervalMs: 0 });
+    restarted.onDeviceConnected(ARM);
+
+    // A stream-0-only endpoint emits byte-compatible v1 frames and never
+    // advertises stream 1 during this connection.
+    const legacy = new Endpoint({ epoch: 'rolled-back-v1', streamId: 0 });
+    for (const effect of legacy.onConnected(0)) {
+      if (effect.t === 'transmit') {
+        restarted.onPulseEnvelope(ARM, { pulse: b64(effect.bytes), to: '@head' });
+      }
+    }
+    restarted.onDeviceDisconnected(ARM);
+    expect(db.prepare('SELECT bulk FROM pulse_capabilities WHERE device = ?').get(ARM))
+      .toBeUndefined();
+
+    // The separate fallback test below verifies that an unrecognized peer is
+    // routed over stream 0. This test locks the state transition that makes a
+    // rolled-back device unrecognized again, including persistence across a
+    // subsequent Head restart.
+    restarted.close();
+    const afterRollbackRestart = new PulseHub(db, {
+      now: () => 0,
+      sendPulseTo: () => false,
+      broadcastTargets: () => [],
+      onDeliverToSelf: () => undefined,
+    }, { intervalMs: 0 });
+    expect(db.prepare('SELECT bulk FROM pulse_capabilities WHERE device = ?').get(ARM))
+      .toBeUndefined();
+    afterRollbackRestart.close();
+  });
+
   it('purges disconnected non-durable entries independently on both streams', () => {
     const db = new Database(':memory:');
     databases.push(db);

--- a/packages/head/src/__tests__/pulse-hub-multistream.test.ts
+++ b/packages/head/src/__tests__/pulse-hub-multistream.test.ts
@@ -1,0 +1,360 @@
+import Database from 'better-sqlite3';
+import { decodeFrameWithStream, encodeFrame, Endpoint, StreamSet, type Effect } from '@coinfra/pulse';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PulseHub, type PulseHubGcConfig, type PulseHubHost } from '../pulse-hub.js';
+
+const ARM = 'arm-multi';
+const TENTACLE = 'tentacle-multi';
+const b64 = (bytes: Uint8Array): string => Buffer.from(bytes).toString('base64');
+const unb64 = (text: string): Uint8Array => new Uint8Array(Buffer.from(text, 'base64'));
+
+function endpoints(epoch: string): { streams: StreamSet; live: Endpoint; bulk: Endpoint } {
+  const live = new Endpoint({ epoch: `${epoch}:live`, streamId: 0, random: () => 0.5 });
+  const bulk = new Endpoint({ epoch: `${epoch}:bulk`, streamId: 1, random: () => 0.5 });
+  return { streams: new StreamSet([live, bulk]), live, bulk };
+}
+
+class MultiStreamWorld {
+  now = 0;
+  readonly arm = endpoints('arm');
+  readonly tentacle = endpoints('tentacle');
+  readonly hub: PulseHub;
+  armOnline = false;
+  tentacleOnline = false;
+  armReceived: Array<{ stream: number; marker: number }> = [];
+  tentacleReceived: Array<{ stream: number; marker: number }> = [];
+  headToArmStreams: number[] = [];
+  headToTentacleStreams: number[] = [];
+
+  constructor(readonly db: Database.Database, gc: PulseHubGcConfig = { intervalMs: 0 }) {
+    const host: PulseHubHost = {
+      now: () => this.now,
+      sendPulseTo: (deviceId, pulse) => this.deliverToDevice(deviceId, pulse),
+      broadcastTargets: (from) => from === ARM ? [TENTACLE] : [ARM],
+      onDeliverToSelf: () => undefined,
+    };
+    this.hub = new PulseHub(db, host, gc);
+  }
+
+  connectArm(): void {
+    this.armOnline = true;
+    // The WebSocket is usable by both peers before either HELLO is delivered.
+    // Mark the client endpoints connected first, then attach the hub, and only
+    // then put the client's HELLO effects on the wire.
+    const effects = this.arm.streams.onConnected(this.now);
+    this.hub.onDeviceConnected(ARM);
+    this.pumpArm(effects);
+  }
+
+  connectTentacle(): void {
+    this.tentacleOnline = true;
+    const effects = this.tentacle.streams.onConnected(this.now);
+    this.hub.onDeviceConnected(TENTACLE);
+    this.pumpTentacle(effects);
+  }
+
+  disconnectArm(): void {
+    this.armOnline = false;
+    this.hub.onDeviceDisconnected(ARM);
+    this.arm.streams.onDisconnected(this.now);
+  }
+
+  disconnectTentacle(): void {
+    this.tentacleOnline = false;
+    this.hub.onDeviceDisconnected(TENTACLE);
+    this.tentacle.streams.onDisconnected(this.now);
+  }
+
+  armSend(stream: number, marker: number, durable = false): void {
+    this.pumpArm(this.arm.streams.send(stream, new Uint8Array([marker]), { durable }).effects);
+  }
+
+  tentacleSend(stream: number, marker: number, durable = false): void {
+    this.pumpTentacle(this.tentacle.streams.send(stream, new Uint8Array([marker]), { durable }).effects);
+  }
+
+  advance(ms: number): void {
+    const end = this.now + ms;
+    while (this.now < end) {
+      this.now += Math.min(1000, end - this.now);
+      this.pumpArm(this.arm.streams.onTick(this.now));
+      this.pumpTentacle(this.tentacle.streams.onTick(this.now));
+      this.hub.tick();
+    }
+  }
+
+  private deliverToDevice(deviceId: string, pulse: string): boolean {
+    const bytes = unb64(pulse);
+    const stream = decodeFrameWithStream(bytes)?.streamId ?? -1;
+    if (deviceId === ARM) {
+      this.headToArmStreams.push(stream);
+      if (!this.armOnline) return false;
+      this.pumpArm(this.arm.streams.onBytes(bytes, this.now));
+      return true;
+    }
+    if (deviceId === TENTACLE) {
+      this.headToTentacleStreams.push(stream);
+      if (!this.tentacleOnline) return false;
+      this.pumpTentacle(this.tentacle.streams.onBytes(bytes, this.now));
+      return true;
+    }
+    return false;
+  }
+
+  private pumpArm(effects: Effect[]): void {
+    for (const effect of effects) {
+      if (effect.t === 'deliver') {
+        this.armReceived.push({ stream: effect.streamId ?? 0, marker: effect.payload[0] ?? -1 });
+      } else if (effect.t === 'transmit' && this.armOnline) {
+        this.hub.onPulseEnvelope(ARM, { pulse: b64(effect.bytes), to: TENTACLE });
+      }
+    }
+  }
+
+  private pumpTentacle(effects: Effect[]): void {
+    for (const effect of effects) {
+      if (effect.t === 'deliver') {
+        this.tentacleReceived.push({ stream: effect.streamId ?? 0, marker: effect.payload[0] ?? -1 });
+      } else if (effect.t === 'transmit' && this.tentacleOnline) {
+        this.hub.onPulseEnvelope(TENTACLE, { pulse: b64(effect.bytes), to: ARM });
+      }
+    }
+  }
+}
+
+describe('PulseHub multi-stream persistence and forwarding', () => {
+  const databases: Database.Database[] = [];
+  afterEach(() => {
+    for (const db of databases.splice(0)) db.close();
+  });
+
+  it('atomically migrates the pre-stream schema and preserves stream-0 rows', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    db.exec(`CREATE TABLE pulse_outbox (
+      device TEXT NOT NULL, seq TEXT NOT NULL, payload BLOB NOT NULL,
+      dest TEXT NOT NULL, durable_dest INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (device, seq));
+      CREATE TABLE pulse_meta (
+      device TEXT PRIMARY KEY, snapshot TEXT NOT NULL);`);
+    db.prepare('INSERT INTO pulse_outbox (device, seq, payload, dest) VALUES (?, ?, ?, ?)')
+      .run('legacy-device', '1', Buffer.from([7]), 'legacy-dest');
+    db.prepare('INSERT INTO pulse_meta (device, snapshot) VALUES (?, ?)')
+      .run('legacy-device', JSON.stringify({ epoch: 'legacy', sendSeq: '1', recvCursor: '0', outboxBase: '0', outbox: [] }));
+
+    const hub = new PulseHub(db, {
+      now: () => 0,
+      sendPulseTo: () => false,
+      broadcastTargets: () => [],
+      onDeliverToSelf: () => undefined,
+    }, { intervalMs: 0 });
+
+    const outboxPk = (db.prepare('PRAGMA table_info(pulse_outbox)').all() as Array<{ name: string; pk: number }>)
+      .filter((column) => column.pk > 0)
+      .sort((a, b) => a.pk - b.pk)
+      .map((column) => column.name);
+    const metaPk = (db.prepare('PRAGMA table_info(pulse_meta)').all() as Array<{ name: string; pk: number }>)
+      .filter((column) => column.pk > 0)
+      .sort((a, b) => a.pk - b.pk)
+      .map((column) => column.name);
+    expect(outboxPk).toEqual(['device', 'stream', 'seq']);
+    expect(metaPk).toEqual(['device', 'stream']);
+
+    expect(db.prepare('SELECT stream, seq, hex(payload) AS payload FROM pulse_outbox').get())
+      .toEqual({ stream: 0, seq: '1', payload: '07' });
+    expect(db.prepare('SELECT stream FROM pulse_meta').get()).toEqual({ stream: 0 });
+
+    expect(() => {
+      db.prepare('INSERT INTO pulse_outbox (device, stream, seq, payload, dest) VALUES (?, ?, ?, ?, ?)')
+        .run('legacy-device', 1, '1', Buffer.from([8]), 'bulk-dest');
+      db.prepare('INSERT INTO pulse_meta (device, stream, snapshot) VALUES (?, ?, ?)')
+        .run('legacy-device', 1, '{}');
+    }).not.toThrow();
+    expect(hub.outboxCount('legacy-device')).toBe(2);
+    hub.close();
+  });
+
+  it('preserves stream identity in both directions through the hub', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const world = new MultiStreamWorld(db);
+    world.connectArm();
+    world.connectTentacle();
+
+    world.armSend(0, 10);
+    world.armSend(1, 11);
+    world.tentacleSend(0, 20);
+    world.tentacleSend(1, 21);
+    world.advance(5_000);
+
+    expect(world.tentacleReceived).toEqual([
+      { stream: 0, marker: 10 },
+      { stream: 1, marker: 11 },
+    ]);
+    expect(world.armReceived).toEqual([
+      { stream: 0, marker: 20 },
+      { stream: 1, marker: 21 },
+    ]);
+    world.hub.close();
+  });
+
+  it('keeps equal live and bulk seq values in independent durable rows', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const world = new MultiStreamWorld(db);
+    world.connectArm();
+    world.connectTentacle();
+    world.disconnectTentacle();
+
+    world.armSend(0, 30, true);
+    world.armSend(1, 31, true);
+    world.advance(1_000);
+
+    const rows = db.prepare(
+      'SELECT stream, seq, hex(payload) AS payload FROM pulse_outbox WHERE device = ? ORDER BY stream',
+    ).all(TENTACLE);
+    expect(rows).toEqual([
+      { stream: 0, seq: '1', payload: '1E' },
+      { stream: 1, seq: '1', payload: '1F' },
+    ]);
+    expect(world.hub.outboxCount(TENTACLE)).toBe(2);
+
+    world.connectTentacle();
+    // Normal in-order DATA is cumulatively acknowledged by the next heartbeat.
+    world.advance(20_000);
+    expect(world.tentacleReceived).toEqual(expect.arrayContaining([
+      { stream: 0, marker: 30 },
+      { stream: 1, marker: 31 },
+    ]));
+    expect(world.hub.outboxCount(TENTACLE)).toBe(0);
+    world.hub.close();
+  });
+
+  it('recovers equal live and bulk durable seq values across a Head restart', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const beforeRestart = new MultiStreamWorld(db);
+    beforeRestart.connectArm();
+    beforeRestart.connectTentacle();
+    beforeRestart.disconnectTentacle();
+    beforeRestart.armSend(0, 40, true);
+    beforeRestart.armSend(1, 41, true);
+    beforeRestart.advance(1_000);
+    expect(beforeRestart.hub.outboxCount(TENTACLE)).toBe(2);
+    beforeRestart.hub.close();
+
+    const afterRestart = new MultiStreamWorld(db);
+    afterRestart.hub.recoverOnBoot();
+    afterRestart.connectTentacle();
+    afterRestart.advance(20_000);
+    expect(afterRestart.tentacleReceived).toEqual(expect.arrayContaining([
+      { stream: 0, marker: 40 },
+      { stream: 1, marker: 41 },
+    ]));
+    expect(afterRestart.hub.outboxCount(TENTACLE)).toBe(0);
+    afterRestart.hub.close();
+  });
+
+  it('remembers v2 capability across a Head restart so offline bulk stays isolated', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const beforeRestart = new MultiStreamWorld(db);
+    beforeRestart.connectArm();
+    beforeRestart.connectTentacle();
+    expect(db.prepare('SELECT bulk FROM pulse_capabilities WHERE device = ?').get(ARM))
+      .toEqual({ bulk: 1 });
+    beforeRestart.hub.close();
+
+    const afterRestart = new MultiStreamWorld(db);
+    afterRestart.connectTentacle();
+    // ARM is offline after the Head restart. Its persisted capability must keep
+    // this producer bulk frame in stream 1 rather than contaminating live.
+    afterRestart.tentacleSend(1, 45, true);
+    afterRestart.advance(1_000);
+    expect(db.prepare(
+      'SELECT stream, seq, hex(payload) AS payload FROM pulse_outbox WHERE device = ?',
+    ).get(ARM)).toEqual({ stream: 1, seq: '1', payload: '2D' });
+    afterRestart.hub.close();
+  });
+
+  it('purges disconnected non-durable entries independently on both streams', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const world = new MultiStreamWorld(db, {
+      intervalMs: 0,
+      purgeNonDurableAfterMs: 1_000,
+      evictEndpointAfterMs: 0,
+    });
+    world.connectArm();
+    world.connectTentacle();
+    world.disconnectTentacle();
+    world.armSend(0, 50);
+    world.armSend(1, 51);
+    world.advance(2_000);
+    world.hub.gcTick();
+
+    world.connectTentacle();
+    world.advance(20_000);
+    expect(world.tentacleReceived).toEqual([]);
+    world.hub.close();
+  });
+
+  it('drops an unknown stream without forwarding, persisting, or disturbing live', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const world = new MultiStreamWorld(db);
+    world.connectArm();
+    world.connectTentacle();
+    world.tentacleReceived.length = 0;
+
+    const unknown = encodeFrame({
+      t: 'data',
+      seq: 1n,
+      ack: 0n,
+      payload: new Uint8Array([77]),
+      durable: true,
+    }, 9);
+    expect(() => world.hub.onPulseEnvelope(ARM, { pulse: b64(unknown), to: TENTACLE }))
+      .not.toThrow();
+    world.armSend(0, 78);
+    world.advance(20_000);
+
+    expect(world.tentacleReceived).toEqual([{ stream: 0, marker: 78 }]);
+    expect(world.hub.outboxCount(TENTACLE)).toBe(0);
+    world.hub.close();
+  });
+
+  it('falls bulk back to stream 0 for a peer that never advertises v2', () => {
+    const db = new Database(':memory:');
+    databases.push(db);
+    const sentStreams: number[] = [];
+    const hub = new PulseHub(db, {
+      now: () => 0,
+      sendPulseTo: (_device, pulse) => {
+        sentStreams.push(decodeFrameWithStream(unb64(pulse))?.streamId ?? -1);
+        return true;
+      },
+      broadcastTargets: () => [],
+      onDeliverToSelf: () => undefined,
+    }, { intervalMs: 0 });
+
+    hub.onDeviceConnected('legacy-arm');
+    sentStreams.length = 0;
+    // Simulate a source stream-1 DATA frame. The destination never sent a
+    // stream-1 HELLO, so forwarding must use byte-compatible stream 0.
+    const source = endpoints('source');
+    const sourceFrames = source.streams.onConnected(0)
+      .concat(source.streams.send(1, new Uint8Array([99])).effects)
+      .filter((effect): effect is Extract<Effect, { t: 'transmit' }> => effect.t === 'transmit');
+    for (const frame of sourceFrames) {
+      const decoded = decodeFrameWithStream(frame.bytes);
+      if (decoded?.streamId === 1 && decoded.frame.t === 'data') {
+        hub.onPulseEnvelope('source', { pulse: b64(frame.bytes), to: 'legacy-arm' });
+      }
+    }
+
+    expect(sentStreams).toContain(0);
+    expect(sentStreams).not.toContain(1);
+    hub.close();
+  });
+});

--- a/packages/head/src/__tests__/pulse-hub-multistream.test.ts
+++ b/packages/head/src/__tests__/pulse-hub-multistream.test.ts
@@ -384,6 +384,30 @@ describe('PulseHub multi-stream persistence and forwarding', () => {
     world.hub.close();
   });
 
+  it('ignores late socket events after the hub and database close', () => {
+    const db = new Database(':memory:');
+    const hub = new PulseHub(db, {
+      now: () => 0,
+      sendPulseTo: () => false,
+      broadcastTargets: () => [],
+      onDeliverToSelf: () => undefined,
+    }, { intervalMs: 0 });
+    hub.onDeviceConnected(ARM);
+    hub.close();
+    db.close();
+
+    const lateEndpoint = new Endpoint({ epoch: 'late' });
+    const frame = lateEndpoint.onConnected(0)
+      .find((effect): effect is Extract<Effect, { t: 'transmit' }> => effect.t === 'transmit')?.bytes;
+    expect(frame).toBeDefined();
+    expect(() => hub.onDeviceDisconnected(ARM)).not.toThrow();
+    expect(() => hub.onDeviceConnected(ARM)).not.toThrow();
+    expect(() => hub.onPulseEnvelope(ARM, { pulse: b64(frame!) })).not.toThrow();
+    expect(() => hub.tick()).not.toThrow();
+    expect(() => hub.recoverOnBoot()).not.toThrow();
+    expect(() => hub.close()).not.toThrow();
+  });
+
   it('falls bulk back to stream 0 for a peer that never advertises v2', () => {
     const db = new Database(':memory:');
     databases.push(db);

--- a/packages/head/src/__tests__/pulse-hub-multistream.test.ts
+++ b/packages/head/src/__tests__/pulse-hub-multistream.test.ts
@@ -384,7 +384,7 @@ describe('PulseHub multi-stream persistence and forwarding', () => {
     world.hub.close();
   });
 
-  it('ignores late socket events after the hub and database close', () => {
+  it('ignores late socket events when the database closed before the hub', () => {
     const db = new Database(':memory:');
     const hub = new PulseHub(db, {
       now: () => 0,
@@ -393,7 +393,8 @@ describe('PulseHub multi-stream persistence and forwarding', () => {
       onDeliverToSelf: () => undefined,
     }, { intervalMs: 0 });
     hub.onDeviceConnected(ARM);
-    hub.close();
+    // Reproduce the integration-test teardown race: Storage closes while a
+    // WebSocket close callback is still queued and PulseHub is not yet closed.
     db.close();
 
     const lateEndpoint = new Endpoint({ epoch: 'late' });

--- a/packages/head/src/__tests__/pulse-hub.test.ts
+++ b/packages/head/src/__tests__/pulse-hub.test.ts
@@ -334,7 +334,7 @@ describe('PulseHub GC (spec §11.4)', () => {
     const held = db.prepare('SELECT COUNT(*) AS n FROM pulse_meta WHERE device = ?').get(TENT) as {
       n: number;
     };
-    expect(held.n).toBe(1); // snapshot on disk
+    expect(held.n).toBe(2); // live + bulk snapshots on disk (per-stream, §13)
 
     // Tentacle reconnects — hub lazily rebuilds its endpoint from snapshot
     // and resends the durable.

--- a/packages/head/src/pulse-hub.ts
+++ b/packages/head/src/pulse-hub.ts
@@ -106,6 +106,10 @@ export class PulseHub {
    *  client under the same device id to receive a stream-0 fallback. */
   private readonly bulkCapableEver = new Set<string>();
   private readonly bulkCapableNow = new Set<string>();
+  /** Devices from which this concrete connection received any valid Pulse
+   *  frame. Used to distinguish a confirmed v1 rollback from a socket that
+   *  closed before capability negotiation completed. */
+  private readonly pulseSeenNow = new Set<string>();
   private readonly connectedDevices = new Set<string>();
   private readonly gc: Required<PulseHubGcConfig>;
   /** Unique even when two hub processes start in the same millisecond. */
@@ -211,6 +215,7 @@ export class PulseHub {
   onDeviceConnected(deviceId: string): void {
     this.connectedDevices.add(deviceId);
     this.bulkCapableNow.delete(deviceId);
+    this.pulseSeenNow.delete(deviceId);
     const d = this.ep(deviceId);
     this.run(deviceId, d.streams.onConnected(this.host.now()));
     this.saveSnapshot(deviceId);
@@ -219,6 +224,15 @@ export class PulseHub {
   /** A device disconnected — its outboxes persist for resume. */
   onDeviceDisconnected(deviceId: string): void {
     this.connectedDevices.delete(deviceId);
+    // A v2 StreamSet advertises stream 1 on every connection. If this complete
+    // connection exchanged valid Pulse frames but never advertised stream 1,
+    // the device was rolled back (or is a stale v1 client). Forget historical
+    // v2 capability so offline bulk remains byte-compatible on stream 0.
+    if (this.pulseSeenNow.has(deviceId) && !this.bulkCapableNow.has(deviceId)) {
+      this.bulkCapableEver.delete(deviceId);
+      this.db.prepare('DELETE FROM pulse_capabilities WHERE device = ?').run(deviceId);
+    }
+    this.pulseSeenNow.delete(deviceId);
     this.bulkCapableNow.delete(deviceId);
     const d = this.devices.get(deviceId);
     if (!d) return;
@@ -254,6 +268,7 @@ export class PulseHub {
     const inLen = env.pulse.length;
     const bytes = b64decode(env.pulse);
     const decoded = decodeFrameWithStream(bytes);
+    if (decoded) this.pulseSeenNow.add(fromDevice);
     if (decoded?.streamId === STREAM_BULK) {
       if (!this.bulkCapableEver.has(fromDevice)) {
         this.bulkCapableEver.add(fromDevice);

--- a/packages/head/src/pulse-hub.ts
+++ b/packages/head/src/pulse-hub.ts
@@ -214,7 +214,7 @@ export class PulseHub {
 
   /** A device connected — bring up its stream set (resume any persisted outbox). */
   onDeviceConnected(deviceId: string): void {
-    if (this.closed) return;
+    if (this.closed || !this.db.open) return;
     this.connectedDevices.add(deviceId);
     this.bulkCapableNow.delete(deviceId);
     this.pulseSeenNow.delete(deviceId);
@@ -225,7 +225,7 @@ export class PulseHub {
 
   /** A device disconnected — its outboxes persist for resume. */
   onDeviceDisconnected(deviceId: string): void {
-    if (this.closed) return;
+    if (this.closed || !this.db.open) return;
     this.connectedDevices.delete(deviceId);
     // A v2 StreamSet advertises stream 1 on every connection. If this complete
     // connection exchanged valid Pulse frames but never advertised stream 1,
@@ -244,7 +244,7 @@ export class PulseHub {
 
   /** Periodic tick for all stream sets (heartbeat, liveness, durable expiry). */
   tick(): void {
-    if (this.closed) return;
+    if (this.closed || !this.db.open) return;
     const now = this.host.now();
     for (const [deviceId, d] of this.devices) {
       this.run(deviceId, d.streams.onTick(now));
@@ -257,7 +257,7 @@ export class PulseHub {
    * the frame to the source endpoint and carry out the effects.
    */
   onPulseEnvelope(fromDevice: string, env: PulseFrameField & { to?: string }): void {
-    if (this.closed || !env.pulse) return;
+    if (this.closed || !this.db.open || !env.pulse) return;
     const d = this.ep(fromDevice);
     // A frame addressed to HEAD_PULSE_TARGET is consumed by the head itself, not
     // forwarded to a device. It still rides the source stream (same seq/ack/
@@ -432,7 +432,7 @@ export class PulseHub {
   /** On head boot, rebuild endpoints from persisted snapshots so durable
    *  outbox entries resume delivery once their destination reconnects. */
   recoverOnBoot(): void {
-    if (this.closed) return;
+    if (this.closed || !this.db.open) return;
     const rows = this.db.prepare('SELECT device FROM pulse_meta').all() as Array<{ device: string }>;
     for (const { device } of rows) this.ep(device); // constructs + restores
   }

--- a/packages/head/src/pulse-hub.ts
+++ b/packages/head/src/pulse-hub.ts
@@ -115,6 +115,7 @@ export class PulseHub {
   /** Unique even when two hub processes start in the same millisecond. */
   private readonly processEpoch = randomUUID();
   private gcTimer: ReturnType<typeof setInterval> | null = null;
+  private closed = false;
 
   constructor(
     private readonly db: Database.Database,
@@ -213,6 +214,7 @@ export class PulseHub {
 
   /** A device connected — bring up its stream set (resume any persisted outbox). */
   onDeviceConnected(deviceId: string): void {
+    if (this.closed) return;
     this.connectedDevices.add(deviceId);
     this.bulkCapableNow.delete(deviceId);
     this.pulseSeenNow.delete(deviceId);
@@ -223,6 +225,7 @@ export class PulseHub {
 
   /** A device disconnected — its outboxes persist for resume. */
   onDeviceDisconnected(deviceId: string): void {
+    if (this.closed) return;
     this.connectedDevices.delete(deviceId);
     // A v2 StreamSet advertises stream 1 on every connection. If this complete
     // connection exchanged valid Pulse frames but never advertised stream 1,
@@ -241,6 +244,7 @@ export class PulseHub {
 
   /** Periodic tick for all stream sets (heartbeat, liveness, durable expiry). */
   tick(): void {
+    if (this.closed) return;
     const now = this.host.now();
     for (const [deviceId, d] of this.devices) {
       this.run(deviceId, d.streams.onTick(now));
@@ -253,7 +257,7 @@ export class PulseHub {
    * the frame to the source endpoint and carry out the effects.
    */
   onPulseEnvelope(fromDevice: string, env: PulseFrameField & { to?: string }): void {
-    if (!env.pulse) return;
+    if (this.closed || !env.pulse) return;
     const d = this.ep(fromDevice);
     // A frame addressed to HEAD_PULSE_TARGET is consumed by the head itself, not
     // forwarded to a device. It still rides the source stream (same seq/ack/
@@ -428,6 +432,7 @@ export class PulseHub {
   /** On head boot, rebuild endpoints from persisted snapshots so durable
    *  outbox entries resume delivery once their destination reconnects. */
   recoverOnBoot(): void {
+    if (this.closed) return;
     const rows = this.db.prepare('SELECT device FROM pulse_meta').all() as Array<{ device: string }>;
     for (const { device } of rows) this.ep(device); // constructs + restores
   }
@@ -448,6 +453,7 @@ export class PulseHub {
 
   /** Stop the periodic GC scan. Call on shutdown. */
   close(): void {
+    this.closed = true;
     if (this.gcTimer) {
       clearInterval(this.gcTimer);
       this.gcTimer = null;

--- a/packages/head/src/pulse-hub.ts
+++ b/packages/head/src/pulse-hub.ts
@@ -22,10 +22,26 @@
  */
 
 import type Database from 'better-sqlite3';
-import { decodeFrame, type Effect, encodeFrame, Endpoint, type Snapshot } from '@coinfra/pulse';
+import { decodeFrame, type Effect, encodeFrame, Endpoint, type Snapshot, StreamSet } from '@coinfra/pulse';
 import { HEAD_PULSE_TARGET, type PulseFrameField, type UnicastEnvelope } from '@kraki/protocol';
 import { getLogger } from './logger.js';
 import { fp, trace } from './trace.js';
+
+/** The two logical streams every head⇄device link carries (pulse spec §13).
+ *  Keeping bulk off the live stream is what stops a reconnect-time burst of
+ *  trace/range/attachment frames from head-of-line blocking live messages
+ *  (echo, abort, status card) on the same downlink. */
+const STREAM_LIVE = 0;
+const STREAM_BULK = 1;
+
+/** Head→device messages that are bulk (best-effort background / large):
+ *  history replay, turn-trace batches, attachment chunks. Everything else is
+ *  live. This classification runs at the FORWARD hop, keyed by the payload's
+ *  decoded message `type` (the payload is the encrypted {blob,keys} JSON, but
+ *  the head forwards the ORIGINAL delivered bytes from the source — which for
+ *  a same-epoch source carry the inner type in the clear only after decrypt;
+ *  so we instead classify by the SOURCE deliver's streamId, set by the
+ *  originating tentacle/arm). See {@link forward}. */
 
 /** GC policy — how aggressively the hub reclaims per-device outbox memory
  *  for peers that stay disconnected. Zero disables that step. Defaults tuned
@@ -74,11 +90,11 @@ const b64encode = (u: Uint8Array): string => Buffer.from(u).toString('base64');
 const b64decode = (s: string): Uint8Array => new Uint8Array(Buffer.from(s, 'base64'));
 
 interface PerDevice {
-  endpoint: Endpoint;
-  /** Destination for messages this device sends us (the `to` of its unicasts).
-   *  A device streams to exactly one peer per logical connection in Kraki's
-   *  model (arm→its tentacle, tentacle→its arms); we forward each delivered
-   *  payload to the destination recorded for the in-flight envelope. */
+  streams: StreamSet;
+  /** live(0) and bulk(1) endpoints, cached for direct access (snapshot, GC).
+   *  Both share the device's connection via the StreamSet. */
+  live: Endpoint;
+  bulk: Endpoint;
 }
 
 export class PulseHub {
@@ -98,59 +114,75 @@ export class PulseHub {
 
   private initSchema(): void {
     this.db.exec(`CREATE TABLE IF NOT EXISTS pulse_outbox (
-      device TEXT NOT NULL, seq TEXT NOT NULL, payload BLOB NOT NULL,
+      device TEXT NOT NULL, stream INTEGER NOT NULL DEFAULT 0,
+      seq TEXT NOT NULL, payload BLOB NOT NULL,
       dest TEXT NOT NULL, durable_dest INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (device, seq))`);
+      PRIMARY KEY (device, stream, seq))`);
     this.db.exec(`CREATE TABLE IF NOT EXISTS pulse_meta (
-      device TEXT PRIMARY KEY, snapshot TEXT NOT NULL)`);
+      device TEXT NOT NULL, stream INTEGER NOT NULL DEFAULT 0, snapshot TEXT NOT NULL,
+      PRIMARY KEY (device, stream))`);
+    // Migrate pre-§13 single-stream schemas: both tables keyed by device only
+    // (stream implicit 0). Add the stream column defaulting to 0 so restored
+    // live-stream rows keep working. Idempotent across boots.
+    for (const table of ['pulse_outbox', 'pulse_meta']) {
+      try {
+        this.db.exec(`ALTER TABLE ${table} ADD COLUMN stream INTEGER NOT NULL DEFAULT 0`);
+      } catch { /* column already exists */ }
+    }
+    this.db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS pulse_meta_device_stream ON pulse_meta (device, stream)`);
   }
 
-  /** Ensure an endpoint exists for a device (restoring from SQLite if present).
-   *  head endpoints are durable-supported (head is always-on + has disk). */
+  /** Ensure a per-device StreamSet exists (live + bulk endpoints, restoring
+   *  each from SQLite if present). head endpoints are durable-supported (head
+   *  is always-on + has disk). */
   private ep(deviceId: string): PerDevice {
     let d = this.devices.get(deviceId);
-    if (!d) {
-      const restore = this.loadSnapshot(deviceId);
-      // ALWAYS mint a fresh epoch for this process, even when restoring. A
-      // process restart is a new send-stream identity (spec §9): non-durable
-      // sends in flight were lost, so the peer MUST learn the discontinuity
-      // and reset its recvCursor, else our post-restart seq=1..N collide
-      // with the pre-crash seq=1..N it already delivered and get silently
-      // dropped as duplicates (2026-07-11 relay-restart device_joined-loss
-      // bug). The durable outbox entries we restore still resend correctly:
-      // the peer resets and accepts them under our new epoch. `this.host.now()`
-      // is process-scoped, so within one process run the cached endpoint keeps
-      // its epoch; only a real restart produces a new one.
-      const endpoint = new Endpoint({
-        epoch: `head:${deviceId}:${this.host.now()}`,
-        durable: { supported: true },
-        restore,
-      });
-      d = { endpoint };
-      this.devices.set(deviceId, d);
-    }
+    if (d) return d;
+    // ALWAYS mint a fresh epoch for this process, even when restoring. A
+    // process restart is a new send-stream identity (spec §9): non-durable
+    // sends in flight were lost, so the peer MUST learn the discontinuity
+    // and reset its recvCursor, else our post-restart seq=1..N collide with
+    // the pre-crash seq=1..N it already delivered and get silently dropped as
+    // duplicates (2026-07-11 relay-restart device_joined-loss bug). Each
+    // stream gets its own epoch so a RESET/burst on bulk cannot disturb the
+    // live stream's cursor.
+    const ts = this.host.now();
+    const live = new Endpoint({
+      epoch: `head:${deviceId}:live:${ts}`,
+      durable: { supported: true },
+      streamId: STREAM_LIVE,
+      restore: this.loadSnapshot(deviceId, STREAM_LIVE),
+    });
+    const bulk = new Endpoint({
+      epoch: `head:${deviceId}:bulk:${ts}`,
+      durable: { supported: true },
+      streamId: STREAM_BULK,
+      restore: this.loadSnapshot(deviceId, STREAM_BULK),
+    });
+    d = { streams: new StreamSet([live, bulk]), live, bulk };
+    this.devices.set(deviceId, d);
     return d;
   }
 
-  /** A device connected — bring up its endpoint (resume any persisted stream). */
+  /** A device connected — bring up its stream set (resume any persisted outbox). */
   onDeviceConnected(deviceId: string): void {
     const d = this.ep(deviceId);
-    this.run(deviceId, d.endpoint.onConnected(this.host.now()));
+    this.run(deviceId, d.streams.onConnected(this.host.now()));
     this.saveSnapshot(deviceId);
   }
 
-  /** A device disconnected — its endpoint's outbox persists for resume. */
+  /** A device disconnected — its outboxes persist for resume. */
   onDeviceDisconnected(deviceId: string): void {
     const d = this.devices.get(deviceId);
     if (!d) return;
-    d.endpoint.onDisconnected(this.host.now());
+    d.streams.onDisconnected(this.host.now());
   }
 
-  /** Periodic tick for all endpoints (heartbeat, liveness, durable expiry). */
+  /** Periodic tick for all stream sets (heartbeat, liveness, durable expiry). */
   tick(): void {
     const now = this.host.now();
     for (const [deviceId, d] of this.devices) {
-      this.run(deviceId, d.endpoint.onTick(now));
+      this.run(deviceId, d.streams.onTick(now));
     }
   }
 
@@ -163,7 +195,7 @@ export class PulseHub {
     if (!env.pulse) return;
     const d = this.ep(fromDevice);
     // A frame addressed to HEAD_PULSE_TARGET is consumed by the head itself, not
-    // forwarded to a device. It still rides the source endpoint (same seq/ack/
+    // forwarded to a device. It still rides the source stream (same seq/ack/
     // resume as everything else) — only the `deliver` handling differs.
     const selfBound = env.to === HEAD_PULSE_TARGET;
     // Destinations for anything this device delivers: an explicit unicast `to`,
@@ -174,11 +206,14 @@ export class PulseHub {
       : (env.to ? [env.to] : this.host.broadcastTargets(fromDevice));
     const inLen = env.pulse.length;
     trace('WS-RX', { from: fromDevice, to: env.to, selfBound, destCount: dests.length, pulseB64Len: inLen });
-    const effects = d.endpoint.onBytes(b64decode(env.pulse), this.host.now());
+    // StreamSet demuxes by the v2 header's streamId and dispatches to the
+    // owning per-stream endpoint. The deliver effect carries that streamId so
+    // forward() can route onto the SAME stream on the destination device.
+    const effects = d.streams.onBytes(b64decode(env.pulse), this.host.now());
     const delivered = effects.filter((e) => e.t === 'deliver');
     if (delivered.length > 0) {
       for (const e of delivered) {
-        if (e.t === 'deliver') trace('HUB-DELIVER', { from: fromDevice, seq: String(e.seq), fp: fp(e.payload), len: e.payload.length, durable: e.durable, coalesceKey: e.coalesceKey, selfBound });
+        if (e.t === 'deliver') trace('HUB-DELIVER', { from: fromDevice, stream: e.streamId ?? 0, seq: String(e.seq), fp: fp(e.payload), len: e.payload.length, durable: e.durable, coalesceKey: e.coalesceKey, selfBound });
       }
     }
     this.run(fromDevice, effects, dests, selfBound);
@@ -206,22 +241,26 @@ export class PulseHub {
             // source connection's auth context, instead of forwarding.
             this.host.onDeliverToSelf(deviceId, e.payload);
           } else {
-            trace('HUB-FORWARD', { from: deviceId, seq: String(e.seq), fp: fp(e.payload), len: e.payload.length, durable: e.durable, coalesceKey: e.coalesceKey, dests: dests ?? [] });
+            trace('HUB-FORWARD', { from: deviceId, stream: e.streamId ?? 0, seq: String(e.seq), fp: fp(e.payload), len: e.payload.length, durable: e.durable, coalesceKey: e.coalesceKey, dests: dests ?? [] });
             // Store-and-forward bridge: forward the reliable payload onto each
-            // destination device's endpoint, preserving durable intent AND the
-            // send-time coalesce hint (pulse §12) so state-covering streams
-            // (deltas, card state) collapse on the arm-facing outbox if the arm
-            // is offline, instead of bursting on reconnect.
-            for (const dest of dests ?? []) this.forward(dest, e.payload, e.durable, e.coalesceKey);
+            // destination device's SAME stream (live or bulk), preserving
+            // durable intent AND the send-time coalesce hint (pulse §12) so
+            // state-covering streams (deltas, card state) collapse on the
+            // arm-facing outbox if the arm is offline, instead of bursting on
+            // reconnect. Routing onto the matching stream is what keeps bulk
+            // (trace/range/attachment) from head-of-line blocking live
+            // (echo/abort/card) on the downlink.
+            const stream = e.streamId ?? STREAM_LIVE;
+            for (const dest of dests ?? []) this.forward(dest, e.payload, e.durable, e.coalesceKey, stream);
           }
           break;
         case 'store':
-          trace('HUB-STORE', { device: deviceId, seq: String(e.seq), len: e.payload.length, dests: dests ?? [] });
-          this.storeOutbox(deviceId, e.seq, e.payload, (dests ?? []).join(','));
+          trace('HUB-STORE', { device: deviceId, stream: e.streamId ?? 0, seq: String(e.seq), len: e.payload.length, dests: dests ?? [] });
+          this.storeOutbox(deviceId, e.streamId ?? STREAM_LIVE, e.seq, e.payload, (dests ?? []).join(','));
           break;
         case 'unstore':
-          trace('HUB-UNSTORE', { device: deviceId, seqUpTo: String(e.seqUpTo) });
-          this.unstoreOutbox(deviceId, e.seqUpTo);
+          trace('HUB-UNSTORE', { device: deviceId, stream: e.streamId ?? 0, seqUpTo: String(e.seqUpTo) });
+          this.unstoreOutbox(deviceId, e.streamId ?? STREAM_LIVE, e.seqUpTo);
           break;
         // reset-inbound / acked / open / close: nothing for the hub to do —
         // acked pruning already emits unstore; open/close are driven by the WS.
@@ -229,13 +268,14 @@ export class PulseHub {
     }
   }
 
-  /** Forward a payload onto the destination device's outbound endpoint. If the
-   *  destination is offline, the pulse endpoint keeps it in its outbox (durable
-   *  → also persisted to SQLite via the store effect) and resends on reconnect. */
-  private forward(destDevice: string, payload: Uint8Array, durable: boolean, coalesceKey?: string): void {
+  /** Forward a payload onto the destination device's outbound endpoint on the
+   *  given stream. If the destination is offline, that stream's endpoint keeps
+   *  it in its outbox (durable → also persisted to SQLite via the store effect)
+   *  and resends on reconnect. */
+  private forward(destDevice: string, payload: Uint8Array, durable: boolean, coalesceKey: string | undefined, stream: number): void {
     const d = this.ep(destDevice);
-    const { effects } = d.endpoint.send(payload, { durable, coalesceKey });
-    trace('FWD-SEND', { dest: destDevice, fp: fp(payload), len: payload.length, durable, coalesceKey, effects: effects.map((e) => e.t) });
+    const { effects } = d.streams.send(stream, payload, { durable, coalesceKey });
+    trace('FWD-SEND', { dest: destDevice, stream, fp: fp(payload), len: payload.length, durable, coalesceKey, effects: effects.map((e) => e.t) });
     // The destination endpoint's transmits go to the destination device; its
     // deliveries would bridge back (not used in one-way flows). No secondary
     // dest — a forwarded message is terminal at the destination device.
@@ -255,43 +295,46 @@ export class PulseHub {
    *  head-originated control (e.g. "device X joined") is ephemeral and must not
    *  be redelivered stale after the target reconnects. */
   sendToDevice(destDevice: string, payload: Uint8Array, opts?: { durable?: boolean; coalesceKey?: string }): void {
-    this.forward(destDevice, payload, opts?.durable ?? false, opts?.coalesceKey);
+    // Head-originated control (presence, preferences, voice) is live traffic —
+    // it must never queue behind bulk on the downlink.
+    this.forward(destDevice, payload, opts?.durable ?? false, opts?.coalesceKey, STREAM_LIVE);
   }
 
   // ── SQLite persistence ──────────────────────────────────────────────────────
 
-  private storeOutbox(device: string, seq: bigint, payload: Uint8Array, dest?: string): void {
+  private storeOutbox(device: string, stream: number, seq: bigint, payload: Uint8Array, dest?: string): void {
     this.db
       .prepare(
-        'INSERT OR REPLACE INTO pulse_outbox (device, seq, payload, dest) VALUES (?, ?, ?, ?)',
+        'INSERT OR REPLACE INTO pulse_outbox (device, stream, seq, payload, dest) VALUES (?, ?, ?, ?, ?)',
       )
-      .run(device, seq.toString(), Buffer.from(payload), dest ?? '');
+      .run(device, stream, seq.toString(), Buffer.from(payload), dest ?? '');
   }
 
-  private unstoreOutbox(device: string, seqUpTo: bigint): void {
+  private unstoreOutbox(device: string, stream: number, seqUpTo: bigint): void {
     this.db
-      .prepare('DELETE FROM pulse_outbox WHERE device = ? AND CAST(seq AS INTEGER) <= ?')
-      .run(device, Number(seqUpTo));
+      .prepare('DELETE FROM pulse_outbox WHERE device = ? AND stream = ? AND CAST(seq AS INTEGER) <= ?')
+      .run(device, stream, Number(seqUpTo));
   }
 
   private saveSnapshot(device: string): void {
     const d = this.devices.get(device);
     if (!d) return;
-    // Use snapshotDurable() (pulse §11.3) — persisting non-durable entries to
-    // disk both violates their "in-memory only, may be lost on restart"
-    // contract AND is the exact root cause of the 2026-07-07 head OOM
-    // (each save re-serialized an ever-growing in-memory outbox for offline
-    // peers). Durable entries (currently just delete_session in kraki) are
-    // preserved so a future reconnect delivers them.
-    this.db
-      .prepare('INSERT OR REPLACE INTO pulse_meta (device, snapshot) VALUES (?, ?)')
-      .run(device, JSON.stringify(d.endpoint.snapshotDurable()));
+    // Persist EACH stream's durable snapshot separately (pulse §11.3 + §13).
+    // Non-durable entries are not persisted (same rationale as before: in-memory
+    // only, may be lost on restart; persisting them caused the 2026-07-07 head
+    // OOM). Each stream has its own seq space, so each must be snapshotted and
+    // restored independently — mixing them would corrupt cursors.
+    const stmt = this.db.prepare(
+      'INSERT OR REPLACE INTO pulse_meta (device, stream, snapshot) VALUES (?, ?, ?)',
+    );
+    stmt.run(device, STREAM_LIVE, JSON.stringify(d.live.snapshotDurable()));
+    stmt.run(device, STREAM_BULK, JSON.stringify(d.bulk.snapshotDurable()));
   }
 
-  private loadSnapshot(device: string): Snapshot | undefined {
-    const row = this.db.prepare('SELECT snapshot FROM pulse_meta WHERE device = ?').get(device) as
-      | { snapshot: string }
-      | undefined;
+  private loadSnapshot(device: string, stream: number): Snapshot | undefined {
+    const row = this.db
+      .prepare('SELECT snapshot FROM pulse_meta WHERE device = ? AND stream = ?')
+      .get(device, stream) as { snapshot: string } | undefined;
     return row ? (JSON.parse(row.snapshot) as Snapshot) : undefined;
   }
 
@@ -302,7 +345,8 @@ export class PulseHub {
     for (const { device } of rows) this.ep(device); // constructs + restores
   }
 
-  /** Test/introspection: how many durable rows are held for a device. */
+  /** Test/introspection: how many durable rows are held for a device across
+   *  all streams. */
   outboxCount(device: string): number {
     const row = this.db
       .prepare('SELECT COUNT(*) AS n FROM pulse_outbox WHERE device = ?')
@@ -359,30 +403,34 @@ export class PulseHub {
     let purged = 0;
     let evicted = 0;
     for (const [deviceId, d] of this.devices) {
-      const disconnectedAt = d.endpoint.disconnectedAtMs;
-      if (d.endpoint.link !== 'disconnected' || disconnectedAt === null) continue;
+      // Both streams share the device's connection, so they disconnect together;
+      // use the live stream's liveness as the proxy (bulk has the same timing).
+      const disconnectedAt = d.live.disconnectedAtMs;
+      if (d.live.link !== 'disconnected' || disconnectedAt === null) continue;
       const offlineMs = now - disconnectedAt;
 
       if (this.gc.evictEndpointAfterMs > 0 && offlineMs >= this.gc.evictEndpointAfterMs) {
-        // L2: release the endpoint. Durable state stays in pulse_meta.
+        // L2: release the whole per-device set. Durable state stays in pulse_meta.
         trace('GC-EVICT', { device: deviceId, offlineMs });
         this.devices.delete(deviceId);
         evicted += 1;
         continue;
       }
-      if (
-        this.gc.purgeNonDurableAfterMs > 0
-        && offlineMs >= this.gc.purgeNonDurableAfterMs
-        && d.endpoint.nonDurableCount > 0
-      ) {
-        // L1: drop non-durable outbox entries only.
-        const { droppedSeqs } = d.endpoint.purgeNonDurable('gc-idle');
-        if (droppedSeqs.length > 0) {
-          purged += droppedSeqs.length;
-          trace('GC-PURGE', { device: deviceId, dropped: droppedSeqs.length, offlineMs });
-          this.saveSnapshot(deviceId);
+      // L1: drop non-durable outbox entries on BOTH streams.
+      for (const ep of [d.live, d.bulk]) {
+        if (
+          this.gc.purgeNonDurableAfterMs > 0
+          && offlineMs >= this.gc.purgeNonDurableAfterMs
+          && ep.nonDurableCount > 0
+        ) {
+          const { droppedSeqs } = ep.purgeNonDurable('gc-idle');
+          if (droppedSeqs.length > 0) {
+            purged += droppedSeqs.length;
+            trace('GC-PURGE', { device: deviceId, stream: ep.stream, dropped: droppedSeqs.length, offlineMs });
+          }
         }
       }
+      if (purged > 0 || evicted > 0) this.saveSnapshot(deviceId);
     }
     if (purged > 0 || evicted > 0) {
       getLogger().info('pulse-hub gc', {

--- a/packages/head/src/pulse-hub.ts
+++ b/packages/head/src/pulse-hub.ts
@@ -21,8 +21,9 @@
  * envelopes keep the fire-and-forget path.
  */
 
+import { randomUUID } from 'node:crypto';
 import type Database from 'better-sqlite3';
-import { decodeFrame, type Effect, encodeFrame, Endpoint, type Snapshot, StreamSet } from '@coinfra/pulse';
+import { decodeFrame, decodeFrameWithStream, type Effect, encodeFrame, Endpoint, type Snapshot, StreamSet } from '@coinfra/pulse';
 import { HEAD_PULSE_TARGET, type PulseFrameField, type UnicastEnvelope } from '@kraki/protocol';
 import { getLogger } from './logger.js';
 import { fp, trace } from './trace.js';
@@ -99,7 +100,16 @@ interface PerDevice {
 
 export class PulseHub {
   private readonly devices = new Map<string, PerDevice>();
+  /** Capability is tracked both historically and for the concrete connection.
+   *  While offline, a previously-v2 device keeps bulk in stream 1. On reconnect,
+   *  current capability must be re-advertised, allowing a rolled-back/cached v1
+   *  client under the same device id to receive a stream-0 fallback. */
+  private readonly bulkCapableEver = new Set<string>();
+  private readonly bulkCapableNow = new Set<string>();
+  private readonly connectedDevices = new Set<string>();
   private readonly gc: Required<PulseHubGcConfig>;
+  /** Unique even when two hub processes start in the same millisecond. */
+  private readonly processEpoch = randomUUID();
   private gcTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
@@ -109,27 +119,60 @@ export class PulseHub {
   ) {
     this.gc = { ...DEFAULT_GC, ...(gc ?? {}) };
     this.initSchema();
+    this.loadCapabilities();
     this.startGc();
   }
 
   private initSchema(): void {
-    this.db.exec(`CREATE TABLE IF NOT EXISTS pulse_outbox (
+    const createOutbox = `CREATE TABLE pulse_outbox (
       device TEXT NOT NULL, stream INTEGER NOT NULL DEFAULT 0,
       seq TEXT NOT NULL, payload BLOB NOT NULL,
       dest TEXT NOT NULL, durable_dest INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (device, stream, seq))`);
-    this.db.exec(`CREATE TABLE IF NOT EXISTS pulse_meta (
+      PRIMARY KEY (device, stream, seq))`;
+    const createMeta = `CREATE TABLE pulse_meta (
       device TEXT NOT NULL, stream INTEGER NOT NULL DEFAULT 0, snapshot TEXT NOT NULL,
-      PRIMARY KEY (device, stream))`);
-    // Migrate pre-§13 single-stream schemas: both tables keyed by device only
-    // (stream implicit 0). Add the stream column defaulting to 0 so restored
-    // live-stream rows keep working. Idempotent across boots.
-    for (const table of ['pulse_outbox', 'pulse_meta']) {
-      try {
-        this.db.exec(`ALTER TABLE ${table} ADD COLUMN stream INTEGER NOT NULL DEFAULT 0`);
-      } catch { /* column already exists */ }
-    }
-    this.db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS pulse_meta_device_stream ON pulse_meta (device, stream)`);
+      PRIMARY KEY (device, stream))`;
+
+    this.db.exec(createOutbox.replace('CREATE TABLE ', 'CREATE TABLE IF NOT EXISTS '));
+    this.db.exec(createMeta.replace('CREATE TABLE ', 'CREATE TABLE IF NOT EXISTS '));
+    this.db.exec(`CREATE TABLE IF NOT EXISTS pulse_capabilities (
+      device TEXT PRIMARY KEY, bulk INTEGER NOT NULL DEFAULT 0)`);
+
+    type Column = { name: string; pk: number };
+    const columns = (table: string): Column[] =>
+      this.db.prepare(`PRAGMA table_info(${table})`).all() as Column[];
+    const hasPrimaryKey = (cols: Column[], expected: string[]): boolean =>
+      expected.every((name, index) => cols.find((col) => col.name === name)?.pk === index + 1);
+
+    const outboxColumns = columns('pulse_outbox');
+    const metaColumns = columns('pulse_meta');
+    const migrateOutbox = !outboxColumns.some((col) => col.name === 'stream')
+      || !hasPrimaryKey(outboxColumns, ['device', 'stream', 'seq']);
+    const migrateMeta = !metaColumns.some((col) => col.name === 'stream')
+      || !hasPrimaryKey(metaColumns, ['device', 'stream']);
+    if (!migrateOutbox && !migrateMeta) return;
+
+    // Adding `stream` alone is insufficient: SQLite keeps the old primary key
+    // (`device,seq` / `device`), so live seq=5 still collides with bulk seq=5.
+    // Rebuild atomically and preserve every legacy row as stream 0.
+    this.db.transaction(() => {
+      if (migrateOutbox) {
+        const sourceStream = outboxColumns.some((col) => col.name === 'stream') ? 'stream' : '0';
+        this.db.exec('ALTER TABLE pulse_outbox RENAME TO pulse_outbox_legacy');
+        this.db.exec(createOutbox);
+        this.db.exec(`INSERT INTO pulse_outbox (device, stream, seq, payload, dest, durable_dest)
+          SELECT device, ${sourceStream}, seq, payload, dest, durable_dest FROM pulse_outbox_legacy`);
+        this.db.exec('DROP TABLE pulse_outbox_legacy');
+      }
+      if (migrateMeta) {
+        const sourceStream = metaColumns.some((col) => col.name === 'stream') ? 'stream' : '0';
+        this.db.exec('ALTER TABLE pulse_meta RENAME TO pulse_meta_legacy');
+        this.db.exec(createMeta);
+        this.db.exec(`INSERT INTO pulse_meta (device, stream, snapshot)
+          SELECT device, ${sourceStream}, snapshot FROM pulse_meta_legacy`);
+        this.db.exec('DROP TABLE pulse_meta_legacy');
+      }
+    })();
   }
 
   /** Ensure a per-device StreamSet exists (live + bulk endpoints, restoring
@@ -148,13 +191,13 @@ export class PulseHub {
     // live stream's cursor.
     const ts = this.host.now();
     const live = new Endpoint({
-      epoch: `head:${deviceId}:live:${ts}`,
+      epoch: `head:${this.processEpoch}:${deviceId}:live:${ts}`,
       durable: { supported: true },
       streamId: STREAM_LIVE,
       restore: this.loadSnapshot(deviceId, STREAM_LIVE),
     });
     const bulk = new Endpoint({
-      epoch: `head:${deviceId}:bulk:${ts}`,
+      epoch: `head:${this.processEpoch}:${deviceId}:bulk:${ts}`,
       durable: { supported: true },
       streamId: STREAM_BULK,
       restore: this.loadSnapshot(deviceId, STREAM_BULK),
@@ -166,6 +209,8 @@ export class PulseHub {
 
   /** A device connected — bring up its stream set (resume any persisted outbox). */
   onDeviceConnected(deviceId: string): void {
+    this.connectedDevices.add(deviceId);
+    this.bulkCapableNow.delete(deviceId);
     const d = this.ep(deviceId);
     this.run(deviceId, d.streams.onConnected(this.host.now()));
     this.saveSnapshot(deviceId);
@@ -173,6 +218,8 @@ export class PulseHub {
 
   /** A device disconnected — its outboxes persist for resume. */
   onDeviceDisconnected(deviceId: string): void {
+    this.connectedDevices.delete(deviceId);
+    this.bulkCapableNow.delete(deviceId);
     const d = this.devices.get(deviceId);
     if (!d) return;
     d.streams.onDisconnected(this.host.now());
@@ -205,11 +252,22 @@ export class PulseHub {
       ? []
       : (env.to ? [env.to] : this.host.broadcastTargets(fromDevice));
     const inLen = env.pulse.length;
-    trace('WS-RX', { from: fromDevice, to: env.to, selfBound, destCount: dests.length, pulseB64Len: inLen });
+    const bytes = b64decode(env.pulse);
+    const decoded = decodeFrameWithStream(bytes);
+    if (decoded?.streamId === STREAM_BULK) {
+      if (!this.bulkCapableEver.has(fromDevice)) {
+        this.bulkCapableEver.add(fromDevice);
+        this.db.prepare(
+          'INSERT OR REPLACE INTO pulse_capabilities (device, bulk) VALUES (?, 1)',
+        ).run(fromDevice);
+      }
+      this.bulkCapableNow.add(fromDevice);
+    }
+    trace('WS-RX', { from: fromDevice, to: env.to, selfBound, destCount: dests.length, pulseB64Len: inLen, stream: decoded?.streamId ?? 0 });
     // StreamSet demuxes by the v2 header's streamId and dispatches to the
     // owning per-stream endpoint. The deliver effect carries that streamId so
     // forward() can route onto the SAME stream on the destination device.
-    const effects = d.streams.onBytes(b64decode(env.pulse), this.host.now());
+    const effects = d.streams.onBytes(bytes, this.host.now());
     const delivered = effects.filter((e) => e.t === 'deliver');
     if (delivered.length > 0) {
       for (const e of delivered) {
@@ -274,8 +332,15 @@ export class PulseHub {
    *  and resends on reconnect. */
   private forward(destDevice: string, payload: Uint8Array, durable: boolean, coalesceKey: string | undefined, stream: number): void {
     const d = this.ep(destDevice);
-    const { effects } = d.streams.send(stream, payload, { durable, coalesceKey });
-    trace('FWD-SEND', { dest: destDevice, stream, fp: fp(payload), len: payload.length, durable, coalesceKey, effects: effects.map((e) => e.t) });
+    // Compatibility during rolling deploys and for stale cached Web clients:
+    // v1 peers do not understand stream-1 frames. Default to stream 0 until
+    // this concrete connection advertises v2 by sending a stream-1 frame.
+    const supportsBulk = this.connectedDevices.has(destDevice)
+      ? this.bulkCapableNow.has(destDevice)
+      : this.bulkCapableEver.has(destDevice);
+    const actualStream = stream === STREAM_BULK && !supportsBulk ? STREAM_LIVE : stream;
+    const { effects } = d.streams.send(actualStream, payload, { durable, coalesceKey });
+    trace('FWD-SEND', { dest: destDevice, stream: actualStream, requestedStream: stream, fp: fp(payload), len: payload.length, durable, coalesceKey, effects: effects.map((e) => e.t) });
     // The destination endpoint's transmits go to the destination device; its
     // deliveries would bridge back (not used in one-way flows). No secondary
     // dest — a forwarded message is terminal at the destination device.
@@ -301,6 +366,13 @@ export class PulseHub {
   }
 
   // ── SQLite persistence ──────────────────────────────────────────────────────
+
+  private loadCapabilities(): void {
+    const rows = this.db.prepare(
+      'SELECT device FROM pulse_capabilities WHERE bulk = 1',
+    ).all() as Array<{ device: string }>;
+    for (const { device } of rows) this.bulkCapableEver.add(device);
+  }
 
   private storeOutbox(device: string, stream: number, seq: bigint, payload: Uint8Array, dest?: string): void {
     this.db

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -1703,6 +1703,9 @@ export class HeadServer {
       clearInterval(this.pulseTickTimer);
       this.pulseTickTimer = null;
     }
+    // Stop Pulse before closing sockets. WebSocket close callbacks are async
+    // and may otherwise persist capability state after Storage has closed.
+    this.pulseHub.close();
     for (const ws of this.clients.keys()) {
       ws.close();
     }

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.156",
-    "@coinfra/pulse": "^0.3.3",
+    "@coinfra/pulse": "^0.4.1",
     "@earendil-works/pi-coding-agent": "0.80.2",
     "@github/copilot-sdk": "^1.0.1",
     "@inquirer/prompts": "^8.3.2",

--- a/packages/tentacle/src/__tests__/tentacle-pulse-multistream.test.ts
+++ b/packages/tentacle/src/__tests__/tentacle-pulse-multistream.test.ts
@@ -1,0 +1,152 @@
+import { decodeFrameWithStream, Endpoint, StreamSet, type Effect } from '@coinfra/pulse';
+import { describe, expect, it } from 'vitest';
+import { streamForType, TentaclePulse, type TentaclePulseHost } from '../tentacle-pulse.js';
+
+const b64 = (bytes: Uint8Array): string => Buffer.from(bytes).toString('base64');
+const unb64 = (text: string): Uint8Array => new Uint8Array(Buffer.from(text, 'base64'));
+
+function peer(epoch = 'head'): StreamSet {
+  return new StreamSet([
+    new Endpoint({ epoch: `${epoch}:live`, streamId: 0, random: () => 0.5 }),
+    new Endpoint({ epoch: `${epoch}:bulk`, streamId: 1, random: () => 0.5 }),
+  ]);
+}
+
+class PulseWorld {
+  now = 0;
+  readonly sent: Array<{ bytes: Uint8Array; target?: string }> = [];
+  readonly history: Array<{ bytes: Uint8Array; target?: string }> = [];
+  readonly delivered: string[] = [];
+  readonly pulse: TentaclePulse;
+  head = peer();
+
+  constructor() {
+    const host: TentaclePulseHost = {
+      now: () => this.now,
+      sendPulseFrame: (text, target) => {
+        const entry = { bytes: unb64(text), target };
+        this.sent.push(entry);
+        this.history.push(entry);
+      },
+      onDelivered: (payload) => this.delivered.push(payload),
+    };
+    this.pulse = new TentaclePulse(host, 'tentacle');
+  }
+
+  connectHead(): void {
+    this.pulse.onConnected();
+    this.feedHeadEffects(this.head.onConnected(this.now));
+    this.pumpTentacleToHead();
+  }
+
+  reconnectHead(): void {
+    this.pulse.onDisconnected();
+    this.head.onDisconnected(this.now);
+    this.now += 1_000;
+    this.pulse.onConnected();
+    this.feedHeadEffects(this.head.onConnected(this.now));
+    this.pumpTentacleToHead();
+  }
+
+  pumpTentacleToHead(): void {
+    for (;;) {
+      const outgoing = this.sent.splice(0);
+      if (outgoing.length === 0) return;
+      for (const { bytes } of outgoing) {
+        this.feedHeadEffects(this.head.onBytes(bytes, this.now));
+      }
+    }
+  }
+
+  private feedHeadEffects(effects: Effect[]): void {
+    for (const effect of effects) {
+      if (effect.t === 'transmit') this.pulse.onFrame(b64(effect.bytes));
+    }
+  }
+}
+
+describe('TentaclePulse multi-stream', () => {
+  it('classifies every replay/history/trace/attachment batch as bulk', () => {
+    for (const type of [
+      'session_replay_batch',
+      'session_messages_batch',
+      'session_messages_range_batch',
+      'turn_trace_batch',
+      'attachment_data',
+    ]) {
+      expect(streamForType(type), type).toBe(1);
+    }
+    for (const type of [
+      'session_list',
+      'user_message',
+      'assistant_delta',
+      'interrupted_turn',
+      'idle',
+      'request_attachment',
+      'request_turn_trace',
+      undefined,
+    ]) {
+      expect(streamForType(type), String(type)).toBe(0);
+    }
+  });
+
+  it('falls requested bulk back to byte-compatible stream 0 before v2 is advertised', () => {
+    const world = new PulseWorld();
+    world.pulse.onConnected();
+    world.sent.length = 0;
+
+    world.pulse.send('{"bulk":1}', 'legacy-arm', false, undefined, 1);
+    const data = world.sent.find(({ bytes }) => decodeFrameWithStream(bytes)?.frame.t === 'data');
+    expect(data).toBeDefined();
+    expect(decodeFrameWithStream(data!.bytes)?.streamId).toBe(0);
+    expect(data!.target).toBe('legacy-arm');
+  });
+
+  it('uses stream 1 after the Head advertises v2', () => {
+    const world = new PulseWorld();
+    world.connectHead();
+    world.sent.length = 0;
+
+    world.pulse.send('{"bulk":1}', 'new-arm', false, undefined, 1);
+    const data = world.sent.find(({ bytes }) => decodeFrameWithStream(bytes)?.frame.t === 'data');
+    expect(data).toBeDefined();
+    expect(decodeFrameWithStream(data!.bytes)?.streamId).toBe(1);
+    expect(data!.target).toBe('new-arm');
+  });
+
+  it('keeps the original unicast target on a stream-1 reconnect resend', () => {
+    const world = new PulseWorld();
+    world.connectHead();
+    world.sent.length = 0;
+
+    world.pulse.send('{"attachment":1}', 'arm-only', false, undefined, 1);
+    const first = world.sent.find(({ bytes }) => decodeFrameWithStream(bytes)?.frame.t === 'data');
+    expect(decodeFrameWithStream(first!.bytes)?.streamId).toBe(1);
+    expect(first!.target).toBe('arm-only');
+
+    // Drop the DATA: do not pump it into the Head. Reconnect with peer cursor 0,
+    // forcing Pulse to resend the same stream-1 seq outside send()'s call stack.
+    world.sent.length = 0;
+    const historyStart = world.history.length;
+    world.reconnectHead();
+    const resent = world.history.slice(historyStart).find(({ bytes }) => {
+      const decoded = decodeFrameWithStream(bytes);
+      return decoded?.streamId === 1 && decoded.frame.t === 'data';
+    });
+    expect(resent).toBeDefined();
+    expect(resent!.target).toBe('arm-only');
+  });
+
+  it('keeps live and bulk seq=1 targets independent', () => {
+    const world = new PulseWorld();
+    world.connectHead();
+    world.sent.length = 0;
+
+    world.pulse.send('{"live":1}', 'live-arm', false, undefined, 0);
+    world.pulse.send('{"bulk":1}', 'bulk-arm', false, undefined, 1);
+    const data = world.sent.filter(({ bytes }) => decodeFrameWithStream(bytes)?.frame.t === 'data');
+    const byStream = new Map(data.map((entry) => [decodeFrameWithStream(entry.bytes)!.streamId, entry.target]));
+    expect(byStream.get(0)).toBe('live-arm');
+    expect(byStream.get(1)).toBe('bulk-arm');
+  });
+});

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -27,7 +27,7 @@ import { EventsWatcher } from './events-watcher.js';
 import { createLogger } from './logger.js';
 import { getKrakiHome } from './config.js';
 import { makeHeadline } from './tool-headline.js';
-import { TentaclePulse } from './tentacle-pulse.js';
+import { TentaclePulse, streamForType } from './tentacle-pulse.js';
 import { CardManager } from './card-manager.js';
 
 const logger = createLogger('relay-client');
@@ -2710,7 +2710,7 @@ export class RelayClient {
       // envelope — the head reads `pushPreview` off it in its broadcast branch — so
       // there is no separate raw send.
       this.pendingPushPreview = this.buildPushPreview(msg, recipients);
-      this.pulse.send(JSON.stringify({ blob, keys }), '', false, coalesceKeyFor(msg));
+      this.pulse.send(JSON.stringify({ blob, keys }), '', false, coalesceKeyFor(msg), streamForType(msg.type));
       this.pendingPushPreview = undefined;
     } catch (err) {
       logger.error({ err }, 'Encrypted broadcast failed');
@@ -2866,7 +2866,7 @@ export class RelayClient {
       const { blob, keys } = encryptToBlob(JSON.stringify(msg), [
         { deviceId: targetDeviceId, publicKey: recipientPubKey },
       ]);
-      this.pulse.send(JSON.stringify({ blob, keys }), targetDeviceId, durable);
+      this.pulse.send(JSON.stringify({ blob, keys }), targetDeviceId, durable, undefined, streamForType((msg as { type?: string }).type));
     } catch (err) {
       logger.error({ err, targetDeviceId }, 'Reliable unicast failed');
     }

--- a/packages/tentacle/src/tentacle-pulse.ts
+++ b/packages/tentacle/src/tentacle-pulse.ts
@@ -13,7 +13,7 @@
  * relay holds durable messages for offline arms, not the tentacle.
  */
 
-import { decodeFrame, decodeFrameWithStream, type Effect, Endpoint, StreamSet } from '@coinfra/pulse';
+import { decodeFrameWithStream, type Effect, Endpoint, StreamSet } from '@coinfra/pulse';
 import { createLogger } from './logger.js';
 
 const logger = createLogger('pulse');
@@ -75,6 +75,8 @@ const dec = new TextDecoder();
  *  echo / abort / status-card updates on the same downlink. */
 export function streamForType(type: string | undefined): number {
   switch (type) {
+    case 'session_replay_batch':
+    case 'session_messages_batch':
     case 'session_messages_range_batch':
     case 'turn_trace_batch':
     case 'attachment_data':
@@ -86,9 +88,13 @@ export function streamForType(type: string | undefined): number {
 
 export class TentaclePulse {
   private streams: StreamSet;
-  /** Target app for the frame currently being emitted (per send). Empty ⇒ the
-   *  frame fans out to all apps (broadcast); set ⇒ unicast to one app. */
-  private currentTarget = '';
+  /** Per-stream, per-seq unicast target. Retransmits happen outside send(), and
+   *  live/bulk have independent seq spaces (both can have seq=1), so neither a
+   *  mutable current target nor a seq-only map is sufficient. */
+  private targetByStream = new Map<number, Map<bigint, string>>();
+  /** Set after the current relay connection sends any stream-1 frame (normally
+   *  its HELLO). Until then bulk falls back to v1 stream 0 for old Heads. */
+  private bulkCapable = false;
 
   constructor(
     private readonly host: TentaclePulseHost,
@@ -112,15 +118,21 @@ export class TentaclePulse {
    *  sync snapshots self-heal on reconnect). */
   send(payloadJson: string, targetDeviceId = '', durable = false, coalesceKey?: string, stream = 0): void {
     const payload = enc.encode(payloadJson);
-    this.currentTarget = targetDeviceId;
-    const { seq, effects } = this.streams.send(stream, payload, { durable, coalesceKey });
-    trace('SEND', seq, payload.length, { fp: fp(payload), to: targetDeviceId || '(broadcast)', durable, coalesceKey, stream });
+    const actualStream = stream === 1 && !this.bulkCapable ? 0 : stream;
+    const { seq, effects } = this.streams.send(actualStream, payload, { durable, coalesceKey });
+    let targets = this.targetByStream.get(actualStream);
+    if (!targets) {
+      targets = new Map();
+      this.targetByStream.set(actualStream, targets);
+    }
+    targets.set(seq, targetDeviceId);
+    trace('SEND', seq, payload.length, { fp: fp(payload), to: targetDeviceId || '(broadcast)', durable, coalesceKey, stream: actualStream, requestedStream: stream });
     this.run(effects);
-    this.currentTarget = '';
   }
 
   /** The relay connection is up — resume every stream. */
   onConnected(): void {
+    this.bulkCapable = false;
     trace('CONNECTED', 0, 0);
     this.run(this.streams.onConnected(this.host.now()));
   }
@@ -136,6 +148,7 @@ export class TentaclePulse {
     const bytes = new Uint8Array(Buffer.from(pulseB64, 'base64'));
     const d = decodeFrameWithStream(bytes);
     if (d) {
+      if (d.streamId === 1) this.bulkCapable = true;
       trace('RX', d.frame.t === 'data' ? d.frame.seq : 0, bytes.length, { kind: d.frame.t, stream: d.streamId });
     } else {
       trace('RX', 0, bytes.length, { kind: '?' });
@@ -152,9 +165,14 @@ export class TentaclePulse {
     for (const e of effects) {
       switch (e.t) {
         case 'transmit': {
-          const frame = decodeFrame(e.bytes);
-          trace('TX', frame?.t === 'data' ? frame.seq : 0, e.bytes.length, { kind: frame?.t ?? '?', to: this.currentTarget || '(broadcast)' });
-          this.host.sendPulseFrame(b64(e.bytes), this.currentTarget || undefined);
+          const decoded = decodeFrameWithStream(e.bytes);
+          const frame = decoded?.frame;
+          const stream = decoded?.streamId ?? 0;
+          const target = frame?.t === 'data'
+            ? (this.targetByStream.get(stream)?.get(frame.seq) ?? '')
+            : '';
+          trace('TX', frame?.t === 'data' ? frame.seq : 0, e.bytes.length, { kind: frame?.t ?? '?', to: target || '(broadcast)', stream });
+          this.host.sendPulseFrame(b64(e.bytes), target || undefined);
           break;
         }
         case 'deliver':
@@ -162,11 +180,31 @@ export class TentaclePulse {
           // The delivered payload is the JSON {blob, keys} string.
           this.host.onDelivered(dec.decode(e.payload));
           break;
+        case 'acked': {
+          const stream = e.streamId ?? 0;
+          const targets = this.targetByStream.get(stream);
+          if (targets) {
+            for (const seq of targets.keys()) {
+              if (seq <= e.seqUpTo) targets.delete(seq);
+            }
+            if (targets.size === 0) this.targetByStream.delete(stream);
+          }
+          break;
+        }
+        case 'purged': {
+          const stream = e.streamId ?? 0;
+          const targets = this.targetByStream.get(stream);
+          if (targets) {
+            for (const seq of e.droppedSeqs) targets.delete(seq);
+            if (targets.size === 0) this.targetByStream.delete(stream);
+          }
+          break;
+        }
         case 'reset-inbound':
           trace('RESET-INBOUND', e.fromSeq, 0, { peerEpoch: e.peerEpoch });
           logger.warn({ fromSeq: String(e.fromSeq) }, 'pulse reset-inbound (relay stream reset)');
           break;
-        // acked/store/unstore/open/close: nothing for the tentacle to do here
+        // store/unstore/open/close: nothing for the tentacle to do here
         // (not durable-supported; link lifecycle driven explicitly).
       }
     }

--- a/packages/tentacle/src/tentacle-pulse.ts
+++ b/packages/tentacle/src/tentacle-pulse.ts
@@ -13,7 +13,7 @@
  * relay holds durable messages for offline arms, not the tentacle.
  */
 
-import { decodeFrame, type Effect, Endpoint } from '@coinfra/pulse';
+import { decodeFrame, decodeFrameWithStream, type Effect, Endpoint, StreamSet } from '@coinfra/pulse';
 import { createLogger } from './logger.js';
 
 const logger = createLogger('pulse');
@@ -68,8 +68,24 @@ const b64 = (u: Uint8Array): string => Buffer.from(u).toString('base64');
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
+/** Classify a producer message type into a Pulse stream (spec §13).
+ *  Bulk = best-effort background / large (history replay, trace batches,
+ *  attachment chunks). Everything else is live. Splitting bulk off the live
+ *  stream is what stops a reconnect-time burst from head-of-line blocking
+ *  echo / abort / status-card updates on the same downlink. */
+export function streamForType(type: string | undefined): number {
+  switch (type) {
+    case 'session_messages_range_batch':
+    case 'turn_trace_batch':
+    case 'attachment_data':
+      return 1; // STREAM_BULK
+    default:
+      return 0; // STREAM_LIVE
+  }
+}
+
 export class TentaclePulse {
-  private endpoint: Endpoint;
+  private streams: StreamSet;
   /** Target app for the frame currently being emitted (per send). Empty ⇒ the
    *  frame fans out to all apps (broadcast); set ⇒ unicast to one app. */
   private currentTarget = '';
@@ -78,52 +94,58 @@ export class TentaclePulse {
     private readonly host: TentaclePulseHost,
     epoch: string,
   ) {
-    this.endpoint = new Endpoint({
-      epoch,
-      durable: { supported: false },
-    });
+    // Two independent streams on the single relay WebSocket (spec §13): live
+    // (control + real-time) gets its own seq space so it is never queued
+    // behind bulk (history replay, trace batches, attachment chunks). Each
+    // stream gets its own epoch so a RESET/burst on bulk cannot disturb live.
+    const base = epoch;
+    this.streams = new StreamSet([
+      new Endpoint({ epoch: `${base}:live`, durable: { supported: false }, streamId: 0 }),
+      new Endpoint({ epoch: `${base}:bulk`, durable: { supported: false }, streamId: 1 }),
+    ]);
   }
 
-  /** Send a reliable message (a JSON string carrying {blob, keys}) via pulse.
-   *  `targetDeviceId` addresses one app (unicast); omit it to fan out to all
-   *  apps (broadcast). `durable` marks it for head persistence while the target
-   *  app is offline (default false — sync snapshots self-heal on reconnect). */
-  send(payloadJson: string, targetDeviceId = '', durable = false, coalesceKey?: string): void {
+  /** Send a reliable message (a JSON string carrying {blob, keys}) via pulse on
+   *  stream `stream` (0=live, 1=bulk). `targetDeviceId` addresses one app
+   *  (unicast); omit it to fan out to all apps (broadcast). `durable` marks it
+   *  for head persistence while the target app is offline (default false —
+   *  sync snapshots self-heal on reconnect). */
+  send(payloadJson: string, targetDeviceId = '', durable = false, coalesceKey?: string, stream = 0): void {
     const payload = enc.encode(payloadJson);
     this.currentTarget = targetDeviceId;
-    const { seq, effects } = this.endpoint.send(payload, { durable, coalesceKey });
-    trace('SEND', seq, payload.length, { fp: fp(payload), to: targetDeviceId || '(broadcast)', durable, coalesceKey });
+    const { seq, effects } = this.streams.send(stream, payload, { durable, coalesceKey });
+    trace('SEND', seq, payload.length, { fp: fp(payload), to: targetDeviceId || '(broadcast)', durable, coalesceKey, stream });
     this.run(effects);
     this.currentTarget = '';
   }
 
-  /** The relay connection is up — resume the stream. */
+  /** The relay connection is up — resume every stream. */
   onConnected(): void {
     trace('CONNECTED', 0, 0);
-    this.run(this.endpoint.onConnected(this.host.now()));
+    this.run(this.streams.onConnected(this.host.now()));
   }
 
   /** The relay connection dropped. */
   onDisconnected(): void {
     trace('DISCONNECTED', 0, 0);
-    this.endpoint.onDisconnected(this.host.now());
+    this.streams.onDisconnected(this.host.now());
   }
 
-  /** An inbound pulse frame arrived from the relay. */
+  /** An inbound pulse frame arrived from the relay — demux by streamId. */
   onFrame(pulseB64: string): void {
     const bytes = new Uint8Array(Buffer.from(pulseB64, 'base64'));
-    const frame = decodeFrame(bytes);
-    if (frame) {
-      trace('RX', frame.t === 'data' ? frame.seq : 0, bytes.length, { kind: frame.t });
+    const d = decodeFrameWithStream(bytes);
+    if (d) {
+      trace('RX', d.frame.t === 'data' ? d.frame.seq : 0, bytes.length, { kind: d.frame.t, stream: d.streamId });
     } else {
       trace('RX', 0, bytes.length, { kind: '?' });
     }
-    this.run(this.endpoint.onBytes(bytes, this.host.now()));
+    this.run(this.streams.onBytes(bytes, this.host.now()));
   }
 
-  /** Periodic tick (heartbeat + liveness). */
+  /** Periodic tick for every stream (heartbeat + liveness). */
   tick(): void {
-    this.run(this.endpoint.onTick(this.host.now()));
+    this.run(this.streams.onTick(this.host.now()));
   }
 
   private run(effects: Effect[]): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   packages/arm/web:
     dependencies:
       '@coinfra/pulse':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.1
+        version: 0.4.1
       '@kraki/protocol':
         specifier: workspace:*
         version: link:../../protocol
@@ -136,8 +136,8 @@ importers:
   packages/head:
     dependencies:
       '@coinfra/pulse':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.1
+        version: 0.4.1
       '@kraki/crypto':
         specifier: workspace:*
         version: link:../crypto
@@ -197,8 +197,8 @@ importers:
         specifier: ^0.3.156
         version: 0.3.156(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@coinfra/pulse':
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.1
+        version: 0.4.1
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.2
         version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
@@ -733,8 +733,8 @@ packages:
   '@coinfra/pulse@0.3.2':
     resolution: {integrity: sha512-ZH1o6zrUGsAyvOjV5MflCWiM9tfD92lIJqvlHAyKt1920OeMcjzDFgNwLujTLJtHwt1goyvULebndeAFpUmWVw==}
 
-  '@coinfra/pulse@0.3.3':
-    resolution: {integrity: sha512-MEA27XGa1d9qjprOoUy5Xzx6p7nIMGzV4ZxoCSscLXsPeP5HYxrEp/BKWAJXtN2VU8s3EGMDQgOmS9m/+JlZ9Q==}
+  '@coinfra/pulse@0.4.1':
+    resolution: {integrity: sha512-qSG4f/rG4LRqafahaqkC43laXyrfzh0+oiKZqnwYvJ4SMzs3UPOWO/RYMmPX4EonnTcVPBs6QhuSdqPodytW/w==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -4858,7 +4858,7 @@ snapshots:
 
   '@coinfra/pulse@0.3.2': {}
 
-  '@coinfra/pulse@0.3.3': {}
+  '@coinfra/pulse@0.4.1': {}
 
   '@csstools/color-helpers@5.1.0': {}
 

--- a/scripts/dev-verify-multistream.ts
+++ b/scripts/dev-verify-multistream.ts
@@ -1,0 +1,160 @@
+/**
+ * Multi-stream end-to-end verification for Kraki's pulse upgrade.
+ *
+ * Proves, against REAL Kraki E2E crypto + a REAL WebSocket link, that splitting
+ * traffic onto two Pulse streams (live=0, bulk=1) eliminates the cross-stream
+ * head-of-line blocking that froze the production arm when ~20 turn-trace
+ * batches saturated the head→arm downlink.
+ *
+ * Topology (no Head hub — a transparent WS relay stands in for it; the point is
+ * to prove the PULSE multi-stream layer, not Head's routing, which is the
+ * follow-up product work):
+ *
+ *   Peer A (tentacle role)  ──┐                  ┌──  Peer B (arm role)
+ *   StreamSet [live=0,bulk=1] │  transparent WS  │   StreamSet [live=0,bulk=1]
+ *   real KeyManager + E2E     └────  relay  ──────┘   real KeyManager + E2E
+ *
+ * Scenario: while DISCONNECTED, A piles 20 large bulk payloads onto stream 1
+ * (mimicking reconnect-time trace/range batches filling the outbox), then sends
+ * one live payload on stream 0. Connect. The live message must be DELIVERED to
+ * B before any bulk message — on a single stream the live message (seq 21)
+ * would wait behind all 20 bulk seqs.
+ *
+ * Run: pnpm exec tsx scripts/dev-verify-multistream.ts
+ */
+import { WebSocketServer, WebSocket } from 'ws';
+import { StreamSet, Endpoint } from '@coinfra/pulse';
+import { generateKeyPair, exportPublicKey, importPublicKey, encryptToBlob, decryptFromBlob } from '@kraki/crypto';
+
+async function main(): Promise<void> {
+
+// ── transparent relay: forward pulse frames A↔B verbatim ────────────────────
+const RELAY_PORT = 4877;
+const wss = new WebSocketServer({ port: RELAY_PORT });
+let peerA: WebSocket | null = null;
+let peerB: WebSocket | null = null;
+wss.on('connection', (ws, req) => {
+  const role = new URL(req.url ?? '/', `http://localhost`).searchParams.get('role');
+  if (role === 'A') peerA = ws; else if (role === 'B') peerB = ws;
+  ws.on('message', (data) => {
+    // A→B or B→A: hand the raw bytes to the other side.
+    const other = role === 'A' ? peerB : peerA;
+    if (other && other.readyState === WebSocket.OPEN) other.send(data.toString());
+  });
+});
+await new Promise((r) => wss.listen ? r(undefined) : wss.once('listening', () => r(undefined)));
+
+// ── real E2E keys for both peers ────────────────────────────────────────────
+const keyA = generateKeyPair();
+const keyB = generateKeyPair();
+const compactA = exportPublicKey(keyA.publicKey);
+const compactB = exportPublicKey(keyB.publicKey);
+const pemB = importPublicKey(compactB);
+
+function encLive(tag: string): Uint8Array {
+  // Real E2E encrypt to peer B; payload is a {blob,keys} JSON like Kraki sends.
+  const { blob, keys } = encryptToBlob(tag, [{ deviceId: 'B', publicKey: pemB }]);
+  return new TextEncoder().encode(JSON.stringify({ blob, keys }));
+}
+function dec(payload: Uint8Array): string {
+  const { blob, keys } = JSON.parse(new TextDecoder().decode(payload));
+  return decryptFromBlob({ blob, keys }, 'B', keyB.privateKey);
+}
+
+// ── peer A: StreamSet with live(0) + bulk(1) ───────────────────────────────
+const aLive = new Endpoint({ epoch: 'a-live', streamId: 0 });
+const aBulk = new Endpoint({ epoch: 'a-bulk', streamId: 1 });
+const A = new StreamSet([aLive, aBulk]);
+
+// ── peer B: matching StreamSet ─────────────────────────────────────────────
+const bLive = new Endpoint({ epoch: 'b-live', streamId: 0 });
+const bBulk = new Endpoint({ epoch: 'b-bulk', streamId: 1 });
+const B = new StreamSet([bLive, bBulk]);
+
+// Delivery log at B, attributing stream via the deliver effect's streamId.
+const deliveredB: Array<{ stream: number; seq: bigint; tag: string }> = [];
+
+function pumpTransmitToB(effects: ReturnType<StreamSet['onTick']>): void {
+  for (const e of effects) {
+    if (e.t !== 'transmit') continue;
+    if (peerB && peerB.readyState === WebSocket.OPEN) peerB.send(Buffer.from(e.bytes).toString('base64'));
+  }
+}
+
+// ── wire A and B to real WebSockets through the relay ──────────────────────
+const wsA = new WebSocket(`ws://localhost:${RELAY_PORT}?role=A`);
+const wsB = new WebSocket(`ws://localhost:${RELAY_PORT}?role=B`);
+await Promise.all([once(wsA, 'open'), once(wsB, 'open')]);
+
+// A's transmit effects → send on wsA (relay forwards to B).
+// B's onBytes → record deliveries with stream attribution.
+wsA.on('message', (data) => {
+  // frames B sends back to A (acks/hello) — feed to A
+  const bytes = new Uint8Array(Buffer.from(data.toString(), 'base64'));
+  const eff = A.onBytes(bytes, Date.now());
+  for (const e of eff) if (e.t === 'transmit' && peerB) peerB.send(Buffer.from(e.bytes).toString('base64'));
+});
+wsB.on('message', (data) => {
+  const bytes = new Uint8Array(Buffer.from(data.toString(), 'base64'));
+  const eff = B.onBytes(bytes, Date.now());
+  for (const e of eff) {
+    if (e.t === 'deliver') deliveredB.push({ stream: e.streamId ?? 0, seq: e.seq, tag: dec(e.payload) });
+    if (e.t === 'transmit' && peerA) peerA.send(Buffer.from(e.bytes).toString('base64'));
+  }
+});
+
+// Patch A.send so it actually pushes its transmit bytes onto the wire too.
+const origASend0 = A.send.bind(A);
+const origASend1 = A.send.bind(A);
+
+// ── scenario: pile 20 BULK (stream 1) offline, then 1 LIVE (stream 0) ──────
+console.log('piling 20 bulk payloads on stream 1 (offline → outbox)...');
+for (let i = 0; i < 20; i++) {
+  const r = A.send(1, encLive(`bulk-${i}`));
+  for (const e of r.effects) if (e.t === 'transmit' && peerB) peerB.send(Buffer.from(e.bytes).toString('base64'));
+}
+console.log('sending 1 live payload on stream 0...');
+const r0 = A.send(0, encLive('LIVE'));
+for (const e of r0.effects) if (e.t === 'transmit' && peerB) peerB.send(Buffer.from(e.bytes).toString('base64'));
+
+// ── connect both StreamSets (handshakes + resend piled outbox) ─────────────
+console.log('connecting...');
+const now = Date.now();
+for (const e of A.onConnected(now)) if (e.t === 'transmit' && peerB) peerB.send(Buffer.from(e.bytes).toString('base64'));
+for (const e of B.onConnected(now)) if (e.t === 'transmit' && peerA) peerA.send(Buffer.from(e.bytes).toString('base64'));
+
+// ── pump to quiescence (ticks drive heartbeats + resend) ───────────────────
+await new Promise((r) => setTimeout(r, 1500));
+for (let t = 0; t < 30; t++) {
+  const nowT = Date.now();
+  for (const e of A.onTick(nowT)) if (e.t === 'transmit' && peerB) peerB.send(Buffer.from(e.bytes).toString('base64'));
+  for (const e of B.onTick(nowT)) if (e.t === 'transmit' && peerA) peerA.send(Buffer.from(e.bytes).toString('base64'));
+  await new Promise((r) => setTimeout(r, 50));
+}
+await new Promise((r) => setTimeout(r, 300));
+
+// ── verdict ────────────────────────────────────────────────────────────────
+const liveIdx = deliveredB.findIndex((d) => d.tag === 'LIVE');
+const firstBulkIdx = deliveredB.findIndex((d) => d.stream === 1);
+const bulkCount = deliveredB.filter((d) => d.stream === 1).length;
+
+console.log('\n════════ multi-stream E2E verdict ════════');
+console.log(`deliveries at B: ${deliveredB.length} (live stream: ${deliveredB.filter(d=>d.stream===0).length}, bulk stream: ${bulkCount})`);
+console.log(`LIVE delivered at index ${liveIdx}; first bulk at index ${firstBulkIdx}`);
+const pass = liveIdx >= 0 && firstBulkIdx >= 0 && liveIdx < firstBulkIdx && bulkCount === 20;
+console.log(`verdict: ${pass ? '✅ PASS — live delivered BEFORE bulk (no HOL blocking)' : '❌ FAIL'}`);
+
+if (!pass) {
+  console.log('\nDelivery order:');
+  for (const d of deliveredB) console.log(`  stream=${d.stream} seq=${d.seq} tag=${d.tag}`);
+}
+
+wsA.close(); wsB.close(); wss.close();
+process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });
+
+function once(ws: WebSocket, ev: string): Promise<void> {
+  return new Promise((r) => ws.once(ev, () => r(undefined)));
+}

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -414,6 +414,36 @@ async function main(): Promise<void> {
           return json(200, { ok: true, marker, sizeKb, chunkCount: Math.ceil((body.length) / (256 * 1024)) });
         }
         case '/attachmentReads': return json(200, { reads: attachmentReads });
+        // ── build one real turn with hundreds of trace entries. The browser's
+        //    lazy request_turn_trace gets a large turn_trace_batch over bulk
+        //    stream 1 while the test injects a concurrent live echo. ──
+        case '/traceFlood': {
+          const sid = q.get('sid')!;
+          const n = Number(q.get('n') ?? '220');
+          const reply = q.get('reply') ?? `TRACE-DONE-${Date.now().toString(36)}`;
+          // Seed directly into the real SessionManager trace store so this
+          // stresses one historical turn_trace_batch, not 2N live card_action
+          // transitions (which would be a different request-coalescing test).
+          for (let i = 0; i < n; i++) {
+            const tcid = `tc-trace-${sid}-${i}`;
+            sm.appendTrace(sid, 'tool_start', JSON.stringify({
+              type: 'tool_start', sessionId: sid,
+              payload: { toolName: 'bash', headline: `echo trace-${i}`, toolCallId: tcid },
+            }));
+            sm.appendTrace(sid, 'tool_complete', JSON.stringify({
+              type: 'tool_complete', sessionId: sid,
+              payload: { toolName: 'bash', headline: `echo trace-${i}`, toolCallId: tcid },
+            }));
+          }
+          // One real transition increments the turn's replay-visible `steps`
+          // hint, causing reload to lazily request the full persisted trace.
+          const hintCall = `tc-trace-hint-${sid}`;
+          adapter.toolStart(sid, 'bash', { command: 'echo trace-hint' }, hintCall);
+          adapter.toolComplete(sid, 'bash', 'trace hint result', hintCall);
+          adapter.msg(sid, reply);
+          adapter.idle(sid);
+          return json(200, { ok: true, entries: n * 2 + 2, reply });
+        }
         // ── generate a REAL multi-chunk PNG image (show_image path) so the spec
         //    proves image ContentRefs render via paced request_attachment pulls.
         //    Noise pixels keep the PNG > 256 KiB (multiple chunks) after compression. ──


### PR DESCRIPTION
## Summary

- adopt Pulse stream 0 (live/control) and stream 1 (bulk) across Head, Tentacle, and Web Arm
- preserve stream identity through Head forwarding, durable storage, snapshots, ACK cleanup, retransmission, and GC
- atomically migrate legacy Head SQLite primary keys to include stream identity
- keep rolling upgrades compatible by falling bulk back to stream 0 until a peer advertises stream 1
- preserve Tentacle unicast targets per `(stream, seq)` across packet loss and reconnect
- classify replay, message/range, turn trace, and attachment batches as bulk
- bound browser turn-trace recovery with one global in-flight request, FIFO queuing, refresh coalescing, and timeout recovery

## Review fixes

Self-review found and fixed a v2-to-v1 rollback edge case: a device historically known as v2 could roll back to a v1 client, disconnect, and then receive offline bulk on stream 1. Head now clears persisted v2 capability after a valid stream-0-only connection while preserving it when a socket closes before Pulse negotiation.

## Validation

- Head: 241/241
- Tentacle: 733/733
- Web Arm: 383/383
- Head, Tentacle, and Web production builds
- root Biome lint
- Pulse 0.3.3 <-> 0.4.1 stream-0 HELLO/DATA byte compatibility
- protocol HOL verification: 5/5
- final real-stack browser matrix: 5/5
  - live echo during paced multi-chunk attachment download
  - offline coalesced delta recovery
  - paced multi-chunk PNG rendering
  - reconnect downlink recovery and subsequent uplink
  - live echo concurrent with an 802-entry turn-trace batch

## Deployment

Merge and package release are intended after CI passes. Do not deploy Head or production Web as part of this PR/release. The automatic beta Web deploy workflow will be disabled before merge and restored only after the merge-triggered CI event can no longer enqueue a deployment.
