### PR TITLE
fix(tentacle): changing model on an idle session must not start a turn

### DIFF
--- a/packages/arm/web/e2e/real-stack/model-change-idle.spec.ts
+++ b/packages/arm/web/e2e/real-stack/model-change-idle.spec.ts
@@ -1,0 +1,75 @@
+import { expect, type Browser, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`${path}: ${JSON.stringify(body)}`);
+  return body;
+}
+
+type Debug = { enrichedSessions: Array<{ id: string; state: string; model?: string }>; subscriptions: Record<string, string | null> };
+async function debug(): Promise<Debug> { return (await control('/debug')) as Debug; }
+async function digest(sid: string) { return (await debug()).enrichedSessions.find((s) => s.id === sid); }
+
+async function pair(browser: Browser) {
+  const context = await browser.newContext();
+  await context.addInitScript(() => {
+    (window as unknown as { __modelEvents: Array<{ type: string; sessionId?: string }> }).__modelEvents = [];
+    const parse = JSON.parse.bind(JSON);
+    JSON.parse = function(text: string, reviver?: (this: unknown, key: string, value: unknown) => unknown) {
+      const value = parse(text, reviver);
+      if (value && typeof value === 'object' && 'type' in value) {
+        const m = value as { type: string; sessionId?: string };
+        if (m.type === 'active' || m.type === 'idle' || m.type === 'session_model_set') {
+          (window as unknown as { __modelEvents: Array<{ type: string; sessionId?: string }> }).__modelEvents.push({ type: m.type, sessionId: m.sessionId });
+        }
+      }
+      return value;
+    } as typeof JSON.parse;
+  });
+  const page = await context.newPage();
+  const { token } = await control('/token');
+  await page.goto(`${WEB}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  return { context, page };
+}
+
+test('changing model on an idle/disconnected session does not start a turn', async ({ browser }) => {
+  const sid = `idle-model-${Date.now().toString(36)}`;
+  await control('/createSession', { id: sid });
+  await control('/idle', { sid });
+  const arm = await pair(browser);
+  try {
+    await expect.poll(async () => (await digest(sid))?.state, { timeout: 15_000 }).toBe('idle');
+
+    // Faithful daemon restart: rebuild RelayClient against the same on-disk
+    // SessionManager, leaving the session disconnected (digest maps to idle).
+    await control('/tentacle/restart');
+    await expect.poll(async () => (await digest(sid))?.state, { timeout: 20_000 }).toBe('idle');
+
+    // Clear any earlier lifecycle events, then perform ONLY a model change.
+    await arm.page.evaluate(() => {
+      (window as unknown as { __modelEvents: unknown[] }).__modelEvents = [];
+    });
+    await control('/armSetModel', { sid, model: 'mock-v2' });
+
+    await expect.poll(async () => {
+      const events = await arm.page.evaluate(() => (window as unknown as { __modelEvents: Array<{ type: string; sessionId?: string }> }).__modelEvents);
+      return events.some((e) => e.type === 'session_model_set' && e.sessionId === sid);
+    }, { timeout: 15_000 }).toBe(true);
+
+    // Loading runtime state to apply configuration is not a turn start.
+    expect(await digest(sid)).toMatchObject({ state: 'idle', model: 'mock-v2' });
+    const events = await arm.page.evaluate(() => (window as unknown as { __modelEvents: Array<{ type: string; sessionId?: string }> }).__modelEvents);
+    expect(events.filter((e) => e.sessionId === sid).map((e) => e.type)).toEqual(['session_model_set']);
+  } finally {
+    await arm.context.close();
+  }
+});

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -827,6 +827,27 @@ describe('RelayClient set_session_model', () => {
     await vi.runAllTimersAsync();
     expect(adapter.resumeSession).toHaveBeenCalledWith('sess_d', expect.anything());
     expect(adapter.setSessionModel).toHaveBeenCalledWith('sess_d', 'claude-opus-4', undefined, undefined);
+    // A model change may load the runtime, but it must not start a turn.
+    expect(sm.resumeSession).toHaveBeenCalledWith('sess_d', false);
+    expect(sm.markIdle).not.toHaveBeenCalled();
+  });
+
+  it('keeps an already-active session active when changing model', async () => {
+    const { sm } = buildConnectedClient();
+    sm.getMeta.mockReturnValue({ id: 'sess_1', agent: 'copilot', state: 'active', model: 'old-model' });
+    const ws = sockets[0];
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'set_session_model',
+      sessionId: 'sess_1',
+      deviceId: 'dev_1',
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: { model: 'claude-opus-4' },
+    })));
+
+    await vi.runAllTimersAsync();
+    expect(sm.markIdle).not.toHaveBeenCalled();
   });
 
   it('de-duplicates concurrent lazy resumes for the same session (resume once, not twice)', async () => {

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -308,6 +308,19 @@ describe('SessionManager', () => {
       expect(meta.totalRuns).toBe(2);
     });
 
+    it('can load a new runtime run without starting a turn', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.markDisconnected(sessionId);
+
+      const result = sm.resumeSession(sessionId, false);
+
+      expect(result?.runId).toBe('run_002');
+      const meta = sm.getMeta(sessionId)!;
+      expect(meta.state).toBe('idle');
+      expect(meta.currentRunId).toBe('run_002');
+      expect(meta.totalRuns).toBe(2);
+    });
+
     it('should mark previous run as crashed', () => {
       const { sessionId } = sm.createSession('copilot');
       sm.markDisconnected(sessionId);

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1278,8 +1278,8 @@ export class RelayClient {
           // Other agents retain the established resume-then-set ordering.
           const applyModel = this.sessionManager.getMeta(sessionId)?.agent === 'pi'
             ? this.adapter.setSessionModel(sessionId, model, reasoningEffort, contextTier)
-                .then(() => this.ensureSessionResumed(sessionId, false))
-            : this.ensureSessionResumed(sessionId)
+                .then(() => this.ensureSessionResumed(sessionId, false, false))
+            : this.ensureSessionResumed(sessionId, true, false)
                 .then(() => this.adapter.setSessionModel(sessionId, model, reasoningEffort, contextTier));
           applyModel
             .then(() => {
@@ -2012,7 +2012,7 @@ export class RelayClient {
    * Returns true if the session was freshly resumed, false if it was already
    * active/idle (or the resume failed).
    */
-  private async ensureSessionResumed(sessionId: string, restoreModel = true): Promise<boolean> {
+  private async ensureSessionResumed(sessionId: string, restoreModel = true, active = true): Promise<boolean> {
     const existing = this.resumeInFlight.get(sessionId);
     if (existing) return existing;
 
@@ -2021,7 +2021,7 @@ export class RelayClient {
 
     const promise = (async () => {
       try {
-        const result = this.sessionManager.resumeSession(sessionId);
+        const result = this.sessionManager.resumeSession(sessionId, active);
         if (!result) return false;
         // Tell the adapter which agent owns this session (for multi-agent routing)
         this.adapter.registerSessionAgent(sessionId, meta.agent);

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -400,7 +400,7 @@ export class SessionManager {
    * Resume a session after crash/restart. Creates a new run.
    * Returns context for the agent to recover.
    */
-  resumeSession(sessionId: string): { runId: string; context: SessionContext } | null {
+  resumeSession(sessionId: string, active = true): { runId: string; context: SessionContext } | null {
     const meta = this.readMeta(sessionId);
     if (!meta) return null;
 
@@ -429,8 +429,10 @@ export class SessionManager {
     };
     this.writeRun(sessionId, newRun);
 
-    // Update meta
-    meta.state = 'active';
+    // Update meta. Loading runtime state for a configuration-only operation
+    // (e.g. set_session_model) is not a turn start, so the caller may preserve
+    // idle while still creating a fresh process run.
+    meta.state = active ? 'active' : 'idle';
     meta.currentRunId = runId;
     meta.totalRuns = runNum;
     meta.updatedAt = new Date().toISOString();

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -340,6 +340,14 @@ async function main(): Promise<void> {
         // Tentacle-side turn-termination / session-removal paths without
         // depending on the Arm UI, exercising clearOpenQuestions /
         // purgeSessionToolState exactly as production.
+        case '/armSetModel': {
+          const sid = q.get('sid')!;
+          (relay as unknown as { handleMessage: (m: Record<string, unknown>) => void }).handleMessage({
+            type: 'set_session_model', sessionId: sid, deviceId: q.get('from') ?? 'dev-test-arm', seq: Number(q.get('seq') ?? Date.now()),
+            timestamp: new Date().toISOString(), payload: { model: q.get('model') ?? 'mock-v2' },
+          });
+          return json(200, { ok: true });
+        }
         case '/armAbort': {
           const sid = q.get('sid')!;
           (relay as unknown as { handleMessage: (m: Record<string, unknown>) => void }).handleMessage({


### PR DESCRIPTION
fix(tentacle): changing model on an idle session must not start a turn

Changing the model of an idle/disconnected session resumed its runtime
(lazy-resume to apply config), and resumeSession() unconditionally set
meta.state = 'active'. A pure configuration change then read as a running
turn — the sidebar flipped to "running" with no input sent, and no real
turn was in flight.

Root cause: SessionManager.resumeSession() conflated "load the agent
runtime" with "start a turn", writing 'active' unconditionally.

Fix: resumeSession(sessionId, active = true) now lets the caller preserve
idle while still creating a fresh process run. set_session_model passes
active=false (it is configuration, not a turn); every real turn path
(send_input / answer / steer) keeps the default and then explicitly
markActive() after resume, so they are unaffected.

This is race-free: resumeInFlight still de-duplicates concurrent resumes,
and a send_input racing a model change still wins because send_input
calls markActive() after resume — the config path never writes active.

Validation:
- pnpm validate (lint + build + all unit) ✅
- Tentacle unit 760/760 (incl. new session-manager + relay-client regressions)
- real-stack: model-change-idle repro (1) + restart/preview/subscription (38) = 39 ✅
