### PR TITLE
chore: bump artifact spine release versions

### DIFF
--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/arm-web",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Kraki web receiver — view and control your agents from any browser",
   "type": "module",
   "scripts": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Versions

- `@kraki/protocol`: `0.21.0`
- `@kraki/tentacle`: `0.31.0`
- `@kraki/arm-web`: `0.16.0`
- Head unchanged at `0.17.0`

## Validation

- `NODE_ENV=test pnpm validate`
- dependency-ordered Crypto/Protocol/Tentacle/Web production builds
- `git diff --check`

Prepares the merged artifact-spine feature for npm/CLI release and Web production deployment.