### PR TITLE
fix(preview): open question surfaces pending even when transport state is idle

### DIFF
--- a/packages/arm/web/e2e/real-stack/preview-restart-repro.spec.ts
+++ b/packages/arm/web/e2e/real-stack/preview-restart-repro.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Reproduce: an OPEN question (durable in pending-human-action.json) that the
+ * user CANNOT see — neither the sidebar attention indicator nor the answerable
+ * card in chat — after a Tentacle process restart (e.g. upgrade) restored it.
+ *
+ * Confirmed root cause under test: after restart, resumeDisconnectedSessions
+ * marks the session `disconnected` (→ digest `state:'idle'`) EVEN THOUGH a
+ * question is open, so getSessionStatus() short-circuits to 'idle' before it
+ * can see `previewType === 'question'` — the "waiting" indicator never shows,
+ * and the live question card may not render either.
+ */
+import { expect, type Browser, type BrowserContext, type Page, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`${path}: ${JSON.stringify(body)}`);
+  return body;
+}
+type Debug = { enrichedSessions: Array<{ id: string; state: string; preview?: { text: string; type: string } }>; openQuestions: Record<string, string[]>; subscriptions: Record<string, string | null> };
+async function debug(): Promise<Debug> { return (await control('/debug')) as Debug; }
+async function enrichedFor(sid: string) { return (await debug()).enrichedSessions.find((s) => s.id === sid); }
+async function openQ(sid: string) { return (await debug()).openQuestions[sid] ?? []; }
+
+async function pair(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const { token } = await control('/token');
+  await page.goto(`${WEB}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  const deviceId = await page.evaluate(() => JSON.parse(localStorage.getItem('kraki_device') ?? '{}').deviceId as string);
+  return { context, page, deviceId };
+}
+
+async function sidebarCardFor(page: Page, marker: string): Promise<string | null> {
+  // Session cards are <button> containing the preview text.
+  return await page.evaluate((m) => {
+    const btn = [...document.querySelectorAll('button')].find((b) => (b.textContent ?? '').includes(m));
+    return btn ? (btn.textContent ?? '').replace(/\s+/g, ' ').trim().slice(0, 400) : null;
+  }, marker).catch(() => null);
+}
+
+test.describe.serial('reproduce: open question invisible after restart (sidebar + chat)', () => {
+  let arm: { context: BrowserContext; page: Page; deviceId: string };
+  const sid = `restart-q-${Date.now().toString(36)}`;
+  const QTEXT = `RESTARTQ-${Date.now().toString(36)}`;
+
+  test.beforeAll(async ({ browser }) => {
+    await control('/createSession', { id: sid });
+    await control('/idle', { sid });
+    arm = await pair(browser);
+  });
+  test.afterAll(async () => { await arm?.context.close(); });
+
+  test('fresh question: sidebar shows attention + chat shows answer card', async () => {
+    await control('/question', { sid, id: 'q-r', text: QTEXT, choices: 'alpha|beta' });
+    await expect.poll(async () => (await openQ(sid)).length, { timeout: 15_000 }).toBe(1);
+    await new Promise((r) => setTimeout(r, 800));
+
+    const e = await enrichedFor(sid);
+    const card = await sidebarCardFor(arm.page, QTEXT);
+    console.log(`FRESH digest=${JSON.stringify(e)} sidebarCard=${JSON.stringify(card)}`);
+    // Sidebar card carries the question text.
+    expect(card).toBeTruthy();
+    expect(card!).toContain(QTEXT);
+
+    // Open the session via the sidebar card (real user gesture), check chat.
+    await arm.page.goto(WEB);
+    await new Promise((r) => setTimeout(r, 500));
+    await arm.page.locator('button').filter({ hasText: QTEXT }).first().click();
+    await expect(arm.page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await expect.poll(async () => (await debug()).subscriptions[arm.deviceId], { timeout: 15_000 }).toBe(sid);
+    await new Promise((r) => setTimeout(r, 1200));
+    console.log(`FRESH-CHAT url=${arm.page.url()}`);
+    await expect(arm.page.getByText(QTEXT, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    await expect(arm.page.getByRole('button', { name: 'alpha' })).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('after restart: open question still surfaces pending despite idle transport state', async () => {
+    await control('/tentacle/restart');
+    await expect.poll(async () => (await openQ(sid)).length, { timeout: 20_000 }).toBe(1);
+    await new Promise((r) => setTimeout(r, 1000));
+    const e = await enrichedFor(sid);
+    console.log(`RESTART digest=${JSON.stringify(e)}`);
+    // The question is restored into the digest (preview is authoritative).
+    expect(e?.preview).toMatchObject({ type: 'question', text: QTEXT });
+    // The transport state may legitimately be 'idle' after restart, but the
+    // sidebar status must still read pending so "waiting" shows. We assert it
+    // via the rendered sidebar card text below.
+  });
+
+  test('after restart: sidebar attention + chat answer card still work', async () => {
+    await arm.page.goto(WEB);
+    await new Promise((r) => setTimeout(r, 800));
+    const card = await sidebarCardFor(arm.page, QTEXT);
+    console.log(`RESTART-SIDEBAR card=${JSON.stringify(card)}`);
+    expect(card).toBeTruthy();
+    expect(card!).toContain(QTEXT);
+    // The "waiting" indicator must show even though the transport state is
+    // idle after restart — the open question forces pending status.
+    expect(card!).toContain('waiting');
+
+    // Open the session and confirm the answerable question card renders.
+    await arm.page.locator('button').filter({ hasText: QTEXT }).first().click();
+    await expect(arm.page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+    await expect.poll(async () => (await debug()).subscriptions[arm.deviceId], { timeout: 15_000 }).toBe(sid);
+    await new Promise((r) => setTimeout(r, 1200));
+    console.log(`RESTART-CHAT url=${arm.page.url()}`);
+    await expect(arm.page.getByText(QTEXT, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+    await expect(arm.page.getByRole('button', { name: 'alpha' })).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/packages/arm/web/src/lib/session-status.test.ts
+++ b/packages/arm/web/src/lib/session-status.test.ts
@@ -73,9 +73,15 @@ describe('getSessionStatus', () => {
     expect(getSessionStatus(session({ state: 'idle' }), 0, 'agent')).toBe('idle');
   });
 
-  it('an idle session is never pending even with a stale question preview', () => {
-    // A pending turn is by definition running; once idle the turn concluded, so
-    // a not-yet-refreshed 'question' preview must not resurrect the pending badge.
-    expect(getSessionStatus(session({ state: 'idle' }), 0, 'question')).toBe('idle');
+  it('an open question reads pending even when the transport state is idle', () => {
+    // The digest preview is authoritative: `type:'question'` is only carried
+    // while a question is genuinely open (enrichSessionList overrides it from
+    // the in-memory openQuestions map, and a resolved question reverts the
+    // preview to the spine). So a 'question' preview is never stale. After a
+    // relay restart the transport state collapses to 'idle' even though the
+    // turn is still blocked on a human answer — pending must still surface so
+    // the sidebar shows "waiting" and the user notices the unanswered ask.
+    expect(getSessionStatus(session({ state: 'idle' }), 0, 'question')).toBe('pending');
+    expect(getSessionStatus(session({ state: 'idle' }), 1)).toBe('pending');
   });
 });

--- a/packages/arm/web/src/lib/session-status.ts
+++ b/packages/arm/web/src/lib/session-status.ts
@@ -55,10 +55,13 @@ export function getSessionStatus(
   previewType?: string,
 ): SessionStatus {
   if ((session.state as string) === 'ended') return 'ended';
-  if (session.state === 'idle') return 'idle';
-  // A blocking human affordance remains the highest-priority visible status;
-  // compacting is independent and must not displace it.
+  // A blocking human affordance is the highest-priority visible status: it
+  // must read "pending" even when the transport state is "idle" (e.g. after a
+  // relay restart flattened in-memory liveness but a question is still open).
+  // Checking this before the idle short-circuit is the whole point.
   if (livePendingCount > 0 || previewType === 'question') return 'pending';
+  if (session.state === 'idle') return 'idle';
+  // compacting is independent and must not displace pending (checked above).
   if (session.state === 'compacting') return 'compacting';
   return 'working';
 }

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -412,6 +412,28 @@ async function main(): Promise<void> {
         // ── tentacle link control ──
         case '/tentacle/disconnect': relay!.disconnect(); return json(200, { ok: true });
         case '/tentacle/connect': relay!.connect(); return json(200, { ok: true });
+        case '/tentacle/restart': {
+          // Faithful process-restart simulation: destroy the RelayClient and
+          // rebuild it against the SAME SessionManager (disk state persists),
+          // so reconnect runs the real auth -> restorePendingHumanActions ->
+          // resumeDisconnectedSessions -> broadcastSessionList path with
+          // in-memory openQuestions/card starting EMPTY. This is what a real
+          // upgrade restart does.
+          const adapter2 = adapter;
+          const sm2 = sm;
+          relay!.disconnect();
+          await new Promise((r) => setTimeout(r, 300));
+          relay = new RelayClient(adapter2 as unknown as AgentAdapter, sm2, {
+            relayUrl: RELAY_URL,
+            device: { name: 'RealStack Tentacle', role: 'tentacle', kind: 'desktop' },
+          }, keyManager, attachmentStore);
+          await new Promise<void>((resolve, reject) => {
+            relay!.onAuthenticated = () => resolve();
+            relay!.onFatalError = (m: string) => reject(new Error(`tentacle restart auth failed: ${m}`));
+            relay!.connect();
+          });
+          return json(200, { ok: true });
+        }
         // ── seed a session as READ on the tentacle (readSeq = lastSeq), so a
         //    subsequent UI "Mark unread" produces an observable readSeq rollback. ──
         case '/read': {


### PR DESCRIPTION
fix(preview): open question surfaces pending even when transport state is idle

After a Tentacle process restart (e.g. upgrade), a session with an open
question had its digest state collapse to `idle` (resumeDisconnectedSessions
flattens in-memory liveness), so the sidebar dropped its "waiting"
indicator — the user saw no sign of the unanswered question unless they
happened to open that session.

Root cause: `getSessionStatus()` short-circuited on `state === 'idle'`
*before* checking for an open question. But the digest `preview.type ===
'question'` is authoritative — `enrichSessionList()` only carries it while
a question is genuinely open (from the in-memory `openQuestions` map), and
a resolved question reverts the preview to the spine. So a `question`
preview is never stale, and an open question is the highest-priority
visible status regardless of transport state.

Fix: check the open-question condition before the idle short-circuit.

Verified end-to-end against a faithful process-restart simulation
(harness `/tentacle/restart` rebuilds the RelayClient against the same
on-disk SessionManager, so reconnect runs the real
restorePendingHumanActions → resumeDisconnectedSessions →
broadcastSessionList path with in-memory state empty):

- before: post-restart sidebar card = `...· mock-v1 QTEXT` (no "waiting")
- after:  post-restart sidebar card = `...waiting · mock-v1 QTEXT` ✅
- chat answer card (choice buttons) renders after opening the session ✅

The pre-existing unit test `an idle session is never pending even with a
stale question preview` encoded the bug; its "stale preview" premise can't
occur now that the digest is the single preview authority (#179), so it is
inverted to assert pending.

Validation:
- pnpm validate (lint + build + all unit) ✅ 400/400
- real-stack: restart repro (3) + lifecycle (7) + stress (9) + existing (25) = 44 ✅
