### PR TITLE
fix(preview): clear stale attention previews on resolution

### DIFF
--- a/packages/arm/web/e2e/real-stack/preview-lifecycle-diagnostic.spec.ts
+++ b/packages/arm/web/e2e/real-stack/preview-lifecycle-diagnostic.spec.ts
@@ -1,0 +1,158 @@
+import { expect, type Browser, type BrowserContext, type Page, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+type Debug = {
+  sessions: Array<{ id: string; state: string; preview?: { text: string; type: string; timestamp: string } }>;
+  enrichedSessions: Array<{ id: string; state: string; preview?: { text: string; type: string; timestamp: string } }>;
+  openQuestions: Record<string, string[]>;
+  openPermissions: Record<string, string[]>;
+  subscriptions: Record<string, string | null>;
+};
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const context = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const response = await context.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await response.json();
+  await context.dispose();
+  if (!response.ok()) throw new Error(`${path}: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function debug(): Promise<Debug> {
+  return await control('/debug') as unknown as Debug;
+}
+
+async function pair(browser: Browser): Promise<{ context: BrowserContext; page: Page; deviceId: string }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const { token } = await control('/token');
+  await page.goto(`${WEB}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  const deviceId = await page.evaluate(() => JSON.parse(localStorage.getItem('kraki_device') ?? '{}').deviceId as string);
+  return { context, page, deviceId };
+}
+
+function digest(d: Debug, sid: string, enriched = true) {
+  return (enriched ? d.enrichedSessions : d.sessions).find((s) => s.id === sid);
+}
+
+async function cardText(page: Page, marker: string): Promise<string | null> {
+  const button = page.getByRole('button').filter({ hasText: marker }).first();
+  if (await button.count() === 0) return null;
+  return (await button.innerText()).replace(/\s+/g, ' ').trim();
+}
+
+async function snapshot(page: Page, sid: string, marker: string, label: string) {
+  const d = await debug();
+  const value = {
+    label,
+    sid,
+    raw: digest(d, sid, false),
+    enriched: digest(d, sid, true),
+    openQuestions: d.openQuestions[sid] ?? [],
+    openPermissions: d.openPermissions[sid] ?? [],
+    uiCard: await cardText(page, marker),
+    markerCount: await page.getByText(marker, { exact: false }).count(),
+  };
+  console.log(`PREVIEW_STATE ${JSON.stringify(value)}`);
+  return value;
+}
+
+test('preview lifecycle matrix: question, permission, resolution, failure cleanup, refresh', async ({ browser }) => {
+  const arm = await pair(browser);
+  const failures: string[] = [];
+  try {
+    // 1. Non-subscribed question: digest overlay should appear globally.
+    const qSid = `preview-q-${Date.now().toString(36)}`;
+    const qText = `QUESTION-${Date.now().toString(36)}`;
+    await control('/createSession', { id: qSid });
+    await control('/idle', { sid: qSid });
+    await control('/question', { sid: qSid, id: 'q-auto', text: qText, choices: 'yes|no' });
+    await expect(arm.page.getByText(qText, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    let state = await snapshot(arm.page, qSid, qText, 'question-open-unsubscribed');
+    if (state.enriched?.preview?.type !== 'question') failures.push('question open: Tentacle digest is not question');
+    if (!state.uiCard?.includes('waiting')) failures.push('question open: sidebar is not waiting');
+
+    // Agent auto-cancels it while this Arm is not subscribed. The enriched
+    // digest has no preview, so Web must remove the old question preview.
+    await control('/questionAutoResolved', { sid: qSid, id: 'q-auto' });
+    await expect.poll(async () => (await debug()).openQuestions[qSid]?.length ?? 0).toBe(0);
+    await arm.page.waitForTimeout(800);
+    state = await snapshot(arm.page, qSid, qText, 'question-auto-resolved-unsubscribed');
+    if (state.enriched?.preview?.type === 'question') failures.push('question auto-resolve: Tentacle still reports question');
+    if (state.uiCard?.includes('waiting')) failures.push('question auto-resolve: Web retains false waiting');
+    if (state.markerCount > 0) failures.push('question auto-resolve: Web retains stale question text');
+
+    // Refresh must not resurrect stale persisted question preview.
+    await arm.page.reload();
+    await expect(arm.page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+    await arm.page.waitForTimeout(800);
+    state = await snapshot(arm.page, qSid, qText, 'question-resolved-after-refresh');
+    if (state.uiCard?.includes('waiting')) failures.push('question refresh: false waiting resurrected');
+    if (state.markerCount > 0) failures.push('question refresh: stale question text resurrected');
+
+    // 2. Current-session question answered through the real UI. Optimistic
+    // answer preview should clear waiting immediately, and authoritative digest
+    // must no longer be a question.
+    const answerSid = `preview-answer-${Date.now().toString(36)}`;
+    const answerQuestion = `ANSWER-Q-${Date.now().toString(36)}`;
+    await control('/createSession', { id: answerSid });
+    await control('/idle', { sid: answerSid });
+    await arm.page.goto(`${WEB}/session/${answerSid}`);
+    await expect.poll(async () => (await debug()).subscriptions[arm.deviceId], { timeout: 15_000 }).toBe(answerSid);
+    await control('/question', { sid: answerSid, id: 'q-click', text: answerQuestion, choices: 'choice-one|choice-two' });
+    await expect(arm.page.getByRole('button', { name: 'choice-one' })).toBeVisible({ timeout: 15_000 });
+    await arm.page.getByRole('button', { name: 'choice-one' }).click();
+    await expect.poll(async () => (await control('/answers').then((x) => x.answers as Array<{ answer: string }>)).some((x) => x.answer === 'choice-one')).toBe(true);
+    await arm.page.waitForTimeout(500);
+    state = await snapshot(arm.page, answerSid, 'choice-one', 'question-user-answered');
+    if (state.enriched?.preview?.type === 'question') failures.push('question answer: Tentacle still reports question');
+    if (state.uiCard?.includes('waiting')) failures.push('question answer: sidebar still waiting');
+
+    // 3. Non-subscribed permission auto-resolution. Permission is a badge /
+    // preview attention item, but should not display waiting (waiting is reserved
+    // for blocking ask_user questions). It must disappear after resolution.
+    await arm.page.goto(WEB);
+    const pSid = `preview-perm-${Date.now().toString(36)}`;
+    const pText = `PERMISSION-${Date.now().toString(36)}`;
+    await control('/createSession', { id: pSid });
+    await control('/idle', { sid: pSid });
+    await control('/perm', { sid: pSid, id: 'perm-auto', tool: 'bash', desc: pText });
+    await expect(arm.page.getByText(pText, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    state = await snapshot(arm.page, pSid, pText, 'permission-open-unsubscribed');
+    if (state.enriched?.preview?.type !== 'permission') failures.push('permission open: Tentacle digest is not permission');
+    if (state.uiCard?.includes('waiting')) failures.push('permission open: sidebar incorrectly says waiting');
+    await control('/permissionAutoResolved', { sid: pSid, id: 'perm-auto' });
+    await expect.poll(async () => (await debug()).openPermissions[pSid]?.length ?? 0).toBe(0);
+    await arm.page.waitForTimeout(800);
+    state = await snapshot(arm.page, pSid, pText, 'permission-auto-resolved-unsubscribed');
+    if (state.enriched?.preview?.type === 'permission') failures.push('permission auto-resolve: Tentacle still reports permission');
+    if (state.markerCount > 0) failures.push('permission auto-resolve: Web retains stale permission preview');
+
+    // 4. Question + permission followed by terminal error/idle. Both attention
+    // maps must clear. This catches boolean short-circuit cleanup.
+    const mixedSid = `preview-mixed-${Date.now().toString(36)}`;
+    const mixedQ = `MIXED-Q-${Date.now().toString(36)}`;
+    const mixedP = `MIXED-P-${Date.now().toString(36)}`;
+    await control('/createSession', { id: mixedSid });
+    await control('/idle', { sid: mixedSid });
+    await control('/perm', { sid: mixedSid, id: 'perm-mixed', tool: 'bash', desc: mixedP });
+    await control('/question', { sid: mixedSid, id: 'q-mixed', text: mixedQ, choices: 'a|b' });
+    await control('/error', { sid: mixedSid, message: 'terminal mixed failure' });
+    await control('/idle', { sid: mixedSid });
+    await arm.page.waitForTimeout(800);
+    state = await snapshot(arm.page, mixedSid, mixedP, 'mixed-terminal-cleanup');
+    if (state.openQuestions.length > 0) failures.push('mixed cleanup: question map retained');
+    if (state.openPermissions.length > 0) failures.push('mixed cleanup: permission map retained');
+    if (state.enriched?.preview?.type === 'question' || state.enriched?.preview?.type === 'permission') failures.push('mixed cleanup: attention digest retained');
+
+    console.log(`PREVIEW_FAILURES ${JSON.stringify(failures)}`);
+    expect(failures).toEqual([]);
+  } finally {
+    await arm.context.close();
+  }
+});

--- a/packages/arm/web/e2e/real-stack/preview-stress.spec.ts
+++ b/packages/arm/web/e2e/real-stack/preview-stress.spec.ts
@@ -1,0 +1,290 @@
+/**
+ * High-intensity preview / attention stress matrix.
+ *
+ * Each scenario targets a specific boundary that the simple lifecycle spec
+ * does NOT cover: cross-device resolution, turn abort, session deletion,
+ * Tentacle reconnect rehydration, interleaved attention cycling, and
+ * multi-Arm attention isolation. All driven against the REAL Head + REAL
+ * Tentacle + REAL browser stack so the Pulse transport is exercised.
+ */
+import { expect, type Browser, type BrowserContext, type Page, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+type Debug = {
+  sessions: Array<{ id: string; state: string; preview?: { text: string; type: string; timestamp: string } }>;
+  enrichedSessions: Array<{ id: string; state: string; preview?: { text: string; type: string; timestamp: string } }>;
+  openQuestions: Record<string, string[]>;
+  openPermissions: Record<string, string[]>;
+  subscriptions: Record<string, string | null>;
+};
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`${path}: ${JSON.stringify(body)}`);
+  return body;
+}
+async function debug(): Promise<Debug> { return (await control('/debug')) as unknown as Debug; }
+async function enrichedPreview(sid: string): Promise<{ type: string; text: string } | undefined> {
+  const d = await debug();
+  return d.enrichedSessions.find((s) => s.id === sid)?.preview as { type: string; text: string } | undefined;
+}
+async function openQ(sid: string): Promise<string[]> { return (await debug()).openQuestions[sid] ?? []; }
+async function openP(sid: string): Promise<string[]> { return (await debug()).openPermissions[sid] ?? []; }
+
+async function pair(browser: Browser): Promise<{ context: BrowserContext; page: Page; deviceId: string }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const { token } = await control('/token');
+  await page.goto(`${WEB}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  const deviceId = await page.evaluate(() => JSON.parse(localStorage.getItem('kraki_device') ?? '{}').deviceId as string);
+  return { context, page, deviceId };
+}
+async function createSession(id: string): Promise<void> {
+  await control('/createSession', { id });
+  await control('/idle', { sid: id });
+}
+async function settle(ms = 600): Promise<void> { await new Promise((r) => setTimeout(r, ms)); }
+
+/** Read the sidebar session-card text for a session id, normalized. */
+async function cardText(page: Page, marker: string): Promise<string | null> {
+  const btn = page.getByRole('button').filter({ hasText: marker }).first();
+  if (await btn.count() === 0) return null;
+  return (await btn.innerText()).replace(/\s+/g, ' ').trim();
+}
+
+test.describe('preview high-intensity stress', () => {
+  let arm: { context: BrowserContext; page: Page; deviceId: string };
+
+  test.beforeAll(async ({ browser }) => { arm = await pair(browser); });
+  test.afterAll(async () => { await arm?.context.close(); });
+
+  // ── 1. Cross-device answer: a second Arm (not subscribed) answers a
+  // question that a third device opened. Both the question preview and the
+  // subscribed Arm's card must clear. Exercises the session_list digest
+  // clearing the non-subscribed Arm's sidebar preview after resolution.
+  test('cross-device answer clears preview on a non-subscribed Arm', async ({ browser }) => {
+    const sid = `xdev-${Date.now().toString(36)}`;
+    const q = `XDEVQ-${Date.now().toString(36)}`;
+    await createSession(sid);
+    await control('/question', { sid, id: 'q-xdev', text: q, choices: 'alpha|beta' });
+    await expect(arm.page.getByText(q, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question' });
+    expect((await cardText(arm.page, q)) ?? '').toContain('waiting');
+
+    // A DIFFERENT Arm answers it directly over Pulse.
+    const other = await pair(browser);
+    try {
+      await other.page.goto(`${WEB}/session/${sid}`);
+      await expect.poll(async () => (await debug()).subscriptions[other.deviceId], { timeout: 15_000 }).toBe(sid);
+      await expect(other.page.getByRole('button', { name: 'alpha' })).toBeVisible({ timeout: 15_000 });
+      await other.page.getByRole('button', { name: 'alpha' }).click();
+      await expect.poll(async () => {
+        const x = await control('/answers');
+        return (x.answers as Array<{ answer: string }>).some((a) => a.answer === 'alpha');
+      }).toBe(true);
+      await settle();
+
+      // The first (non-subscribed) Arm's sidebar must drop the question badge.
+      expect(await openQ(sid)).toEqual([]);
+      expect(await enrichedPreview(sid)).toBeUndefined();
+      expect((await cardText(arm.page, q)) ?? '').not.toContain('waiting');
+    } finally {
+      await other.context.close();
+    }
+  });
+
+  // ── 2. Turn abort (user_abort) while a question is open: the question
+  // preview must clear and the card must not be left frozen on "waiting".
+  test('turn abort clears an open question preview (no phantom waiting)', async () => {
+    const sid = `abort-${Date.now().toString(36)}`;
+    const q = `ABORTQ-${Date.now().toString(36)}`;
+    await createSession(sid);
+    await control('/question', { sid, id: 'q-abort', text: q, choices: 'yes|no' });
+    await expect(arm.page.getByText(q, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question' });
+
+    // Abort the turn through the real Arm->Tentacle message path.
+    await control('/armAbort', { sid });
+    await settle();
+
+    expect(await openQ(sid)).toEqual([]);
+    expect(await enrichedPreview(sid)).toBeUndefined();
+    expect((await cardText(arm.page, q)) ?? '').not.toContain('waiting');
+  });
+
+  // ── 3. Question + permission interleaved, each resolved independently,
+  // then a new question opens on a fresh turn. The sidebar must always track
+  // the CURRENT attention, never a stale resolved one.
+  test('interleaved Q->P->resolve P->resolve Q->new turn new Q tracks current attention', async () => {
+    const sid = `interleave-${Date.now().toString(36)}`;
+    const q1 = `IQQ1-${Date.now().toString(36)}`;
+    const p1 = `IQP1-${Date.now().toString(36)}`;
+    const q2 = `IQQ2-${Date.now().toString(36)}`;
+    await createSession(sid);
+
+    await control('/perm', { sid, id: 'p-inter', tool: 'bash', desc: p1 });
+    await control('/question', { sid, id: 'q-inter-1', text: q1, choices: 'a|b' });
+    await settle();
+    // Newest attention wins: question is more recent.
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question', text: q1 });
+
+    await control('/permissionAutoResolved', { sid, id: 'p-inter' });
+    await settle();
+    expect(await openP(sid)).toEqual([]);
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question', text: q1 });
+
+    await control('/questionAutoResolved', { sid, id: 'q-inter-1' });
+    await settle();
+    expect(await openQ(sid)).toEqual([]);
+    expect(await enrichedPreview(sid)).toBeUndefined();
+    expect((await cardText(arm.page, q1)) ?? '').not.toContain('waiting');
+
+    // New turn, new question: sidebar must reflect ONLY q2, not resurrect q1.
+    await control('/active', { sid });
+    await control('/question', { sid, id: 'q-inter-2', text: q2, choices: 'c|d' });
+    await settle();
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question', text: q2 });
+    expect((await cardText(arm.page, q2)) ?? '').toContain('waiting');
+    expect((await cardText(arm.page, q1)) ?? '').not.toContain('waiting');
+  });
+
+  // ── 4. Tentacle disconnect/reconnect while a question is open: the
+  // pending human action is rehydrated from durable storage and the digest
+  // must re-advertise the question preview (no false clear, no loss).
+  test('Tentacle reconnect rehydrates an open question preview', async () => {
+    const sid = `reconnect-${Date.now().toString(36)}`;
+    const q = `RCQ-${Date.now().toString(36)}`;
+    await createSession(sid);
+    await control('/question', { sid, id: 'q-rc', text: q, choices: 'y|n' });
+    await expect(arm.page.getByText(q, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question' });
+
+    await control('/tentacle/disconnect');
+    await settle(1500);
+    // While tentacle is offline the preview stays (we don't falsely clear).
+    await control('/tentacle/connect');
+    // Give the relay time to re-auth + re-broadcast session_list.
+    await expect.poll(async () => (await debug()).openQuestions[sid]?.length ?? 0, { timeout: 20_000 }).toBe(1);
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question', text: q });
+    // The sidebar status badge depends on session.state derivation, not just
+    // the digest preview, so we assert the transport-level recovery (digest
+    // preview) rather than a UI status string here.
+
+    // Now resolve it; must clear cleanly post-reconnect.
+    await control('/questionAutoResolved', { sid, id: 'q-rc' });
+    await settle();
+    expect(await openQ(sid)).toEqual([]);
+    expect(await enrichedPreview(sid)).toBeUndefined();
+    expect((await cardText(arm.page, q)) ?? '').not.toContain('waiting');
+  });
+
+  // ── 5. delete_session while a question is open: the session disappears
+  // from the sidebar entirely; no phantom preview row lingers.
+  test('delete_session removes the session and its open-question preview', async () => {
+    const sid = `del-${Date.now().toString(36)}`;
+    const q = `DELQ-${Date.now().toString(36)}`;
+    await createSession(sid);
+    await control('/question', { sid, id: 'q-del', text: q, choices: 'y|n' });
+    await expect(arm.page.getByText(q, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question' });
+
+    await control('/armDelete', { sid });
+    await settle(1000);
+
+    const d = await debug();
+    expect(d.enrichedSessions.find((s) => s.id === sid)).toBeUndefined();
+    // Sidebar card gone too.
+    await expect(arm.page.getByText(q, { exact: false })).toHaveCount(0);
+  });
+
+  // ── 6. Permission abandoned on idle (agent finishes without resolving):
+  // the idle turn-end must clear the permission attention, not strand it.
+  test('permission abandoned on idle clears (no stranded permission badge)', async () => {
+    const sid = `abandon-${Date.now().toString(36)}`;
+    const p = `ABANDONP-${Date.now().toString(36)}`;
+    await createSession(sid);
+    await control('/perm', { sid, id: 'p-abandon', tool: 'bash', desc: p });
+    await expect(arm.page.getByText(p, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'permission' });
+
+    // Agent idles without the user ever approving/denying.
+    await control('/idle', { sid });
+    await settle();
+    expect(await openP(sid)).toEqual([]);
+    expect(await enrichedPreview(sid)).toBeUndefined();
+    expect((await cardText(arm.page, p)) ?? '').not.toContain('PERMISSION');
+  });
+
+  // ── 7. Two sessions each with independent attention, resolved in opposite
+  // order: clearing one must NOT touch the other.
+  test('independent sessions resolve without cross-contamination', async () => {
+    const sidA = `indep-a-${Date.now().toString(36)}`;
+    const sidB = `indep-b-${Date.now().toString(36)}`;
+    const qA = `INDEPA-${Date.now().toString(36)}`;
+    const pB = `INDEPB-${Date.now().toString(36)}`;
+    await createSession(sidA);
+    await createSession(sidB);
+    await control('/question', { sid: sidA, id: 'q-indep-a', text: qA, choices: 'y|n' });
+    await control('/perm', { sid: sidB, id: 'p-indep-b', tool: 'bash', desc: pB });
+    await settle();
+    expect(await enrichedPreview(sidA)).toMatchObject({ type: 'question' });
+    expect(await enrichedPreview(sidB)).toMatchObject({ type: 'permission' });
+
+    // Resolve B first, then A. A must still be intact after B clears.
+    await control('/permissionAutoResolved', { sid: sidB, id: 'p-indep-b' });
+    await settle();
+    expect(await enrichedPreview(sidB)).toBeUndefined();
+    expect(await enrichedPreview(sidA)).toMatchObject({ type: 'question', text: qA });
+
+    await control('/questionAutoResolved', { sid: sidA, id: 'q-indep-a' });
+    await settle();
+    expect(await enrichedPreview(sidA)).toBeUndefined();
+    expect(await enrichedPreview(sidB)).toBeUndefined();
+  });
+
+  // ── 8. Rapid open/autoresolve churn: many question cycles collapse to a
+  // clean final state with no leaked attention maps or stale previews.
+  test('rapid open/autoresolve churn leaves a clean final state', async () => {
+    const sid = `churn-${Date.now().toString(36)}`;
+    await createSession(sid);
+    for (let i = 0; i < 8; i++) {
+      const id = `q-churn-${i}`;
+      await control('/question', { sid, id, text: `CHURN-${i}`, choices: 'y|n' });
+      await control('/questionAutoResolved', { sid, id });
+    }
+    await settle(1000);
+    expect(await openQ(sid)).toEqual([]);
+    expect(await enrichedPreview(sid)).toBeUndefined();
+  });
+
+  // ── 9. Non-attention (agent_message) preview survives a digest that has
+  // no attention: the fix must only clear question/permission previews,
+  // never strand a normal agent reply.
+  test('agent_message preview survives a no-attention digest', async () => {
+    const sid = `spine-${Date.now().toString(36)}`;
+    const agentText = `SPINE-${Date.now().toString(36)}`;
+    await createSession(sid);
+    await control('/msg', { sid, text: agentText });
+    await control('/idle', { sid });
+    await expect(arm.page.getByText(agentText, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    // Open then auto-resolve a question; the agent preview must return.
+    await control('/question', { sid, id: 'q-spine', text: 'QTEMP', choices: 'y|n' });
+    await settle();
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'question' });
+    await control('/questionAutoResolved', { sid, id: 'q-spine' });
+    await settle();
+    // Question resolved -> the digest reverts to the spine agent_message
+    // preview (NOT undefined - the agent reply is the durable sidebar text).
+    expect(await enrichedPreview(sid)).toMatchObject({ type: 'agent', text: agentText });
+    // The agent_message preview should be back on the sidebar card.
+    expect((await cardText(arm.page, agentText)) ?? '').toContain(agentText);
+  });
+});

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -348,6 +348,14 @@ export const useStore = create<Store>()(persist((set) => ({
       return { sessionPreviews: previews };
     }),
 
+  clearSessionPreview: (sessionId) =>
+    set((state) => {
+      if (!state.sessionPreviews.has(sessionId)) return state;
+      const previews = new Map(state.sessionPreviews);
+      previews.delete(sessionId);
+      return { sessionPreviews: previews };
+    }),
+
   setDraft: (sessionId, text) =>
     set((state) => {
       const next = new Map(state.drafts);

--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -1305,6 +1305,88 @@ describe('KrakiWSClient', () => {
       expect(useStore.getState().sessionPreviews.get('sess-pending')?.type).toBe('question');
     });
 
+    it('clears a stale question preview when session_list digest no longer carries attention', async () => {
+      // Regression: handleSessionList only WROTE previews when the digest had
+      // one. When the question was resolved (answered/cancelled/turn-ended),
+      // the enriched digest stopped carrying a preview, but the stale
+      // `type:'question'` entry persisted in the store (and localStorage),
+      // pinning the sidebar on a phantom "waiting" badge - even after reload.
+      const client = new KrakiWSClient('ws://localhost:9999');
+      await connectAndAuth(client);
+
+      // Seed a question preview.
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-t1', seq: 1, timestamp: new Date().toISOString(),
+        payload: { sessions: [{
+          id: 'sess-q', agent: 'pi', state: 'active', mode: 'execute',
+          lastSeq: 5, readSeq: 5, messageCount: 5, createdAt: new Date().toISOString(),
+          preview: { type: 'question', text: 'Which DB?', timestamp: new Date().toISOString() },
+        }] },
+      });
+      expect(useStore.getState().sessionPreviews.get('sess-q')?.type).toBe('question');
+
+      // Tentacle resolves the question; the next digest has no preview.
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-t1', seq: 2, timestamp: new Date().toISOString(),
+        payload: { sessions: [{
+          id: 'sess-q', agent: 'pi', state: 'active', mode: 'execute',
+          lastSeq: 6, readSeq: 6, messageCount: 6, createdAt: new Date().toISOString(),
+        }] },
+      });
+      expect(useStore.getState().sessionPreviews.get('sess-q')).toBeUndefined();
+    });
+
+    it('clears a stale permission preview when session_list digest no longer carries attention', async () => {
+      const client = new KrakiWSClient('ws://localhost:9999');
+      await connectAndAuth(client);
+
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-t1', seq: 1, timestamp: new Date().toISOString(),
+        payload: { sessions: [{
+          id: 'sess-p', agent: 'pi', state: 'active', mode: 'execute',
+          lastSeq: 5, readSeq: 5, messageCount: 5, createdAt: new Date().toISOString(),
+          preview: { type: 'permission', text: 'Run npm test', timestamp: new Date().toISOString() },
+        }] },
+      });
+      expect(useStore.getState().sessionPreviews.get('sess-p')?.type).toBe('permission');
+
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-t1', seq: 2, timestamp: new Date().toISOString(),
+        payload: { sessions: [{
+          id: 'sess-p', agent: 'pi', state: 'active', mode: 'execute',
+          lastSeq: 6, readSeq: 6, messageCount: 6, createdAt: new Date().toISOString(),
+        }] },
+      });
+      expect(useStore.getState().sessionPreviews.get('sess-p')).toBeUndefined();
+    });
+
+    it('does NOT clear a non-attention preview when the digest has no attention', async () => {
+      // An agent/user/error preview belongs to the durable spine; it must
+      // survive a digest that carries no attention, and be left for
+      // rebuildPreview / the next subscription ACK to refresh.
+      const client = new KrakiWSClient('ws://localhost:9999');
+      await connectAndAuth(client);
+
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-t1', seq: 1, timestamp: new Date().toISOString(),
+        payload: { sessions: [{
+          id: 'sess-agent', agent: 'pi', state: 'idle', mode: 'discuss',
+          lastSeq: 5, readSeq: 5, messageCount: 5, createdAt: new Date().toISOString(),
+          preview: { type: 'agent', text: 'Done.', timestamp: new Date().toISOString() },
+        }] },
+      });
+      expect(useStore.getState().sessionPreviews.get('sess-agent')?.type).toBe('agent');
+
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-t1', seq: 2, timestamp: new Date().toISOString(),
+        payload: { sessions: [{
+          id: 'sess-agent', agent: 'pi', state: 'idle', mode: 'discuss',
+          lastSeq: 5, readSeq: 5, messageCount: 5, createdAt: new Date().toISOString(),
+        }] },
+      });
+      expect(useStore.getState().sessionPreviews.get('sess-agent')?.type).toBe('agent');
+    });
+
     it('only warms up sessions within 24h or active/pinned', async () => {
       const client = new KrakiWSClient('ws://localhost:9999');
       await connectAndAuth(client);

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -514,6 +514,20 @@ export class KrakiWSClient {
       const preview = tsRecord.preview as { text: string; type: string; timestamp: string } | undefined;
       if (preview?.text) {
         store.setSessionPreview(ts.id, { text: preview.text, type: preview.type, timestamp: preview.timestamp });
+      } else {
+        // Tentacle's enriched digest carries no attention preview for this
+        // session, so the question/permission that produced the local one has
+        // been resolved (answered/approved/cancelled/turn-ended). The previous
+        // code skipped the write entirely, leaking a stale `type:'question'`
+        // preview that keeps the sidebar pinned on "waiting" long after the
+        // ask is gone - and it is persisted to localStorage, so it survives
+        // reloads. Only clear ATTENTION previews (question/permission);
+        // normal agent/user/error previews belong to the durable spine and
+        // must be left for rebuildPreview / the next subscription ACK.
+        const existing = getStore().sessionPreviews.get(ts.id);
+        if (existing && (existing.type === 'question' || existing.type === 'permission')) {
+          store.clearSessionPreview(ts.id);
+        }
       }
 
       if (tsRecord.usage && typeof tsRecord.usage === 'object') {

--- a/packages/arm/web/src/types/store.ts
+++ b/packages/arm/web/src/types/store.ts
@@ -163,6 +163,7 @@ export interface AppActions {
   incrementUnread: (sessionId: string) => void;
   clearUnread: (sessionId: string) => void;
   setSessionPreview: (sessionId: string, preview: SessionPreview, incrementUnread?: boolean) => void;
+  clearSessionPreview: (sessionId: string) => void;
   setDraft: (sessionId: string, text: string) => void;
   setLastError: (message: string | null) => void;
   setNavigateToSession: (sessionId: string | null) => void;

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2041,6 +2041,7 @@ describe('RelayClient pending-question digest', () => {
     })));
     let seq = 100;
     const askQ = (id: string) => (adapter.onQuestionRequest as (sid: string, e: Record<string, unknown>) => void)('sess_1', { id, question: `Q ${id}`, choices: ['a', 'b'] });
+    const askP = (id: string, desc = `P ${id}`) => (adapter.onPermissionRequest as (sid: string, e: Record<string, unknown>) => void)('sess_1', { id, description: desc, toolArgs: { toolName: 'shell' } });
     const answerQ = (id: string) => ws.emit('message', Buffer.from(JSON.stringify({
       type: 'answer', sessionId: 'sess_1', deviceId: 'app-x', seq: ++seq,
       timestamp: new Date().toISOString(), payload: { questionId: id, answer: 'a' },
@@ -2062,7 +2063,7 @@ describe('RelayClient pending-question digest', () => {
       return undefined;
     };
     const preview = () => digest()?.preview as { type: string; text: string } | undefined;
-    return { adapter, sm, client, ws, askQ, answerQ, digest, preview };
+    return { adapter, sm, client, ws, askQ, askP, answerQ, digest, preview };
   }
 
   it('restores compacting from session_list state without replaying runtime events', () => {
@@ -2116,6 +2117,37 @@ describe('RelayClient pending-question digest', () => {
     askQ('q1');
     (adapter.onQuestionAutoResolved as (sid: string, qid: string) => void)('sess_1', 'q1');
     expect(preview()?.type).not.toBe('question');
+  });
+
+  it('clears BOTH question and permission attention on terminal turn end (no short-circuit leak)', () => {
+    // Regression: clearOpenQuestions used `openQuestions.delete(sid) ||
+    // openPermissions.delete(sid)`. The `||` short-circuited when the question
+    // map delete returned true, so a permission open on the same session
+    // leaked into every subsequent session_list digest and kept the sidebar
+    // pinned on a stale permission badge forever.
+    //
+    // Real trigger path: a terminal adapter error stages a failed outcome,
+    // then idle freezes it via finishTurnWithStatus -> clearOpenQuestions
+    // (bypassing the soleOpenQuestion guard, which would otherwise hold the
+    // question open while the agent waits for an answer).
+    const { adapter, askQ, askP, preview } = buildClient();
+    askQ('q1');
+    askP('p1');
+    // Both attention items are open.
+    expect(preview()?.type).toBe('question');
+    // Terminal error + idle ends the turn and clears both maps independently.
+    (adapter.onError as (sid: string, e: { message: string }) => void)('sess_1', { message: 'boom' });
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    expect(preview()?.type).not.toBe('question');
+    expect(preview()?.type).not.toBe('permission');
+  });
+
+  it('clears a lone permission attention on terminal turn end', () => {
+    const { adapter, askP, preview } = buildClient();
+    askP('p1');
+    expect(preview()?.type).toBe('permission');
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+    expect(preview()?.type).not.toBe('permission');
   });
 
   it('serializes distinct composer prompts until the preceding turn idles', async () => {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -449,9 +449,14 @@ export class RelayClient {
 
   /** Clear all open human attention for a session (turn ended / session gone). */
   private clearOpenQuestions(sessionId: string): void {
-    const changed = this.openQuestions.delete(sessionId) || this.openPermissions.delete(sessionId);
+    // Delete both maps independently. The previous `a || b` form short-
+    // circuited: when a session had BOTH a question and a permission open,
+    // `openQuestions.delete()` returning true skipped `openPermissions.delete()`,
+    // leaking the permission into every subsequent session_list digest.
+    const qChanged = this.openQuestions.delete(sessionId);
+    const pChanged = this.openPermissions.delete(sessionId);
     this.sessionManager.clearPendingHumanAction(sessionId);
-    if (changed) this.broadcastSessionList();
+    if (qChanged || pChanged) this.broadcastSessionList();
   }
 
   private soleOpenQuestion(sessionId: string): PendingHumanAction | null {

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -110,6 +110,12 @@ class MockAdapter extends AgentAdapter {
     this.active(sid);
     this.onQuestionRequest?.(sid, { id, question: q, choices, allowFreeform: true });
   }
+  questionAutoResolved(sid: string, id: string) {
+    this.onQuestionAutoResolved?.(sid, id);
+  }
+  permissionAutoResolved(sid: string, id: string) {
+    this.onPermissionAutoResolved?.(sid, id);
+  }
   toolStart(sid: string, tool: string, args: Record<string, unknown> = {}, toolCallId?: string) {
     this.active(sid);
     const id = toolCallId ?? `tc-${sid}-${Date.now().toString(36)}`;
@@ -322,11 +328,42 @@ async function main(): Promise<void> {
         case '/delta': adapter.delta(q.get('sid')!, q.get('text') ?? '...'); return json(200, { ok: true });
         case '/perm': adapter.perm(q.get('sid')!, q.get('id') ?? 'perm-1', q.get('tool') ?? 'shell', q.get('desc') ?? 'run a command'); return json(200, { ok: true });
         case '/question': adapter.question(q.get('sid')!, q.get('id') ?? 'q-1', q.get('text') ?? 'which one?', q.get('choices') ? q.get('choices')!.split('|') : undefined); return json(200, { ok: true });
+        case '/questionAutoResolved': adapter.questionAutoResolved(q.get('sid')!, q.get('id') ?? 'q-1'); return json(200, { ok: true });
+        case '/permissionAutoResolved': adapter.permissionAutoResolved(q.get('sid')!, q.get('id') ?? 'perm-1'); return json(200, { ok: true });
         case '/toolStart': adapter.toolStart(q.get('sid')!, q.get('tool') ?? 'bash', q.get('cmd') ? { command: q.get('cmd')! } : {}); return json(200, { ok: true });
         case '/toolComplete': adapter.toolComplete(q.get('sid')!, q.get('tool') ?? 'bash', q.get('result') ?? 'done'); return json(200, { ok: true });
         case '/active': adapter.active(q.get('sid')!); return json(200, { ok: true });
         case '/idle': adapter.idle(q.get('sid')!); return json(200, { ok: true });
         case '/error': adapter.error(q.get('sid')!, q.get('message') ?? 'error'); return json(200, { ok: true });
+        // Inject an inbound Arm->Tentacle control message through the real
+        // relay-client message path (abort/kill/delete). Lets tests drive the
+        // Tentacle-side turn-termination / session-removal paths without
+        // depending on the Arm UI, exercising clearOpenQuestions /
+        // purgeSessionToolState exactly as production.
+        case '/armAbort': {
+          const sid = q.get('sid')!;
+          (relay as unknown as { handleMessage: (m: Record<string, unknown>) => void }).handleMessage({
+            type: 'abort_session', sessionId: sid, deviceId: q.get('from') ?? 'dev-test-arm', seq: Number(q.get('seq') ?? Date.now()),
+            timestamp: new Date().toISOString(), payload: {},
+          });
+          return json(200, { ok: true });
+        }
+        case '/armKill': {
+          const sid = q.get('sid')!;
+          (relay as unknown as { handleMessage: (m: Record<string, unknown>) => void }).handleMessage({
+            type: 'kill_session', sessionId: sid, deviceId: q.get('from') ?? 'dev-test-arm', seq: Number(q.get('seq') ?? Date.now()),
+            timestamp: new Date().toISOString(), payload: {},
+          });
+          return json(200, { ok: true });
+        }
+        case '/armDelete': {
+          const sid = q.get('sid')!;
+          (relay as unknown as { handleMessage: (m: Record<string, unknown>) => void }).handleMessage({
+            type: 'delete_session', sessionId: sid, deviceId: q.get('from') ?? 'dev-test-arm', seq: Number(q.get('seq') ?? Date.now()),
+            timestamp: new Date().toISOString(), payload: {},
+          });
+          return json(200, { ok: true });
+        }
         // Legacy-history compatibility: inject the old durable Abort message
         // through RelayClient's real persistence + pulse broadcast path. The UI
         // must normalize it to the modern frozen LiveAgentBubble renderer.
@@ -357,9 +394,16 @@ async function main(): Promise<void> {
             consumerKeys?: Map<string, string>;
             onlineConsumers?: Set<string>;
             currentSessionByArm?: Map<string, string | null>;
+            openQuestions?: Map<string, Map<string, unknown>>;
+            openPermissions?: Map<string, Map<string, unknown>>;
+            enrichSessionList?: (sessions: ReturnType<SessionManager['getSessionList']>) => ReturnType<SessionManager['getSessionList']>;
           };
+          const rawSessions = sm.getSessionList();
           return json(200, {
-            sessions: sm.getSessionList(),
+            sessions: rawSessions,
+            enrichedSessions: r.enrichSessionList ? r.enrichSessionList(rawSessions) : rawSessions,
+            openQuestions: r.openQuestions ? Object.fromEntries([...r.openQuestions].map(([sid, items]) => [sid, [...items.keys()]])) : 'n/a',
+            openPermissions: r.openPermissions ? Object.fromEntries([...r.openPermissions].map(([sid, items]) => [sid, [...items.keys()]])) : 'n/a',
             consumerKeys: r.consumerKeys ? Array.from(r.consumerKeys.keys()) : 'n/a',
             onlineConsumers: r.onlineConsumers ? Array.from(r.onlineConsumers) : 'n/a',
             subscriptions: r.currentSessionByArm ? Object.fromEntries(r.currentSessionByArm) : 'n/a',


### PR DESCRIPTION
## Summary

Fixes two independent bugs that left a stale **question** ("waiting") or **permission** badge on the sidebar after the underlying attention was resolved — even surviving page reloads.

Both were reproduced on the real Head + Tentacle + browser stack before fixing, and locked in with regression tests + a high-intensity real-stack stress suite.

## Root causes

### Bug 1 — Arm: stale attention preview never cleared (root cause of phantom "waiting")

`handleSessionList()` only **wrote** the session preview when Tentacle's enriched digest carried one. When a question/permission was resolved (answered / approved / auto-cancelled / turn-ended), the digest stopped carrying an attention preview — but the stale `type:'question'` entry persisted in the store.

`getSessionStatus()` forces `pending` when `previewType === 'question'`, so the sidebar stayed on **"waiting"** indefinitely. The preview is persisted to `localStorage`, so it survived reloads too.

Only the current-session `answer()` path masked this (it writes an optimistic `answer` preview). Every other resolution path — agent auto-resolve, cross-device answer, idle/abort turn-end — had no local write to overwrite the stale entry, so the phantom badge stuck.

**Fix:** when the digest has no attention preview, clear a locally-held `question`/`permission` preview. Leave non-attention (`agent`/`user`/`error`) previews untouched — those belong to the durable spine and are refreshed by `rebuildPreview()` / the next subscription ACK.

### Bug 2 — Tentacle: `clearOpenQuestions` short-circuit leaked permissions

```ts
const changed = this.openQuestions.delete(sessionId) || this.openPermissions.delete(sessionId);
```

The `||` short-circuited when the question-map delete returned `true`, so a permission open on the **same** session was never deleted. `latestOpenAttention()` then kept advertising the stale permission in every subsequent `session_list` digest, pinning a permission badge on a session that had long since ended.

**Fix:** delete both maps independently.

## Files

**Fixes**
- `packages/arm/web/src/lib/ws-client.ts` — clear stale attention preview when digest has none
- `packages/arm/web/src/hooks/useStore.ts` + `packages/arm/web/src/types/store.ts` — add `clearSessionPreview()`
- `packages/tentacle/src/relay-client.ts` — independent deletes in `clearOpenQuestions()`

**Regression tests**
- `packages/tentacle/src/__tests__/relay-client.test.ts` — mixed Q+P terminal cleanup; lone permission cleanup
- `packages/arm/web/src/lib/ws-client.test.ts` — stale question/permission clear; non-attention preview preserved

**Real-stack validation suites** (real Head + real Tentacle + real browser)
- `packages/arm/web/e2e/real-stack/preview-lifecycle-diagnostic.spec.ts` — 7-scenario lifecycle matrix
- `packages/arm/web/e2e/real-stack/preview-stress.spec.ts` — 9 high-intensity boundary scenarios
- `scripts/pulse-realstack-server.ts` — harness additions: `questionAutoResolved` / `permissionAutoResolved` adapter callbacks, `/armAbort` `/armKill` `/armDelete` inbound-message injection, `/debug` enriched-digest + open-attention introspection

## Validation

| Suite | Result |
|---|---|
| `pnpm validate` (lint + build + all unit tests) | ✅ |
| Tentacle unit | 758/758 (incl. 2 new regression tests) |
| Arm web unit | 400/400 (incl. 3 new regression tests) |
| Real-stack lifecycle matrix (7 scenarios) | ✅ all pass |
| Real-stack high-intensity stress (9 scenarios) | ✅ all pass |
| Real-stack existing (pulse-realstack + session-subscription) | 25/25 |

### High-intensity scenarios covered
1. Cross-device answer clears preview on a non-subscribed Arm
2. Turn abort clears an open question preview (no phantom waiting)
3. Interleaved Q→P→resolve P→resolve Q→new turn Q tracks current attention
4. Tentacle reconnect rehydrates an open question preview
5. `delete_session` removes the session and its open-question preview
6. Permission abandoned on idle clears (no stranded badge)
7. Independent sessions resolve without cross-contamination
8. Rapid 8× open/autoresolve churn leaves a clean final state
9. `agent_message` preview survives a no-attention digest

## Backward compatibility & deployment

Both fixes are **independently deployable** and backward-compatible:
- **Bug 1 (Arm)** is pure client-side; takes effect on Web beta deploy. An Arm running this fix against an old Tentacle is safe (clearing is a no-op when no stale preview exists).
- **Bug 2 (Tentacle)** is pure relay-side; takes effect on the next Tentacle release. A Tentacle running this fix against an old Arm is safe (the digest shape is unchanged).
- No protocol changes, no Head changes, no coordinated upgrade required.

`deploy-web.yml` triggers on CI completion for `main`; this PR follows the normal beta CD path. Production Web deploy remains a separate manual dispatch. Tentacle binary release follows the standard `release.yml` flow when ready.

## Reproduction evidence

Before the fix, the diagnostic matrix reported 7 failures including:
- question auto-resolved (non-subscribed): `uiCard:"waiting · QUESTION-..."`, `markerCount:4`
- question resolved + **reload**: same phantom waiting resurrected from `localStorage`
- mixed Q+P terminal cleanup: `openPermissions:["perm-mixed"]` leaked, digest still `permission`

After the fix: `PREVIEW_FAILURES []` across all 7 scenarios.
