### PR TITLE
chore(release): Pulse multi-stream packages

### DIFF
--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/arm-web",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Kraki web receiver — view and control your agents from any browser",
   "type": "module",
   "scripts": {

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.29.15",
+  "version": "0.29.16",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release versions

- `@kraki/tentacle` 0.29.16
- `@kraki/head` 0.16.5
- Web Arm 0.14.1

These versions release the Pulse multi-stream integration merged in #173.

## Deployment

Package publication and Tentacle release assets only. The `Deploy Web` workflow is manually disabled, and no Head or Web deployment will be triggered as part of this release.
