### PR TITLE
feat: persist turn artifacts in the session spine

### DIFF
--- a/packages/arm/web/e2e/real-stack/pulse-image-pull.spec.ts
+++ b/packages/arm/web/e2e/real-stack/pulse-image-pull.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, request } from '@playwright/test';
+import { test, expect, type Browser, type Page, request } from '@playwright/test';
 
 /**
  * REAL-STACK image regression for paced attachment pulls.
@@ -29,10 +29,21 @@ async function control(path: string, params: Record<string, string> = {}): Promi
 async function pairBrowser(page: Page): Promise<string> {
   const { token, web, sessionId } = await control('/token');
   await page.goto(web as string);
-  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(() => {
+    localStorage.clear();
+    localStorage.setItem('kraki_pulse_trace', '1');
+  });
   await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
   await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
   return sessionId as string;
+}
+
+async function newPairedPage(browser: Browser, pageErrors: string[]): Promise<{ page: Page; close: () => Promise<void> }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+  await pairBrowser(page);
+  return { page, close: () => context.close() };
 }
 
 test.describe.serial('real-stack pulse: image rendering via paced pull', () => {
@@ -49,7 +60,7 @@ test.describe.serial('real-stack pulse: image rendering via paced pull', () => {
     await page?.close();
   });
 
-  test('a multi-chunk PNG image renders in the chat via paced request_attachment', async () => {
+  test('a multi-chunk PNG image renders in the chat via paced request_attachment', async ({ browser }) => {
     const sessionId = 'realstack-1';
     await page.goto(`${WEB_URL}/session/${sessionId}`);
     await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
@@ -72,29 +83,52 @@ test.describe.serial('real-stack pulse: image rendering via paced pull', () => {
     const chunkCount = img.chunkCount as number;
     expect(chunkCount).toBeGreaterThan(1);
 
-    // 3. Reload so the image ContentRef renders from replay with no cached
-    //    bytes — the only way the PNG arrives is a paced pull.
-    await page.reload();
-    await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
-    await expect(page.locator('[data-chat-scroll]').getByText(reply, { exact: false }).first())
+    // 3. The durable idle ref is live too. Let the producer's initial pull
+    //    settle, then open a completely fresh Arm identity with no attachment
+    //    cache or Pulse repair state.
+    const liveImg = page.locator('[data-chat-scroll] img[alt="gen.png"]');
+    await expect(liveImg).toBeVisible({ timeout: 30_000 });
+    await expect.poll(async () => liveImg.evaluate((el) => (el as HTMLImageElement).naturalWidth), {
+      timeout: 30_000,
+    }).toBeGreaterThan(0);
+    const readsBeforeRecovery = ((await control('/attachmentReads')).reads as unknown[]).length;
+
+    // 4. A fresh browser learns the ContentRef only from durable spine replay,
+    //    then pulls the bytes. TRACE must not be used for artifact discovery.
+    const recovery = await newPairedPage(browser, pageErrors);
+    const recoveryPage = recovery.page;
+    await recoveryPage.goto(`${WEB_URL}/session/${sessionId}`);
+    await expect(recoveryPage.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await expect(recoveryPage.locator('[data-chat-scroll]').getByText(reply, { exact: false }).first())
       .toBeVisible({ timeout: 20_000 });
 
-    // 4. The PNG <img> loads successfully — naturalWidth > 0 proves the
+    // 5. The PNG <img> loads successfully — naturalWidth > 0 proves the
     //    browser reassembled all chunks into a valid, displayable PNG blob.
-    const imgEl = page.locator('[data-chat-scroll] img[alt="gen.png"]');
+    const imgEl = recoveryPage.locator('[data-chat-scroll] img[alt="gen.png"]');
     await expect(imgEl).toBeVisible({ timeout: 30_000 });
     await expect.poll(async () => imgEl.evaluate((el) => (el as HTMLImageElement).naturalWidth), {
       timeout: 30_000,
       message: 'image never decoded (naturalWidth stayed 0)',
     }).toBeGreaterThan(0);
 
-    // 5. The paced pull served every chunk (one request_attachment per chunk).
+    // 6. Artifact discovery is spine-only: no automatic TRACE pull occurred,
+    //    while the bytes still arrived through the attachment path.
+    const sentTypes = await recoveryPage.evaluate(() => ((window as unknown as { _pulseTrace?: Array<{ evt?: string; type?: string }> })._pulseTrace ?? [])
+      .filter((event) => event.evt === 'APP-SEND-ENCRYPTED')
+      .map((event) => event.type));
+    expect(sentTypes).not.toContain('request_turn_trace');
+    expect(sentTypes).toContain('request_attachment');
+
+    // 7. The cold recovery pull served every chunk beyond the producer's live
+    //    pull baseline.
     await expect.poll(async () => {
       const { reads } = await control('/attachmentReads');
-      return (reads as unknown[]).length;
-    }, { timeout: 30_000, message: 'paced image pull did not serve all chunks' }).toBe(chunkCount);
+      return (reads as unknown[]).length - readsBeforeRecovery;
+    }, { timeout: 30_000, message: 'paced image recovery did not serve all chunks' }).toBe(chunkCount);
 
-    // 6. No browser errors.
+    await recovery.close();
+
+    // 8. No browser errors.
     expect(pageErrors).toEqual([]);
   });
 });

--- a/packages/arm/web/src/components/chat/ChatView.test.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.test.tsx
@@ -150,32 +150,29 @@ describe('ChatView', () => {
     expect(screen.queryByText('Working…')).not.toBeInTheDocument();
   });
 
-  it('renders show_image output inside the concluding agent bubble', () => {
+  it('renders show_image output from closing idle artifact metadata', () => {
     useStore.getState().setSessions([
-      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 2 },
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 3 },
     ]);
     useStore.getState().appendMessage('s1', {
       type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1',
       payload: { content: 'Show me the result' },
     } as ChatMessage);
     useStore.getState().appendMessage('s1', {
-      type: 'tool_complete', deviceId: 'd1', seq: 1.5, timestamp: '', sessionId: 's1',
-      payload: {
-        toolName: 'show_image', headline: 'result.png', success: true,
-        attachments: [{ type: 'image', mimeType: 'image/png', data: 'aW1hZ2U=', caption: 'Rendered result' }],
-      },
-    } as ChatMessage);
-    useStore.getState().appendMessage('s1', {
       type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1',
       payload: { content: 'Here is the finished image.' },
+    } as ChatMessage);
+    useStore.getState().appendMessage('s1', {
+      type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1',
+      payload: { turnArtifacts: [{ type: 'content_ref', id: 'result', mimeType: 'image/png', size: 5, caption: 'Rendered result' }] },
     } as ChatMessage);
 
     renderChatView('s1');
 
     const reply = screen.getByText('Here is the finished image.').closest('.rounded-2xl');
     expect(reply).not.toBeNull();
-    expect(within(reply as HTMLElement).getByRole('img', { name: 'Rendered result' })).toBeInTheDocument();
     expect(within(reply as HTMLElement).getByText('Rendered result')).toBeInTheDocument();
+    expect(within(reply as HTMLElement).getByLabelText('Loading')).toBeInTheDocument();
   });
 
   it('puts turn images only in the last agent bubble when a turn has multiple replies', () => {
@@ -192,15 +189,12 @@ describe('ChatView', () => {
         payload: { content: 'Earlier bubble' },
       } as ChatMessage,
       {
-        type: 'tool_complete', deviceId: 'd1', seq: 2.5, timestamp: '', sessionId: 's1',
-        payload: {
-          toolName: 'show_image', headline: 'result.png', success: true,
-          attachments: [{ type: 'image', mimeType: 'image/png', data: 'bGFzdA==', caption: 'Last bubble image' }],
-        },
-      } as ChatMessage,
-      {
         type: 'agent_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1',
         payload: { content: 'Last bubble' },
+      } as ChatMessage,
+      {
+        type: 'idle', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1',
+        payload: { turnArtifacts: [{ type: 'content_ref', id: 'last', mimeType: 'image/png', size: 4, caption: 'Last bubble image' }] },
       } as ChatMessage,
     ];
     for (const message of messages) useStore.getState().appendMessage('s1', message);
@@ -209,8 +203,8 @@ describe('ChatView', () => {
 
     const earlier = screen.getByText('Earlier bubble').closest('.rounded-2xl');
     const last = screen.getByText('Last bubble').closest('.rounded-2xl');
-    expect(within(earlier as HTMLElement).queryByRole('img', { name: 'Last bubble image' })).not.toBeInTheDocument();
-    expect(within(last as HTMLElement).getByRole('img', { name: 'Last bubble image' })).toBeInTheDocument();
+    expect(within(earlier as HTMLElement).queryByText('Last bubble image')).not.toBeInTheDocument();
+    expect(within(last as HTMLElement).getByText('Last bubble image')).toBeInTheDocument();
   });
 
   it('keeps show_image output scoped to the turn that produced it', () => {
@@ -223,24 +217,22 @@ describe('ChatView', () => {
         payload: { content: 'First request' },
       } as ChatMessage,
       {
-        type: 'tool_complete', deviceId: 'd1', seq: 1.5, timestamp: '', sessionId: 's1',
-        payload: {
-          toolName: 'show_image', headline: 'first.png', success: true,
-          attachments: [{ type: 'image', mimeType: 'image/png', data: 'Zmlyc3Q=', caption: 'First image' }],
-        },
-      } as ChatMessage,
-      {
         type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1',
         payload: { content: 'First reply' },
       } as ChatMessage,
       {
-        type: 'user_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1',
+        type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1',
+        payload: { turnArtifacts: [{ type: 'content_ref', id: 'first', mimeType: 'image/png', size: 5, caption: 'First image' }] },
+      } as ChatMessage,
+      {
+        type: 'user_message', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1',
         payload: { content: 'Second request' },
       } as ChatMessage,
       {
-        type: 'agent_message', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1',
+        type: 'agent_message', deviceId: 'd1', seq: 5, timestamp: '', sessionId: 's1',
         payload: { content: 'Second reply' },
       } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 6, timestamp: '', sessionId: 's1', payload: {} } as ChatMessage,
     ];
     for (const message of messages) useStore.getState().appendMessage('s1', message);
 
@@ -248,8 +240,8 @@ describe('ChatView', () => {
 
     const firstReply = screen.getByText('First reply').closest('.rounded-2xl');
     const secondReply = screen.getByText('Second reply').closest('.rounded-2xl');
-    expect(within(firstReply as HTMLElement).getByRole('img', { name: 'First image' })).toBeInTheDocument();
-    expect(within(secondReply as HTMLElement).queryByRole('img', { name: 'First image' })).not.toBeInTheDocument();
+    expect(within(firstReply as HTMLElement).getByText('First image')).toBeInTheDocument();
+    expect(within(secondReply as HTMLElement).queryByText('First image')).not.toBeInTheDocument();
   });
 
   it('deduplicates repeated content refs within the final bubble', () => {
@@ -265,16 +257,12 @@ describe('ChatView', () => {
       id: 'same-image', mimeType: 'image/png', size: 128, caption: 'One image', width: 20, height: 20,
     };
     useStore.getState().appendMessage('s1', {
-      type: 'tool_complete', deviceId: 'd1', seq: 1.3, timestamp: '', sessionId: 's1',
-      payload: { toolName: 'show_image', headline: 'one.png', success: true, attachments: [attachment] },
-    } as ChatMessage);
-    useStore.getState().appendMessage('s1', {
-      type: 'tool_complete', deviceId: 'd1', seq: 1.6, timestamp: '', sessionId: 's1',
-      payload: { toolName: 'show_image', headline: 'one.png', success: true, attachments: [attachment] },
-    } as ChatMessage);
-    useStore.getState().appendMessage('s1', {
       type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1',
-      payload: { content: 'Only one tile follows.' },
+      payload: { content: 'Only one tile follows.', attachments: [attachment] },
+    } as ChatMessage);
+    useStore.getState().appendMessage('s1', {
+      type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1',
+      payload: { turnArtifacts: [attachment, attachment] },
     } as ChatMessage);
 
     renderChatView('s1');
@@ -283,20 +271,20 @@ describe('ChatView', () => {
     expect(within(reply as HTMLElement).getAllByText('One image')).toHaveLength(1);
   });
 
-  it('renders each turn HTML report in its concluding bubble and opens the selected report', () => {
+  it('renders each turn HTML report from its closing idle and opens the selected report', () => {
     const onOpen = vi.fn();
     const first = { type: 'content_ref' as const, id: 'report-1', mimeType: 'text/html', size: 2048, name: 'first.html', caption: 'First report' };
     const second = { type: 'content_ref' as const, id: 'report-2', mimeType: 'text/html', size: 4096, name: 'second.html', caption: 'Second report' };
     useStore.getState().setSessions([
-      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 4 },
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 6 },
     ]);
     const messages: ChatMessage[] = [
       { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'First' } } as ChatMessage,
-      { type: 'tool_complete', deviceId: 'd1', seq: 1.5, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [first] } } as ChatMessage,
       { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'First reply' } } as ChatMessage,
-      { type: 'user_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { content: 'Second' } } as ChatMessage,
-      { type: 'tool_complete', deviceId: 'd1', seq: 3.5, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [second] } } as ChatMessage,
-      { type: 'agent_message', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1', payload: { content: 'Second reply' } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { turnArtifacts: [first] } } as ChatMessage,
+      { type: 'user_message', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1', payload: { content: 'Second' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 5, timestamp: '', sessionId: 's1', payload: { content: 'Second reply' } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 6, timestamp: '', sessionId: 's1', payload: { turnArtifacts: [second] } } as ChatMessage,
     ];
     for (const message of messages) useStore.getState().appendMessage('s1', message);
 
@@ -338,9 +326,8 @@ describe('ChatView', () => {
     ]);
     const messages: ChatMessage[] = [
       { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'Reports' } } as ChatMessage,
-      { type: 'tool_complete', deviceId: 'd1', seq: 1.2, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [first, second] } } as ChatMessage,
-      { type: 'tool_complete', deviceId: 'd1', seq: 1.4, timestamp: '', sessionId: 's1', payload: { toolName: 'show_html', success: true, attachments: [first] } } as ChatMessage,
-      { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'Both reports' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'Both reports', attachments: [first] } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { turnArtifacts: [first, second, first] } } as ChatMessage,
     ];
     for (const message of messages) useStore.getState().appendMessage('s1', message);
 
@@ -350,30 +337,27 @@ describe('ChatView', () => {
     expect(screen.getByText('second.html')).toBeInTheDocument();
   });
 
-  it('requests every historical final bubble trace on open so artifacts recover after reload', async () => {
+  it('does not request historical TRACE on open merely because a bubble has steps', async () => {
     const spy = vi.spyOn(messageProvider, 'requestTurnTrace').mockImplementation(() => {});
     useStore.getState().setDevices([
       { id: 'd1', name: 'Mac', role: 'tentacle', online: true, encryptionKey: 'key' },
     ]);
     useStore.getState().setSessions([
-      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 2 },
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 3 },
     ]);
+    const report = { type: 'content_ref' as const, id: 'report', mimeType: 'text/html', size: 10, name: 'report.html' };
     const messages: ChatMessage[] = [
       { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'First' } } as ChatMessage,
-      { type: 'agent_message', deviceId: 'd1', seq: 1.5, timestamp: '', sessionId: 's1', payload: { content: 'Intermediate reply', steps: 1 } } as ChatMessage,
       { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'First reply', steps: 1 } } as ChatMessage,
-      { type: 'user_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { content: 'Second' } } as ChatMessage,
-      { type: 'agent_message', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1', payload: { content: 'Second reply', steps: 2 } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { turnArtifacts: [report] } } as ChatMessage,
     ];
     for (const message of messages) useStore.getState().appendMessage('s1', message);
 
     renderChatView('s1');
 
-    await vi.waitFor(() => {
-      expect(spy).toHaveBeenCalledWith('s1', 2);
-      expect(spy).toHaveBeenCalledWith('s1', 4);
-      expect(spy).not.toHaveBeenCalledWith('s1', 1.5);
-    });
+    expect(await screen.findByText('report.html')).toBeInTheDocument();
+    await act(async () => { await Promise.resolve(); });
+    expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -7,7 +7,7 @@ import { MessageInput } from './MessageInput';
 import { useScrollController } from '../../hooks/useScrollController';
 import { messageProvider } from '../../lib/message-provider';
 import { getSessionStatus, cardActionKey } from '../../lib/session-status';
-import type { Attachment, ContentRef } from '@kraki/protocol';
+import type { ContentRef } from '@kraki/protocol';
 import type { ChatMessage } from '../../types/store';
 import { projectSpineMessages } from '../../lib/turn-projection';
 
@@ -18,73 +18,13 @@ function getSeq(m: ChatMessage): number {
   return 'seq' in m ? (m as { seq?: number }).seq ?? 0 : 0;
 }
 
-function attachmentKey(attachment: Attachment): string {
-  if (attachment.type === 'content_ref') return `ref:${attachment.id}`;
-  if (attachment.type === 'image') return `image:${attachment.mimeType}:${attachment.data}`;
-  return JSON.stringify(attachment);
-}
-
-/** Images produced by show_image/tool steps in the turn concluding at
- *  `bubbleSeq`. They stay on the TRACE axis for history, but are also rendered
- *  inside that turn's final agent bubble. */
-function collectTurnAttachments(
-  messages: ChatMessage[],
-  bubbleSeq: number,
-  directAttachments: Attachment[],
-  matches: (attachment: Attachment) => boolean,
-): Attachment[] {
-  const directKeys = new Set(directAttachments.map(attachmentKey));
-  const targetIdx = messages.findIndex((message) => getSeq(message) === bubbleSeq);
-  if (targetIdx < 0 || !['agent_message', 'turn_status', 'interrupted_turn'].includes(messages[targetIdx].type)) return [];
-  let turnStartIdx = -1;
-  for (let i = targetIdx - 1; i >= 0; i--) {
-    if (messages[i].type === 'user_message') {
-      turnStartIdx = i;
-      break;
-    }
-  }
-  const seen = new Set<string>();
-  const attachments: Attachment[] = [];
-  for (let i = turnStartIdx + 1; i < targetIdx; i++) {
-    const step = messages[i];
-    if (step.type !== 'tool_complete') continue;
-    for (const attachment of step.payload.attachments ?? []) {
-      if (!matches(attachment)) continue;
-      const key = attachmentKey(attachment);
-      if (directKeys.has(key) || seen.has(key)) continue;
-      seen.add(key);
-      attachments.push(attachment);
-    }
-  }
-  return attachments;
-}
-
-/** Images produced by tool steps in the turn concluding at `bubbleSeq`. */
-export function collectTurnImages(
-  messages: ChatMessage[],
-  bubbleSeq: number,
-  directAttachments: Attachment[] = [],
-): Attachment[] {
-  return collectTurnAttachments(messages, bubbleSeq, directAttachments, (attachment) =>
-    attachment.type === 'image' ||
-    (attachment.type === 'content_ref' && attachment.mimeType.startsWith('image/')),
+function htmlArtifacts(message: ChatMessage): ContentRef[] {
+  const attachments = (message.payload as { attachments?: unknown[] }).attachments ?? [];
+  return attachments.filter((attachment): attachment is ContentRef =>
+    !!attachment && typeof attachment === 'object'
+    && (attachment as ContentRef).type === 'content_ref'
+    && (attachment as ContentRef).mimeType === 'text/html',
   );
-}
-
-/** HTML reports produced by show_html in the turn concluding at `bubbleSeq`. */
-export function collectTurnHtmlArtifacts(
-  messages: ChatMessage[],
-  bubbleSeq: number,
-  directAttachments: Attachment[] = [],
-): ContentRef[] {
-  const directArtifacts = directAttachments.filter(
-    (attachment): attachment is ContentRef =>
-      attachment.type === 'content_ref' && attachment.mimeType === 'text/html',
-  );
-  const tracedArtifacts = collectTurnAttachments(messages, bubbleSeq, directAttachments, (attachment) =>
-    attachment.type === 'content_ref' && attachment.mimeType === 'text/html',
-  ) as ContentRef[];
-  return [...directArtifacts, ...tracedArtifacts];
 }
 
 export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtifact?: (artifact: ContentRef) => void }) {
@@ -101,51 +41,21 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
     useCallback((s) => deviceId ? s.devices.get(deviceId)?.online ?? false : false, [deviceId]),
   );
   const isConnected = useStore((s) => s.status === 'connected');
-  // Whether the tentacle device is encryptable yet — a `request_card` snapshot
-  // pull needs its key, which may arrive AFTER this view first mounts (fresh
-  // reload). Gate + re-trigger the seed effect on this so the pull isn't lost.
-  const isTentacleEncryptable = useStore(
-    useCallback((s) => {
-      const d = deviceId ? s.devices.get(deviceId) : undefined;
-      return !!(d?.encryptionKey ?? d?.publicKey);
-    }, [deviceId]),
-  );
 
   // ── SPINE ─────────────────────────────────────────────
   // Persistent, replayed bubbles rendered directly in seq order. Excludes the
   // transient TRACE/activity axis (tool_start/tool_complete/agent_narration/
   // active), which is shown only from the Steps popover.
   const spine = useMemo(() => projectSpineMessages(messages), [messages]);
-  const finalAgentSeqs = useMemo(() => {
-    const seqs = new Set<number>();
-    let lastAgentSeq = 0;
-    for (const msg of spine) {
-      if (msg.type === 'user_message') {
-        if (lastAgentSeq > 0) seqs.add(lastAgentSeq);
-        lastAgentSeq = 0;
-      } else if (msg.type === 'agent_message') {
-        lastAgentSeq = getSeq(msg);
-      }
-    }
-    if (lastAgentSeq > 0) seqs.add(lastAgentSeq);
-    return seqs;
-  }, [spine]);
-  const turnAttachmentsByBubbleSeq = useMemo(() => {
-    const images = new Map<number, Attachment[]>();
+  const turnArtifactsByBubbleSeq = useMemo(() => {
     const artifacts = new Map<number, ContentRef[]>();
     for (const msg of spine) {
-      const terminal = msg.type === 'turn_status' || msg.type === 'interrupted_turn';
-      if (msg.type !== 'agent_message' && !terminal) continue;
-      const seq = getSeq(msg);
-      if (msg.type === 'agent_message' && !finalAgentSeqs.has(seq)) continue;
-      const directAttachments = (msg.payload as { attachments?: Attachment[] }).attachments ?? [];
-      const turnImages = collectTurnImages(messages, seq, directAttachments);
-      const turnArtifacts = collectTurnHtmlArtifacts(messages, seq, directAttachments);
-      if (turnImages.length > 0) images.set(seq, turnImages);
-      if (turnArtifacts.length > 0) artifacts.set(seq, turnArtifacts);
+      if (msg.type !== 'agent_message' && msg.type !== 'turn_status' && msg.type !== 'interrupted_turn' && msg.type !== 'system_message') continue;
+      const refs = htmlArtifacts(msg);
+      if (refs.length > 0) artifacts.set(getSeq(msg), refs);
     }
-    return { images, artifacts };
-  }, [finalAgentSeqs, messages, spine]);
+    return artifacts;
+  }, [spine]);
 
   // Derived human-facing status decides card visibility.
   const cardAction = card?.action;
@@ -193,17 +103,6 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
     const seqs = spine.map(getSeq).filter(s => s > 0);
     return seqs.length > 0 ? seqs[0] : 0;
   }, [spine]);
-
-  useEffect(() => {
-    if (!sessionId || !isTentacleEncryptable) return;
-    for (const msg of spine) {
-      const seq = getSeq(msg);
-      const isFinalAgent = msg.type === 'agent_message' && finalAgentSeqs.has(seq);
-      if ((isFinalAgent || msg.type === 'interrupted_turn' || msg.type === 'turn_status') && (msg.payload.steps ?? 0) > 0) {
-        messageProvider.requestTurnTrace(sessionId, seq);
-      }
-    }
-  }, [sessionId, isTentacleEncryptable, finalAgentSeqs, spine]);
 
   // `idle` here is the message-level marker (last spine entry is an idle
   // event), used by the scroll controller for the working→idle reposition. It
@@ -284,8 +183,7 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
                   message={msg}
                   agent={session.agent}
                   sessionId={sessionId}
-                  turnImages={turnAttachmentsByBubbleSeq.images.get(getSeq(msg))}
-                  turnArtifacts={turnAttachmentsByBubbleSeq.artifacts.get(getSeq(msg))}
+                  turnArtifacts={turnArtifactsByBubbleSeq.get(getSeq(msg))}
                   onOpenArtifact={onOpenArtifact}
                 />
               </div>

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -74,7 +74,9 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
                   {message.payload.content}
                 </Markdown>
               </div>
-              <ImageAttachments attachments={message.payload.attachments as Attachment[] | undefined} sessionId={sessionId} />
+              <ImageAttachments attachments={(message.payload.attachments as Attachment[] | undefined)?.filter(
+                (attachment) => attachment.type === 'image' || (attachment.type === 'content_ref' && attachment.mimeType.startsWith('image/')),
+              )} sessionId={sessionId} />
               {turnImages && turnImages.length > 0 && <ImageAttachments attachments={turnImages} sessionId={sessionId} />}
               {turnArtifacts && turnArtifacts.length > 0 && (
                 <HtmlArtifactCards artifacts={turnArtifacts} onOpen={onOpenArtifact} />
@@ -153,6 +155,12 @@ export function MessageBubble({ message, agent, forceExpanded, turnImages, turnA
           <div className="min-w-0 max-w-[85%] overflow-x-auto rounded-2xl rounded-bl-md border border-dashed border-border-primary bg-surface-secondary px-4 py-2.5 sm:max-w-[70%]">
             <p className="text-[10px] font-medium uppercase tracking-wide text-text-muted">Kraki</p>
             <p className="mt-0.5 text-sm italic leading-relaxed text-text-secondary">{text}</p>
+            <ImageAttachments attachments={((message.payload as { attachments?: Attachment[] }).attachments ?? []).filter(
+              (attachment) => attachment.type === 'image' || (attachment.type === 'content_ref' && attachment.mimeType.startsWith('image/')),
+            )} sessionId={sessionId} />
+            {turnArtifacts && turnArtifacts.length > 0 && (
+              <HtmlArtifactCards artifacts={turnArtifacts} onOpen={onOpenArtifact} />
+            )}
             <div className="mt-1 flex items-center gap-2">
               <p className="text-[10px] text-text-muted">{formatTime(message.timestamp)}</p>
               {sessionId && typeof message.seq === 'number' && message.seq > 0 && (

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -301,26 +301,6 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
       if (!replaying && isViewingSession(sid) && document.hasFocus()) {
         import('./ws-client').then(({ wsClient }) => wsClient.markRead(sid)).catch(() => {});
       }
-      // The turn just concluded — pull the authoritative TRACE for its bubble
-      // once (reconciles/replaces whatever live steps we accumulated). Find the
-      // concluding agent_message (the bubble that crystallized this turn).
-      {
-        const sessionMsgs = store.messages.get(sid);
-        if (sessionMsgs) {
-          for (let i = sessionMsgs.length - 1; i >= 0; i--) {
-            const m = sessionMsgs[i];
-            if (m.type === 'agent_message' && 'seq' in m) {
-              const bubbleSeq = (m as { seq?: number }).seq;
-              if (typeof bubbleSeq === 'number') {
-                messageProvider.invalidateTurnTrace(sid, bubbleSeq);
-                messageProvider.requestTurnTrace(sid, bubbleSeq);
-              }
-              break;
-            }
-            if (m.type === 'user_message' || m.type === 'idle') break;
-          }
-        }
-      }
       break;
     }
 

--- a/packages/arm/web/src/lib/turn-projection.test.ts
+++ b/packages/arm/web/src/lib/turn-projection.test.ts
@@ -62,4 +62,44 @@ describe('projectSpineMessages', () => {
 
     expect(projected.map((message) => message.type)).toEqual(['user_message', 'agent_message', 'idle']);
   });
+
+  it('projects closing idle artifacts onto the final agent outcome and deduplicates direct refs', () => {
+    const image = { type: 'content_ref' as const, id: 'img', mimeType: 'image/png', size: 1 };
+    const html = { type: 'content_ref' as const, id: 'html', mimeType: 'text/html', size: 2 };
+    const projected = projectSpineMessages([
+      { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'go' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { content: 'first' } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { content: 'final', attachments: [image] } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 4, timestamp: '', sessionId: 's1', payload: { turnArtifacts: [image, html] } } as ChatMessage,
+    ]);
+
+    expect((projected[2].payload as { attachments?: unknown[] }).attachments).toEqual([image, html]);
+    expect((projected[1].payload as { attachments?: unknown[] }).attachments).toBeUndefined();
+  });
+
+  it.each(['turn_status', 'interrupted_turn'] as const)('projects idle artifacts onto %s terminal outcome once', (type) => {
+    const artifact = { type: 'content_ref' as const, id: type, mimeType: 'image/png', size: 1 };
+    const outcome = type === 'turn_status'
+      ? { type, deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { draft: '', action: { type: 'user_abort', payload: { abortedAt: '' } }, finishedAt: '' } }
+      : { type, deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { reason: 'user_aborted', draft: '', action: null, interruptedAt: '', cancelled: true } };
+    const projected = projectSpineMessages([
+      { type: 'agent_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'draft' } } as ChatMessage,
+      outcome as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { turnArtifacts: [artifact] } } as ChatMessage,
+    ]);
+
+    expect(projected.map((message) => message.type)).toEqual([type, 'idle']);
+    expect((projected[0].payload as { attachments?: unknown[] }).attachments).toEqual([artifact]);
+  });
+
+  it('projects idle artifacts onto a no-reply system outcome', () => {
+    const report = { type: 'content_ref' as const, id: 'report', mimeType: 'text/html', size: 4 };
+    const projected = projectSpineMessages([
+      { type: 'user_message', deviceId: 'd1', seq: 1, timestamp: '', sessionId: 's1', payload: { content: 'go' } } as ChatMessage,
+      { type: 'system_message', deviceId: 'd1', seq: 2, timestamp: '', sessionId: 's1', payload: { kind: 'no_reply' } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 3, timestamp: '', sessionId: 's1', payload: { turnArtifacts: [report] } } as ChatMessage,
+    ]);
+
+    expect((projected[1].payload as { attachments?: unknown[] }).attachments).toEqual([report]);
+  });
 });

--- a/packages/arm/web/src/lib/turn-projection.ts
+++ b/packages/arm/web/src/lib/turn-projection.ts
@@ -1,29 +1,61 @@
-import type { Attachment } from '@kraki/protocol';
+import type { Attachment, ContentRef } from '@kraki/protocol';
 import type { ChatMessage } from '../types/store';
 
 /** TRACE / transient activity types — never top-level chat bubbles. */
 const TRACE_TYPES = new Set(['tool_start', 'tool_complete', 'agent_narration', 'active']);
 
+function attachmentKey(attachment: Attachment): string {
+  return attachment.type === 'content_ref'
+    ? `ref:${attachment.id}`
+    : `image:${attachment.mimeType}:${attachment.data}`;
+}
+
+function withTurnArtifacts(message: ChatMessage, artifacts: ContentRef[]): ChatMessage {
+  if (artifacts.length === 0) return message;
+  const payload = message.payload as { attachments?: Attachment[] };
+  const existing = payload.attachments ?? [];
+  const seen = new Set(existing.map(attachmentKey));
+  const merged = [...existing];
+  for (const artifact of artifacts) {
+    const key = attachmentKey(artifact);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(artifact);
+  }
+  return {
+    ...message,
+    payload: { ...message.payload, attachments: merged },
+  } as ChatMessage;
+}
+
 /** Project durable wire/history records into visual chat bubbles.
  *
  * `error` is turn detail, never a top-level bubble. When a turn ends with a
  * terminal status after already emitting its final `agent_message`, merge that
- * reply into the terminal card's draft and render only the terminal card. The
- * raw records remain untouched in storage and continue to feed Steps/replay. */
+ * reply into the terminal card and render only the terminal card. The closing
+ * idle's `turnArtifacts` are durable spine metadata projected onto the visible
+ * outcome anchor; idle itself remains non-visual. */
 export function projectSpineMessages(messages: ChatMessage[]): ChatMessage[] {
   const projected: ChatMessage[] = [];
   let segment: ChatMessage[] = [];
 
   const flush = () => {
     if (segment.length === 0) return;
-    const terminalIdx = segment.findLastIndex(
-      (msg) => msg.type === 'turn_status' || msg.type === 'interrupted_turn',
-    );
-    if (terminalIdx >= 0) {
-      const terminal = segment[terminalIdx];
+    const closingIdle = [...segment].reverse().find((msg) => msg.type === 'idle');
+    const turnArtifacts = ((closingIdle?.payload as { turnArtifacts?: ContentRef[] } | undefined)?.turnArtifacts ?? [])
+      .filter((artifact): artifact is ContentRef => artifact?.type === 'content_ref');
+
+    const terminalIdx = segment.findLastIndex((msg) => msg.type === 'turn_status');
+    const interruptedIdx = segment.findLastIndex((msg) => msg.type === 'interrupted_turn');
+    const outcomeIdx = terminalIdx >= 0 ? terminalIdx : interruptedIdx;
+
+    let visibleSegment: ChatMessage[];
+    let visibleOutcomeIdx = -1;
+    if (outcomeIdx >= 0) {
+      const terminal = segment[outcomeIdx];
       let fallbackDraft = '';
       let fallbackAttachments: Attachment[] | undefined;
-      for (let i = terminalIdx - 1; i >= 0; i--) {
+      for (let i = outcomeIdx - 1; i >= 0; i--) {
         const candidate = segment[i];
         if (candidate.type === 'agent_message') {
           const attachments = candidate.payload.attachments;
@@ -51,16 +83,25 @@ export function projectSpineMessages(messages: ChatMessage[]): ChatMessage[] {
             },
           } as ChatMessage);
 
+      visibleSegment = [];
       for (let i = 0; i < segment.length; i++) {
         const msg = segment[i];
         if (msg.type === 'error' || msg.type === 'agent_message') continue;
-        projected.push(i === terminalIdx ? normalizedTerminal : msg);
+        if (i === outcomeIdx) visibleOutcomeIdx = visibleSegment.length;
+        visibleSegment.push(i === outcomeIdx ? normalizedTerminal : msg);
       }
     } else {
-      for (const msg of segment) {
-        if (msg.type !== 'error') projected.push(msg);
+      visibleSegment = segment.filter((msg) => msg.type !== 'error');
+      visibleOutcomeIdx = visibleSegment.findLastIndex((msg) => msg.type === 'agent_message');
+      if (visibleOutcomeIdx < 0) {
+        visibleOutcomeIdx = visibleSegment.findLastIndex((msg) => msg.type === 'system_message');
       }
     }
+
+    if (visibleOutcomeIdx >= 0 && turnArtifacts.length > 0) {
+      visibleSegment[visibleOutcomeIdx] = withTurnArtifacts(visibleSegment[visibleOutcomeIdx], turnArtifacts);
+    }
+    projected.push(...visibleSegment);
     segment = [];
   };
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -464,6 +464,9 @@ export interface IdleMessage extends BaseEnvelope {
     usage?: import('./sessions.js').SessionUsage;
     /** Why the session went idle */
     reason?: 'completed' | 'aborted' | 'failed';
+    /** User-visible image/HTML artifacts produced during the turn closed by
+     *  this idle. Durable spine authority; bytes remain in AttachmentStore. */
+    turnArtifacts?: ContentRef[];
   };
 }
 

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -188,6 +188,7 @@ function createSessionManager(): Record<string, unknown> {
     appendMessage: vi.fn(() => 1),
     appendTrace: vi.fn(),
     readTurnTrace: vi.fn(() => ({ entries: [], complete: false, turnStartSeq: 0 })),
+    readCurrentTurnArtifacts: vi.fn(() => []),
     setUsage: vi.fn(),
     getAllLinks: vi.fn(() => []),
     getLink: vi.fn(() => null),
@@ -527,6 +528,23 @@ describe('RelayClient title generation', () => {
     expect(adapter.generateTitle).toHaveBeenCalledWith(
       expect.objectContaining({ lastUserMessage: 'fix the login bug' }),
     );
+  });
+
+  it('persists current-turn artifacts on a normal adapter idle', () => {
+    const { adapter, sm } = connectClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    const artifacts = [
+      { type: 'content_ref', id: 'img', mimeType: 'image/png', size: 3 },
+      { type: 'content_ref', id: 'html', mimeType: 'text/html', size: 4 },
+    ];
+    smMock.readCurrentTurnArtifacts.mockReturnValue(artifacts);
+
+    (adapter.onIdle as (sessionId: string) => void)('s1');
+
+    const idleCall = smMock.appendMessage.mock.calls.find((call) => call[1] === 'idle');
+    expect(idleCall).toBeDefined();
+    expect(JSON.parse(idleCall![2]).payload).toEqual({ turnArtifacts: artifacts });
+    expect(smMock.readCurrentTurnArtifacts).toHaveBeenCalledWith('s1');
   });
 
   it('skips title generation when manual title is set', () => {
@@ -2378,8 +2396,27 @@ describe('RelayClient pending-question digest', () => {
     expect(sm.clearPendingHumanAction).toHaveBeenCalledWith('sess_1');
   });
 
+  it('writes current-turn artifacts on explicit abort idle', async () => {
+    const { adapter, ws, sm } = buildClient();
+    const artifact = { type: 'content_ref', id: 'abort-img', mimeType: 'image/png', size: 4 };
+    (sm.readCurrentTurnArtifacts as ReturnType<typeof vi.fn>).mockReturnValue([artifact]);
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'abort_session', sessionId: 'sess_1', deviceId: 'app-x', seq: 508,
+      timestamp: new Date().toISOString(), payload: {},
+    })));
+    await vi.runAllTimersAsync();
+
+    const idleCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.find((call) => call[1] === 'idle');
+    expect(idleCall).toBeDefined();
+    expect(JSON.parse(idleCall![2]).payload).toEqual({ reason: 'aborted', turnArtifacts: [artifact] });
+    expect(sm.readCurrentTurnArtifacts).toHaveBeenCalledWith('sess_1');
+    expect(adapter.abortSession).toHaveBeenCalledWith('sess_1');
+  });
+
   it('freezes an adapter error as failed only when the turn reaches idle and stamps step count', async () => {
     const { adapter, sm } = buildClient();
+    const artifact = { type: 'content_ref', id: 'failed-report', mimeType: 'text/html', size: 9 };
+    (sm.readCurrentTurnArtifacts as ReturnType<typeof vi.fn>).mockReturnValue([artifact]);
     // Drive a tool_start so the turn has a chip-producing step before failing.
     (adapter.onToolStart as (sid: string, e: Record<string, unknown>) => void)('sess_1', { toolName: 'bash', args: { command: 'npm test' }, toolCallId: 'tc-1' });
     (adapter.onError as (sid: string, event: { message: string }) => void)('sess_1', { message: '524 status code (no body)' });
@@ -2403,6 +2440,8 @@ describe('RelayClient pending-question digest', () => {
       .map((call) => JSON.parse(call[2]) as { type: string; payload: Record<string, unknown> })
       .find((e) => e.type === 'tool_complete' && e.payload.toolCallId === 'tc-1' && e.payload.termination === 'interrupted');
     expect(interruptedTool).toBeDefined();
+    const idleCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.find((call) => call[1] === 'idle');
+    expect(JSON.parse(idleCall![2]).payload).toEqual({ reason: 'failed', turnArtifacts: [artifact] });
   });
 
   it('dispatches push through @head when every consumer is offline', () => {

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SessionManager } from '../session-manager.js';
-import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync, appendFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -1144,6 +1144,65 @@ describe('SessionManager', () => {
 
       const sm2 = new SessionManager(dir);
       expect(sm2.readTurnTrace(sessionId, bubble).entries).toHaveLength(2);
+    });
+
+    it('extracts only successful show_image/show_html ContentRefs from the current persisted turn', () => {
+      const { sessionId } = sm.createSession('pi');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: { content: 'render' } }));
+      const image = { type: 'content_ref', id: 'img-1', mimeType: 'image/png', size: 10, name: 'a.png', width: 2, height: 3 };
+      const html = { type: 'content_ref', id: 'html-1', mimeType: 'text/html', size: 20, name: 'report.html', caption: 'Report' };
+      const appendComplete = (payload: Record<string, unknown>) => sm.appendTrace(sessionId, 'tool_complete', JSON.stringify({
+        type: 'tool_complete', sessionId, payload,
+      }));
+
+      appendComplete({ toolName: 'show_image', success: true, attachments: [image] });
+      appendComplete({ toolName: 'show_html', attachments: [html, html] });
+      appendComplete({ toolName: 'show_image', success: false, attachments: [{ ...image, id: 'failed' }] });
+      appendComplete({ toolName: 'show_image', termination: 'cancelled', attachments: [{ ...image, id: 'cancelled' }] });
+      appendComplete({ toolName: 'bash', attachments: [{ ...image, id: 'unrelated' }] });
+      appendComplete({ toolName: 'show_image', attachments: [{ ...html, id: 'wrong-image-mime' }] });
+      appendComplete({ toolName: 'show_html', attachments: [{ ...image, id: 'wrong-html-mime' }] });
+      appendComplete({ toolName: 'show_image', resultRef: { ...image, id: 'result-ref' }, argsRef: { ...image, id: 'args-ref' } });
+      appendComplete({ toolName: 'show_image', attachments: [{ type: 'content_ref', id: '', mimeType: 'image/png', size: 1 }] });
+      appendComplete({ toolName: 'show_image', attachments: [{ type: 'content_ref', id: 'bad-size', mimeType: 'image/png', size: -1 }] });
+
+      expect(sm.readCurrentTurnArtifacts(sessionId)).toEqual([image, html]);
+    });
+
+    it('reads current-turn artifacts after restart and never leaks previous-turn refs', () => {
+      const { sessionId } = sm.createSession('pi');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: { content: 'first' } }));
+      sm.appendTrace(sessionId, 'tool_complete', JSON.stringify({
+        type: 'tool_complete', sessionId, payload: {
+          toolName: 'show_image', attachments: [{ type: 'content_ref', id: 'old', mimeType: 'image/png', size: 1 }],
+        },
+      }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ type: 'agent_message', payload: {} }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ type: 'idle', payload: {} }));
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: { content: 'second' } }));
+      const current = { type: 'content_ref' as const, id: 'current', mimeType: 'text/html', size: 2 };
+      sm.appendTrace(sessionId, 'tool_complete', JSON.stringify({
+        type: 'tool_complete', sessionId, payload: { toolName: 'show_html', attachments: [current] },
+      }));
+
+      const restarted = new SessionManager(dir);
+      expect(restarted.readCurrentTurnArtifacts(sessionId)).toEqual([current]);
+      restarted.appendMessage(sessionId, 'idle', JSON.stringify({ type: 'idle', payload: { turnArtifacts: [current] } }));
+      expect(restarted.readCurrentTurnArtifacts(sessionId)).toEqual([]);
+    });
+
+    it('returns no current-turn artifacts without a durable user turn id or with corrupt trace', () => {
+      const { sessionId } = sm.createSession('pi');
+      sm.appendTrace(sessionId, 'tool_complete', JSON.stringify({
+        type: 'tool_complete', sessionId, payload: {
+          toolName: 'show_image', attachments: [{ type: 'content_ref', id: 'unscoped', mimeType: 'image/png', size: 1 }],
+        },
+      }));
+      expect(sm.readCurrentTurnArtifacts(sessionId)).toEqual([]);
+
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: {} }));
+      appendFileSync(join(dir, sessionId, 'trace.jsonl'), '{bad json\n');
+      expect(sm.readCurrentTurnArtifacts(sessionId)).toEqual([]);
     });
   });
 });

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -1150,12 +1150,13 @@ describe('SessionManager', () => {
       const { sessionId } = sm.createSession('pi');
       sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: { content: 'render' } }));
       const image = { type: 'content_ref', id: 'img-1', mimeType: 'image/png', size: 10, name: 'a.png', width: 2, height: 3 };
+      const imageWithUnknownField = { ...image, localPath: '/private/result.png' };
       const html = { type: 'content_ref', id: 'html-1', mimeType: 'text/html', size: 20, name: 'report.html', caption: 'Report' };
       const appendComplete = (payload: Record<string, unknown>) => sm.appendTrace(sessionId, 'tool_complete', JSON.stringify({
         type: 'tool_complete', sessionId, payload,
       }));
 
-      appendComplete({ toolName: 'show_image', success: true, attachments: [image] });
+      appendComplete({ toolName: 'show_image', success: true, attachments: [imageWithUnknownField] });
       appendComplete({ toolName: 'show_html', attachments: [html, html] });
       appendComplete({ toolName: 'show_image', success: false, attachments: [{ ...image, id: 'failed' }] });
       appendComplete({ toolName: 'show_image', termination: 'cancelled', attachments: [{ ...image, id: 'cancelled' }] });

--- a/packages/tentacle/src/__tests__/tool-name.test.ts
+++ b/packages/tentacle/src/__tests__/tool-name.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalArtifactToolName } from '../adapters/tool-name.js';
+
+describe('canonicalArtifactToolName', () => {
+  it.each([
+    ['show_image', undefined, undefined, 'show_image'],
+    ['kraki-show_image', undefined, undefined, 'show_image'],
+    ['mcp__kraki__show_image', undefined, undefined, 'show_image'],
+    ['show_html', undefined, undefined, 'show_html'],
+    ['kraki-show_html', undefined, undefined, 'show_html'],
+    ['mcp__kraki__show_html', undefined, undefined, 'show_html'],
+    ['view', 'kraki', 'show_image', 'show_image'],
+    ['tool', 'kraki', 'show_html', 'show_html'],
+  ])('normalizes %s / %s / %s to %s', (name, server, tool, expected) => {
+    expect(canonicalArtifactToolName(name, server, tool)).toBe(expected);
+  });
+
+  it.each([
+    ['my_show_image_wrapper', undefined, undefined],
+    ['show_image', 'other', 'show_image'],
+    ['view', 'kraki', 'other'],
+    ['bash', undefined, undefined],
+  ])('does not normalize unrelated identity %s / %s / %s', (name, server, tool) => {
+    expect(canonicalArtifactToolName(name, server, tool)).toBe(name);
+  });
+});

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -29,6 +29,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { getConfigDir } from '../config.js';
 import { isKrakiSelfManagementCommand, SELF_MANAGEMENT_DENIAL_REASON, shellCommandFromInput } from '../self-management-guard.js';
+import { canonicalArtifactToolName } from './tool-name.js';
 
 const logger = createLogger('claude-adapter');
 
@@ -1186,10 +1187,11 @@ export class ClaudeAdapter extends AgentAdapter {
               sessionTools = new Map();
               this.pendingToolCalls.set(sessionId, sessionTools);
             }
-            sessionTools.set(toolBlock.id, { toolName: toolBlock.name, args });
+            const canonicalToolName = canonicalArtifactToolName(toolBlock.name);
+            sessionTools.set(toolBlock.id, { toolName: canonicalToolName, args });
 
             this.onToolStart?.(sessionId, {
-              toolName: toolBlock.name,
+              toolName: canonicalToolName,
               args,
               toolCallId: toolBlock.id,
             });
@@ -1280,9 +1282,11 @@ export class ClaudeAdapter extends AgentAdapter {
                   .map(c => c.text as string)
                   .join('\n');
 
-                // Extract image blocks from MCP tool results (e.g. kraki-show_image)
-                if (this.attachmentStore) {
-                  const isKrakiShowImage = tracked?.toolName?.includes('show_image') ?? false;
+                // Extract image blocks only from Kraki's explicit show_image
+                // tool. Other tools may return image-shaped diagnostic blocks,
+                // but they do not own user-visible artifact semantics.
+                const isKrakiShowImage = tracked?.toolName === 'show_image';
+                if (this.attachmentStore && isKrakiShowImage) {
                   for (const c of blocks) {
                     if (c.type === 'image' && typeof c.data === 'string' && typeof c.mimeType === 'string') {
                       try {

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -45,6 +45,7 @@ import {
 import { parsePermission } from '../parse-permission.js';
 import { createLogger } from '../logger.js';
 import { isKrakiSelfManagementCommand, SELF_MANAGEMENT_DENIAL_REASON, shellCommandFromInput } from '../self-management-guard.js';
+import { canonicalArtifactToolName } from './tool-name.js';
 
 const logger = createLogger('copilot-adapter');
 type CopilotSdkModule = typeof import('@github/copilot-sdk');
@@ -1677,8 +1678,13 @@ export class CopilotAdapter extends AgentAdapter {
         }
         inflight.add(toolCallId);
       }
+      const protocolToolName = canonicalArtifactToolName(
+        data.toolName as string,
+        data.mcpServerName as string | undefined,
+        data.mcpToolName as string | undefined,
+      );
       this.onToolStart?.(sessionId, {
-        toolName: data.toolName as string,
+        toolName: protocolToolName,
         args,
         toolCallId,
       });
@@ -1688,7 +1694,8 @@ export class CopilotAdapter extends AgentAdapter {
       const data = event.data as unknown as Record<string, unknown>;
       const toolCallId = data.toolCallId as string | undefined;
       const identity = toolCallId ? this.pendingToolIdentity.get(toolCallId) : undefined;
-      const toolName = identity?.toolName ?? (data.toolName as string | undefined) ?? 'tool';
+      const rawToolName = identity?.toolName ?? (data.toolName as string | undefined) ?? 'tool';
+      const toolName = canonicalArtifactToolName(rawToolName, identity?.mcpServerName, identity?.mcpToolName);
       const clearInflight = () => {
         if (!toolCallId) return;
         this.pendingToolIdentity.delete(toolCallId);

--- a/packages/tentacle/src/adapters/tool-name.ts
+++ b/packages/tentacle/src/adapters/tool-name.ts
@@ -1,0 +1,26 @@
+/** Canonical protocol names for Kraki-owned artifact tools.
+ *
+ * Agent SDKs expose MCP identity differently: Copilot provides structured
+ * server/tool fields, while Claude flattens the identity into a display name.
+ * Normalize only exact Kraki-owned forms; arbitrary tools must never become
+ * durable artifacts merely because their names contain a substring. */
+export function canonicalArtifactToolName(
+  toolName: string,
+  mcpServerName?: string,
+  mcpToolName?: string,
+): string {
+  if (mcpServerName === 'kraki' && (mcpToolName === 'show_image' || mcpToolName === 'show_html')) {
+    return mcpToolName;
+  }
+  if (
+    toolName === 'show_image'
+    || toolName === 'kraki-show_image'
+    || toolName === 'mcp__kraki__show_image'
+  ) return 'show_image';
+  if (
+    toolName === 'show_html'
+    || toolName === 'kraki-show_html'
+    || toolName === 'mcp__kraki__show_html'
+  ) return 'show_html';
+  return toolName;
+}

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -14,7 +14,7 @@ import type {
   ProducerMessage, ConsumerMessage,
   DeviceInfo, AuthOkMessage, AuthErrorMessage, DeviceSummary, AuthMethod,
   BroadcastEnvelope, UnicastEnvelope, MulticastEnvelope, CardActionState,
-  SessionLiveSnapshot, SessionDigest,
+  SessionLiveSnapshot, SessionDigest, IdleMessage,
 } from '@kraki/protocol';
 import { HEAD_PULSE_TARGET } from '@kraki/protocol';
 import { importPublicKey, encryptToBlob, decryptFromBlob, signChallenge } from '@kraki/crypto';
@@ -252,8 +252,26 @@ export class RelayClient {
     this.clearCompacting(sessionId);
     const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
     if (usage) this.sessionManager.setUsage(sessionId, usage);
-    this.send({ type: 'idle', sessionId, payload: { usage, ...(terminalError && { reason: 'failed' as const }) } });
+    this.sendTurnIdle(sessionId, { usage, ...(terminalError && { reason: 'failed' as const }) });
     this.maybeGenerateTitle(sessionId);
+  }
+
+  /** Persist the durable user-visible outputs of a genuine completed turn on
+   *  its closing idle. Initialization/import/fork idles deliberately bypass
+   *  this helper because they do not close a user turn. */
+  private sendTurnIdle(
+    sessionId: string,
+    payload: Omit<IdleMessage['payload'], 'turnArtifacts'>,
+  ): void {
+    const turnArtifacts = this.sessionManager.readCurrentTurnArtifacts(sessionId);
+    this.send({
+      type: 'idle',
+      sessionId,
+      payload: {
+        ...payload,
+        ...(turnArtifacts.length > 0 && { turnArtifacts }),
+      },
+    });
   }
 
   private dispatchInput(sessionId: string, task: () => Promise<void>): Promise<void> {
@@ -1175,7 +1193,7 @@ export class RelayClient {
               this.resolveTurnIdle(sessionId);
               this.sessionManager.markIdle(sessionId);
               this.clearCompacting(sessionId);
-              this.send({ type: 'idle', sessionId, payload: { reason: 'aborted' } });
+              this.sendTurnIdle(sessionId, { reason: 'aborted' });
             })
             .catch((err) => {
               logger.error({ err, sessionId }, 'abortSession failed');

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -972,14 +972,24 @@ export class SessionManager {
     if (ref.type !== 'content_ref') return null;
     if (typeof ref.id !== 'string' || ref.id.trim().length === 0) return null;
     if (typeof ref.mimeType !== 'string') return null;
-    if (!Number.isFinite(ref.size) || (ref.size ?? -1) < 0) return null;
+    if (typeof ref.size !== 'number' || !Number.isFinite(ref.size) || ref.size < 0) return null;
     if (toolName === 'show_image' && !ref.mimeType.startsWith('image/')) return null;
     if (toolName === 'show_html' && ref.mimeType !== 'text/html') return null;
     if (ref.name !== undefined && typeof ref.name !== 'string') return null;
     if (ref.caption !== undefined && typeof ref.caption !== 'string') return null;
-    if (ref.width !== undefined && (!Number.isFinite(ref.width) || ref.width < 0)) return null;
-    if (ref.height !== undefined && (!Number.isFinite(ref.height) || ref.height < 0)) return null;
-    return ref as ContentRef;
+    if (ref.width !== undefined && (typeof ref.width !== 'number' || !Number.isFinite(ref.width) || ref.width < 0)) return null;
+    if (ref.height !== undefined && (typeof ref.height !== 'number' || !Number.isFinite(ref.height) || ref.height < 0)) return null;
+    const sanitized: ContentRef = {
+      type: 'content_ref',
+      id: ref.id,
+      mimeType: ref.mimeType,
+      size: ref.size,
+      ...(ref.caption !== undefined && { caption: ref.caption }),
+      ...(ref.name !== undefined && { name: ref.name }),
+      ...(ref.width !== undefined && { width: ref.width }),
+      ...(ref.height !== undefined && { height: ref.height }),
+    };
+    return sanitized;
   }
 
   /**

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -10,7 +10,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, rename
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { getConfigDir } from './config.js';
-import type { CardActionState } from '@kraki/protocol';
+import type { CardActionState, ContentRef } from '@kraki/protocol';
 
 const PREVIEW_MAX = 80;
 
@@ -894,30 +894,92 @@ export class SessionManager {
 
     const complete = (meta.idleSeqs ?? []).some(s => s >= bubbleSeq);
 
-    const tracePath = join(this.sessionDir(sessionId), 'trace.jsonl');
-    if (turnStartSeq === 0 || !existsSync(tracePath)) {
-      return { entries: [], complete, turnStartSeq };
+    return {
+      entries: this.readTraceEntriesForTurnStart(sessionId, turnStartSeq),
+      complete,
+      turnStartSeq,
+    };
+  }
+
+  /**
+   * Read durable user-visible artifact refs produced in the current turn.
+   * Persisted TRACE is the authority so a Tentacle restart between tool
+   * completion and idle does not lose the refs.
+   */
+  readCurrentTurnArtifacts(sessionId: string): ContentRef[] {
+    const meta = this.readMeta(sessionId);
+    const turnStartSeq = meta?.currentTurnStartSeq ?? 0;
+    if (turnStartSeq <= 0) return [];
+    if ((meta?.idleSeqs ?? []).some((idleSeq) => idleSeq > turnStartSeq)) return [];
+
+    const entries = this.readTraceEntriesForTurnStart(sessionId, turnStartSeq);
+    const seen = new Set<string>();
+    const artifacts: ContentRef[] = [];
+
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      const message = entry as { type?: unknown; payload?: unknown };
+      if (message.type !== 'tool_complete' || !message.payload || typeof message.payload !== 'object') continue;
+      const payload = message.payload as {
+        toolName?: unknown;
+        success?: unknown;
+        termination?: unknown;
+        attachments?: unknown;
+      };
+      if (payload.success === false || payload.termination !== undefined) continue;
+      if (payload.toolName !== 'show_image' && payload.toolName !== 'show_html') continue;
+      if (!Array.isArray(payload.attachments)) continue;
+
+      for (const candidate of payload.attachments) {
+        const ref = this.validTurnArtifact(candidate, payload.toolName);
+        if (!ref || seen.has(ref.id)) continue;
+        seen.add(ref.id);
+        artifacts.push(ref);
+      }
     }
+    return artifacts;
+  }
+
+  private readTraceEntriesForTurnStart(sessionId: string, turnStartSeq: number): unknown[] {
+    if (turnStartSeq <= 0) return [];
+    const tracePath = join(this.sessionDir(sessionId), 'trace.jsonl');
+    if (!existsSync(tracePath)) return [];
 
     let content: string;
     try {
       content = readFileSync(tracePath, 'utf8');
     } catch {
-      return { entries: [], complete, turnStartSeq };
+      return [];
     }
 
     const entries: unknown[] = [];
     for (const line of content.split('\n')) {
       if (!line) continue;
       try {
-        const t = JSON.parse(line) as TraceLine;
-        if (t.turnStartSeq !== turnStartSeq) continue;
-        entries.push(JSON.parse(t.payload));
+        const trace = JSON.parse(line) as TraceLine;
+        if (trace.turnStartSeq !== turnStartSeq) continue;
+        entries.push(JSON.parse(trace.payload));
       } catch {
-        // Skip corrupted lines
+        // Skip corrupted lines.
       }
     }
-    return { entries, complete, turnStartSeq };
+    return entries;
+  }
+
+  private validTurnArtifact(candidate: unknown, toolName: 'show_image' | 'show_html'): ContentRef | null {
+    if (!candidate || typeof candidate !== 'object') return null;
+    const ref = candidate as Partial<ContentRef>;
+    if (ref.type !== 'content_ref') return null;
+    if (typeof ref.id !== 'string' || ref.id.trim().length === 0) return null;
+    if (typeof ref.mimeType !== 'string') return null;
+    if (!Number.isFinite(ref.size) || (ref.size ?? -1) < 0) return null;
+    if (toolName === 'show_image' && !ref.mimeType.startsWith('image/')) return null;
+    if (toolName === 'show_html' && ref.mimeType !== 'text/html') return null;
+    if (ref.name !== undefined && typeof ref.name !== 'string') return null;
+    if (ref.caption !== undefined && typeof ref.caption !== 'string') return null;
+    if (ref.width !== undefined && (!Number.isFinite(ref.width) || ref.width < 0)) return null;
+    if (ref.height !== undefined && (!Number.isFinite(ref.height) || ref.height < 0)) return null;
+    return ref as ContentRef;
   }
 
   /**


### PR DESCRIPTION
## Summary

- add durable `idle.payload.turnArtifacts?: ContentRef[]` metadata to the session spine
- derive new-turn image/HTML refs from persisted TRACE at the genuine closing-idle boundary
- project closing-idle artifacts onto the visible Web turn outcome without making `idle` a bubble
- remove automatic historical TRACE pulls driven by `steps > 0`; TRACE is requested only when Steps UI is opened
- normalize exact Kraki `show_image` / `show_html` tool identities across Claude and Copilot adapters

## Architecture

- persisted TRACE remains the extraction authority at turn close
- the spine stores only validated `ContentRef` metadata; attachment bytes remain in `AttachmentStore`
- accepted artifacts are limited to successful, non-terminated `show_image -> image/*` and `show_html -> text/html` results
- refs are deduplicated by id and scoped by the persisted current-turn start sequence
- initialization/import/fork idles do not acquire turn artifacts
- no historical compatibility or backfill is included
- Head is unchanged and remains content-blind
- iOS is out of scope

## Web behavior

- artifacts attach to terminal status, interrupted turn, final agent reply, or no-reply system outcome
- direct message attachments and idle refs are deduplicated
- image and HTML artifacts render on normal, terminal, interrupted, and no-reply outcomes
- fresh clients hydrate bytes via `request_attachment`; artifact discovery no longer depends on TRACE

## Validation

- Protocol build: pass
- Tentacle tests: 755/755 pass
- Web tests: 394/394 pass (`NODE_ENV=test`)
- focused Tentacle review suite: 311/311 pass
- focused Web artifact suite: 35/35 pass
- Protocol/Tentacle/Web production builds: pass
- workspace lint: pass
- `git diff --check`: pass
- real-stack Playwright cold-browser recovery: 1/1 pass
  - fresh Arm identity
  - no attachment cache
  - no Pulse repair state
  - no `request_turn_trace`
  - paced `request_attachment` pulls and reassembles every PNG chunk

## Self-review fix

During pre-PR review, tightened Claude image extraction so only the canonical Kraki `show_image` tool may persist image blocks; arbitrary tools returning image-shaped data cannot become user-visible artifacts.

## Operational scope

No release, deployment, production Tentacle update, or process restart is part of this PR.
