### PR TITLE
chore(release): v0.31.2

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Cut `@kraki/tentacle@0.31.2` to ship the Tentacle-side fix from #183.

## What's in 0.31.2

One fix vs 0.31.1:

- **#183** — Changing the model of an idle/disconnected session resumed its runtime and `resumeSession()` unconditionally set `meta.state = 'active'`, so a pure configuration change read as a running turn (sidebar flipped to "running" with no input sent). Fixed: `resumeSession(sessionId, active = true)` now lets the caller preserve idle while still creating a fresh process run; `set_session_model` passes `active=false`. Real turn paths (send_input / answer / steer) are unaffected — they keep the default and explicitly markActive() after resume.

## Release plan

1. Merge this version bump.
2. Wait for `Validate` CI to pass on the merge commit.
3. Tag the merge commit `v0.31.2` → triggers `release.yml`.
4. `release.yml` publishes npm package + signed/notarized macOS binaries + checksums + GitHub Release.

## Verification

- `pnpm build:tentacle` ✅
- `pnpm --filter @kraki/tentacle test` → 760/760 ✅
