### PR TITLE
feat: single-session live subscriptions and opaque multicast

### DIFF
--- a/docs/session-subscription-protocol-proposal.md
+++ b/docs/session-subscription-protocol-proposal.md
@@ -1,0 +1,15 @@
+# Superseded Protocol Draft
+
+This English draft has been superseded by the reviewed single-session protocol proposal:
+
+- [`session-subscription-protocol-proposal.zh-CN.md`](./session-subscription-protocol-proposal.zh-CN.md)
+
+The authoritative v2 proposal intentionally removes:
+
+- capability negotiation and mixed-version compatibility;
+- plural session subscriptions;
+- `targetDeviceId` from the encrypted inner request;
+- subscription epoch and generation;
+- a dedicated `SessionAttentionMessage`.
+
+The accepted direction is a single current `sessionId | null`, a serialized page-entry request/ACK/snapshot assurance flow, existing `session_list[].preview` for online permission/question attention, independent offline push dispatch, and Head-visible opaque target-set multicast.

--- a/docs/session-subscription-protocol-proposal.zh-CN.md
+++ b/docs/session-subscription-protocol-proposal.zh-CN.md
@@ -1,0 +1,1375 @@
+# Single Session Subscription + Opaque Multicast 协议提案
+
+**状态：** Protocol / Head / Tentacle / Web 已实现并通过真实 dev-stack 验证；iOS 不在本次范围  
+**日期：** 2026-07-15  
+**基于版本：** `9848c4822c423763b02ca824cc86a473efd02e5b`（workspace `v0.29.16`，Head `v0.16.5`）  
+**范围：** 权威协议与已实现行为；本次实现覆盖 Protocol、Head、Tentacle、Web，不包含 iOS。  
+**版本策略：** 不考虑旧 Head、旧 Tentacle 或旧 Arm 的兼容；相关组件按同一协议版本发布。
+
+---
+
+## 1. 最终模型
+
+每个 Arm 在任一时刻最多只观看一个 session。
+
+因此 subscription 不是集合：
+
+```ts
+sessionId: string | null
+```
+
+含义：
+
+- `string`：当前 Arm 正在观看这个 session；
+- `null`：当前 Arm 没有观看任何 session；
+- A → B：直接把当前 subscription 从 A 原子替换为 B；
+- A → null：离开 session 页面；
+- 不支持一次订阅多个 session；
+- 不需要 `sessionIds[]`、generation 或 subscription epoch。
+
+核心链路：
+
+```text
+Arm --E2E unicast set_session_subscription(B)--> Tentacle
+
+Tentacle:
+  currentSessionByArm[armDeviceId] = B
+
+Tentacle --E2E unicast session_subscription_set(B, snapshot)--> Arm
+
+之后：
+  session B delta/card
+    -> opaque multicast(to: every Arm currently watching B)
+    -> Head
+    -> each target Arm
+```
+
+第一阶段只有以下高频消息受 subscription 过滤：
+
+```text
+agent_message_delta
+card_action
+```
+
+以下消息继续发送给所有在线 Arm：
+
+```text
+session_list
+user_message
+agent_message
+active
+idle
+compacting
+session metadata
+permission/question preview state
+```
+
+TRACE、附件和历史 spine 继续按需 unicast pull。
+
+---
+
+# Part I：Outer relay protocol + Pulse 0.4 streams
+
+## 2. Pulse 0.4 的优先级模型
+
+本提案基于 Pulse `0.4.1` 的 multi-stream transport，不新增业务层 numeric priority 字段。
+
+Kraki 固定使用两条逻辑 stream：
+
+```ts
+const STREAM_LIVE = 0;
+const STREAM_BULK = 1;
+```
+
+| Stream | 语义 | 本提案中的消息 |
+|---|---|---|
+| `0` live | 高优先级、交互和当前状态 | `session_list`、`set_session_subscription`、`session_subscription_set`、`agent_message_delta`、`card_action`、input/abort/permission/question control |
+| `1` bulk | 后台、大响应 | `session_messages_*_batch`、`turn_trace_batch`、`attachment_data` |
+
+Pulse 0.4 的保证：
+
+- 每条 stream 有独立 `epoch/seq/ack/outbox/recvCursor`；
+- 同一 stream 内 in-order、exactly-once 或 explicit reset；
+- stream 0 的 hole 不阻塞 stream 1，stream 1 的 hole 也不阻塞 stream 0；
+- `StreamSet.onTick()` 按较低 stream ID 先返回 transmit effects，因此 live 获得调度优先；
+- stream 之间没有全局顺序保证；
+- 这不是对已经进入 WebSocket/kernel buffer 的 bulk bytes 做硬抢占。
+
+因此 subscription assure 的控制链必须全部留在 stream 0。历史 spine、TRACE 和 attachment reconcile 位于 stream 1，不能被当成 stream-0 页面进入 barrier 的一部分。
+
+当前 release 的 Head、Tentacle 和 Web 已采用 Pulse 0.4 multi-stream；本协议不考虑兼容，iOS 实现 subscription 时也必须接入相同的 live/bulk `StreamSet`。
+
+## 3. 新增 `MulticastEnvelope`
+
+当前协议：
+
+```ts
+export type RelayEnvelope =
+  | UnicastEnvelope
+  | BroadcastEnvelope;
+```
+
+修改为：
+
+```ts
+export interface MulticastEnvelope extends PulseFrameField {
+  type: 'multicast';
+
+  /** Head 可见的明确目标设备集合。 */
+  to: string[];
+
+  /** Pulse 模式下不使用；ciphertext 位于 pulse DATA payload。 */
+  blob: string;
+
+  /** Pulse 模式下不使用；recipient keys 位于 pulse DATA payload。 */
+  keys: Record<string, string>;
+
+  /** 可选错误关联 ID。 */
+  ref?: string;
+}
+
+export type RelayEnvelope =
+  | UnicastEnvelope
+  | MulticastEnvelope
+  | BroadcastEnvelope;
+```
+
+外层 JSON：
+
+```json
+{
+  "type": "multicast",
+  "to": ["app_phone", "app_web"],
+  "pulse": "<base64 Pulse frame>",
+  "blob": "",
+  "keys": {}
+}
+```
+
+Pulse DATA payload 内保持现有 E2E 结构：
+
+```json
+{
+  "blob": "<一份 AES ciphertext>",
+  "keys": {
+    "app_phone": "<phone wrapped AES key>",
+    "app_web": "<web wrapped AES key>"
+  }
+}
+```
+
+因此：
+
+- plaintext 只序列化一次；
+- 内容只 AES 加密一次；
+- 每个 recipient 只增加一个 wrapped key；
+- Head 只根据外层 `to` 转发；
+- Head 不看到 `sessionId`、消息类型或内容。
+
+## 4. 三种 envelope 的职责
+
+| Envelope | 目标 | 用途 |
+|---|---|---|
+| `unicast` | 一个 device ID | Arm command、subscription request/ACK、range、TRACE、attachment |
+| `multicast` | 明确的一组 device IDs | subscriber live data、全局 app 控制消息 |
+| `broadcast` | Head 动态选择同用户设备 | 不再用于新业务数据面；可在后续删除 |
+
+即使消息要发送给所有在线 Arm，Tentacle 也应先构造明确的 app device target list，再用 multicast，而不是 broadcast。
+
+这会自然解决当前 Tentacle 数据被无效 fanout 到其他 Tentacle 的问题。
+
+## 5. Head multicast 校验
+
+Head 收到 authenticated multicast 后必须：
+
+1. 要求 `pulse` 是字符串；
+2. 要求 `to` 是非空数组；
+3. 要求每个 target 是非空 device ID；
+4. 对 target 去重；
+5. 限制 target 数量，例如最多 64；
+6. 拒绝 sender 自己；
+7. 拒绝 `@head`；
+8. 要求所有 target 与 sender 属于同一 user；
+9. 第一阶段只允许 `tentacle -> app` multicast；
+10. 跳过当前离线 target；
+11. 不为离线 target 创建 non-durable backlog；
+12. 不解析 Pulse DATA payload；
+13. 不比较 outer `to` 与 inner E2E `keys`。
+
+推荐上限：
+
+```text
+MAX_MULTICAST_TARGETS = 64
+```
+
+如果 Tentacle 的目标数超过 64，应分成多个稳定分组，每组单独构建 ciphertext 和 multicast。
+
+## 6. Multicast 只承载 non-durable live/control data
+
+第一阶段 multicast 用于：
+
+```text
+agent_message_delta
+card_action
+session_list
+user_message / agent_message live notification
+active / idle / compacting
+session metadata
+```
+
+这些数据都有独立恢复权威，因此 multicast DATA 必须：
+
+```text
+durable = false
+```
+
+离线 Arm 不积累 multicast live backlog，而是在 reconnect 后通过：
+
+```text
+session_list
+subscription snapshot
+spine range sync
+TRACE pull
+```
+
+恢复。
+
+建议为 Head 增加可选 machine-readable error code：
+
+```ts
+export type ServerErrorCode =
+  | 'multicast_invalid_targets'
+  | 'multicast_too_many_targets'
+  | 'multicast_target_forbidden'
+  | 'multicast_durable_not_supported'
+  | 'push_dispatch_forbidden';
+
+export interface ServerErrorMessage {
+  type: 'server_error';
+  message: string;
+  code?: ServerErrorCode;
+  ref?: string;
+}
+```
+
+---
+
+## 7. Pulse routing target 必须绑定 `(streamId, DATA seq)`
+
+Pulse 0.4 的 live 和 bulk 有独立 seq space；两条 stream 都可能同时存在 `seq = 1`。因此只按 seq 保存 target 会发生碰撞。
+
+当前 Tentacle Pulse 0.4 实现已经用 per-stream target map 修复了旧 unicast repair 丢 target 的问题。Multicast 必须扩展同一个抽象：
+
+```ts
+export type DeliveryTarget =
+  | { kind: 'unicast'; deviceId: string }
+  | { kind: 'multicast'; deviceIds: string[] }
+  | { kind: 'broadcast' };
+
+private targetByStream = new Map<
+  number,
+  Map<bigint, DeliveryTarget>
+>();
+```
+
+发送：
+
+```ts
+const { seq, effects } = streams.send(streamId, payload, options);
+let targets = targetByStream.get(streamId);
+if (!targets) {
+  targets = new Map();
+  targetByStream.set(streamId, targets);
+}
+targets.set(seq, target);
+run(effects);
+```
+
+每次 transmit，包括 repair/resend：
+
+```ts
+const decoded = decodeFrameWithStream(effect.bytes);
+const target = decoded?.frame.t === 'data'
+  ? targetByStream.get(decoded.streamId)?.get(decoded.frame.seq)
+  : undefined;
+```
+
+ACK 后清理：
+
+```ts
+const targets = targetByStream.get(effect.streamId ?? STREAM_LIVE);
+for (const seq of targets?.keys() ?? []) {
+  if (seq <= effect.seqUpTo) targets?.delete(seq);
+}
+```
+
+这保证 unicast 和 multicast 在两条 stream 上的 repair 都保留正确目标。
+
+### 7.1 Head 不保存第二份 route registry
+
+验证 Pulse 0.4 的 hole/repair 行为后，Head 不需要维护独立的：
+
+```text
+(sourceDeviceId, streamId, seq) -> route
+```
+
+当 source stream 收到乱序 DATA 时，Pulse 不会把后一个 payload 缓存在应用层并在前一个 frame 到达时一起 deliver；它会显式要求 repair。缺失 DATA 的 resend 是一个新的、独立的 `transmit` effect。
+
+因此 sender 的职责是：每次原始发送或 repair/resend 都根据 `(streamId, seq)` 重新生成带正确 target 的 outer envelope。
+
+Head 对当前 envelope 只需：
+
+1. decode `streamId`；
+2. 校验当前 outer `to` 或 `to[]`；
+3. feed frame to source `StreamSet`；
+4. 如果当前 frame产生 `deliver`，使用当前 envelope 的目标；
+5. 把 payload forward 到每个 destination 的相同 `streamId`。
+
+这与当前 Pulse 0.4 unicast target-retention 模式一致。Multicast 只需要把 sender 端保存的 target value 从单个 device ID 扩展为 device ID 数组。
+
+Control frame 没有业务 target；其 envelope 不参与 DATA delivery。
+
+---
+
+## 8. Push 独立于 live multicast
+
+当前 `pushPreview` 附着在 broadcast live envelope 上。如果没有在线 recipient，Tentacle 会在生成 preview 之前返回，导致全离线时没有 push。
+
+Subscription 后必须把 push 拆成独立 Head-bound operation。
+
+复用现有：
+
+```ts
+HEAD_PULSE_TARGET = '@head'
+```
+
+新增 Head-terminated control message：
+
+```ts
+export interface DispatchPushMessage {
+  type: 'dispatch_push';
+  payload: {
+    preview: BlobPayload;
+  };
+}
+```
+
+Tentacle 发送 outer unicast：
+
+```json
+{
+  "type": "unicast",
+  "to": "@head",
+  "pulse": "<包含 dispatch_push JSON 的 Pulse frame>",
+  "blob": "",
+  "keys": {}
+}
+```
+
+Head self-channel 看到：
+
+```json
+{
+  "type": "dispatch_push",
+  "payload": {
+    "preview": {
+      "blob": "<encrypted preview>",
+      "keys": {
+        "app_phone": "<wrapped key>",
+        "app_web": "<wrapped key>"
+      }
+    }
+  }
+}
+```
+
+Head 规则：
+
+1. sender 必须 authenticated；
+2. sender role 必须为 `tentacle`；
+3. 只向同 user 的 offline app devices 发 push；
+4. target 必须有对应 `preview.keys[deviceId]`；
+5. Head 不解密 preview；
+6. 是否存在 session subscriber 不影响 push。
+
+---
+
+# Part II：Single session subscription protocol
+
+## 9. 新增 `set_session_subscription`
+
+Arm 到 Tentacle 的 E2E inner message：
+
+```ts
+export interface SetSessionSubscriptionMessage extends BaseEnvelope {
+  type: 'set_session_subscription';
+  payload: {
+    /** 当前希望观看的唯一 session；null 表示不观看任何 session。 */
+    sessionId: string | null;
+  };
+}
+```
+
+订阅 session A：
+
+```json
+{
+  "type": "set_session_subscription",
+  "deviceId": "app_phone",
+  "seq": 901,
+  "timestamp": "2026-07-15T10:00:01.000Z",
+  "payload": {
+    "sessionId": "sess_A"
+  }
+}
+```
+
+取消当前 subscription：
+
+```json
+{
+  "type": "set_session_subscription",
+  "deviceId": "app_phone",
+  "seq": 902,
+  "timestamp": "2026-07-15T10:01:00.000Z",
+  "payload": {
+    "sessionId": null
+  }
+}
+```
+
+它通过现有 outer unicast 发往 Tentacle：
+
+```json
+{
+  "type": "unicast",
+  "to": "dev_tentacle",
+  "pulse": "<E2E set_session_subscription>",
+  "blob": "",
+  "keys": {}
+}
+```
+
+因此 inner message 不需要 `targetDeviceId`。Outer unicast 的 `to` 已经是唯一 routing authority。
+
+## 10. 为什么不需要 generation
+
+Generation 原本用于处理多个 replace-set request 乱序到达。
+
+当前协议已有：
+
+```text
+同一个 Arm -> Tentacle Pulse source stream
+严格 seq 顺序
+in-order deliver
+```
+
+产品层又要求：
+
+```text
+一个 Arm 同时只有一个 session 页面
+subscription transition 必须串行 assure
+同一时刻最多一个 subscription request in flight
+```
+
+因此不需要第二套 ordering number。
+
+正确约束是：
+
+```text
+Arm 不并发发送多个 set_session_subscription
+Pulse 负责当前 request 的可靠发送/重传
+Arm 不另起应用层并发 retry
+首次连接/重连必须等待 post-auth session_list inbound barrier
+barrier 前的 subscription ACK 一律不参与页面 assure
+barrier 后从当前 desiredSessionId 执行唯一 request
+```
+
+如果用户在 ACK 前快速切换页面：
+
+1. Arm 更新本地 `desiredSessionId`；
+2. 当前 request 继续等待 ACK；
+3. ACK 到达后，如果 ACK session 已不是 desired session，不进入 ready；
+4. 立即发送最新 desired session；
+5. 中间页面选择可以 coalesce，只发送最终 desired value。
+
+这是一台串行状态机，不是多 generation replicated state。
+
+## 11. Tentacle subscription state
+
+Tentacle 只保存：
+
+```ts
+private currentSessionByArm = new Map<DeviceId, SessionId | null>();
+```
+
+收到 request 时：
+
+```text
+sessionId = string
+  -> 校验 session 属于本 Tentacle
+  -> 原子替换该 Arm 的旧 subscription
+
+sessionId = null
+  -> 删除/置空该 Arm 的 subscription
+```
+
+一个 Arm 从 A 切换到 B：
+
+```text
+currentSessionByArm[arm] = A
+收到 set_session_subscription(B)
+currentSessionByArm[arm] = B
+```
+
+不需要先发送 unsubscribe A。
+
+设备断开时：
+
+```text
+device_left -> currentSessionByArm.delete(deviceId)
+```
+
+Tentacle restart 后 map 为空。Arm 在 reconnect/session page assure 中重新发送当前 desired session。
+
+---
+
+## 12. 新增 `session_subscription_set` ACK
+
+### 11.1 Snapshot 类型
+
+```ts
+export interface SessionLiveSnapshot {
+  /** runtime/sidebar authority */
+  digest: SessionDigest;
+
+  /** persistent spine recovery boundary */
+  spineHeadSeq: number;
+
+  /** 当前 CardManager state */
+  card: {
+    draft: string;
+    action: CardActionState | null;
+  };
+}
+```
+
+### 11.2 ACK 类型
+
+```ts
+export interface SessionSubscriptionSetMessage extends BaseEnvelope {
+  type: 'session_subscription_set';
+  payload:
+    | {
+        accepted: true;
+        sessionId: string;
+        snapshot: SessionLiveSnapshot;
+      }
+    | {
+        accepted: true;
+        sessionId: null;
+        snapshot: null;
+      }
+    | {
+        accepted: false;
+        sessionId: string;
+        error: {
+          code: 'session_not_found';
+          message: string;
+        };
+      };
+}
+```
+
+订阅成功：
+
+```json
+{
+  "type": "session_subscription_set",
+  "deviceId": "dev_tentacle",
+  "seq": 2204,
+  "timestamp": "2026-07-15T10:00:01.020Z",
+  "payload": {
+    "accepted": true,
+    "sessionId": "sess_A",
+    "snapshot": {
+      "digest": {
+        "id": "sess_A",
+        "agent": "pi",
+        "state": "active",
+        "mode": "execute",
+        "lastSeq": 42,
+        "readSeq": 38,
+        "messageCount": 42,
+        "createdAt": "2026-07-15T09:00:00.000Z"
+      },
+      "spineHeadSeq": 42,
+      "card": {
+        "draft": "I am checking the protocol…",
+        "action": {
+          "type": "tool_start",
+          "payload": {
+            "toolName": "read",
+            "headline": "Read protocol files"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+取消成功：
+
+```json
+{
+  "type": "session_subscription_set",
+  "deviceId": "dev_tentacle",
+  "seq": 2205,
+  "timestamp": "2026-07-15T10:01:00.020Z",
+  "payload": {
+    "accepted": true,
+    "sessionId": null,
+    "snapshot": null
+  }
+}
+```
+
+### 11.3 失败 ACK
+
+Unknown session 仍然使用专用 ACK，而不是通用 `error`，让页面 subscription assure 只等待一种响应类型：
+
+```json
+{
+  "type": "session_subscription_set",
+  "deviceId": "dev_tentacle",
+  "seq": 2206,
+  "timestamp": "2026-07-15T10:02:00.020Z",
+  "payload": {
+    "accepted": false,
+    "sessionId": "sess_missing",
+    "error": {
+      "code": "session_not_found",
+      "message": "Session not found"
+    }
+  }
+}
+```
+
+失败时：
+
+- Tentacle 不修改该 Arm 的当前 subscription；
+- Arm 不进入 liveReady；
+- 页面显示加载失败或返回列表；
+- 因为同一时刻只有一个 subscription request in flight，不需要额外 request ID、generation 或 ref。
+
+---
+
+# Part III：页面时序 assure
+
+## 13. 同一 Tentacle 内从 A 切换到 B
+
+页面层必须维护：
+
+```ts
+interface SessionSubscriptionState {
+  desiredSessionId: string | null;
+  confirmedSessionId: string | null;
+  requestInFlight: boolean;
+}
+```
+
+切换步骤：
+
+```text
+1. 用户从 A 导航到 B
+2. desiredSessionId = B
+3. confirmedSessionId = null，立刻停止应用 A 的 subscriber-only live frame
+4. B 页面进入 subscriptionPending 状态
+5. 如果没有 request in flight：发送 set_session_subscription(B)
+6. Tentacle 原子 A -> B
+7. Tentacle capture B snapshot
+8. Tentacle 返回 `accepted: true` 的 unicast session_subscription_set(B, snapshot)
+9. Arm 确认 desiredSessionId 仍然是 B
+10. apply digest/card snapshot
+11. confirmedSessionId = B
+12. B 页面进入 liveReady
+13. 比较本地 spine head 与 snapshot.spineHeadSeq
+14. 如有缺口，在 bulk stream 1 发起 range reconcile
+15. range 完成后 spineReady
+```
+
+B 页面在第 11 步之前：
+
+- 可以显示 loading/skeleton；
+- 不把旧 card state 视为 B 的当前状态；
+- 不假设 live stream 已建立。
+
+第 12 步之后：
+
+- 立即应用后续 stream-0 delta/card；
+- 可以显示本地持久 spine cache；
+- 如果 `spineHeadSeq` 表明存在缺口，单独显示历史 reconcile/loading 状态；
+- 不等待 bulk stream 1 才接收 live stream 0。
+
+## 14. 快速 A -> B -> C
+
+如果 B request 已经发送但尚未 ACK，用户又进入 C：
+
+```text
+desiredSessionId = C
+```
+
+不并发发送 C。
+
+收到 B ACK 后：
+
+```text
+ACK.sessionId = B
+desiredSessionId = C
+```
+
+Arm：
+
+1. 不把 B 设为 liveReady；
+2. 可以丢弃 B snapshot；
+3. 立即发送 `set_session_subscription(C)`；
+4. 等 C ACK；
+5. C ACK 后进入 liveReady。
+
+因为 request 串行，A/B/C 同值重复也不会产生 generation ambiguity。
+
+## 15. 离开 session 页面
+
+```text
+desiredSessionId = null
+send set_session_subscription(null)
+```
+
+UI 不需要等待 null ACK 才离开页面，但连接层必须继续完成该 request，之后才能发送下一次 subscription request。
+
+如果用户在 null ACK 前重新打开 B：
+
+```text
+desiredSessionId = B
+```
+
+等待 null ACK 后再发送 B。
+
+## 16. 跨 Tentacle 切换
+
+如果 A 属于 Tentacle X，B 属于 Tentacle Y：
+
+```text
+1. 向 X 发送 set_session_subscription(null)
+2. 立即设置 confirmedSessionId = null
+3. 等待 X 的 null ACK
+4. 向 Y 发送 set_session_subscription(B)
+5. 等待 Y 的 B snapshot ACK
+6. confirmedSessionId = B
+7. B liveReady
+```
+
+这样始终保持“一个 Arm 同时只有一个 full live session”的产品不变量。
+
+如果产品未来允许 split view，这个协议需要重新扩展；当前不为未存在的多 session UI 预留数组语义。
+
+## 17. Reconnect
+
+Arm reconnect 后不能只以 `auth_ok` 作为 subscription assure 起点。Head 的 destination Pulse endpoint 可能仍有上一次连接留下的短暂 non-durable frames；如果立即发送新 request，一个旧的 `session_subscription_set` 理论上可能先到达。
+
+因此必须等待本次 Tentacle post-auth 发出的权威 `session_list` 作为 inbound ordering barrier：
+
+```text
+1. Pulse/auth ready
+2. 收到本次 Tentacle post-auth session_list
+   - 它在 Tentacle source stream 中晚于本次 auth 初始化
+   - 它在 Arm destination stream 中排在此前残留帧之后
+3. 丢弃 barrier 之前收到的任何 session_subscription_set
+4. confirmedSessionId = null
+5. 如果当前页面仍是 B，desiredSessionId = B
+6. send set_session_subscription(B) on stream 0
+7. wait matching B snapshot ACK on stream 0
+8. apply digest/card snapshot
+9. confirmedSessionId = B
+10. liveReady
+11. 如有 spine gap，通过 stream-0 request / stream-1 response 发起 range reconcile
+12. range 完成后 spineReady
+```
+
+如果当前没有 session 页面：
+
+```text
+在 session_list barrier 后发送 set_session_subscription(null)
+```
+
+页面 subscription 状态机只接受 barrier 之后、且本地确有 request in flight、并且 `ACK.sessionId === desiredSessionId` 的 ACK。这样旧连接的无关 ACK 不会完成新页面 assure，也不需要 generation/request ID。
+
+注意 Pulse 的两个方向是独立的：Arm live outbox 中未 ACK 的旧 `set_session_subscription` 可能在 reconnect 后自动重发，并在 `session_list` barrier 之后产生一个新 ACK。它仍然安全，因为命令是幂等的 set-value，而不是一次性 operation：
+
+- ACK session 与当前 desired 不同：忽略，不结束当前 request；
+- ACK session 与当前 desired 相同：Tentacle 已在当前时刻重新应用该值并捕获 snapshot，可以接受；
+- 后续重复 ACK 在没有 request in flight 时忽略。
+
+`session_list` barrier 只建立 Tentacle→Arm stream-0 的入站边界，不声称为两个方向提供全局顺序。
+
+`session_list` barrier、subscription request/ACK、card snapshot 和后续 delta/card 全部位于 stream 0，因此它们保持严格顺序。Stream 1 的旧 range/TRACE/attachment frame 不参与这个 barrier，也不能阻塞 liveReady。
+
+这让 Tentacle 的 subscription authority 始终明确。
+
+---
+
+# Part IV：Snapshot ordering
+
+## 18. Tentacle 处理 request 的原子顺序
+
+Tentacle 必须按以下顺序处理：
+
+```text
+1. validate sessionId
+2. replace currentSessionByArm[armDeviceId]
+3. capture SessionDigest
+4. capture spineHeadSeq
+5. capture CardManager draft/action
+6. enqueue unicast session_subscription_set ACK
+7. 才处理/发送之后产生的新 adapter live events
+```
+
+同一 Tentacle source **stream 0** 有序，而且 Head 把 source stream 原样映射到 destination stream，因此对目标 Arm：
+
+```text
+subscription ACK
+before
+subscription 建立后产生的 delta/card
+```
+
+## 19. 旧 session frame
+
+在 A -> B 切换时，A 的旧 frame 可能已经进入 Head -> Arm destination endpoint。
+
+Arm 必须只应用：
+
+```ts
+message.sessionId === confirmedSessionId
+```
+
+对于 subscriber-only 类型：
+
+```text
+agent_message_delta
+card_action
+```
+
+如果 `message.sessionId !== confirmedSessionId`，直接丢弃。
+
+B ACK 之前到达的 B subscriber-only frame 也不应用。正常有序实现下 B live frame 应位于 ACK 之后，这条规则作为防御边界。
+
+## 20. Snapshot 应用
+
+Arm 收到 stream-0 有效 ACK 后：
+
+1. 用 `snapshot.digest` 更新 session runtime/metadata；
+2. 用 `snapshot.card` 全量替换本地 live card；
+3. 设置 `confirmedSessionId`；
+4. 页面进入 `liveReady`，立即允许后续 stream-0 delta/card；
+5. 比较本地 persistent head 与 `snapshot.spineHeadSeq`；
+6. 如果存在缺口，通过 stream 0 发送 `request_session_messages_range` command；
+7. Tentacle 在 stream 1 返回 `session_messages_range_batch`；
+8. range 未完成期间保持 `spineReady = false`，但不撤销 liveReady；
+9. TRACE 继续在 stream 1 独立 pull。
+
+Card snapshot 是 replace，不是与旧 card events merge。
+
+---
+
+# Part V：消息分类
+
+## 21. Subscriber-only
+
+第一阶段：
+
+```text
+agent_message_delta
+card_action
+```
+
+Tentacle 计算目标：
+
+```ts
+function subscribersFor(sessionId: string): string[] {
+  return onlineAppDeviceIds.filter(
+    deviceId => currentSessionByArm.get(deviceId) === sessionId,
+  );
+}
+```
+
+然后：
+
+```text
+targets = subscribersFor(sessionId)
+
+if targets.length === 0:
+  不发送 live frame
+  不进入 pendingE2eQueue
+else:
+  encrypt once for targets
+  multicast(targets)
+```
+
+## 22. 继续全局 multicast
+
+第一阶段继续发给所有在线 Arm：
+
+```text
+session_list
+session_created
+session_ended
+session_deleted
+user_message
+agent_message
+active
+idle
+compacting
+session title/model/mode/pin/read
+permission_resolved
+question_resolved
+```
+
+这样 sidebar、unread 和最终回复行为不需要同时重构。
+
+## 23. Pull-only
+
+继续 unicast request/response，但 request 和 response 位于不同 stream：
+
+| 操作 | Arm request | Tentacle response |
+|---|---:|---:|
+| session messages/range | stream 0 | stream 1 |
+| turn TRACE | stream 0 | stream 1 |
+| attachment | stream 0 | stream 1 |
+
+具体消息：
+
+```text
+request_session_messages
+request_session_messages_range
+request_turn_trace
+request_attachment
+```
+
+## 24. 不再 replay 的 transient state
+
+以下类型不进入通用 offline/pending queue：
+
+```text
+agent_message_delta
+card_action
+compacting
+session_list
+```
+
+恢复权威：
+
+| 数据 | 恢复权威 |
+|---|---|
+| Draft | subscription snapshot `card.draft` |
+| Card action | subscription snapshot `card.action` |
+| Runtime | `SessionDigest.state` |
+| Spine | `messages.jsonl` + range sync |
+| TRACE | `trace.jsonl` + pull |
+
+---
+
+# Part VI：Preview 复用，不新增 Attention message
+
+## 25. `SessionAttentionMessage` 删除
+
+不新增：
+
+```text
+SessionAttentionMessage
+session_attention
+```
+
+原因：现有 `SessionDigest.preview` 已经能表达 sidebar attention。
+
+当前类型：
+
+```ts
+export interface SessionPreviewDigest {
+  text: string;
+  type:
+    | 'agent'
+    | 'user'
+    | 'error'
+    | 'permission'
+    | 'question'
+    | 'answer';
+  timestamp: string;
+}
+```
+
+因此 question/permission 不需要第二套 attention wire state。
+
+## 26. `updatePreview` 是什么
+
+Web/iOS 中已有的 `updatePreview` 是客户端本地 store helper，不是 Tentacle 可以发送的 protocol message。
+
+当前真正的 wire authority 是：
+
+```text
+session_list.payload.sessions[].preview
+```
+
+所以复用路径是：
+
+```text
+Tentacle 更新 SessionDigest.preview
+-> 发送已有 session_list
+-> Web/iOS 收到后调用现有 preview store/update 逻辑
+```
+
+不是新增一个 `update_preview` message。
+
+## 27. Permission/question 打开时
+
+Tentacle 维护一个低频 pending-preview authority：
+
+```ts
+interface PendingPreviewState {
+  kind: 'permission' | 'question';
+  text: string;
+  openedAt: string;
+}
+
+private pendingPreviewBySession = new Map<string, PendingPreviewState>();
+```
+
+它是 Tentacle 内部状态，不是新 wire type。
+
+`openedAt` 必须在 prompt 首次打开时生成并保持稳定。不能在每次构造 `session_list` 时使用新的当前时间，否则一个长期 pending prompt 会在任何 session-list 刷新时不断跳到 sidebar 顶部。
+
+Tentacle 从当前 pending prompt 生成 digest preview。
+
+### Permission
+
+```ts
+{
+  type: 'permission',
+  text: pending.text,
+  timestamp: pending.openedAt,
+}
+```
+
+其中 `pending.text` 来自：
+
+```ts
+action.payload.description || action.payload.toolName
+```
+
+### Question
+
+```ts
+{
+  type: 'question',
+  text: pending.text,
+  timestamp: pending.openedAt,
+}
+```
+
+其中 `pending.text` 来自 `action.payload.question`。
+
+随后向所有在线 Arm 发送现有：
+
+```text
+session_list
+```
+
+未订阅该 session 的 Arm 因此仍会：
+
+- 在 sidebar 看到 permission/question preview；
+- 显示 pending 状态；
+- 排序到最新 activity；
+- 点击后进入 session subscription assure；
+- 从 snapshot 得到完整 card。
+
+## 28. Permission/question 解决时
+
+当 permission/question：
+
+```text
+approved
+denied
+answered
+auto-resolved
+cancelled
+idle-cleared
+```
+
+Tentacle 重新计算该 session preview：
+
+- 如果还有 pending human action，保留其稳定 `openedAt` 和 pending preview；
+- 如果当前 pending action 已解决，删除 `pendingPreviewBySession[sessionId]`；
+- 然后回退到持久 spine 计算出的 preview；
+- 更新 SessionDigest.state；
+- 再发送现有 `session_list`。
+
+这样 sidebar pending badge 被权威清理。
+
+## 29. 为什么第一阶段接受全量 `session_list`
+
+Permission/question 是低频控制事件，不是 token firehose。
+
+第一阶段复用 `session_list` 的好处：
+
+- 不增加新 wire type；
+- Web/iOS 已有完整处理；
+- preview、state、lastSeq、readSeq 同时保持一致；
+- reconnect authority 不分裂；
+- 减少协议面。
+
+如果未来 session 数量很大、全量 `session_list` 成为明确成本，再新增通用：
+
+```text
+session_digest_updated
+```
+
+但不在本提案中预先添加。
+
+## 30. Push 仍然必须独立
+
+在线 sidebar attention 可以复用 `session_list.preview`。
+
+离线设备收不到 session_list，因此仍需：
+
+```text
+dispatch_push -> @head
+```
+
+两者职责不同：
+
+| 路径 | 目标 |
+|---|---|
+| `session_list.preview` | 在线 Arm 的 sidebar/pending state |
+| `dispatch_push` | 离线 Arm 的系统通知 |
+| subscription snapshot | 打开页面后的完整 card/draft/runtime |
+
+---
+
+# Part VII：Delta coalescing
+
+## 31. Incremental delta 不能直接 keep-last
+
+当前 `agent_message_delta` 通常是 incremental chunk：
+
+```json
+{
+  "content": "下一段",
+  "reset": false
+}
+```
+
+如果 transport 用较新 chunk 覆盖旧 chunk，会丢文字。
+
+在 multicast/coalescing 下必须保证待合并 payload 是 state-covering。
+
+二选一：
+
+### A. 合并尚未 flush 的 incremental chunks
+
+```text
+"这" + "是一" + "个测试"
+=> "这是一个测试"
+```
+
+### B. coalescible frame 使用 full draft
+
+```json
+{
+  "content": "当前完整 draft",
+  "reset": true
+}
+```
+
+无论采用哪种，subscription snapshot 始终带完整 draft，作为恢复权威。
+
+---
+
+# Part VIII：完整 TypeScript protocol diff
+
+## 32. Outer relay additions
+
+```ts
+export interface MulticastEnvelope extends PulseFrameField {
+  type: 'multicast';
+  to: string[];
+  blob: string;
+  keys: Record<string, string>;
+  ref?: string;
+}
+
+export type RelayEnvelope =
+  | UnicastEnvelope
+  | MulticastEnvelope
+  | BroadcastEnvelope;
+
+export type ServerErrorCode =
+  | 'multicast_invalid_targets'
+  | 'multicast_too_many_targets'
+  | 'multicast_target_forbidden'
+  | 'multicast_durable_not_supported'
+  | 'push_dispatch_forbidden';
+
+export interface ServerErrorMessage {
+  type: 'server_error';
+  message: string;
+  code?: ServerErrorCode;
+  ref?: string;
+}
+
+export interface DispatchPushMessage {
+  type: 'dispatch_push';
+  payload: {
+    preview: BlobPayload;
+  };
+}
+```
+
+## 33. Inner subscription additions
+
+```ts
+export interface SetSessionSubscriptionMessage extends BaseEnvelope {
+  type: 'set_session_subscription';
+  payload: {
+    sessionId: string | null;
+  };
+}
+
+export interface SessionLiveSnapshot {
+  digest: SessionDigest;
+  spineHeadSeq: number;
+  card: {
+    draft: string;
+    action: CardActionState | null;
+  };
+}
+
+export interface SessionSubscriptionSetMessage extends BaseEnvelope {
+  type: 'session_subscription_set';
+  payload:
+    | {
+        accepted: true;
+        sessionId: string;
+        snapshot: SessionLiveSnapshot;
+      }
+    | {
+        accepted: true;
+        sessionId: null;
+        snapshot: null;
+      }
+    | {
+        accepted: false;
+        sessionId: string;
+        error: {
+          code: 'session_not_found';
+          message: string;
+        };
+      };
+}
+```
+
+Union：
+
+```ts
+export type ConsumerMessage =
+  | SetSessionSubscriptionMessage
+  | /* existing */;
+
+export type ProducerMessage =
+  | SessionSubscriptionSetMessage
+  | /* existing */;
+```
+
+没有新增：
+
+```text
+RelayCapabilities
+ApplicationProtocolCapabilities
+SetSessionSubscriptionsMessage
+SessionSubscriptionsSetMessage
+subscriptionEpoch
+generation
+targetDeviceId
+sessionIds[]
+SessionAttentionMessage
+session_digest_updated
+```
+
+---
+
+# Part IX：实施不变量
+
+## 34. Arm 不变量
+
+```text
+最多一个 desired session
+最多一个 confirmed session
+最多一个 subscription request in flight
+重连后先等待 post-auth session_list inbound barrier
+只接受 barrier 后、request in flight 且 sessionId 匹配 desired 的 subscription ACK
+旧 outbound set-value 自动重发是幂等的，不需要 generation
+只有 confirmed session 的 delta/card 可以应用
+页面只有在 matching snapshot ACK 后 liveReady
+```
+
+## 35. Tentacle 不变量
+
+```text
+每个 Arm 最多一个 current session
+收到新 session 时原子替换旧 session
+ACK snapshot 排在之后的 live events 前
+subscriber-only event 不为离线/非订阅 Arm 排队
+```
+
+## 36. Head 不变量
+
+```text
+不理解 session
+不理解 subscription
+只验证 user/device/role target set
+每个 source DATA frame 使用当前 envelope 上由 sender 按 `(streamId, seq)` 恢复的 target/target-set
+source stream 原样映射到 destination stream
+不解密 payload/push preview
+```
+
+---
+
+## 37. 推荐接受的协议
+
+建议接受以下最终 protocol shape：
+
+1. `MulticastEnvelope { to: string[] }`；
+2. Head 保持 session-blind，只路由 device target set；
+3. `set_session_subscription { sessionId: string | null }`；
+4. inner request 不携带 `targetDeviceId`；
+5. 不使用 capability、compatibility、epoch 或 generation；
+6. 每个 Arm 同时最多一个 subscribed session；
+7. 页面通过 post-auth `session_list` barrier + 串行 request/ACK/snapshot assure 进入 liveReady；
+8. `session_subscription_set` 返回单个 session snapshot；
+9. 第一阶段 subscriber-only 仅为 delta/card；
+10. 不新增 `SessionAttentionMessage`；
+11. 在线 attention 复用现有 `session_list[].preview`；
+12. permission 和 question 都必须生成带稳定 `openedAt` 的 preview，并在打开/解决时刷新 `session_list`；
+13. 离线 notification 继续使用独立 `dispatch_push`；
+14. sender 按 `(streamId, DATA seq)` 保存 target/target-set，Head 无需第二份 route registry；
+15. Head 将 source stream 原样映射到每个 destination stream。
+
+最终数据流：
+
+```text
+全局低频 session_list/preview/runtime
++ 单一当前 session live subscription
++ Head session-blind opaque multicast
++ 页面进入时 snapshot ACK assure
++ spine/TRACE/attachment 独立恢复
++ offline push 独立发送
+```

--- a/docs/session-subscription-validation.md
+++ b/docs/session-subscription-validation.md
@@ -1,0 +1,314 @@
+# Session Subscription / Fanout Validation
+
+Date: 2026-07-15  
+Worktree: `/Users/corelli/Documents/Repos/kraki-session-subscription-validation`  
+Branch: `arch/session-subscription-validation`  
+Current base after rebase: `9848c4822c423763b02ca824cc86a473efd02e5b` (`v0.29.16`)  
+Pulse: `@coinfra/pulse 0.4.1`
+
+This worktree remains isolated from the main checkout and running Tentacle processes. No daemon, relay, deployment, or production state was changed.
+
+The authoritative protocol proposal is:
+
+- `docs/session-subscription-protocol-proposal.zh-CN.md`
+
+## Implementation status
+
+The protocol is implemented end to end for Protocol, Head, Tentacle, and Web in this isolated worktree. iOS was intentionally excluded from this implementation pass.
+
+Implemented behavior includes:
+
+- `MulticastEnvelope` with explicit target sets; Head validates, deduplicates, caps at 64 targets, and remains session/content blind.
+- Head role filtering so app delivery does not fan out to sibling Tentacles.
+- Head-bound `dispatch_push`, independent of online live recipients.
+- Tentacle `currentSessionByArm` single-session subscription authority.
+- Atomic subscribe/replace/unsubscribe ACKs with digest, spine head, and current live-card snapshot.
+- Subscriber-only `agent_message_delta` and `card_action` multicast.
+- Global low-frequency `session_list`, final spine messages, and runtime state.
+- Removal of generic offline delta/card replay and device-join card snapshot duplication.
+- Web `SessionSubscriptionController` with desired/confirmed/in-flight state, reconnect barrier, stale live-frame gating, and independent `liveReady`/spine recovery.
+- Stable permission/question attention timestamps through `session_list.preview`.
+- A separate `SessionManager.markUnread()` rollback path; the previous implementation incorrectly called monotonic `markRead()` and could never move `readSeq` backwards.
+
+## Current conclusion
+
+Kraki should use:
+
+```text
+one current session subscription per Arm
++ Head-blind opaque device multicast
++ Pulse stream 0 for live/control
++ Pulse stream 1 for bulk recovery
++ subscribe-time runtime/card snapshot
++ independent spine/TRACE/attachment recovery
++ existing session_list.preview for online attention
++ independent offline push dispatch
+```
+
+Subscription is an interest filter for the high-frequency live data plane. It does not replace the four recovery authorities:
+
+| Axis | Authority |
+|---|---|
+| Persistent spine | `messages.jsonl` + per-session seq/range fetch |
+| TRACE | `trace.jsonl` + `request_turn_trace` |
+| Live card/draft | `CardManager` snapshot returned by subscription ACK |
+| Runtime/sidebar | `SessionDigest` / `session_list` |
+
+## Pulse 0.4 rebase update
+
+The validation branch was rebased from `f64ddc2f` (`v0.29.15`) to `9848c482` (`v0.29.16`) after Pulse multi-stream landed.
+
+Pulse 0.4 adds two independent reliable streams:
+
+```text
+stream 0 = live/control
+stream 1 = bulk/history/TRACE/attachment
+```
+
+Each stream has its own:
+
+```text
+epoch
+seq/ack
+outbox
+recvCursor
+repair/reset
+```
+
+This eliminates bulk-to-live head-of-line blocking. It does not reduce recipient fanout and does not replace session subscriptions or multicast.
+
+### Required subscription stream placement
+
+Stream 0:
+
+```text
+session_list barrier
+set_session_subscription
+session_subscription_set + runtime/card snapshot
+agent_message_delta
+card_action
+all Arm commands
+```
+
+Stream 1:
+
+```text
+session_messages_batch
+session_messages_range_batch
+turn_trace_batch
+attachment_data
+```
+
+There is no cross-stream ordering guarantee. A subscription ACK on stream 0 therefore establishes `liveReady` immediately; any spine range reconciliation continues independently on stream 1 and establishes `spineReady` later.
+
+### Routing target retention
+
+Pulse 0.4 already fixes the previously characterized Tentacle unicast repair bug by storing targets per:
+
+```text
+(streamId, seq)
+```
+
+The old validation test expecting repair to lose the target was removed after rebase. Upstream tests now verify both live and bulk target retention.
+
+Opaque multicast should extend the same sender-side map from:
+
+```ts
+Map<streamId, Map<seq, deviceId>>
+```
+
+to:
+
+```ts
+Map<streamId, Map<seq, DeliveryTarget>>
+```
+
+where `DeliveryTarget` can be unicast, multicast, or legacy broadcast.
+
+Head does not need a second per-seq routing registry. Pulse hole repair retransmits the missing DATA as a separate frame; the sender reattaches the correct outer target/target-set. Head validates the current envelope and forwards the payload onto the same destination stream.
+
+### Platform status
+
+- Head: Pulse 0.4 live/bulk implemented.
+- Tentacle: Pulse 0.4 live/bulk implemented.
+- Web: Pulse 0.4 live/bulk implemented.
+- iOS mainline: still uses its existing raw WebSocket queue and has not adopted the new `StreamSet` model in this release.
+
+Because the new subscription protocol intentionally does not support mixed protocol versions, iOS must adopt Pulse 0.4 live/bulk before or as part of implementing the subscription protocol.
+
+## Resource measurements
+
+### E2E recipient scaling
+
+Script: `scripts/validate-e2e-recipient-scaling.ts`
+
+Payload: one 256-byte `agent_message_delta`, real RSA-4096/AES implementation.
+
+| Recipients | Encrypted `{blob,keys}` size | Representative p50 encryption |
+|---:|---:|---:|
+| 1 | ~1.2 KB | ~0.07 ms |
+| 8 | ~6.1 KB | ~0.48 ms |
+| 16 | ~11.6 KB | ~1.0 ms |
+| 32 | ~22.8 KB | ~2–3 ms |
+| 64 | ~45.0 KB | ~4 ms |
+
+Wire size and recipient key work scale linearly. Pulse streams do not change this scaling.
+
+### Head fanout scaling
+
+Script: `scripts/validate-fanout.ts`
+
+100 state-covering delta sends with online targets:
+
+| Online targets | Head transport transmissions |
+|---:|---:|
+| 1 | 110 |
+| 2 | 215 |
+| 4 | 425 |
+| 8 | 845 |
+| 16 | 1,685 |
+| 32 | 3,365 |
+
+Pulse 0.4 creates live and bulk endpoints/handshake traffic per device, so the constant baseline is slightly higher than the v0.29.15 measurement. The business fanout slope is unchanged and remains effectively:
+
+```text
+source messages × destination devices
+```
+
+Pulse 0.4 prevents bulk traffic from blocking live traffic, but every unnecessary destination still creates destination endpoint, encryption/decryption, and network work.
+
+## Engineering issues found and resolved during implementation
+
+### 1. Legacy Head broadcast crossed device roles
+
+Resolved: broadcast targets are app-role devices only, while the new multicast path always uses Tentacle-selected explicit app targets.
+
+### 2. Push preview was skipped when every Arm was offline
+
+Resolved: push dispatch is independent of the live-recipient set and uses encrypted `dispatch_push` through the Head self-channel.
+
+### 3. Card reconnect recovery was duplicated
+
+Resolved: transient `agent_message_delta` and `card_action` no longer enter a generic offline queue, and device join no longer pushes all active-card snapshots. The subscription ACK snapshot is the bounded card/draft recovery authority.
+
+### 4. `mark_unread` could not roll read state backwards
+
+Resolved: `SessionManager.markRead()` intentionally remains monotonic, while the new idempotent `markUnread()` lowers the cursor to at most `lastSeq - 1` without ever advancing an already-unread cursor.
+
+## Attention decision
+
+No `SessionAttentionMessage` is needed.
+
+Existing wire authority:
+
+```text
+session_list.payload.sessions[].preview
+```
+
+`SessionPreviewDigest.type` already supports:
+
+```text
+permission
+question
+```
+
+When a permission/question opens or resolves, Tentacle updates the relevant digest preview and sends the existing low-frequency `session_list` globally on stream 0.
+
+Pending preview must retain a stable `openedAt` timestamp; rebuilding `session_list` must not assign a new current time, or a long-running pending prompt will repeatedly jump to the top of the sidebar.
+
+Offline attention remains independent push dispatch.
+
+## Protocol shape after review
+
+```ts
+interface SetSessionSubscriptionMessage {
+  type: 'set_session_subscription';
+  payload: {
+    sessionId: string | null;
+  };
+}
+```
+
+```ts
+interface SessionSubscriptionSetMessage {
+  type: 'session_subscription_set';
+  payload:
+    | {
+        accepted: true;
+        sessionId: string;
+        snapshot: SessionLiveSnapshot;
+      }
+    | {
+        accepted: true;
+        sessionId: null;
+        snapshot: null;
+      }
+    | {
+        accepted: false;
+        sessionId: string;
+        error: {
+          code: 'session_not_found';
+          message: string;
+        };
+      };
+}
+```
+
+Removed from the proposal:
+
+```text
+capability negotiation
+mixed-version compatibility
+multiple simultaneous session subscriptions
+targetDeviceId inside the encrypted request
+subscription epoch
+generation
+SessionAttentionMessage
+session_digest_updated
+```
+
+## Final validation
+
+All validation was run from the isolated worktree without touching the main checkout, iOS, or existing Tentacle processes.
+
+Build and static checks:
+
+- Protocol build: passed.
+- Crypto build: passed.
+- Head build/tests: passed.
+- Tentacle build: passed.
+- Web production build: passed.
+- Workspace Biome lint: passed.
+- `git diff --check`: passed.
+
+Full unit/integration suites:
+
+- Head: `243/243` passed.
+- Tentacle: `738/738` passed.
+- Web: `390/390` passed.
+
+Real dev-stack Playwright (`real browser Arm ⇄ real Head ⇄ real Tentacle`):
+
+- Entire project: `36/36` passed.
+- Subscription/multicast scenarios: `9/9` passed.
+- Covered snapshot seeding, non-subscriber isolation, atomic A→B, rapid A→B→C coalescing, refresh re-subscription, unsubscribe on leaving detail, global sidebar attention, bulk/live concurrency, and two Arms subscribed to different sessions.
+- Existing conversation, question, permission, reconnect, delete, presence, preferences, pin/unread/rename metadata, history range, attachment pulls, image pulls, TRACE flood, coalescing, multi-stream reconnect, and terminal-card scenarios also passed.
+
+## Implementation and validation files
+
+- `packages/protocol/src/messages.ts`
+- `packages/head/src/pulse-hub.ts`
+- `packages/head/src/server.ts`
+- `packages/tentacle/src/relay-client.ts`
+- `packages/tentacle/src/tentacle-pulse.ts`
+- `packages/tentacle/src/session-manager.ts`
+- `packages/arm/web/src/lib/session-subscription.ts`
+- `packages/arm/web/src/lib/session-subscription-lifecycle.ts`
+- `packages/arm/web/src/lib/ws-client.ts`
+- `packages/arm/web/src/pages/SessionPage.tsx`
+- `packages/arm/web/e2e/real-stack/session-subscription.spec.ts`
+- `scripts/pulse-realstack-server.ts`
+- `scripts/validate-e2e-recipient-scaling.ts`
+- `scripts/validate-fanout.ts`
+- `docs/session-subscription-protocol-proposal.zh-CN.md`
+- `docs/session-subscription-validation.md`

--- a/packages/arm/web/e2e/real-stack/pulse-realstack.spec.ts
+++ b/packages/arm/web/e2e/real-stack/pulse-realstack.spec.ts
@@ -137,6 +137,18 @@ test.describe.serial('real-stack pulse: a complete dev conversation', () => {
   });
 
   test('3. agent runs a tool → tool activity renders', async () => {
+    // A real trace-bearing turn starts with a user_message. The previous test's
+    // turn is already idle, so begin a fresh one through the browser before the
+    // adapter emits tool activity.
+    const prompt = 'run the auth tests now';
+    const input = page.getByPlaceholder('Send a message…');
+    await input.fill(prompt);
+    await input.press('Enter');
+    await expect.poll(async () => {
+      const { messages } = await control('/received');
+      return (messages as Array<{ text: string }>).some((m) => m.text === prompt);
+    }, { timeout: 15_000 }).toBe(true);
+
     await control('/toolStart', { sid: sessionId, tool: 'bash', cmd: 'npm test -- auth' });
     // The tool chip renders the toolName + command headline. During the running
     // phase it's prefixed with "Running"; once complete the prefix drops but the
@@ -145,10 +157,17 @@ test.describe.serial('real-stack pulse: a complete dev conversation', () => {
     const chip = page.locator('[data-chat-scroll]').getByText(/npm test -- auth/i);
     await expect(chip).toBeVisible({ timeout: 15_000 });
     await control('/toolComplete', { sid: sessionId, tool: 'bash', result: '1 failing: auth.test.ts' });
+    await control('/msg', { sid: sessionId, text: 'The auth test still has one failing assertion.' });
     await control('/idle', { sid: sessionId });
-    // Still present after completion.
-    await expect(page.locator('[data-chat-scroll]').getByText(/bash/i).first())
-      .toBeVisible({ timeout: 10_000 });
+    // Completed tool activity moves under the concluding bubble's TRACE-axis
+    // Steps affordance. Open it and verify the command survives there.
+    const steps = page.locator('[data-chat-scroll]').getByRole('button', { name: 'Open steps' }).last();
+    await expect(steps).toBeVisible({ timeout: 10_000 });
+    await steps.click();
+    const stepsDialog = page.getByRole('dialog');
+    await expect(stepsDialog.getByText(/npm test -- auth/i)).toBeVisible({ timeout: 10_000 });
+    await stepsDialog.click({ position: { x: 4, y: 4 } });
+    await expect(stepsDialog).toHaveCount(0);
   });
 
   test('4. agent asks a question → user clicks a choice → answer reaches tentacle over pulse', async () => {
@@ -401,14 +420,21 @@ test.describe.serial('real-stack pulse: session metadata round-trips', () => {
     // would target a missing button).
     await page.reload();
     await expect(metaCard(page)).toBeVisible({ timeout: 20_000 });
-    await expect(async () => {
-      await openCardMenu(page, metaCard(page));
-      await expect(page.getByRole('button', { name: /Mark unread/i })).toBeVisible({ timeout: 2_000 });
-    }).toPass({ timeout: 20_000 });
+    await page.evaluate(() => (window as unknown as { _pulseTraceEnable?: () => void })._pulseTraceEnable?.());
+    // Open once and click immediately. Retrying the whole open operation toggles
+    // an already-open context menu closed and can make the later click hit an
+    // unrelated control at the same screen position.
+    await openCardMenu(page, metaCard(page));
+    const markUnread = page.getByRole('button', { name: 'Mark unread', exact: true });
+    await expect(markUnread).toBeVisible({ timeout: 20_000 });
 
     // Mark it UNREAD → mark_unread rides pulse to the tentacle, which rolls readSeq
     // back below lastSeq. Reading the tentacle's own session list back proves it.
-    await page.getByRole('button', { name: /Mark unread/i }).click();
+    await markUnread.evaluate((button: HTMLButtonElement) => button.click());
+    const sendTrace = await page.evaluate(() => (window as unknown as { _pulseTrace?: Array<Record<string, unknown>> })._pulseTrace ?? []);
+    expect(sendTrace.some((e) => e.evt === 'APP-SEND-ENCRYPTED' && e.type === 'mark_unread')).toBe(true);
+    expect(sendTrace.some((e) => e.evt === 'APP-ENCRYPT-OK' && e.type === 'mark_unread')).toBe(true);
+    expect(sendTrace.some((e) => e.evt === 'PULSE-SEND')).toBe(true);
     await expect.poll(async () => {
       const s = await session(sessionId);
       return s ? (s.readSeq as number) < (s.lastSeq as number) : false;
@@ -421,13 +447,16 @@ test.describe.serial('real-stack pulse: session metadata round-trips', () => {
     // panel for THIS session. Open the chat first so that button is present.
     const newTitle = `Renamed ${Date.now().toString(36)}`;
     await page.goto(`${WEB_URL}/session/${sessionId}`);
-    await page.getByRole('button', { name: 'Session settings' }).click();
+    const settingsButton = page.getByRole('button', { name: 'Session settings' });
+    await expect(settingsButton).toBeVisible({ timeout: 10_000 });
+    await settingsButton.evaluate((button: HTMLButtonElement) => button.click());
+    await expect(page).toHaveURL(new RegExp(`/devices\\?.*session=${sessionId}`), { timeout: 10_000 });
 
     // The panel's title is a button; click it to reveal the edit input.
-    const input = page.getByPlaceholder('Session title…');
+    const panel = page.locator('main');
+    const input = panel.getByPlaceholder('Session title…');
     if (!(await input.isVisible().catch(() => false))) {
-      // Title shows as a button until clicked (SessionInfoPanel startEditing).
-      await page.getByRole('button', { name: /Mock-agent|metadata round-trip session/ }).first().click();
+      await panel.getByRole('button', { name: /mock-agent · mock-v1/i }).last().click();
     }
     await expect(input).toBeVisible({ timeout: 10_000 });
     await input.fill(newTitle);
@@ -484,9 +513,20 @@ test.describe.serial('real-stack pulse: request/reply payloads', () => {
     // streams attachment_data back — a deterministic pull (no push race).
     const marker = `ATTACH-${Date.now().toString(36)}`;
     const result = `${marker} ${'x'.repeat(2000)}`; // offloaded to a ref (single chunk)
-    await page.goto(`${WEB_URL}/session/realstack-1`);
+    const attachmentSession = `attachment-${Date.now().toString(36)}`;
+    await control('/createSession', { id: attachmentSession });
+    await control('/idle', { sid: attachmentSession });
+    await page.goto(`${WEB_URL}/session/${attachmentSession}`);
     await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
-    const ref = await control('/toolRef', { sid: 'realstack-1', tool: 'bash', cmd: 'cat big.txt', result });
+    const input = page.getByPlaceholder('Send a message…');
+    const prompt = `inspect attachment ${marker}`;
+    await input.fill(prompt);
+    await input.press('Enter');
+    await expect.poll(async () => {
+      const { messages } = await control('/received');
+      return (messages as Array<{ text: string }>).some((m) => m.text === prompt);
+    }, { timeout: 15_000 }).toBe(true);
+    const ref = await control('/toolRef', { sid: attachmentSession, tool: 'bash', cmd: 'cat big.txt', result });
     // The tentacle must have offloaded the result to its AttachmentStore, else
     // there is no ref to pull and the test is meaningless.
     expect(ref.stored as number).toBeGreaterThan(0);
@@ -494,11 +534,14 @@ test.describe.serial('real-stack pulse: request/reply payloads', () => {
     // Reload so the resultRef renders from replay with no cached bytes → pull.
     await page.reload();
     await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
-    const chip = page.locator('[data-chat-scroll]').getByRole('button', { name: /cat big\.txt/i }).first();
+    const steps = page.locator('[data-chat-scroll]').getByRole('button', { name: 'Open steps' }).last();
+    await expect(steps).toBeVisible({ timeout: 20_000 });
+    await steps.click();
+    const chip = page.getByRole('dialog').getByRole('button', { name: /cat big\.txt/i }).first();
     await expect(chip).toBeVisible({ timeout: 20_000 });
-    // Expand the chip → ToolResultBody pulls the bytes over pulse and renders the
-    // offloaded result text (the marker lives only inside the attachment bytes).
-    const markerText = page.locator('[data-chat-scroll]').getByText(marker, { exact: false }).first();
+    // Expand the tool row → ToolResultBody pulls the bytes over pulse and renders
+    // the offloaded result text (the marker lives only inside attachment bytes).
+    const markerText = page.getByRole('dialog').getByText(marker, { exact: false }).first();
     await expect(async () => {
       if (!(await markerText.isVisible().catch(() => false))) {
         await chip.click();

--- a/packages/arm/web/e2e/real-stack/pulse-trace-flood.spec.ts
+++ b/packages/arm/web/e2e/real-stack/pulse-trace-flood.spec.ts
@@ -34,7 +34,10 @@ async function pairBrowser(page: Page): Promise<string> {
 }
 
 test('live echo stays responsive while a large turn trace is pulled on bulk', async ({ page }) => {
-  const sessionId = await pairBrowser(page);
+  await pairBrowser(page);
+  const sessionId = `trace-flood-${Date.now().toString(36)}`;
+  await control('/createSession', { id: sessionId });
+  await control('/idle', { sid: sessionId });
   await page.goto(`${WEB_URL}/session/${sessionId}`);
   await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
   await control('/idle', { sid: sessionId });

--- a/packages/arm/web/e2e/real-stack/session-subscription.spec.ts
+++ b/packages/arm/web/e2e/real-stack/session-subscription.spec.ts
@@ -1,0 +1,174 @@
+import { expect, type Browser, type BrowserContext, type Page, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB_URL = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const context = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const response = await context.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await response.json();
+  await context.dispose();
+  if (!response.ok()) throw new Error(`control ${path} failed: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pairBrowser(browser: Browser): Promise<{ context: BrowserContext; page: Page; deviceId: string }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const { token, web } = await control('/token');
+  await page.goto(web as string);
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  const deviceId = await page.evaluate(() => JSON.parse(localStorage.getItem('kraki_device') ?? '{}').deviceId as string);
+  expect(deviceId).toBeTruthy();
+  return { context, page, deviceId };
+}
+
+async function createSession(id: string): Promise<void> {
+  await control('/createSession', { id });
+  await control('/idle', { sid: id });
+}
+
+async function openSession(page: Page, id: string): Promise<void> {
+  await page.goto(`${WEB_URL}/session/${id}`);
+  await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+}
+
+async function subscriptionFor(deviceId: string): Promise<string | null | undefined> {
+  const debug = await control('/debug');
+  return (debug.subscriptions as Record<string, string | null>)[deviceId];
+}
+
+async function expectSubscribed(deviceId: string, sessionId: string | null): Promise<void> {
+  await expect.poll(() => subscriptionFor(deviceId), { timeout: 15_000 }).toBe(sessionId);
+}
+
+async function seedLiveCard(sessionId: string, marker: string): Promise<void> {
+  await control('/active', { sid: sessionId });
+  await control('/delta', { sid: sessionId, text: marker });
+  await control('/toolStart', { sid: sessionId, tool: 'bash', cmd: `echo ${marker}` });
+}
+
+test.describe.serial('real-stack session subscription + opaque multicast', () => {
+  let arm1: Awaited<ReturnType<typeof pairBrowser>>;
+  let sessionA: string;
+  let sessionB: string;
+  let sessionC: string;
+
+  test.beforeAll(async ({ browser }) => {
+    sessionA = `sub-a-${Date.now().toString(36)}`;
+    sessionB = `sub-b-${Date.now().toString(36)}`;
+    sessionC = `sub-c-${Date.now().toString(36)}`;
+    await createSession(sessionA);
+    await createSession(sessionB);
+    await createSession(sessionC);
+    arm1 = await pairBrowser(browser);
+  });
+
+  test.afterAll(async () => {
+    await arm1?.context.close();
+  });
+
+  test('subscription ACK snapshot seeds a card that was created before page open', async () => {
+    const marker = `snapshot-${Date.now().toString(36)}`;
+    await seedLiveCard(sessionA, marker);
+    await openSession(arm1.page, sessionA);
+    await expectSubscribed(arm1.deviceId, sessionA);
+    await expect(arm1.page.getByText(marker, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    await expect(arm1.page.getByText(`echo ${marker}`, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('non-subscribed session delta/card is not delivered to the current Arm', async () => {
+    const hidden = `hidden-${Date.now().toString(36)}`;
+    await seedLiveCard(sessionB, hidden);
+    await arm1.page.waitForTimeout(250);
+    await expect(arm1.page.getByText(hidden, { exact: false })).toHaveCount(0);
+    await expectSubscribed(arm1.deviceId, sessionA);
+  });
+
+  test('same-tentacle A→B is an atomic replace and old A live frames stop applying', async () => {
+    await openSession(arm1.page, sessionB);
+    await expectSubscribed(arm1.deviceId, sessionB);
+    await control('/active', { sid: sessionB });
+    const visibleB = `visible-b-${Date.now().toString(36)}`;
+    await control('/delta', { sid: sessionB, text: visibleB });
+    await expect(arm1.page.getByText(visibleB, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+
+    const staleA = `stale-a-${Date.now().toString(36)}`;
+    await control('/delta', { sid: sessionA, text: staleA });
+    await arm1.page.waitForTimeout(250);
+    await expect(arm1.page.getByText(staleA, { exact: false })).toHaveCount(0);
+  });
+
+  test('rapid A→B→C navigation coalesces to final C', async () => {
+    await arm1.page.goto(`${WEB_URL}/session/${sessionA}`);
+    await arm1.page.goto(`${WEB_URL}/session/${sessionB}`);
+    await arm1.page.goto(`${WEB_URL}/session/${sessionC}`);
+    await expect(arm1.page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await expectSubscribed(arm1.deviceId, sessionC);
+    await control('/active', { sid: sessionC });
+    const marker = `only-c-${Date.now().toString(36)}`;
+    await control('/delta', { sid: sessionC, text: marker });
+    await expect(arm1.page.getByText(marker, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('refresh reasserts desired subscription after session_list barrier and restores current card snapshot', async () => {
+    const before = `before-refresh-${Date.now().toString(36)}`;
+    await seedLiveCard(sessionC, before);
+    await expect(arm1.page.getByText(before, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+    await arm1.page.reload();
+    await expect(arm1.page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 20_000 });
+    await expectSubscribed(arm1.deviceId, sessionC);
+    await expect(arm1.page.getByText(before, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    const after = `after-refresh-${Date.now().toString(36)}`;
+    await control('/delta', { sid: sessionC, text: after });
+    await expect(arm1.page.getByText(after, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('leaving the session page confirms null subscription', async () => {
+    await arm1.page.goto(WEB_URL);
+    await expectSubscribed(arm1.deviceId, null);
+  });
+
+  test('question attention updates the sidebar globally while the session is not subscribed', async () => {
+    const question = `attention-${Date.now().toString(36)}`;
+    await control('/question', { sid: sessionA, id: `q-${Date.now()}`, text: question, choices: 'yes|no' });
+    await expect(arm1.page.getByText(question, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    await expectSubscribed(arm1.deviceId, null);
+  });
+
+  test('bulk history recovery does not block current live stream', async () => {
+    await openSession(arm1.page, 'realstack-history');
+    await expectSubscribed(arm1.deviceId, 'realstack-history');
+    await control('/active', { sid: 'realstack-history' });
+    const live = `live-during-history-${Date.now().toString(36)}`;
+    await control('/delta', { sid: 'realstack-history', text: live });
+    await expect(arm1.page.getByText(live, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+    await expect(arm1.page.getByText('history line 60 of 60', { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('two Arms can subscribe to different sessions and receive only their own live multicast', async ({ browser }) => {
+    const arm2 = await pairBrowser(browser);
+    try {
+      await openSession(arm1.page, sessionA);
+      await openSession(arm2.page, sessionB);
+      await expectSubscribed(arm1.deviceId, sessionA);
+      await expectSubscribed(arm2.deviceId, sessionB);
+
+      const markerA = `arm1-only-${Date.now().toString(36)}`;
+      const markerB = `arm2-only-${Date.now().toString(36)}`;
+      await control('/delta', { sid: sessionA, text: markerA });
+      await control('/delta', { sid: sessionB, text: markerB });
+
+      await expect(arm1.page.getByText(markerA, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+      await expect(arm2.page.getByText(markerB, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+      await expect(arm1.page.getByText(markerB, { exact: false })).toHaveCount(0);
+      await expect(arm2.page.getByText(markerA, { exact: false })).toHaveCount(0);
+    } finally {
+      await arm2.context.close();
+    }
+  });
+});

--- a/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
+++ b/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
@@ -56,7 +56,10 @@ test.describe.serial('real-stack terminal status cards', () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
-    sessionId = await pairBrowser(page);
+    await pairBrowser(page);
+    sessionId = `terminal-${Date.now().toString(36)}`;
+    await control('/createSession', { id: sessionId });
+    await control('/idle', { sid: sessionId });
     await openSessionChat(page, sessionId);
   });
 
@@ -90,9 +93,11 @@ test.describe.serial('real-stack terminal status cards', () => {
     const stepsBtn = abortCard.getByRole('button', { name: /Steps/i });
     if (await stepsBtn.isVisible()) {
       await stepsBtn.click();
-      await expect(page.getByText(/Cancelled.*read_file|read_file.*Cancelled/i).or(page.getByText(/Cancelled/i))).toBeVisible({ timeout: 5_000 });
+      const dialog = page.getByRole('dialog').filter({ visible: true }).last();
+      await expect(dialog.getByRole('button', { name: /read_file/i })).toBeVisible({ timeout: 5_000 });
       await page.screenshot({ path: '/tmp/kraki-terminal-abort-steps.png', fullPage: false });
-      await page.keyboard.press('Escape');
+      await dialog.click({ position: { x: 4, y: 4 } });
+      await expect(dialog).toHaveCount(0);
     }
   });
 
@@ -173,10 +178,12 @@ test.describe.serial('real-stack terminal status cards', () => {
 
     // Both backend errors remain available inside Steps.
     await failedCard.getByRole('button', { name: 'Open steps' }).click();
-    await expect(page.getByText('Error', { exact: true })).toHaveCount(2);
-    await expect(page.getByText('524 status code (no body)', { exact: true })).toHaveCount(3);
+    const dialog = page.getByRole('dialog').filter({ visible: true }).last();
+    await expect(dialog.getByText('Error', { exact: true })).toHaveCount(2);
+    await expect(dialog.getByText('524 status code (no body)', { exact: true })).toHaveCount(2);
     await page.screenshot({ path: '/tmp/kraki-terminal-single-failed-bubble-steps.png', fullPage: false });
-    await page.keyboard.press('Escape');
+    await dialog.click({ position: { x: 4, y: 4 } });
+    await expect(dialog).toHaveCount(0);
   });
 
   test('two consecutive failed turns each render exactly one bubble (mrhuha8u-tcpn1tz8 replay)', async () => {

--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/arm-web",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Kraki web receiver — view and control your agents from any browser",
   "type": "module",
   "scripts": {

--- a/packages/arm/web/src/components/chat/ChatView.test.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.test.tsx
@@ -446,7 +446,7 @@ describe('ChatView', () => {
     expect(screen.queryByText('Other session perm')).not.toBeInTheDocument();
   });
 
-  it('requests a card snapshot when opening a working session without a card', async () => {
+  it('does not issue a separate card pull when opening a working session', async () => {
     const spy = vi.spyOn(messageProvider, 'requestCard').mockImplementation(() => {});
     useStore.getState().setStatus('connected');
     useStore.getState().upsertDevice({
@@ -456,9 +456,8 @@ describe('ChatView', () => {
       { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'copilot', state: 'active', messageCount: 0 },
     ]);
     renderChatView('s1');
-    await vi.waitFor(() => {
-      expect(spy).toHaveBeenCalledWith('s1');
-    });
+    await Promise.resolve();
+    expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -186,7 +186,6 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
   // empty card eligible or create a live bubble by itself. Existing real card
   // content/actions may continue rendering independently while compacting.
   const cardEligible = status === 'working' || status === 'pending' || status === 'compacting';
-  const shouldSeedCard = status === 'working' || status === 'pending';
   const showLive = cardEligible && !!card && (draft.length > 0 || actionLive);
 
   // First seq for prepend tracking (passed to scroll controller)
@@ -194,15 +193,6 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
     const seqs = spine.map(getSeq).filter(s => s > 0);
     return seqs.length > 0 ? seqs[0] : 0;
   }, [spine]);
-
-  // Reload mid-turn seed: the server owns the card, so request a snapshot when
-  // opening a non-idle session without local card state. Gated on the tentacle
-  // being encryptable (its key may arrive after mount) and re-runs when it does.
-  useEffect(() => {
-    if (!sessionId || !shouldSeedCard || card) return;
-    if (!isConnected || !isTentacleEncryptable) return;
-    messageProvider.requestCard(sessionId);
-  }, [sessionId, shouldSeedCard, card, isConnected, isTentacleEncryptable]);
 
   useEffect(() => {
     if (!sessionId || !isTentacleEncryptable) return;

--- a/packages/arm/web/src/lib/encryption.ts
+++ b/packages/arm/web/src/lib/encryption.ts
@@ -54,6 +54,27 @@ export class EncryptionHandler {
     }
   }
 
+  /** Encrypt an inner message for an explicitly routed device without adding a
+   *  targetDeviceId field to the encrypted protocol payload. */
+  async encryptForDevice(
+    msg: Record<string, unknown>,
+    targetDeviceId: string,
+  ): Promise<{ blob: string; keys: Record<string, string>; to: string } | null> {
+    if (!this.keyStore.isReady()) return null;
+    const targetDev = getStore().devices.get(targetDeviceId);
+    const targetKey = targetDev?.encryptionKey ?? targetDev?.publicKey;
+    if (!targetKey) return null;
+    try {
+      const { blob, keys } = await this.keyStore.encryptToBlob(JSON.stringify(msg), [
+        { deviceId: targetDeviceId, publicKeyBase64: targetKey },
+      ]);
+      return { blob, keys, to: targetDeviceId };
+    } catch (err) {
+      logger.error('encryptForDevice failed:', err);
+      return null;
+    }
+  }
+
   /** Decrypt a raw blob+keys (used by the pulse inbound path). */
   async decryptBlob(blob: string, keys: Record<string, string>): Promise<InnerMessage | null> {
     const store = getStore();

--- a/packages/arm/web/src/lib/session-subscription-lifecycle.ts
+++ b/packages/arm/web/src/lib/session-subscription-lifecycle.ts
@@ -1,0 +1,7 @@
+import { wsClient } from './ws-client';
+
+/** Thin page-lifecycle boundary kept separate so React page tests do not need to
+ * know the subscription controller internals. */
+export function setDesiredSessionSubscription(sessionId: string | null): void {
+  if (typeof wsClient.setDesiredSession === 'function') wsClient.setDesiredSession(sessionId);
+}

--- a/packages/arm/web/src/lib/session-subscription.test.ts
+++ b/packages/arm/web/src/lib/session-subscription.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionSubscriptionSetMessage } from '@kraki/protocol';
+import { SessionSubscriptionController } from './session-subscription';
+
+function ack(deviceId: string, sessionId: string | null): SessionSubscriptionSetMessage {
+  return {
+    type: 'session_subscription_set', deviceId, seq: 1, timestamp: '',
+    payload: sessionId === null
+      ? { accepted: true, sessionId: null, snapshot: null }
+      : {
+          accepted: true,
+          sessionId,
+          snapshot: {
+            digest: { id: sessionId, agent: 'pi', state: 'active', mode: 'execute', lastSeq: 3, readSeq: 0, messageCount: 3, createdAt: '' },
+            spineHeadSeq: 3,
+            card: { draft: 'live', action: null },
+          },
+        },
+  };
+}
+
+function setup(routes: Record<string, string> = { A: 'T1', B: 'T1', C: 'T1' }) {
+  let connected = true;
+  const sends: Array<[string, string | null]> = [];
+  const applySnapshot = vi.fn();
+  const reportError = vi.fn();
+  const controller = new SessionSubscriptionController({
+    isConnected: () => connected,
+    resolveTentacle: (sessionId) => routes[sessionId],
+    send: async (tentacleId, sessionId) => { sends.push([tentacleId, sessionId]); return true; },
+    applySnapshot,
+    reportError,
+  });
+  return { controller, sends, applySnapshot, reportError, disconnect: () => { connected = false; controller.onDisconnected(); } };
+}
+
+describe('SessionSubscriptionController', () => {
+  it('waits for the post-auth session_list barrier', async () => {
+    const { controller, sends } = setup();
+    controller.setDesired('A');
+    expect(sends).toEqual([]);
+    controller.onSessionList('T1');
+    await Promise.resolve();
+    expect(sends).toEqual([['T1', 'A']]);
+  });
+
+  it('establishes liveReady only after the matching snapshot ACK', async () => {
+    const { controller, applySnapshot } = setup();
+    controller.setDesired('A'); controller.onSessionList('T1'); await Promise.resolve();
+    expect(controller.liveReady).toBe(false);
+    controller.onAck(ack('T1', 'A'));
+    expect(controller.liveReady).toBe(true);
+    expect(controller.acceptsLive('A')).toBe(true);
+    expect(controller.acceptsLive('B')).toBe(false);
+    expect(applySnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('stops accepting A live frames before the same-tentacle B ACK', async () => {
+    const { controller, sends } = setup();
+    controller.setDesired('A'); controller.onSessionList('T1'); await Promise.resolve(); controller.onAck(ack('T1', 'A'));
+    expect(controller.acceptsLive('A')).toBe(true);
+    controller.setDesired('B'); await Promise.resolve();
+    expect(controller.acceptsLive('A')).toBe(false);
+    expect(controller.acceptsLive('B')).toBe(false);
+    expect(sends).toEqual([['T1', 'A'], ['T1', 'B']]);
+  });
+
+  it('coalesces rapid A→B→C while one request is in flight', async () => {
+    const { controller, sends } = setup();
+    controller.onSessionList('T1'); controller.setDesired('A'); await Promise.resolve();
+    controller.setDesired('B'); controller.setDesired('C');
+    controller.onAck(ack('T1', 'A')); await Promise.resolve();
+    expect(sends).toEqual([['T1', 'A'], ['T1', 'C']]);
+  });
+
+  it('unsubscribes the old tentacle before subscribing on a new tentacle', async () => {
+    const { controller, sends } = setup({ A: 'T1', B: 'T2' });
+    controller.onSessionList('T1'); controller.onSessionList('T2');
+    controller.setDesired('A'); await Promise.resolve(); controller.onAck(ack('T1', 'A'));
+    controller.setDesired('B'); await Promise.resolve();
+    expect(sends.at(-1)).toEqual(['T1', null]);
+    controller.onAck(ack('T1', null)); await Promise.resolve();
+    expect(sends.at(-1)).toEqual(['T2', 'B']);
+  });
+
+  it('ignores a stale ACK that does not match the in-flight desired request', async () => {
+    const { controller, applySnapshot } = setup();
+    controller.onSessionList('T1'); controller.setDesired('A'); await Promise.resolve();
+    controller.onAck(ack('T1', 'B'));
+    expect(controller.liveReady).toBe(false);
+    expect(applySnapshot).not.toHaveBeenCalled();
+    controller.onAck(ack('T1', 'A'));
+    expect(controller.liveReady).toBe(true);
+  });
+
+  it('retains desired across reconnect but requires a new barrier and ACK', async () => {
+    const { controller, sends, disconnect } = setup();
+    controller.onSessionList('T1'); controller.setDesired('A'); await Promise.resolve(); controller.onAck(ack('T1', 'A'));
+    disconnect();
+    expect(controller.desired).toBe('A');
+    expect(controller.liveReady).toBe(false);
+    controller.onSessionList('T1');
+    expect(sends).toHaveLength(1); // disconnected host does not send
+  });
+});

--- a/packages/arm/web/src/lib/session-subscription.ts
+++ b/packages/arm/web/src/lib/session-subscription.ts
@@ -1,0 +1,133 @@
+import type { SessionSubscriptionSetMessage } from '@kraki/protocol';
+
+export interface SubscriptionControllerHost {
+  isConnected(): boolean;
+  resolveTentacle(sessionId: string): string | undefined;
+  send(tentacleId: string, sessionId: string | null): Promise<boolean>;
+  applySnapshot(msg: SessionSubscriptionSetMessage): void;
+  reportError(message: string): void;
+}
+
+interface InFlight {
+  tentacleId: string;
+  sessionId: string | null;
+}
+
+/**
+ * Serial single-session subscription assure.
+ *
+ * - At most one request is in flight.
+ * - session_list from a tentacle is the reconnect inbound barrier.
+ * - Same-tentacle A→B is one atomic replace request.
+ * - Cross-tentacle X→Y confirms X:null before subscribing on Y.
+ * - Rapid desired changes coalesce to the final value.
+ */
+export class SessionSubscriptionController {
+  private desiredSessionId: string | null = null;
+  private confirmedSessionId: string | null = null;
+  private confirmedTentacleId: string | null = null;
+  private inFlight: InFlight | null = null;
+  private barriers = new Set<string>();
+  private blockedDesired: string | null = null;
+
+  constructor(private readonly host: SubscriptionControllerHost) {}
+
+  get desired(): string | null { return this.desiredSessionId; }
+  get confirmed(): string | null { return this.confirmedSessionId; }
+  get liveReady(): boolean {
+    return this.desiredSessionId !== null && this.confirmedSessionId === this.desiredSessionId;
+  }
+
+  setDesired(sessionId: string | null): void {
+    if (this.desiredSessionId !== sessionId) {
+      this.blockedDesired = null;
+      // Stop accepting the previous session's high-frequency live frames as
+      // soon as navigation changes. Keep confirmedTentacleId until its null
+      // ACK when crossing tentacles, so the old authority is still released.
+      if (this.confirmedSessionId !== sessionId) this.confirmedSessionId = null;
+    }
+    this.desiredSessionId = sessionId;
+    this.drive();
+  }
+
+  /** Reset connection-scoped authority while retaining the page's desired value. */
+  onDisconnected(): void {
+    this.confirmedSessionId = null;
+    this.confirmedTentacleId = null;
+    this.inFlight = null;
+    this.barriers.clear();
+    this.blockedDesired = null;
+  }
+
+  /** Current post-auth session_list from this tentacle is the inbound barrier. */
+  onSessionList(tentacleId: string): void {
+    this.barriers.add(tentacleId);
+    if (this.desiredSessionId && this.host.resolveTentacle(this.desiredSessionId) === tentacleId) {
+      this.blockedDesired = null;
+    }
+    this.drive();
+  }
+
+  acceptsLive(sessionId: string): boolean {
+    return this.confirmedSessionId !== null && sessionId === this.confirmedSessionId;
+  }
+
+  onAck(msg: SessionSubscriptionSetMessage): void {
+    const flight = this.inFlight;
+    if (!flight) return;
+    if (msg.deviceId !== flight.tentacleId) return;
+    if (msg.payload.sessionId !== flight.sessionId) return;
+
+    this.inFlight = null;
+    if (!msg.payload.accepted) {
+      if (flight.sessionId === this.desiredSessionId) {
+        this.blockedDesired = flight.sessionId;
+        this.host.reportError(msg.payload.error.message);
+      }
+      this.drive();
+      return;
+    }
+
+    if (msg.payload.sessionId === null) {
+      this.confirmedSessionId = null;
+      this.confirmedTentacleId = null;
+    } else {
+      this.host.applySnapshot(msg);
+      this.confirmedSessionId = msg.payload.sessionId;
+      this.confirmedTentacleId = msg.deviceId;
+    }
+    this.drive();
+  }
+
+  private drive(): void {
+    if (!this.host.isConnected() || this.inFlight) return;
+
+    const desired = this.desiredSessionId;
+    const desiredTentacle = desired ? this.host.resolveTentacle(desired) : undefined;
+
+    // Leave the old tentacle before moving to another one.
+    if (this.confirmedTentacleId && this.confirmedTentacleId !== desiredTentacle) {
+      this.issue(this.confirmedTentacleId, null);
+      return;
+    }
+
+    if (desired === null) return;
+    if (!desiredTentacle || !this.barriers.has(desiredTentacle)) return;
+    if (this.confirmedSessionId === desired && this.confirmedTentacleId === desiredTentacle) return;
+    if (this.blockedDesired === desired) return;
+
+    this.issue(desiredTentacle, desired);
+  }
+
+  private issue(tentacleId: string, sessionId: string | null): void {
+    this.inFlight = { tentacleId, sessionId };
+    void this.host.send(tentacleId, sessionId).then((sent) => {
+      if (sent) return;
+      if (this.inFlight?.tentacleId === tentacleId && this.inFlight.sessionId === sessionId) {
+        this.inFlight = null;
+        this.blockedDesired = sessionId;
+        this.host.reportError('Cannot set live session subscription: target is unavailable.');
+      }
+    });
+  }
+}

--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -66,6 +66,9 @@ vi.mock('./encryption', () => ({
       const to = (payload?.targetDeviceId as string) ?? 'test-tentacle';
       return { blob: JSON.stringify(msg), keys: {}, to };
     }
+    async encryptForDevice(msg: Record<string, unknown>, targetDeviceId: string) {
+      return { blob: JSON.stringify(msg), keys: {}, to: targetDeviceId };
+    }
     async drainEncryptedQueue() {}
   },
 }));
@@ -237,11 +240,27 @@ describe('KrakiWSClient', () => {
       lastWsInstance._receive({
         type: 'auth_ok',
         deviceId: 'dev-web-123',
-        devices: [],
+        devices: [{ id: 'dev-1', name: 'MacBook', role: 'tentacle', online: true, encryptionKey: 'mock-key' }],
       });
-      useStore.getState().upsertSession({
-        id: 'sess-1', deviceId: 'dev-1', deviceName: 'MacBook',
-        agent: 'copilot', state: 'active', messageCount: 0,
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-1', seq: 1, timestamp: '',
+        payload: { sessions: [{ id: 'sess-1', agent: 'copilot', state: 'active', mode: 'execute', lastSeq: 0, readSeq: 0, messageCount: 0, createdAt: '' }] },
+      });
+      client.setDesiredSession('sess-1');
+      await vi.waitFor(() => {
+        const sent = lastWsInstance.sentMessages.map(decodePulseSend).filter(Boolean);
+        expect(sent.some((m) => m?.type === 'set_session_subscription')).toBe(true);
+      });
+      receiveInner({
+        type: 'session_subscription_set', deviceId: 'dev-1', seq: 2, timestamp: '',
+        payload: {
+          accepted: true, sessionId: 'sess-1',
+          snapshot: {
+            digest: { id: 'sess-1', agent: 'copilot', state: 'active', mode: 'execute', lastSeq: 0, readSeq: 0, messageCount: 0, createdAt: '' },
+            spineHeadSeq: 0,
+            card: { draft: '', action: null },
+          },
+        },
       });
     }
 

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -1,4 +1,4 @@
-import type { InnerMessage, SessionListMessage, AuthOkMessage, AuthInfoResponse, ServerErrorMessage, AuthChallengeMessage, DeviceJoinedMessage, DeviceLeftMessage, RelayEnvelope, Message, SessionState } from '@kraki/protocol';
+import type { InnerMessage, SessionListMessage, SessionSubscriptionSetMessage, AuthOkMessage, AuthInfoResponse, ServerErrorMessage, AuthChallengeMessage, DeviceJoinedMessage, DeviceLeftMessage, RelayEnvelope, Message, SessionState } from '@kraki/protocol';
 import { HEAD_PULSE_TARGET } from '@kraki/protocol';
 import { createAppKeyStore } from './e2e';
 import { KrakiTransport, type MessageHandler } from './transport';
@@ -13,6 +13,7 @@ import * as commands from './commands';
 import { createLogger, setLogBroadcast } from './logger';
 import { ArmPulse } from './arm-pulse';
 import { traceEvent } from './trace';
+import { SessionSubscriptionController } from './session-subscription';
 import { AttachmentPullQueue } from './attachment-pull-queue';
 
 const logger = createLogger('ws-client');
@@ -24,6 +25,7 @@ export class KrakiWSClient {
   private cmdState = new CommandState();
   private handlers: MessageHandler[] = [];
   private pulse: ArmPulse;
+  private subscription: SessionSubscriptionController;
   private pulseTick: ReturnType<typeof setInterval> | null = null;
   private attachmentPulls = new AttachmentPullQueue(({ sessionId, id, index }) => {
     if (getStore().status !== 'connected') return false;
@@ -47,6 +49,13 @@ export class KrakiWSClient {
   constructor(url?: string) {
     const keyStore = createAppKeyStore();
     this.encryption = new EncryptionHandler(keyStore);
+    this.subscription = new SessionSubscriptionController({
+      isConnected: () => getStore().status === 'connected',
+      resolveTentacle: (sessionId) => getStore().sessions.get(sessionId)?.deviceId,
+      send: (tentacleId, sessionId) => this.sendSessionSubscription(tentacleId, sessionId),
+      applySnapshot: (msg) => this.applySubscriptionSnapshot(msg),
+      reportError: (message) => getStore().setLastError(message),
+    });
 
     // Per-hop pulse endpoint to the relay — the reliable-delivery layer.
     this.pulse = new ArmPulse(
@@ -70,6 +79,7 @@ export class KrakiWSClient {
         },
         onClose: () => {
           this.clearReplayTracking();
+          this.subscription.onDisconnected();
           this.attachmentPulls.disconnect();
           this.pulse.onDisconnected();
         },
@@ -98,6 +108,56 @@ export class KrakiWSClient {
     return () => {
       this.handlers = this.handlers.filter((h) => h !== handler);
     };
+  }
+
+  setDesiredSession(sessionId: string | null): void {
+    this.subscription.setDesired(sessionId);
+  }
+
+  isLiveReady(sessionId: string): boolean {
+    return this.subscription.confirmed === sessionId;
+  }
+
+  private async sendSessionSubscription(tentacleId: string, sessionId: string | null): Promise<boolean> {
+    const deviceId = getStore().deviceId;
+    if (!deviceId) return false;
+    const msg = {
+      type: 'set_session_subscription',
+      deviceId,
+      seq: 0,
+      timestamp: new Date().toISOString(),
+      payload: { sessionId },
+    };
+    const encrypted = await this.encryption.encryptForDevice(msg, tentacleId);
+    if (!encrypted) return false;
+    this.pulse.send(JSON.stringify({ blob: encrypted.blob, keys: encrypted.keys }), encrypted.to, false);
+    return true;
+  }
+
+  private applySubscriptionSnapshot(msg: SessionSubscriptionSetMessage): void {
+    if (!msg.payload.accepted || msg.payload.sessionId === null) return;
+    const { digest, spineHeadSeq, card } = msg.payload.snapshot;
+    const store = getStore();
+    const device = store.devices.get(msg.deviceId);
+    store.upsertSession({
+      id: digest.id,
+      deviceId: msg.deviceId,
+      deviceName: device?.name ?? msg.deviceId,
+      agent: digest.agent,
+      model: digest.model,
+      title: digest.title,
+      autoTitle: digest.autoTitle,
+      state: digest.state,
+      messageCount: digest.messageCount,
+    });
+    store.setSessionMode(digest.id, digest.mode);
+    if (digest.preview) store.setSessionPreview(digest.id, digest.preview);
+    if (digest.usage) store.setSessionUsage(digest.id, digest.usage);
+    store.clearCard(digest.id);
+    store.applyCardMessage(digest.id, card.draft, true);
+    store.setCardAction(digest.id, card.action);
+    messageProvider.setTentacleInfo(digest.id, spineHeadSeq, msg.deviceId);
+    messageProvider.reconcileTail(digest.id, spineHeadSeq);
   }
 
   // --- Actions ---
@@ -160,8 +220,19 @@ export class KrakiWSClient {
     }
   }
 
-  /** Route a decrypted inner message through the normal pipeline. */
+  /** Route a decrypted inner message through subscription gating and the normal pipeline. */
   private dispatchInner(inner: InnerMessage) {
+    if (inner.type === 'session_subscription_set') {
+      this.subscription.onAck(inner as SessionSubscriptionSetMessage);
+      this.handlers.forEach((h) => h(inner as unknown as Message));
+      return;
+    }
+    if (
+      (inner.type === 'agent_message_delta' || inner.type === 'card_action')
+      && (!inner.sessionId || !this.subscription.acceptsLive(inner.sessionId))
+    ) {
+      return;
+    }
     handleDataMessage(inner, {
       cmdState: this.cmdState,
       sendEncrypted: (m) => this.sendEncrypted(m),
@@ -480,6 +551,7 @@ export class KrakiWSClient {
     }
     store.setPinnedSessions(currentPinned);
 
+    this.subscription.onSessionList(tentacleDeviceId);
     // Tier 1: Budget warm-up — pre-fetch messages for likely-needed sessions
     this.runWarmup(tentacleSessions, pinnedFromTentacle);
   }
@@ -657,13 +729,8 @@ export class KrakiWSClient {
 
   private encryptionCallbacks() {
     return {
-      handleDataMessage: (msg: InnerMessage) => handleDataMessage(msg, {
-        cmdState: this.cmdState,
-        sendEncrypted: (m) => this.sendEncrypted(m),
-        onSessionList: (m) => this.handleSessionList(m),
-        onSessionMessagesRangeBatch: (m) => this.handleRangeBatch(m),
-      }),
-      getHandlers: () => this.handlers,
+      handleDataMessage: (msg: InnerMessage) => this.dispatchInner(msg),
+      getHandlers: () => [],
     };
   }
 
@@ -682,6 +749,7 @@ export class KrakiWSClient {
     switch (msg.type) {
       // --- Encrypted envelopes ---
       case 'unicast':
+      case 'multicast':
       case 'broadcast': {
         // Pulse-framed? Feed the frame to our endpoint; a `deliver` calls
         // handlePulseDelivered with the blob to decrypt.
@@ -804,12 +872,7 @@ export class KrakiWSClient {
         // in production but as plaintext from mock relay in E2E tests.
         // Route them to the message router so both paths work.
         if ('sessionId' in msg || 'payload' in msg) {
-          handleDataMessage(msg as InnerMessage, {
-            cmdState: this.cmdState,
-            sendEncrypted: (m) => this.sendEncrypted(m),
-            onSessionList: (m) => this.handleSessionList(m),
-            onSessionMessagesRangeBatch: (m) => this.handleRangeBatch(m),
-          });
+          this.dispatchInner(msg as InnerMessage);
         }
         break;
     }

--- a/packages/arm/web/src/pages/SessionPage.tsx
+++ b/packages/arm/web/src/pages/SessionPage.tsx
@@ -9,6 +9,7 @@ import { SessionInfoPanel } from '../components/devices/SessionInfoPanel';
 import { messageProvider } from '../lib/message-provider';
 import { HtmlArtifactPanel } from '../components/chat/HtmlArtifactPanel';
 import type { ContentRef } from '@kraki/protocol';
+import { setDesiredSessionSubscription } from '../lib/session-subscription-lifecycle';
 
 export function SessionPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -57,6 +58,15 @@ export function SessionPage() {
     setSelectedArtifact(null);
     return () => setActiveSessionId(null);
   }, [sessionId, setActiveSessionId]);
+
+  // Session changes replace the desired value directly (A→B is one atomic
+  // set on the same tentacle; do not emit an intermediate null from effect cleanup).
+  useEffect(() => {
+    if (sessionId) setDesiredSessionSubscription(sessionId);
+  }, [sessionId]);
+
+  // Only leaving the SessionPage route entirely unsubscribes.
+  useEffect(() => () => setDesiredSessionSubscription(null), []);
 
   // Tier 2: on-demand message loading when user opens a session
   useEffect(() => {

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",

--- a/packages/head/src/__tests__/server.test.ts
+++ b/packages/head/src/__tests__/server.test.ts
@@ -352,6 +352,23 @@ describe('HeadServer (thin relay)', () => {
   // ── Broadcast isolation ───────────────────────────────
 
   describe('broadcast isolation', () => {
+    it('targets only same-user online app devices', async () => {
+      head = await createHead();
+      const { ws: source, authOk: sourceAuth } = await authConnect(head.port, 'Source Tentacle', 'tentacle', { deviceId: 'tentacle-source' });
+      const { ws: app, authOk: appAuth } = await authConnect(head.port, 'Phone', 'app', { deviceId: 'app-online' });
+      const { ws: peerTentacle, authOk: peerAuth } = await authConnect(head.port, 'Peer Tentacle', 'tentacle', { deviceId: 'tentacle-peer' });
+
+      const targets = (head.server as unknown as {
+        pulseBroadcastTargets(fromDevice: string): string[];
+      }).pulseBroadcastTargets(sourceAuth.deviceId as string);
+
+      expect(targets).toEqual([appAuth.deviceId as string]);
+
+      source.close();
+      app.close();
+      peerTentacle.close();
+    });
+
     it('should NOT deliver broadcast to devices of another user', async () => {
       const fetcher = mockGitHubFetcher({
         tok_alice: { id: 'alice', login: 'alice' },

--- a/packages/head/src/pulse-hub.ts
+++ b/packages/head/src/pulse-hub.ts
@@ -256,7 +256,7 @@ export class PulseHub {
    * the routing destination the delivered payload should be forwarded to. Feed
    * the frame to the source endpoint and carry out the effects.
    */
-  onPulseEnvelope(fromDevice: string, env: PulseFrameField & { to?: string }): void {
+  onPulseEnvelope(fromDevice: string, env: PulseFrameField & { to?: string | string[] }): void {
     if (this.closed || !this.db.open || !env.pulse) return;
     const d = this.ep(fromDevice);
     // A frame addressed to HEAD_PULSE_TARGET is consumed by the head itself, not
@@ -264,11 +264,14 @@ export class PulseHub {
     // resume as everything else) — only the `deliver` handling differs.
     const selfBound = env.to === HEAD_PULSE_TARGET;
     // Destinations for anything this device delivers: an explicit unicast `to`,
-    // or (for a broadcast) the fan-out targets from the host. '@head' is a
-    // routing sentinel, never a forward destination.
+    // an explicit multicast target set, or (for a legacy broadcast) the fan-out
+    // targets from the host. '@head' is a routing sentinel, never a forward
+    // destination. Server-side validation has already normalized multicast.
     const dests = selfBound
       ? []
-      : (env.to ? [env.to] : this.host.broadcastTargets(fromDevice));
+      : (Array.isArray(env.to)
+          ? env.to
+          : (env.to ? [env.to] : this.host.broadcastTargets(fromDevice)));
     const inLen = env.pulse.length;
     const bytes = b64decode(env.pulse);
     const decoded = decodeFrameWithStream(bytes);

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -100,6 +100,7 @@ const DEFAULT_VOICE_DAILY_QUOTA_SEC = 7_200;
 const VALID_VOICE_RESOURCES = new Set<VoiceResource>(['voice/doubao']);
 
 const DEFAULT_MAX_PAYLOAD = 10 * 1024 * 1024;
+const MAX_MULTICAST_TARGETS = 64;
 
 /** How often the liveness sweep runs (ms). Faster than the 30s ping timer so
  *  device_pending detection latency tracks the recipient's ping cadence
@@ -488,6 +489,50 @@ export class HeadServer {
       return;
     }
 
+    if (msg.type === 'multicast') {
+      if (typeof msg.pulse !== 'string' || !state.deviceId || !state.userId) {
+        this.sendError(ws, 'multicast requires a pulse frame');
+        return;
+      }
+      const sender = this.storage.getDevice(state.deviceId);
+      if (sender?.role !== 'tentacle') {
+        this.sendError(ws, 'multicast is only allowed from tentacle devices');
+        return;
+      }
+      if (!Array.isArray(msg.to)) {
+        this.sendError(ws, 'multicast requires a target array');
+        return;
+      }
+      if (msg.to.some((target) => typeof target !== 'string' || target.length === 0)) {
+        this.sendError(ws, 'multicast targets must be non-empty strings');
+        return;
+      }
+      const requested = [...new Set(msg.to)];
+      if (requested.length === 0 || requested.length > MAX_MULTICAST_TARGETS) {
+        this.sendError(ws, `multicast target count must be between 1 and ${MAX_MULTICAST_TARGETS}`);
+        return;
+      }
+      for (const targetId of requested) {
+        const target = this.storage.getDevice(targetId);
+        if (
+          targetId === state.deviceId
+          || targetId === HEAD_PULSE_TARGET
+          || !target
+          || target.userId !== state.userId
+          || target.role !== 'app'
+        ) {
+          this.sendError(ws, 'multicast contains a forbidden target');
+          return;
+        }
+      }
+      const onlineTargets = requested.filter((targetId) => this.connections.has(targetId));
+      this.pulseHub.onPulseEnvelope(state.deviceId, {
+        pulse: msg.pulse,
+        to: onlineTargets,
+      });
+      return;
+    }
+
     if (msg.type === 'broadcast') {
       // Pulse broadcast frames (control: hello/ack/heartbeat) are addressed to a
       // specific hop via the hub too; a producer fans out per-device unicasts.
@@ -699,6 +744,13 @@ export class HeadServer {
       case 'remove_device':         this.handleRemoveDevice(ws, state, msg.deviceId as string); return true;
       case 'register_push_token':   this.handleRegisterPushToken(ws, state, msg); return true;
       case 'unregister_push_token': this.handleUnregisterPushToken(ws, state, msg); return true;
+      case 'dispatch_push': {
+        const sender = state.deviceId ? this.storage.getDevice(state.deviceId) : undefined;
+        const payload = msg.payload as { preview?: BlobPayload } | undefined;
+        if (sender?.role !== 'tentacle' || !payload?.preview) return true;
+        this.firePushPreview(state, payload.preview);
+        return true;
+      }
       default: return false;
     }
   }
@@ -745,7 +797,7 @@ export class HeadServer {
     if (!userId) return [];
     const targets: string[] = [];
     for (const device of this.storage.getDevicesByUser(userId)) {
-      if (device.id === fromDevice) continue;
+      if (device.id === fromDevice || device.role !== 'app') continue;
       // Only include devices currently connected — see comment above.
       if (!this.connections.has(device.id)) continue;
       targets.push(device.id);

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -67,6 +67,19 @@ export interface UnicastEnvelope extends PulseFrameField {
   ref?: string;
 }
 
+/** Tentacle → explicit same-user app target set. Relay reads only `to` for routing. */
+export interface MulticastEnvelope extends PulseFrameField {
+  type: 'multicast';
+  /** Explicit target device IDs. Must be non-empty after de-duplication. */
+  to: string[];
+  /** Unused in pulse mode; ciphertext is inside the pulse DATA payload. */
+  blob: string;
+  /** Unused in pulse mode; recipient keys are inside the pulse DATA payload. */
+  keys: Record<string, string>;
+  /** Optional reference ID, echoed back in server_error responses. */
+  ref?: string;
+}
+
 /** Tentacle → all devices. Relay broadcasts to all other devices under the user. */
 export interface BroadcastEnvelope extends PulseFrameField {
   type: 'broadcast';
@@ -80,7 +93,7 @@ export interface BroadcastEnvelope extends PulseFrameField {
   pushPreview?: BlobPayload;
 }
 
-export type RelayEnvelope = UnicastEnvelope | BroadcastEnvelope;
+export type RelayEnvelope = UnicastEnvelope | MulticastEnvelope | BroadcastEnvelope;
 
 /** Encrypted blob payload — shared between crypto and app layers. */
 export interface BlobPayload {
@@ -743,6 +756,48 @@ export interface TurnTraceBatchMessage extends BaseEnvelope {
   };
 }
 
+/** Atomic subscribe/replace/unsubscribe request for one Arm's visible session. */
+export interface SetSessionSubscriptionMessage extends BaseEnvelope {
+  type: 'set_session_subscription';
+  payload: {
+    sessionId: string | null;
+  };
+}
+
+/** Bounded live-state snapshot returned with a successful subscription ACK. */
+export interface SessionLiveSnapshot {
+  digest: import('./sessions.js').SessionDigest;
+  spineHeadSeq: number;
+  card: {
+    draft: string;
+    action: CardActionState | null;
+  };
+}
+
+/** Tentacle acknowledgement and live-ready barrier for session subscription. */
+export interface SessionSubscriptionSetMessage extends BaseEnvelope {
+  type: 'session_subscription_set';
+  payload:
+    | {
+        accepted: true;
+        sessionId: string;
+        snapshot: SessionLiveSnapshot;
+      }
+    | {
+        accepted: true;
+        sessionId: null;
+        snapshot: null;
+      }
+    | {
+        accepted: false;
+        sessionId: string;
+        error: {
+          code: 'session_not_found';
+          message: string;
+        };
+      };
+}
+
 /** Sent by tentacle to app with metadata for all active sessions. */
 export interface SessionListMessage extends BaseEnvelope {
   type: 'session_list';
@@ -856,6 +911,7 @@ export type ProducerMessage =
   | SessionReplayBatchMessage
   | SessionMessagesBatchMessage
   | SessionMessagesRangeBatchMessage
+  | SessionSubscriptionSetMessage
   | SessionListMessage
   | PermissionResolvedMessage
   | QuestionResolvedMessage
@@ -1110,7 +1166,8 @@ export type ConsumerMessage =
   | PinSessionMessage
   | RequestLocalSessionsMessage
   | ImportSessionMessage
-  | RequestAttachmentMessage;
+  | RequestAttachmentMessage
+  | SetSessionSubscriptionMessage;
 
 // ============================================================
 // Auth credentials — discriminated union by method
@@ -1344,6 +1401,14 @@ export interface UnregisterPushTokenMessage {
   };
 }
 
+/** Head-terminated encrypted push dispatch, sent over the existing @head Pulse channel. */
+export interface DispatchPushMessage {
+  type: 'dispatch_push';
+  payload: {
+    preview: BlobPayload;
+  };
+}
+
 export type ControlMessage =
   | AuthMessage
   | AuthOkMessage
@@ -1365,7 +1430,8 @@ export type ControlMessage =
   | PreferencesUpdatedMessage
   | RegisterPushTokenMessage
   | PushTokenRegisteredMessage
-  | UnregisterPushTokenMessage;
+  | UnregisterPushTokenMessage
+  | DispatchPushMessage;
 
 // ============================================================
 // Union of all messages

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.29.16",
+  "version": "0.30.0",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -114,6 +114,23 @@ function decodePulseSends(sent: string[]): Array<Record<string, unknown>> {
   return out;
 }
 
+function decodeHeadControls(sent: string[]): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const raw of sent) {
+    const env = JSON.parse(raw) as Record<string, unknown>;
+    if (env.type !== 'unicast' || env.to !== '@head' || typeof env.pulse !== 'string') continue;
+    const frame = decodeFrame(new Uint8Array(Buffer.from(env.pulse, 'base64')));
+    if (!frame || frame.t !== 'data') continue;
+    try { out.push(JSON.parse(new TextDecoder().decode(frame.payload))); } catch { /* ignore */ }
+  }
+  return out;
+}
+
+function subscribeForTest(client: RelayClient, sessionId: string, deviceId = 'consumer-dev'): void {
+  (client as unknown as { currentSessionByArm: Map<string, string | null> })
+    .currentSessionByArm.set(deviceId, sessionId);
+}
+
 function createAdapter(): Record<string, unknown> {
   return {
     onSessionCreated: null,
@@ -162,6 +179,7 @@ function createSessionManager(): Record<string, unknown> {
     setMode: vi.fn(),
     deleteSession: vi.fn(),
     markRead: vi.fn(),
+    markUnread: vi.fn(() => 41),
     getSessionList: vi.fn(() => []),
     getPendingHumanAction: vi.fn(() => null),
     savePendingHumanAction: vi.fn(),
@@ -590,6 +608,7 @@ describe('RelayClient set_session_model', () => {
       markIdle: vi.fn(),
       markActive: vi.fn(),
       markRead: vi.fn(),
+      markUnread: vi.fn(() => 41),
       deleteSession: vi.fn(),
       removeLinkByKrakiId: vi.fn(),
       appendMessage: vi.fn(() => 1),
@@ -973,6 +992,29 @@ describe('RelayClient set_session_model', () => {
     expect(readMsg.sessionId).toBe('sess_1');
   });
 
+  it('rolls readSeq back and broadcasts session_read on mark_unread', () => {
+    const { sm } = buildConnectedClient();
+    const ws = sockets[0];
+    ws.sent.length = 0;
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'mark_unread',
+      sessionId: 'sess_1',
+      deviceId: 'dev_1',
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: {},
+    })));
+
+    expect(sm.markUnread).toHaveBeenCalledWith('sess_1');
+
+    const sent = decodePulseSends(ws.sent);
+    const readMsg = sent.find(m => m.type === 'session_read');
+    expect(readMsg).toBeDefined();
+    expect(readMsg.payload.seq).toBe(41);
+    expect(readMsg.sessionId).toBe('sess_1');
+  });
+
   it('delete_session removes from sessionManager SYNCHRONOUSLY before any awaits', () => {
     // Regression for: pre-fix, session removal happened in adapter.killSession()'s
     // .finally(), so a broadcastSessionList fired immediately after would still see
@@ -1069,6 +1111,7 @@ describe('RelayClient tool message lazy-load shape', () => {
       type: 'device_joined',
       device: { id: 'consumer-dev', role: 'app', encryptionKey: 'consumer-pub' },
     })));
+    subscribeForTest(client, 'sess_1');
     return { adapter, sm, client, ws: sockets[0], store, tmp, cleanup: () => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ } } };
   }
 
@@ -1389,6 +1432,7 @@ describe('RelayClient delta debounce', () => {
       device: { id: 'consumer-dev', role: 'app', encryptionKey: 'consumer-pub' },
     })));
     sockets[0].sent.length = 0;
+    subscribeForTest(client, 's1');
     return { adapter, sm, client };
   }
 
@@ -1433,8 +1477,14 @@ describe('RelayClient delta debounce', () => {
     expect(delta.payload.content).toBe('streaming text');
   });
 
-  it('keeps separate buffers per session', () => {
-    const { adapter } = connectClient();
+  it('only delivers each session buffer to its subscribed Arm', () => {
+    const { adapter, client } = connectClient();
+    sockets[0].emit('message', Buffer.from(JSON.stringify({
+      type: 'device_joined',
+      device: { id: 'consumer-dev-2', role: 'app', encryptionKey: 'consumer-pub-2' },
+    })));
+    subscribeForTest(client, 's2', 'consumer-dev-2');
+    sockets[0].sent.length = 0;
     const onDelta = adapter.onMessageDelta as (sid: string, e: { content: string }) => void;
 
     onDelta('s1', { content: 'a' });
@@ -1443,11 +1493,11 @@ describe('RelayClient delta debounce', () => {
 
     vi.advanceTimersByTime(40);
 
-    const deltas = decodePulseSends(sockets[0].sent)
-      .filter(m => m.type === 'agent_message_delta');
-    const bySession = new Map(deltas.map(d => [d.sessionId, d.payload.content]));
-    expect(bySession.get('s1')).toBe('aa');
-    expect(bySession.get('s2')).toBe('b');
+    const envelopes = sockets[0].sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    const multicasts = envelopes.filter((env) => env.type === 'multicast' && Array.isArray(env.to));
+    expect(multicasts).toHaveLength(2);
+    expect(multicasts.some((env) => (env.to as string[]).length === 1 && (env.to as string[])[0] === 'consumer-dev')).toBe(true);
+    expect(multicasts.some((env) => (env.to as string[]).length === 1 && (env.to as string[])[0] === 'consumer-dev-2')).toBe(true);
   });
 
   it('disconnect() clears pending delta timers', () => {
@@ -1873,7 +1923,8 @@ describe('RelayClient trace mirroring (off-spine)', () => {
       type: 'device_joined',
       device: { id: 'consumer-dev', role: 'app', encryptionKey: 'consumer-pub' },
     })));
-    return { adapter, sm, ws: sockets[0], cleanup: () => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ } } };
+    subscribeForTest(client, 'sess_1');
+    return { adapter, sm, client, ws: sockets[0], cleanup: () => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ } } };
   }
 
   it('keeps compaction transient: compacting message only, never spine or trace', () => {
@@ -1993,7 +2044,7 @@ describe('RelayClient pending-question digest', () => {
       return undefined;
     };
     const preview = () => digest()?.preview as { type: string; text: string } | undefined;
-    return { adapter, sm, ws, askQ, answerQ, digest, preview };
+    return { adapter, sm, client, ws, askQ, answerQ, digest, preview };
   }
 
   it('restores compacting from session_list state without replaying runtime events', () => {
@@ -2354,20 +2405,68 @@ describe('RelayClient pending-question digest', () => {
     expect(interruptedTool).toBeDefined();
   });
 
-  it('pushes the active card snapshot to a freshly-joined device', () => {
-    const { askQ, ws } = buildClient();
+  it('dispatches push through @head when every consumer is offline', () => {
+    const adapter = createAdapter();
+    const sm = createSessionManager();
+    const client = new RelayClient(
+      adapter as unknown as Parameters<typeof RelayClient>[0],
+      sm as unknown as Parameters<typeof RelayClient>[1],
+      { relayUrl: 'ws://localhost:4000', authMethod: 'open', device: { name: 'Test', role: 'tentacle' }, reconnectDelay: 10 },
+      createKeyManager() as unknown as Parameters<typeof RelayClient>[3],
+    );
+    client.connect();
+    const ws = sockets[0];
+    ws.emit('open');
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'auth_ok', deviceId: 'dev_t', authMethod: 'open',
+      user: { id: 'u1', login: 'test', provider: 'open' },
+      devices: [{ id: 'app-offline', name: 'Phone', role: 'app', online: false, encryptionKey: 'app-key' }],
+    })));
+    ws.sent.length = 0;
+
+    (adapter.onQuestionRequest as (sid: string, event: Record<string, unknown>) => void)(
+      'sess_1',
+      { id: 'q-offline', question: 'Need a decision?', choices: ['yes', 'no'] },
+    );
+
+    const controls = decodeHeadControls(ws.sent);
+    expect(controls).toHaveLength(1);
+    expect(controls[0]).toMatchObject({ type: 'dispatch_push', payload: { preview: { blob: expect.any(String) } } });
+  });
+
+  it('does not replay queued card events or push every active-session snapshot on device_joined', () => {
+    const { adapter, askQ, ws } = buildClient();
+    askQ('q1');
+    const ask = adapter.onQuestionRequest as (sid: string, event: Record<string, unknown>) => void;
+    ask('sess_2', { id: 'q2', question: 'Q q2', choices: ['a', 'b'] });
+    ask('sess_3', { id: 'q3', question: 'Q q3', choices: ['a', 'b'] });
+    ws.sent.length = 0;
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'device_joined', relaySeq: 9001,
+      device: { id: 'app-fresh', name: 'Phone', role: 'app', online: true, encryptionKey: 'app-key' },
+    })));
+    const snapshots = decodePulseSends(ws.sent).filter((m) => m.type === 'card_action' || m.type === 'agent_message_delta');
+    expect(snapshots).toEqual([]);
+  });
+
+  it('returns the active card in the subscription ACK snapshot', () => {
+    const { askQ, client, ws } = buildClient();
     askQ('q1');
     ws.sent.length = 0;
     ws.emit('message', Buffer.from(JSON.stringify({
       type: 'device_joined', relaySeq: 9001,
       device: { id: 'app-fresh', name: 'Phone', role: 'app', online: true, encryptionKey: 'app-key' },
     })));
-    const inners = decodePulseSends(ws.sent);
-    const action = inners.find((m) => m.type === 'card_action');
-    expect(action).toBeDefined();
-    expect(action.sessionId).toBe('sess_1');
-    expect(action.payload.action).toMatchObject({ type: 'question', payload: { id: 'q1' } });
-    expect(inners.some((m) => m.type === 'agent_message_delta' && m.sessionId === 'sess_1')).toBe(true);
+    (client as unknown as { handleConsumerMessage: (msg: Record<string, unknown>) => void }).handleConsumerMessage({
+      type: 'set_session_subscription', deviceId: 'app-fresh', seq: 1, timestamp: '', payload: { sessionId: 'sess_1' },
+    });
+    const ack = decodePulseSends(ws.sent).find((m) => m.type === 'session_subscription_set');
+    expect(ack).toBeDefined();
+    expect(ack.payload).toMatchObject({
+      accepted: true,
+      sessionId: 'sess_1',
+      snapshot: { card: { action: { type: 'question', payload: { id: 'q1' } } } },
+    });
   });
 
   it('does not push a card snapshot for sessions with no active card', () => {

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -957,6 +957,26 @@ describe('SessionManager', () => {
       sm.markRead(sessionId, 1);
       expect(sm.getMeta(sessionId)!.readSeq).toBe(3);
     });
+
+    it('markUnread rolls back a fully-read session by one item', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      sm.markRead(sessionId, 2);
+      expect(sm.markUnread(sessionId)).toBe(1);
+      expect(sm.getMeta(sessionId)!.readSeq).toBe(1);
+    });
+
+    it('markUnread is idempotent and never advances an already-unread cursor', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.markRead(sessionId, 1);
+      expect(sm.markUnread(sessionId)).toBe(1);
+      expect(sm.markUnread(sessionId)).toBe(1);
+      expect(sm.getMeta(sessionId)!.readSeq).toBe(1);
+    });
   });
 
   describe('clampOverflowReadSeq migration', () => {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -13,7 +13,8 @@ import { homedir } from 'node:os';
 import type {
   ProducerMessage, ConsumerMessage,
   DeviceInfo, AuthOkMessage, AuthErrorMessage, DeviceSummary, AuthMethod,
-  BroadcastEnvelope, UnicastEnvelope, CardActionState,
+  BroadcastEnvelope, UnicastEnvelope, MulticastEnvelope, CardActionState,
+  SessionLiveSnapshot, SessionDigest,
 } from '@kraki/protocol';
 import { HEAD_PULSE_TARGET } from '@kraki/protocol';
 import { importPublicKey, encryptToBlob, decryptFromBlob, signChallenge } from '@kraki/crypto';
@@ -27,7 +28,7 @@ import { EventsWatcher } from './events-watcher.js';
 import { createLogger } from './logger.js';
 import { getKrakiHome } from './config.js';
 import { makeHeadline } from './tool-headline.js';
-import { TentaclePulse, streamForType } from './tentacle-pulse.js';
+import { TentaclePulse, streamForType, type PulseDeliveryTarget } from './tentacle-pulse.js';
 import { CardManager } from './card-manager.js';
 
 const logger = createLogger('relay-client');
@@ -102,10 +103,25 @@ export class RelayClient {
   private authInfo: AuthOkMessage | null = null;
   /** Cached consumer public keys for E2E encryption (includes offline devices for pushPreview) */
   private consumerKeys = new Map<string, string>();
-  /** Device IDs of currently connected consumers (for queue decision) */
+  /** Device IDs of currently connected consumers. */
   private onlineConsumers = new Set<string>();
-  /** Messages queued when E2E is enabled but no consumer keys are available yet */
-  private pendingE2eQueue: Partial<ProducerMessage>[] = [];
+  /** Accepted in-memory single-session subscription for each connected Arm. */
+  private currentSessionByArm = new Map<string, string | null>();
+  /** High-frequency live card types filtered by current session subscription. */
+  private static readonly SUBSCRIBER_ONLY_TYPES = new Set(['agent_message_delta', 'card_action']);
+
+  /** Messages with explicit reconnect authorities; never replay as generic events. */
+  private static readonly NO_OFFLINE_REPLAY_TYPES = new Set([
+    'agent_message_delta',
+    'card_action',
+    'compacting',
+    'session_list',
+    'active',
+    'idle',
+    'user_message',
+    'agent_message',
+  ]);
+
   /** Maps pre-generated sessionId → requestId for concurrent create_session correlation */
   private pendingRequestIds = new Map<string, string>();
   /** Message types that write to events.jsonl and should be persisted to messages.jsonl.
@@ -254,10 +270,6 @@ export class RelayClient {
   // ── Push preview state ─────────────────────────────
   /** Last agent message content per session (for idle push preview) */
   private lastAgentContent = new Map<string, string>();
-  /** Push preview to attach to the next pulse broadcast envelope (set just
-   *  before pulse.send for a notification-worthy message, consumed by
-   *  sendPulseEnvelope). */
-  private pendingPushPreview: { blob: string; keys: Record<string, string> } | undefined;
 
   // ── Streaming delta debounce ───────────────────────
   // Each agent_message_delta otherwise triggers a full hybrid encryption
@@ -348,7 +360,7 @@ export class RelayClient {
     this.pulse = new TentaclePulse(
       {
         now: () => Date.now(),
-        sendPulseFrame: (pulseB64, targetDeviceId) => this.sendPulseEnvelope(pulseB64, targetDeviceId),
+        sendPulseFrame: (pulseB64, target) => this.sendPulseEnvelope(pulseB64, target),
         onDelivered: (blobB64) => this.handlePulseDelivered(blobB64),
       },
       `tentacle:${options.device.deviceId ?? 'local'}:${Date.now()}`,
@@ -376,6 +388,9 @@ export class RelayClient {
    *  keyed maps leak entries permanently (Phase 1 had the identical issue
    *  in the Copilot adapter; same fix here). */
   private sessionToolCallIds = new Map<string, Set<string>>();
+
+  /** Pending permissions used for stable sidebar attention previews. */
+  private openPermissions = new Map<string, Map<string, { text: string; openedAt: string }>>();
 
   /** Open ask_user question ids per session. A session with a non-empty set is
    *  "pending" — its current turn is blocked waiting on human input. Populated
@@ -414,10 +429,11 @@ export class RelayClient {
     }
   }
 
-  /** Clear all open questions for a session (turn ended / session gone). */
+  /** Clear all open human attention for a session (turn ended / session gone). */
   private clearOpenQuestions(sessionId: string): void {
-    this.openQuestions.delete(sessionId);
+    const changed = this.openQuestions.delete(sessionId) || this.openPermissions.delete(sessionId);
     this.sessionManager.clearPendingHumanAction(sessionId);
+    if (changed) this.broadcastSessionList();
   }
 
   private soleOpenQuestion(sessionId: string): PendingHumanAction | null {
@@ -426,13 +442,17 @@ export class RelayClient {
     return map.values().next().value ?? null;
   }
 
-  /** The newest open (human-blocking) question's text, or undefined if none. */
-  private latestOpenQuestion(sessionId: string): string | undefined {
-    const map = this.openQuestions.get(sessionId);
-    if (!map || map.size === 0) return undefined;
-    let last: string | undefined;
-    for (const q of map.values()) last = q.question;
-    return last;
+  /** The newest open human attention item, preserving its original openedAt. */
+  private latestOpenAttention(sessionId: string): { type: 'permission' | 'question'; text: string; openedAt: string } | undefined {
+    let latest: { type: 'permission' | 'question'; text: string; openedAt: string } | undefined;
+    for (const permission of this.openPermissions.get(sessionId)?.values() ?? []) {
+      if (!latest || permission.openedAt >= latest.openedAt) latest = { type: 'permission', ...permission };
+    }
+    for (const question of this.openQuestions.get(sessionId)?.values() ?? []) {
+      const candidate = { type: 'question' as const, text: question.question, openedAt: question.createdAt };
+      if (!latest || candidate.openedAt >= latest.openedAt) latest = candidate;
+    }
+    return latest;
   }
 
   /** Rehydrate durable pending cards before session-list/card snapshots. */
@@ -479,6 +499,7 @@ export class RelayClient {
 
     this.removeOpenQuestion(sessionId, pending.questionId);
     this.card.resolvePrompt(sessionId, pending.questionId, { answer: answer.text || 'Answered with image' });
+    this.broadcastSessionList();
     this.recordTrace({ type: 'question', sessionId, payload: { id: pending.questionId, question: pending.question, answer: answer.text || 'Answered with image' } });
     this.send({
       type: 'question_resolved',
@@ -799,15 +820,11 @@ export class RelayClient {
         if (key) {
           this.consumerKeys.set(device.id, key);
           this.onlineConsumers.add(device.id);
-          this.flushE2eQueue();
+          this.currentSessionByArm.set(device.id, null);
           // Send a greeting unicast so the app learns our capabilities
           this.sendGreetingTo(device.id, key);
-          // Send session list so the app can sync
+          // Send session list so the app can sync and establish its reconnect barrier.
           this.sendSessionListTo(device.id, key);
-          // Push any active card snapshots so a mid-turn reconnect re-seeds its
-          // status card immediately, using the fresh key we just learned (avoids
-          // a client-pull race where request_card outruns key sync on reload).
-          this.sendCardSnapshotsTo(device.id, key);
         }
       }
       return;
@@ -816,7 +833,7 @@ export class RelayClient {
     if (msg.type === 'device_left') {
       const deviceId = msg.deviceId as string;
       this.onlineConsumers.delete(deviceId);
-      // Keep consumerKeys — offline devices still need pushPreview encrypted for them.
+      this.currentSessionByArm.delete(deviceId);
       return;
     }
 
@@ -824,6 +841,7 @@ export class RelayClient {
       const deviceId = msg.deviceId as string;
       this.consumerKeys.delete(deviceId);
       this.onlineConsumers.delete(deviceId);
+      this.currentSessionByArm.delete(deviceId);
       return;
     }
 
@@ -929,8 +947,15 @@ export class RelayClient {
       return;
     }
 
-    // request_card — pull the current status-card snapshot (message + action)
-    // for a session, used to seed a (re)joining client mid-turn.
+    // set_session_subscription — atomically replace this Arm's one current
+    // session and return the bounded live-ready snapshot in the ACK.
+    if (msg.type === 'set_session_subscription') {
+      this.handleSetSessionSubscription(msg.deviceId, msg.payload.sessionId);
+      return;
+    }
+
+    // request_card — legacy explicit card pull. Subscription ACK is the normal
+    // reconnect/session-open authority, but keep this endpoint for diagnostics.
     if (msg.type === 'request_card') {
       this.handleRequestCard(msg.deviceId, msg.payload.sessionId);
       return;
@@ -1076,6 +1101,8 @@ export class RelayClient {
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'approve')
             .then(() => {
               this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'approve' });
+              this.openPermissions.get(sessionId)?.delete(msg.payload.permissionId);
+              this.broadcastSessionList();
               this.recordTrace({ type: 'permission', sessionId, payload: { id: msg.payload.permissionId, description: '', toolName: '', args: {}, decision: 'approve' } });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'approved' } });
             })
@@ -1088,6 +1115,8 @@ export class RelayClient {
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'deny')
             .then(() => {
               this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'deny' });
+              this.openPermissions.get(sessionId)?.delete(msg.payload.permissionId);
+              this.broadcastSessionList();
               this.recordTrace({ type: 'permission', sessionId, payload: { id: msg.payload.permissionId, description: '', toolName: '', args: {}, decision: 'deny' } });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'denied' } });
             })
@@ -1100,6 +1129,8 @@ export class RelayClient {
           this.adapter.respondToPermission(sessionId, msg.payload.permissionId, 'always_allow')
             .then(() => {
               this.card.resolvePrompt(sessionId, msg.payload.permissionId, { decision: 'always_allow' });
+              this.openPermissions.get(sessionId)?.delete(msg.payload.permissionId);
+              this.broadcastSessionList();
               this.recordTrace({ type: 'permission', sessionId, payload: { id: msg.payload.permissionId, description: '', toolName: '', args: {}, decision: 'always_allow' } });
               this.send({ type: 'permission_resolved', sessionId, payload: { permissionId: msg.payload.permissionId, resolution: 'always_allowed' } });
             })
@@ -1175,10 +1206,8 @@ export class RelayClient {
           });
           break;
         case 'mark_unread': {
-          const meta = this.sessionManager.getMeta(sessionId);
-          if (meta && meta.lastSeq > 0) {
-            const rolledBack = Math.max(0, meta.lastSeq - 1);
-            this.sessionManager.markRead(sessionId, rolledBack);
+          const rolledBack = this.sessionManager.markUnread(sessionId);
+          if (rolledBack !== null) {
             this.send({
               type: 'session_read',
               sessionId,
@@ -1652,12 +1681,24 @@ export class RelayClient {
         payload: { ...event.toolArgs, id: event.id, description: event.description },
       };
       this.card.onPrompt(sessionId, action);
+      let permissions = this.openPermissions.get(sessionId);
+      if (!permissions) {
+        permissions = new Map();
+        this.openPermissions.set(sessionId, permissions);
+      }
+      permissions.set(event.id, {
+        text: event.description || event.toolArgs.toolName,
+        openedAt: new Date().toISOString(),
+      });
+      this.broadcastSessionList();
       this.recordTrace({ type: 'permission', sessionId, payload: action.payload });
     };
 
     // Auto-resolved (e.g. by an Always Allow rule) — mark the slot approved.
     this.adapter.onPermissionAutoResolved = (sessionId, permissionId) => {
       this.card.resolvePrompt(sessionId, permissionId, { decision: 'approve' });
+      this.openPermissions.get(sessionId)?.delete(permissionId);
+      this.broadcastSessionList();
       this.recordTrace({ type: 'permission', sessionId, payload: { id: permissionId, description: '', toolName: '', args: {}, decision: 'approve' } });
     };
 
@@ -1665,6 +1706,7 @@ export class RelayClient {
     this.adapter.onQuestionAutoResolved = (sessionId, questionId) => {
       this.removeOpenQuestion(sessionId, questionId);
       this.card.resolvePrompt(sessionId, questionId);
+      this.broadcastSessionList();
       this.recordTrace({ type: 'question', sessionId, payload: { id: questionId, question: '', cancelled: true } });
     };
 
@@ -1692,6 +1734,7 @@ export class RelayClient {
         action,
         createdAt: new Date().toISOString(),
       });
+      this.broadcastSessionList();
     };
 
     this.adapter.onToolStart = (sessionId, event) => {
@@ -2044,16 +2087,16 @@ export class RelayClient {
   >(sessions: T[]): T[] {
     return sessions.map((s) => {
       const compacting = this.compactingSessions.has(s.id);
-      const question = this.latestOpenQuestion(s.id);
-      if (!compacting && question === undefined) return s;
+      const attention = this.latestOpenAttention(s.id);
+      if (!compacting && attention === undefined) return s;
       return {
         ...s,
         ...(compacting && { state: 'compacting' as const }),
-        ...(question !== undefined && {
+        ...(attention !== undefined && {
           preview: {
-            type: 'question' as const,
-            text: question.slice(0, 200),
-            timestamp: new Date().toISOString(),
+            type: attention.type,
+            text: attention.text.slice(0, 200),
+            timestamp: attention.openedAt,
           },
         }),
       };
@@ -2352,6 +2395,60 @@ export class RelayClient {
     this.sessionManager.appendTrace(msg.sessionId, msg.type, JSON.stringify(enriched));
   }
 
+  private handleSetSessionSubscription(requesterDeviceId: string, sessionId: string | null): void {
+    const requesterKey = this.consumerKeys.get(requesterDeviceId);
+    if (!requesterKey) {
+      logger.warn({ requesterDeviceId, sessionId }, 'Session subscription requested without requester key');
+      return;
+    }
+
+    if (sessionId === null) {
+      this.currentSessionByArm.set(requesterDeviceId, null);
+      this.sendReliableUnicastTo(requesterDeviceId, requesterKey, {
+        type: 'session_subscription_set',
+        deviceId: this.authInfo?.deviceId ?? '',
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: { accepted: true, sessionId: null, snapshot: null },
+      });
+      return;
+    }
+
+    const digest = this.enrichSessionList(this.sessionManager.getSessionList())
+      .find((session) => session.id === sessionId) as SessionDigest | undefined;
+    if (!digest) {
+      this.sendReliableUnicastTo(requesterDeviceId, requesterKey, {
+        type: 'session_subscription_set',
+        deviceId: this.authInfo?.deviceId ?? '',
+        seq: ++this.seqCounter,
+        timestamp: new Date().toISOString(),
+        payload: {
+          accepted: false,
+          sessionId,
+          error: { code: 'session_not_found', message: 'Session not found' },
+        },
+      });
+      return;
+    }
+
+    // Replace membership before capturing/enqueuing the ACK. Any subsequent
+    // card event for this session is sent after the snapshot on stream 0.
+    this.currentSessionByArm.set(requesterDeviceId, sessionId);
+    const card = this.card.state(sessionId);
+    const snapshot: SessionLiveSnapshot = {
+      digest,
+      spineHeadSeq: digest.lastSeq,
+      card: { draft: card.draft, action: card.action },
+    };
+    this.sendReliableUnicastTo(requesterDeviceId, requesterKey, {
+      type: 'session_subscription_set',
+      deviceId: this.authInfo?.deviceId ?? '',
+      seq: ++this.seqCounter,
+      timestamp: new Date().toISOString(),
+      payload: { accepted: true, sessionId, snapshot },
+    });
+  }
+
   /** Reply to `request_card` — unicast the session's current card snapshot
    *  (agent_message_delta full text + current card_action) to the requester. */
   private handleRequestCard(requesterDeviceId: string, sessionId: string): void {
@@ -2368,24 +2465,6 @@ export class RelayClient {
         timestamp: new Date().toISOString(),
       };
       this.sendReliableUnicastTo(requesterDeviceId, requesterKey, enriched);
-    }
-  }
-
-  /** Push the current card snapshot for every session with active card state to
-   *  a freshly-joined consumer. Called from `device_joined` (fresh key in hand)
-   *  so a reconnecting arm re-seeds its status card without a pull round-trip.
-   *  Runtime state is carried independently by the preceding session_list. */
-  private sendCardSnapshotsTo(deviceId: string, key: string): void {
-    for (const sessionId of this.card.activeSessions()) {
-      for (const snap of this.card.snapshot(sessionId)) {
-        const enriched = {
-          ...snap,
-          deviceId: this.authInfo?.deviceId ?? '',
-          seq: ++this.seqCounter,
-          timestamp: new Date().toISOString(),
-        };
-        this.sendReliableUnicastTo(deviceId, key, enriched);
-      }
     }
   }
 
@@ -2579,24 +2658,19 @@ export class RelayClient {
       this.eventsWatcher.skipToEnd(sessionId);
     }
 
-    if (this.consumerKeys.size === 0) {
-      // Runtime state is recovered authoritatively from session_list.state when
-      // a device joins. Never queue compacting start/end events for later replay.
-      if (type !== 'compacting') this.queuePendingE2e(msg);
-      return;
+    if (msg.type === 'agent_message' && msg.sessionId) {
+      const content = (msg.payload as { content?: string } | undefined)?.content;
+      if (content) this.lastAgentContent.set(msg.sessionId, content);
     }
 
-    // Broadcast to all known devices (online get it via WS, offline via pushPreview).
-    // Everything rides pulse — there is no non-E2E plaintext path (a keyManager is
-    // always present; daemon-worker constructs one unconditionally).
+    // Push is a separate Head-bound operation and must happen even when there
+    // are zero online live recipients.
+    this.dispatchPushPreview(msg);
+
+    // Everything with a reconnect authority is recovered by session_list,
+    // subscription snapshot, spine range, or TRACE/attachment pull. Do not keep
+    // a generic offline event queue.
     this.sendEncrypted(msg);
-
-    // Also queue if no online consumers, so new devices get it on connect.
-    // Compacting is a current state, not an event backlog; session_list is its
-    // sole reconnect authority.
-    if (this.onlineConsumers.size === 0 && type !== 'compacting') {
-      this.queuePendingE2e(msg);
-    }
   }
 
   /** Append to a session's card-text buffer, arming a flush timer on first
@@ -2644,103 +2718,71 @@ export class RelayClient {
     this.deltaBuffers.clear();
   }
 
-  /**
-   * Encrypt a producer message to all consumers and send it over pulse.
-   */
+  /** Encrypt a producer message once for its explicit online target set. */
   private sendEncrypted(msg: Partial<ProducerMessage>): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN || !this.keyManager) return;
 
-    // Encrypt for ONLINE consumers only. Offline consumers can't receive the
-    // message anyway (head filters broadcastTargets to online devices), and
-    // adding them here wastes CPU + bytes: each recipient costs one RSA-4096
-    // wrap (~15-30 ms) and adds a ~700-byte base64 RSA blob to the on-wire
-    // frame. For a user with N total registered devices (mostly stale web
-    // tabs), each broadcast frame was N × wrap + N × ~700 B ⇒ a 40 KB
-    // user_message echo on the wire even for a "OK" reply, and hundreds of
-    // ms of RSA CPU per streaming delta. Pushed E2E deltas to offline devices
-    // wouldn't decrypt anyway (offline endpoint state=disconnected on head
-    // side after v0.15.2), so the extra keys were pure overhead.
-    // The pushPreview side-channel (see buildPushPreview) still encrypts to
-    // offline devices with its own tiny AES key wrap — that's the correct
-    // place for offline delivery.
-    const recipients: RecipientKey[] = [];
-    for (const deviceId of this.onlineConsumers) {
-      const compactKey = this.consumerKeys.get(deviceId);
-      if (!compactKey) {
-        traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'SEND-DECISION', type: (msg as { type?: string }).type, sessionId: (msg as { sessionId?: string }).sessionId, seq: (msg as { seq?: number }).seq, droppedReason: 'no-online-key', deviceId });
-        continue;
-      }
-      try {
-        recipients.push({ deviceId, publicKey: importPublicKey(compactKey) });
-      } catch (err) {
-        traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'SEND-DECISION', type: (msg as { type?: string }).type, seq: (msg as { seq?: number }).seq, droppedReason: 'invalid-key', deviceId });
-        logger.warn({ err, deviceId }, 'Skipping device with invalid public key');
-      }
-    }
-    if (recipients.length === 0) {
-      // No usable online recipient key. The caller's `send()` already handles
-      // `onlineConsumers.size === 0`, but we can also arrive here when an
-      // online device's key is invalid (test fixture or key rotation race).
-      // Do NOT queue in that case — the message would loop forever in
-      // flushE2eQueue on every reconnect because the key never becomes valid.
-      // The original message is still preserved locally (events.jsonl + card
-      // state), so a reconnecting arm picks it up via session replay.
-      traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'SEND-DECISION', type: (msg as { type?: string }).type, seq: (msg as { seq?: number }).seq, droppedReason: 'recipients-empty', onlineConsumers: this.onlineConsumers.size, consumerKeys: this.consumerKeys.size });
+    const type = msg.type;
+    const sessionId = msg.sessionId;
+    const targetIds = type && RelayClient.SUBSCRIBER_ONLY_TYPES.has(type)
+      ? [...this.onlineConsumers].filter((deviceId) => this.currentSessionByArm.get(deviceId) === sessionId)
+      : [...this.onlineConsumers];
+
+    if (targetIds.length === 0) {
+      traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'SEND-DECISION', type, sessionId, droppedReason: 'targets-empty' });
       return;
     }
 
-    traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'SEND-OK', type: (msg as { type?: string }).type, seq: (msg as { seq?: number }).seq, recipients: recipients.map((r) => r.deviceId), coalesceKey: coalesceKeyFor(msg) });
+    const recipients: RecipientKey[] = [];
+    const usableTargets: string[] = [];
+    for (const deviceId of targetIds) {
+      const compactKey = this.consumerKeys.get(deviceId);
+      if (!compactKey) continue;
+      try {
+        recipients.push({ deviceId, publicKey: importPublicKey(compactKey) });
+        usableTargets.push(deviceId);
+      } catch (err) {
+        logger.warn({ err, deviceId }, 'Skipping device with invalid public key');
+      }
+    }
+    if (recipients.length === 0) return;
+
+    traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'SEND-OK', type, sessionId, recipients: usableTargets, coalesceKey: coalesceKeyFor(msg) });
 
     try {
       const plaintext = JSON.stringify(msg);
       const { blob, keys } = encryptToBlob(plaintext, recipients);
-
-      // Track last agent message for idle push preview (needed by both paths).
       if (msg.type === 'agent_message' && msg.sessionId) {
         const content = (msg.payload as Record<string, unknown>).content as string;
-        if (content) this.lastAgentContent.set(msg.sessionId as string, content);
+        if (content) this.lastAgentContent.set(msg.sessionId, content);
       }
-
-      // All producer messages ride the per-hop pulse endpoint to head (head fans
-      // out + acks + durably holds for offline arms). The pulse frame's payload
-      // carries BOTH the ciphertext blob AND the per-recipient keys, so everything
-      // the receiver needs travels together through head (head never touches keys).
-      //
-      // The push preview (for notification-worthy messages) rides the SAME pulse
-      // envelope — the head reads `pushPreview` off it in its broadcast branch — so
-      // there is no separate raw send.
-      this.pendingPushPreview = this.buildPushPreview(msg, recipients);
-      this.pulse.send(JSON.stringify({ blob, keys }), '', false, coalesceKeyFor(msg), streamForType(msg.type));
-      this.pendingPushPreview = undefined;
+      this.pulse.send(
+        JSON.stringify({ blob, keys }),
+        usableTargets,
+        false,
+        coalesceKeyFor(msg),
+        streamForType(msg.type),
+      );
     } catch (err) {
-      logger.error({ err }, 'Encrypted broadcast failed');
+      logger.error({ err }, 'Encrypted multicast failed');
     }
   }
 
-  /** Put a pulse frame on the wire. With no target it rides a BROADCAST envelope
-   *  (head fans out to all the user's apps); with a `targetDeviceId` it rides a
-   *  UNICAST envelope so head forwards it to exactly that one app. head reads
-   *  `pulse` for transport (+ `to` for unicast routing); the payload ({blob,keys})
-   *  is inside the frame. */
-  private sendPulseEnvelope(pulseB64: string, targetDeviceId?: string): void {
+  /** Put a pulse frame on the wire using the sender-retained delivery target. */
+  private sendPulseEnvelope(pulseB64: string, target?: PulseDeliveryTarget): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-    const envelope: Record<string, unknown> = targetDeviceId
-      ? { type: 'unicast', to: targetDeviceId, pulse: pulseB64, blob: '', keys: {} }
-      : { type: 'broadcast', pulse: pulseB64, blob: '', keys: {} };
-    // Attach a pending push preview (broadcast messages only) to this same
-    // envelope so the head's push manager reaches offline devices — no separate
-    // raw send. Consume it so it rides exactly one frame.
-    if (!targetDeviceId && this.pendingPushPreview) {
-      envelope.pushPreview = this.pendingPushPreview;
-      this.pendingPushPreview = undefined;
-    }
+    const envelope: UnicastEnvelope | MulticastEnvelope | BroadcastEnvelope = Array.isArray(target)
+      ? { type: 'multicast', to: target, pulse: pulseB64, blob: '', keys: {} }
+      : target
+        ? { type: 'unicast', to: target, pulse: pulseB64, blob: '', keys: {} }
+        : { type: 'broadcast', pulse: pulseB64, blob: '', keys: {} };
     const raw = JSON.stringify(envelope);
     traceLog.info({
       ns: process.hrtime.bigint().toString(),
       comp: 'tentacle',
       evt: 'WS-TX',
       type: envelope.type,
-      to: targetDeviceId,
+      to: Array.isArray(target) ? target : target,
       rawLen: raw.length,
     });
     this.ws.send(raw);
@@ -2789,19 +2831,23 @@ export class RelayClient {
     }
   }
 
-  /** Build the encrypted push preview for a notification-worthy message, or
-   *  undefined if the message isn't one. The preview rides the SAME pulse
-   *  envelope as the reliable message (attached by sendPulseEnvelope), so the
-   *  head's push manager can notify offline devices without a separate raw send.
-   *
-   *  IMPORTANT: the preview is encrypted to ALL consumerKeys (online + offline),
-   *  NOT just the online `recipients`. Offline devices are the entire point of
-   *  push notifications — if we only encrypt to online devices, the head's
-   *  PushManager finds `keys[offlineDeviceId] === undefined` and bails, so no
-   *  push is ever sent. (This was the ec6a255c regression.) */
+  /** Build and dispatch an encrypted push preview over the Head self-channel.
+   *  This operation is independent of live subscribers and online targets. */
+  private dispatchPushPreview(msg: Partial<ProducerMessage>): void {
+    const preview = this.buildPushPreview(msg);
+    if (!preview) return;
+    this.pulse.send(
+      JSON.stringify({ type: 'dispatch_push', payload: { preview } }),
+      HEAD_PULSE_TARGET,
+      false,
+      undefined,
+      0,
+    );
+  }
+
+  /** Build the encrypted push preview for a notification-worthy message. */
   private buildPushPreview(
     msg: Partial<ProducerMessage>,
-    _recipients: RecipientKey[],
   ): { blob: string; keys: Record<string, string> } | undefined {
     let previewType: string | undefined;
     let previewSummary: string | undefined;
@@ -2909,51 +2955,23 @@ export class RelayClient {
     this.sendReliableUnicastTo(targetDeviceId, compactPubKey, greeting);
   }
 
-  /**
-   * Enqueue a producer message for later delivery (no consumer keys/online
-   * consumers yet). State-covering messages (deltas, card actions) coalesce
-   * via {@link coalesceKeyFor}: only the latest per-key is kept, so a
-   * reconnecting arm receives one current snapshot per key rather than a
-   * burst of stale frames. Event messages always append.
-   */
-  private queuePendingE2e(msg: Partial<ProducerMessage>): void {
-    const key = coalesceKeyFor(msg);
-    if (key) {
-      this.pendingE2eQueue = this.pendingE2eQueue.filter((m) => coalesceKeyFor(m) !== key);
-    }
-    if (this.pendingE2eQueue.length < 1000) {
-      this.pendingE2eQueue.push(msg);
-    } else {
-      logger.warn({ type: msg.type }, 'E2E queue full (1000) — dropping message');
-    }
-  }
-
-  /**
-   * Flush queued E2E messages once consumer keys become available.
-   */
-  private flushE2eQueue(): void {
-    if (this.onlineConsumers.size === 0 || this.pendingE2eQueue.length === 0) return;
-    const queued = this.pendingE2eQueue.splice(0);
-    for (const msg of queued) {
-      this.sendEncrypted(msg);
-    }
-  }
-
   private updateConsumerKeys(devices: DeviceSummary[]): void {
     this.consumerKeys.clear();
     this.onlineConsumers.clear();
+    this.currentSessionByArm.clear();
     this.legacyReplayWarned.clear();
     for (const d of devices) {
       if (d.role === 'app') {
         const key = d.encryptionKey ?? d.publicKey;
         if (key) {
           this.consumerKeys.set(d.id, key);
-          if (d.online) this.onlineConsumers.add(d.id);
+          if (d.online) {
+            this.onlineConsumers.add(d.id);
+            this.currentSessionByArm.set(d.id, null);
+          }
         }
       }
     }
-    // Flush queued messages now that we have consumer keys
-    this.flushE2eQueue();
   }
 
   // ── Title generation scheduling ──────────────────────

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -939,6 +939,23 @@ export class SessionManager {
   }
 
   /**
+   * Mark at least the latest spine item unread without ever advancing readSeq.
+   * Returns the authoritative cursor to echo to Arms, or null when the session
+   * has no spine entries.
+   */
+  markUnread(sessionId: string): number | null {
+    const meta = this.readMeta(sessionId);
+    if (!meta || (meta.lastSeq ?? 0) <= 0) return null;
+    const rolledBack = Math.min(meta.readSeq ?? 0, Math.max(0, meta.lastSeq - 1));
+    if (rolledBack !== (meta.readSeq ?? 0)) {
+      meta.readSeq = rolledBack;
+      meta.updatedAt = new Date().toISOString();
+      this.writeMeta(sessionId, meta);
+    }
+    return rolledBack;
+  }
+
+  /**
    * Get digests for all existing sessions (for session_list sync).
    */
   getSessionList(): Array<{

--- a/packages/tentacle/src/tentacle-pulse.ts
+++ b/packages/tentacle/src/tentacle-pulse.ts
@@ -53,11 +53,12 @@ function fp(u: Uint8Array): string {
   return (h >>> 0).toString(16).padStart(8, '0');
 }
 
+export type PulseDeliveryTarget = string | string[];
+
 export interface TentaclePulseHost {
-  /** Send a pulse frame to the relay. When `targetDeviceId` is set, the frame
-   *  rides a unicast envelope so head forwards it to exactly that one app;
-   *  otherwise a broadcast envelope so head fans it out to all the user's apps. */
-  sendPulseFrame(pulseB64: string, targetDeviceId?: string): void;
+  /** Send a pulse frame to the relay. A string is unicast, a string[] is
+   *  explicit multicast, and undefined is legacy broadcast/control. */
+  sendPulseFrame(pulseB64: string, target?: PulseDeliveryTarget): void;
   /** A reliable payload was delivered in order — the JSON string carrying
    *  {blob, keys} for the normal decrypt+dispatch path. */
   onDelivered(payloadJson: string): void;
@@ -88,10 +89,9 @@ export function streamForType(type: string | undefined): number {
 
 export class TentaclePulse {
   private streams: StreamSet;
-  /** Per-stream, per-seq unicast target. Retransmits happen outside send(), and
-   *  live/bulk have independent seq spaces (both can have seq=1), so neither a
-   *  mutable current target nor a seq-only map is sufficient. */
-  private targetByStream = new Map<number, Map<bigint, string>>();
+  /** Per-stream, per-seq delivery target. Retransmits happen outside send(),
+   *  and live/bulk have independent seq spaces (both can have seq=1). */
+  private targetByStream = new Map<number, Map<bigint, PulseDeliveryTarget | undefined>>();
   /** Set after the current relay connection sends any stream-1 frame (normally
    *  its HELLO). Until then bulk falls back to v1 stream 0 for old Heads. */
   private bulkCapable = false;
@@ -116,7 +116,7 @@ export class TentaclePulse {
    *  (unicast); omit it to fan out to all apps (broadcast). `durable` marks it
    *  for head persistence while the target app is offline (default false —
    *  sync snapshots self-heal on reconnect). */
-  send(payloadJson: string, targetDeviceId = '', durable = false, coalesceKey?: string, stream = 0): void {
+  send(payloadJson: string, target: PulseDeliveryTarget | undefined = undefined, durable = false, coalesceKey?: string, stream = 0): void {
     const payload = enc.encode(payloadJson);
     const actualStream = stream === 1 && !this.bulkCapable ? 0 : stream;
     const { seq, effects } = this.streams.send(actualStream, payload, { durable, coalesceKey });
@@ -125,8 +125,8 @@ export class TentaclePulse {
       targets = new Map();
       this.targetByStream.set(actualStream, targets);
     }
-    targets.set(seq, targetDeviceId);
-    trace('SEND', seq, payload.length, { fp: fp(payload), to: targetDeviceId || '(broadcast)', durable, coalesceKey, stream: actualStream, requestedStream: stream });
+    targets.set(seq, target);
+    trace('SEND', seq, payload.length, { fp: fp(payload), to: Array.isArray(target) ? target : target ?? '(broadcast)', durable, coalesceKey, stream: actualStream, requestedStream: stream });
     this.run(effects);
   }
 
@@ -169,10 +169,10 @@ export class TentaclePulse {
           const frame = decoded?.frame;
           const stream = decoded?.streamId ?? 0;
           const target = frame?.t === 'data'
-            ? (this.targetByStream.get(stream)?.get(frame.seq) ?? '')
-            : '';
-          trace('TX', frame?.t === 'data' ? frame.seq : 0, e.bytes.length, { kind: frame?.t ?? '?', to: target || '(broadcast)', stream });
-          this.host.sendPulseFrame(b64(e.bytes), target || undefined);
+            ? this.targetByStream.get(stream)?.get(frame.seq)
+            : undefined;
+          trace('TX', frame?.t === 'data' ? frame.seq : 0, e.bytes.length, { kind: frame?.t ?? '?', to: Array.isArray(target) ? target : target ?? '(broadcast)', stream });
+          this.host.sendPulseFrame(b64(e.bytes), target);
           break;
         }
         case 'deliver':

--- a/packages/tests/src/head-tentacle.test.ts
+++ b/packages/tests/src/head-tentacle.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { generateKeyPair, exportPublicKey, importPublicKey, encryptToBlob, decryptFromBlob } from "@kraki/crypto";
 import {
   createTestEnv, connectApp, connectAppWithCrypto, createRelayClient,
-  createTmpSessionDir, waitMs, createPulseAppLayer, type TestEnv, type MockApp,
+  createTmpSessionDir, waitMs, createPulseAppLayer, type TestEnv, type MockApp, subscribeApp,
 } from "./helpers.js";
 import { SessionManager, RelayClient, KeyManager } from "@kraki/tentacle";
 import type { AgentAdapter, CreateSessionConfig, SessionInfo, SessionContext } from "@kraki/tentacle";
@@ -206,6 +206,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     adapter.simulatePermissionRequest(sessionId, "perm_1", "shell", "Run npm test");
     const ca = await app.waitFor("card_action");
@@ -233,6 +234,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     adapter.simulateQuestion(sessionId, "q_1", "Which DB?", ["Postgres", "SQLite"]);
     const q = await app.waitFor("card_action");
@@ -260,6 +262,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     adapter.simulatePermissionRequest(sessionId, "perm_2", "write_file", "Write app.js");
     const perm = await app.waitFor("card_action");
@@ -284,6 +287,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     // Burst within the debounce window — tentacle coalesces these into
     // one merged agent_message_delta to amortize per-recipient RSA encryption cost.
@@ -329,6 +333,8 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
     const { sessionId } = await adapter.createSession();
     await app1.waitFor("session_created");
     await app2.waitFor("session_created");
+    await subscribeApp(app1, sessionId);
+    await subscribeApp(app2, sessionId);
 
     adapter.simulateAgentMessage(sessionId, "broadcast to all");
     const m1 = await app1.waitFor("agent_message");
@@ -371,6 +377,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
     const s2 = await adapter2.createSession();
     await app.waitFor("session_created");
     await app.waitFor("session_created");
+    await subscribeApp(app, s1.sessionId);
 
     adapter1.simulateAgentMessage(s1.sessionId, "from laptop");
     adapter2.simulateAgentMessage(s2.sessionId, "from workpc");
@@ -461,25 +468,21 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     adapter.simulateAgentMessage(sessionId, "before disconnect");
     await app.waitFor("agent_message");
 
-    // App disconnects
+    // App disconnects. Transient messages during the gap are intentionally not
+    // replayed; spine/session_list/card snapshot are the reconnect authorities.
     app.close();
     await waitMs(200);
-
-    // Tentacle sends another message — should not crash (queued in E2E queue)
     adapter.simulateAgentMessage(sessionId, "after disconnect");
     await waitMs(200);
 
-    // Verify relay is still alive by connecting a new app
+    // Verify relay is still alive by connecting a new app and subscribing it.
     const app2 = await connectApp(env.port);
-
-    // Tentacle receives device_joined for app2 — keys update automatically (no reconnect needed)
-    // The queued "after disconnect" message gets flushed to app2
-    const flushed = await app2.waitFor("agent_message");
-    expect(flushed.payload.content).toBe("after disconnect");
+    await subscribeApp(app2, sessionId);
 
     adapter.simulateAgentMessage(sessionId, "to new app");
     const msg = await app2.waitFor("agent_message");
@@ -506,7 +509,8 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
     });
     expect(relay.getState()).toBe("connected");
 
-    // Verify messages still flow after reconnect
+    // Verify messages still flow after reconnect. agent_message is a global
+    // low-frequency broadcast (not subscriber-only), so no subscription needed.
     const { sessionId } = await adapter.createSession();
     await waitMs(100);
     adapter.simulateAgentMessage(sessionId, "post-reconnect");
@@ -570,6 +574,9 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
     // Verify paired app can receive broadcasts
     const { sessionId } = await adapter.createSession();
     await waitMs(100);
+    // The raw paired app is intentionally outside MockApp; exercise its
+    // subscription through the normal encrypted test client in the scenarios
+    // above. This legacy pairing assertion only covers auth and device setup.
     adapter.simulateAgentMessage(sessionId, "to paired app");
     const received = await new Promise<Record<string, unknown>>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error("No message received")), 5000);
@@ -632,6 +639,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await waitMs(100);
+    await subscribeApp(app2, sessionId);
     adapter.simulateAgentMessage(sessionId, "post-challenge message");
     const msg = await app2.waitFor("agent_message");
     expect(msg.payload.content).toBe("post-challenge message");
@@ -647,6 +655,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     const bigContent = "x".repeat(100_000);
     adapter.simulateAgentMessage(sessionId, bigContent);
@@ -664,6 +673,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     const secretContent = "top secret agent code";
     adapter.simulateAgentMessage(sessionId, secretContent);
@@ -1109,6 +1119,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
     // Trigger a permission — tentacle should build pushPreview
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     adapter.onPermissionRequest?.(sessionId, {
       id: "perm-1",
@@ -1132,6 +1143,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     adapter.onPermissionRequest?.(sessionId, {
       id: "perm-preview",
@@ -1169,6 +1181,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     // Send an agent message first
     adapter.onMessage?.(sessionId, { content: "I fixed the bug in auth module" });
@@ -1207,6 +1220,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     adapter.onMessage?.(sessionId, { content: "hello world" });
     await app.waitFor("agent_message");
@@ -1227,6 +1241,7 @@ describe("Thin Relay Integration: Head + Tentacle + App", () => {
 
     const { sessionId } = await adapter.createSession();
     await app.waitFor("session_created");
+    await subscribeApp(app, sessionId);
 
     const longDescription = "This is a very long permission description that should definitely be truncated to fit the lock screen";
     adapter.onPermissionRequest?.(sessionId, {

--- a/packages/tests/src/helpers.ts
+++ b/packages/tests/src/helpers.ts
@@ -269,6 +269,46 @@ export function sendToTentacle(app: MockApp, inner: Record<string, unknown>): vo
   app.sendUnicast(t.id, inner, t.key);
 }
 
+/** Establish the single-session subscription required for live card/delta data. */
+export async function subscribeApp(app: MockApp, sessionId: string | null): Promise<Record<string, unknown>> {
+  // Resolve the tentacle target. The initial auth_ok snapshot may not yet
+  // include the tentacle (it connected after this app), so fall back to the
+  // device_joined control frame the head broadcasts when the tentacle joins.
+  let target: { id: string; key: string } | undefined;
+  const fromRoster = (() => {
+    const devs = (app.authOk.devices as Array<Record<string, unknown>>) ?? [];
+    const t = devs.find((d) => d.role === 'tentacle');
+    if (!t) return undefined;
+    const key = (t.encryptionKey ?? t.publicKey) as string | undefined;
+    return key ? { id: t.id as string, key } : undefined;
+  })();
+  target = fromRoster;
+  if (!target) {
+    for (;;) {
+      const joined = await app.waitFor('device_joined');
+      const device = joined.device as Record<string, unknown>;
+      const key = device.encryptionKey ?? device.publicKey;
+      if (device.role === 'tentacle' && typeof device.id === 'string' && typeof key === 'string') {
+        target = { id: device.id, key };
+        break;
+      }
+    }
+  }
+  app.sendUnicast(target.id, {
+    type: 'set_session_subscription',
+    deviceId: app.deviceId,
+    seq: 0,
+    timestamp: new Date().toISOString(),
+    payload: { sessionId },
+  }, target.key);
+  const ack = await app.waitFor('session_subscription_set');
+  const acceptedSession = (ack.payload as Record<string, unknown>).sessionId;
+  if (acceptedSession !== sessionId) {
+    throw new Error(`subscription ACK mismatch: expected ${sessionId}, got ${String(acceptedSession)}`);
+  }
+  return ack;
+}
+
 /**
  * Connect a mock app client with E2E crypto support.
  * Generates a keypair, authenticates, and auto-decrypts broadcast/unicast envelopes.

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -58,6 +58,7 @@ class MockAdapter extends AgentAdapter {
   /** Records inbound-from-browser calls (over pulse) so the spec can prove the
    *  browser's reliable sends actually reached the tentacle adapter. */
   readonly receivedMessages: Array<{ sid: string; text: string }> = [];
+  private readonly activeToolCalls = new Map<string, string>();
   readonly permissionResponses: Array<{ sid: string; pid: string; decision: string }> = [];
   readonly questionAnswers: Array<{ sid: string; qid: string; answer: string; freeform: boolean }> = [];
 
@@ -77,7 +78,10 @@ class MockAdapter extends AgentAdapter {
   }
   async sendMessage(sid: string, text: string) { this.receivedMessages.push({ sid, text }); }
   async respondToPermission(sid: string, pid: string, d: PermissionDecision) { this.permissionResponses.push({ sid, pid, decision: d }); }
-  async respondToQuestion(sid: string, qid: string, answer: string, freeform: boolean) { this.questionAnswers.push({ sid, qid, answer, freeform }); }
+  async respondToQuestion(sid: string, qid: string, answer: { text: string } | string, freeform: boolean) {
+    this.questionAnswers.push({ sid, qid, answer: typeof answer === 'string' ? answer : answer.text, freeform });
+    return 'accepted' as const;
+  }
   async killSession(sessionId: string) {
     const s = this.sessions.get(sessionId);
     if (s) s.ended = true;
@@ -92,19 +96,30 @@ class MockAdapter extends AgentAdapter {
   async listModels(): Promise<string[]> { return ['mock-v1']; }
 
   // Simulation helpers (control plane calls these to drive the agent side)
+  active(sid: string) {
+    sessionManagerForControl?.markActive(sid);
+    (relay as unknown as { send: (msg: Record<string, unknown>) => void }).send({ type: 'active', sessionId: sid, payload: {} });
+  }
   msg(sid: string, content: string) { this.onMessage?.(sid, { content }); }
-  delta(sid: string, content: string) { this.onMessageDelta?.(sid, { content }); }
+  delta(sid: string, content: string) { this.active(sid); this.onMessageDelta?.(sid, { content }); }
   perm(sid: string, id: string, tool: string, desc: string) {
+    this.active(sid);
     this.onPermissionRequest?.(sid, { id, toolArgs: { toolName: tool, args: {} }, description: desc });
   }
   question(sid: string, id: string, q: string, choices?: string[]) {
+    this.active(sid);
     this.onQuestionRequest?.(sid, { id, question: q, choices, allowFreeform: true });
   }
   toolStart(sid: string, tool: string, args: Record<string, unknown> = {}, toolCallId?: string) {
-    this.onToolStart?.(sid, { toolName: tool, args, ...(toolCallId && { toolCallId }) });
+    this.active(sid);
+    const id = toolCallId ?? `tc-${sid}-${Date.now().toString(36)}`;
+    this.activeToolCalls.set(sid, id);
+    this.onToolStart?.(sid, { toolName: tool, args, toolCallId: id });
   }
   toolComplete(sid: string, tool: string, result: string, toolCallId?: string, attachments?: unknown[]) {
-    this.onToolComplete?.(sid, { toolName: tool, result, ...(toolCallId && { toolCallId }), ...(attachments && { attachments }) });
+    const id = toolCallId ?? this.activeToolCalls.get(sid);
+    this.onToolComplete?.(sid, { toolName: tool, result, ...(id && { toolCallId: id }), ...(attachments && { attachments }) });
+    this.activeToolCalls.delete(sid);
   }
   idle(sid: string) { this.onIdle?.(sid); }
   error(sid: string, message: string) { this.onError?.(sid, { message }); }
@@ -112,6 +127,7 @@ class MockAdapter extends AgentAdapter {
 
 const children: ChildProcess[] = [];
 let relay: RelayClient | null = null;
+let sessionManagerForControl: SessionManager | null = null;
 // Second tentacle (same open-auth user) — connected on demand by the presence
 // tests to prove device_joined/left/removed reach the browser over pulse.
 let relay2: RelayClient | null = null;
@@ -233,6 +249,7 @@ async function main(): Promise<void> {
   // 2. Embedded tentacle (MockAdapter + RelayClient)
   const adapter = new MockAdapter();
   const sm = new SessionManager(mkdtempSync(join(tmpdir(), 'kraki-realstack-sess-')));
+  sessionManagerForControl = sm;
   // A real KeyManager is REQUIRED: without it RelayClient.sendUnicastTo()
   // early-returns, so the tentacle silently never sends session_list / greeting
   // / replay to apps — the browser would pair but see no sessions. dev-demo gets
@@ -307,6 +324,7 @@ async function main(): Promise<void> {
         case '/question': adapter.question(q.get('sid')!, q.get('id') ?? 'q-1', q.get('text') ?? 'which one?', q.get('choices') ? q.get('choices')!.split('|') : undefined); return json(200, { ok: true });
         case '/toolStart': adapter.toolStart(q.get('sid')!, q.get('tool') ?? 'bash', q.get('cmd') ? { command: q.get('cmd')! } : {}); return json(200, { ok: true });
         case '/toolComplete': adapter.toolComplete(q.get('sid')!, q.get('tool') ?? 'bash', q.get('result') ?? 'done'); return json(200, { ok: true });
+        case '/active': adapter.active(q.get('sid')!); return json(200, { ok: true });
         case '/idle': adapter.idle(q.get('sid')!); return json(200, { ok: true });
         case '/error': adapter.error(q.get('sid')!, q.get('message') ?? 'error'); return json(200, { ok: true });
         // Legacy-history compatibility: inject the old durable Abort message
@@ -335,11 +353,16 @@ async function main(): Promise<void> {
         }
         // ── debug: what does the tentacle see? ──
         case '/debug': {
-          const r = relay as unknown as { consumerKeys?: Map<string, string>; onlineConsumers?: Set<string> };
+          const r = relay as unknown as {
+            consumerKeys?: Map<string, string>;
+            onlineConsumers?: Set<string>;
+            currentSessionByArm?: Map<string, string | null>;
+          };
           return json(200, {
             sessions: sm.getSessionList(),
             consumerKeys: r.consumerKeys ? Array.from(r.consumerKeys.keys()) : 'n/a',
             onlineConsumers: r.onlineConsumers ? Array.from(r.onlineConsumers) : 'n/a',
+            subscriptions: r.currentSessionByArm ? Object.fromEntries(r.currentSessionByArm) : 'n/a',
           });
         }
         // ── tentacle link control ──
@@ -377,6 +400,7 @@ async function main(): Promise<void> {
           const tcid = `tc-${q.get('sid')}-${q.get('cmd') ?? 'x'}`;
           adapter.toolStart(sid, tool, q.get('cmd') ? { command: q.get('cmd')! } : {}, tcid);
           adapter.toolComplete(sid, tool, result, tcid);
+          adapter.msg(sid, q.get('reply') ?? 'Done — open the step to inspect the full tool result.');
           adapter.idle(sid);
           // Diagnostic: confirm the tentacle offloaded the result to the store.
           let stored = 0;

--- a/scripts/validate-e2e-recipient-scaling.ts
+++ b/scripts/validate-e2e-recipient-scaling.ts
@@ -1,0 +1,39 @@
+import { performance } from 'node:perf_hooks';
+import {
+  encryptToBlob,
+  exportPublicKey,
+  generateKeyPair,
+  importPublicKey,
+} from '../packages/crypto/dist/index.js';
+
+const keyPair = generateKeyPair();
+const compactKey = exportPublicKey(keyPair.publicKey);
+const plaintext = JSON.stringify({
+  type: 'agent_message_delta',
+  sessionId: 'session-1',
+  payload: { content: 'x'.repeat(256) },
+});
+
+for (const recipientCount of [1, 2, 4, 8, 16, 32, 64]) {
+  const samples: number[] = [];
+  let wireBytes = 0;
+  for (let run = 0; run < 100; run++) {
+    const started = performance.now();
+    const recipients = Array.from({ length: recipientCount }, (_, index) => ({
+      deviceId: `app-${index}`,
+      publicKey: importPublicKey(compactKey),
+    }));
+    const encrypted = encryptToBlob(plaintext, recipients);
+    wireBytes = JSON.stringify(encrypted).length;
+    samples.push(performance.now() - started);
+  }
+  samples.sort((a, b) => a - b);
+  const mean = samples.reduce((sum, sample) => sum + sample, 0) / samples.length;
+  console.log(JSON.stringify({
+    recipients: recipientCount,
+    meanMs: Number(mean.toFixed(3)),
+    p50Ms: Number(samples[49].toFixed(3)),
+    p95Ms: Number(samples[94].toFixed(3)),
+    wireBytes,
+  }));
+}

--- a/scripts/validate-fanout.ts
+++ b/scripts/validate-fanout.ts
@@ -1,0 +1,77 @@
+import Database from 'better-sqlite3';
+import { Endpoint } from '@coinfra/pulse';
+import { PulseHub, type PulseHubHost } from '../packages/head/src/pulse-hub.js';
+
+const b64 = (u: Uint8Array): string => Buffer.from(u).toString('base64');
+
+function run(targetCount: number, sends: number): { targets: number; sends: number; hubTransmits: number; endpointCount: number } {
+  const db = new Database(':memory:');
+  let now = 0;
+  let hubTransmits = 0;
+  const sourceId = 'tentacle';
+  const targetIds = Array.from({ length: targetCount }, (_, i) => `app-${i}`);
+  const source = new Endpoint({ epoch: `source-${targetCount}` });
+  const targets = new Map(targetIds.map((id) => [id, new Endpoint({ epoch: id })]));
+  let hub!: PulseHub;
+
+  const pumpSource = (effects: ReturnType<Endpoint['onTick']>) => {
+    for (const e of effects) {
+      if (e.t === 'transmit') hub.onPulseEnvelope(sourceId, { pulse: b64(e.bytes) });
+    }
+  };
+  const pumpTarget = (id: string, effects: ReturnType<Endpoint['onTick']>) => {
+    for (const e of effects) {
+      if (e.t === 'transmit') hub.onPulseEnvelope(id, { pulse: b64(e.bytes), to: sourceId });
+    }
+  };
+
+  const host: PulseHubHost = {
+    now: () => now,
+    broadcastTargets: () => targetIds,
+    onDeliverToSelf: () => {},
+    sendPulseTo: (id, pulse) => {
+      hubTransmits++;
+      if (id === sourceId) {
+        pumpSource(source.onBytes(new Uint8Array(Buffer.from(pulse, 'base64')), now));
+        return true;
+      }
+      const target = targets.get(id);
+      if (!target) return false;
+      pumpTarget(id, target.onBytes(new Uint8Array(Buffer.from(pulse, 'base64')), now));
+      return true;
+    },
+  };
+  hub = new PulseHub(db, host, { intervalMs: 0 });
+  hub.onDeviceConnected(sourceId);
+  pumpSource(source.onConnected(now));
+  for (const [id, target] of targets) {
+    hub.onDeviceConnected(id);
+    pumpTarget(id, target.onConnected(now));
+  }
+
+  for (let i = 0; i < sends; i++) {
+    pumpSource(source.send(new TextEncoder().encode(`delta-${i}`), {
+      durable: false,
+      coalesceKey: 'agent_message_delta:s1',
+    }).effects);
+    now += 10;
+    pumpSource(source.onTick(now));
+    for (const [id, target] of targets) pumpTarget(id, target.onTick(now));
+    hub.tick();
+  }
+  for (let i = 0; i < 20; i++) {
+    now += 1000;
+    pumpSource(source.onTick(now));
+    for (const [id, target] of targets) pumpTarget(id, target.onTick(now));
+    hub.tick();
+  }
+
+  const result = { targets: targetCount, sends, hubTransmits, endpointCount: hub.endpointCount() };
+  hub.close();
+  db.close();
+  return result;
+}
+
+for (const targets of [1, 2, 4, 8, 16, 32]) {
+  console.log(JSON.stringify(run(targets, 100)));
+}


### PR DESCRIPTION
## Summary

- add single-session subscription protocol and subscribe-time live/card snapshots
- add Head-blind opaque multicast with explicit app target sets
- route live deltas/cards only to the subscribed session while preserving spine, TRACE, runtime, and push authorities
- add Web subscription controller with reconnect barrier, stale-frame gating, and atomic navigation assurance
- fix `mark_unread` read cursor rollback and remove duplicate reconnect card recovery
- bump protocol/tentacle/head/web versions for the breaking protocol release

## Validation

- Head: 243/243
- Tentacle: 738/738
- Web: 390/390 (`NODE_ENV=test`)
- Real dev-stack Playwright: 36/36
- Workspace lint and `git diff --check`: passed

## Scope

- iOS is intentionally excluded from this PR.
- Main checkout and running Tentacle processes were not touched.
