### PR TITLE
refactor(preview): digest is the single preview authority

### DIFF
--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -1360,31 +1360,36 @@ describe('KrakiWSClient', () => {
       expect(useStore.getState().sessionPreviews.get('sess-p')).toBeUndefined();
     });
 
-    it('does NOT clear a non-attention preview when the digest has no attention', async () => {
-      // An agent/user/error preview belongs to the durable spine; it must
-      // survive a digest that carries no attention, and be left for
-      // rebuildPreview / the next subscription ACK to refresh.
+    it('overwrites a stale question preview with the digest agent preview', async () => {
+      // The digest is the single authority. When a question resolves on a
+      // session that has a spine agent_message, the enriched digest reverts to
+      // the agent preview - which must overwrite the stale `type:'question'`
+      // entry (clearing the phantom "waiting" badge) rather than be ignored.
       const client = new KrakiWSClient('ws://localhost:9999');
       await connectAndAuth(client);
 
+      // Seed a question preview.
       receiveInner({
         type: 'session_list', deviceId: 'dev-t1', seq: 1, timestamp: new Date().toISOString(),
         payload: { sessions: [{
-          id: 'sess-agent', agent: 'pi', state: 'idle', mode: 'discuss',
+          id: 'sess-agent', agent: 'pi', state: 'active', mode: 'discuss',
           lastSeq: 5, readSeq: 5, messageCount: 5, createdAt: new Date().toISOString(),
-          preview: { type: 'agent', text: 'Done.', timestamp: new Date().toISOString() },
+          preview: { type: 'question', text: 'Which DB?', timestamp: new Date().toISOString() },
         }] },
       });
-      expect(useStore.getState().sessionPreviews.get('sess-agent')?.type).toBe('agent');
+      expect(useStore.getState().sessionPreviews.get('sess-agent')?.type).toBe('question');
 
+      // Question resolved; the digest reverts to the spine agent preview.
       receiveInner({
         type: 'session_list', deviceId: 'dev-t1', seq: 2, timestamp: new Date().toISOString(),
         payload: { sessions: [{
           id: 'sess-agent', agent: 'pi', state: 'idle', mode: 'discuss',
-          lastSeq: 5, readSeq: 5, messageCount: 5, createdAt: new Date().toISOString(),
+          lastSeq: 6, readSeq: 6, messageCount: 6, createdAt: new Date().toISOString(),
+          preview: { type: 'agent', text: 'Done.', timestamp: new Date().toISOString() },
         }] },
       });
       expect(useStore.getState().sessionPreviews.get('sess-agent')?.type).toBe('agent');
+      expect(useStore.getState().sessionPreviews.get('sess-agent')?.text).toBe('Done.');
     });
 
     it('only warms up sessions within 24h or active/pinned', async () => {

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -509,25 +509,20 @@ export class KrakiWSClient {
         store.setSessionMode(ts.id, ts.mode as 'safe' | 'discuss' | 'execute' | 'delegate');
       }
 
-      // Apply sidebar preview from tentacle (Tier 0: instant sidebar)
+      // Apply sidebar preview from tentacle (Tier 0: instant sidebar).
+      // The enriched digest is the single authority: it carries an attention
+      // preview while one is open, otherwise it carries the spine-derived
+      // preview (agent/user/error/answer) - or nothing for an empty session.
+      // Mirror that exactly: set when present, clear when absent, so a resolved
+      // question/permission can never leave a stale `type:'question'` preview
+      // pinning the sidebar on a phantom "waiting" badge (persisted to
+      // localStorage, so it survived reloads too).
       const tsRecord = ts as Record<string, unknown>;
       const preview = tsRecord.preview as { text: string; type: string; timestamp: string } | undefined;
       if (preview?.text) {
         store.setSessionPreview(ts.id, { text: preview.text, type: preview.type, timestamp: preview.timestamp });
       } else {
-        // Tentacle's enriched digest carries no attention preview for this
-        // session, so the question/permission that produced the local one has
-        // been resolved (answered/approved/cancelled/turn-ended). The previous
-        // code skipped the write entirely, leaking a stale `type:'question'`
-        // preview that keeps the sidebar pinned on "waiting" long after the
-        // ask is gone - and it is persisted to localStorage, so it survives
-        // reloads. Only clear ATTENTION previews (question/permission);
-        // normal agent/user/error previews belong to the durable spine and
-        // must be left for rebuildPreview / the next subscription ACK.
-        const existing = getStore().sessionPreviews.get(ts.id);
-        if (existing && (existing.type === 'question' || existing.type === 'permission')) {
-          store.clearSessionPreview(ts.id);
-        }
+        store.clearSessionPreview(ts.id);
       }
 
       if (tsRecord.usage && typeof tsRecord.usage === 'object') {

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -449,10 +449,8 @@ export class RelayClient {
 
   /** Clear all open human attention for a session (turn ended / session gone). */
   private clearOpenQuestions(sessionId: string): void {
-    // Delete both maps independently. The previous `a || b` form short-
-    // circuited: when a session had BOTH a question and a permission open,
-    // `openQuestions.delete()` returning true skipped `openPermissions.delete()`,
-    // leaking the permission into every subsequent session_list digest.
+    // Delete both maps independently: `a || b` short-circuited and leaked a
+    // permission when a question was also open on the same session.
     const qChanged = this.openQuestions.delete(sessionId);
     const pChanged = this.openPermissions.delete(sessionId);
     this.sessionManager.clearPendingHumanAction(sessionId);


### PR DESCRIPTION
## Summary

Follow-up to #178. Drops the attention-type guard from the preview-clear fix so the code is a direct mirror of its single authority: the enriched `session_list` digest.

## Why

#178 cleared a locally-held preview when the digest carried none, but **only** if the local preview was `question`/`permission`:

```ts
const existing = getStore().sessionPreviews.get(ts.id);
if (existing && (existing.type === 'question' || existing.type === 'permission')) {
  store.clearSessionPreview(ts.id);
}
```

That type check was a defensive guess, not a correctness requirement. The digest already encodes the full truth:

- `enrichSessionList()` overrides the preview **only** while an attention is open (`question`/`permission`).
- Otherwise it returns the session unchanged, whose `preview` is derived from the durable spine by `SessionManager.getSessionPreview()` - the last `agent_message`/`user_message`/`error`/`answer`, or an **unresolved** question/permission (resolved ones are skipped by the `!payload.answer` / `!payload.resolution` guards).
- An empty session has no preview at all.

So "digest has no preview" genuinely means "this session has no preview" - clearing whatever we hold locally is correct, regardless of its type. The guard only existed to hedge against a case that can't happen.

## Change

```ts
if (preview?.text) {
  store.setSessionPreview(ts.id, { text: preview.text, type: preview.type, timestamp: preview.timestamp });
} else {
  store.clearSessionPreview(ts.id);
}
```

One line in the `else`. The Tentacle side's comment is also trimmed.

## Test

The previous "does NOT clear a non-attention preview" unit test was constructed to validate the guard against an impossible input (a digest with no preview for a session that has a spine message - the digest always carries one). Replaced with the realistic resolution path: a digest reverting to the `agent` preview overwrites a stale `question` preview.

## Validation

| Suite | Result |
|---|---|
| `pnpm validate` (lint + build + all unit) | ✅ |
| Arm web unit | 400/400 |
| Real-stack lifecycle matrix (7) | ✅ |
| Real-stack high-intensity stress (9) | ✅ |
| Real-stack existing (pulse-realstack + session-subscription) | 25/25 |
