### PR TITLE
chore(release): v0.31.1

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Cut `@kraki/tentacle@0.31.1` to ship the Tentacle-side fix from #178, which is currently only on `main` and not in any released Tentacle.

## What's in 0.31.1

One fix vs 0.31.0:

- **#178** — `clearOpenQuestions()` leaked a permission when a question was also open on the same session. The `a || b` short-circuit skipped `openPermissions.delete()` whenever `openQuestions.delete()` returned `true`, so the permission stayed in the attention map and `latestOpenAttention()` kept advertising it in every subsequent `session_list` digest. Fixed by deleting both maps independently.

(The Arm-side stale-preview fix from #178/#179 shipped via Web deploy and is not part of this package.)

## Release plan

1. Merge this version bump.
2. Wait for `Validate` CI to pass on the merge commit.
3. Tag the merge commit `v0.31.1` — this triggers `release.yml` (`on: push: tags: v*`).
4. `release.yml` publishes the npm package + signed/notarized macOS binaries + checksums + GitHub Release.

The release workflow enforces: release commit must be on `main`, and its `Validate` check must be `success`, before it will publish.

## Verification

- `pnpm build:tentacle` ✅
- `pnpm --filter @kraki/tentacle test` → 758/758 ✅
