### PR TITLE
fix(auth): don't wipe paired credentials on a transient backend outage

### DIFF
--- a/packages/arm/web/src/lib/auth.test.ts
+++ b/packages/arm/web/src/lib/auth.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the browser globals + store adapter processAuthError touches.
+const localStorageMock = (() => {
+  let store = new Map<string, string>();
+  return {
+    getItem: vi.fn((k: string) => store.get(k) ?? null),
+    setItem: vi.fn((k: string, v: string) => { store.set(k, v); }),
+    removeItem: vi.fn((k: string) => { store.delete(k); }),
+    clear: () => { store = new Map(); },
+    _seed: (k: string, v: string) => store.set(k, v),
+  };
+})();
+vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('window', { location: { reload: vi.fn() } });
+
+// Stub the modules auth.ts imports, BEFORE importing it.
+vi.mock('../store-adapter', () => ({
+  getStore: vi.fn(() => ({
+    githubClientId: undefined,
+    setLastError: vi.fn(),
+    setReconnectState: vi.fn(),
+    setStatus: vi.fn(),
+  })),
+}));
+vi.mock('../oauth', () => ({ supportsOAuthLogin: () => false }));
+vi.mock('../logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }), setDebugLogging: vi.fn() }));
+vi.mock('../transport', () => ({ saveStoredDevice: vi.fn(), STORAGE_KEY: 'kraki_device' }));
+vi.mock('../../hooks/useTheme', () => ({ setTheme: vi.fn() }));
+
+import { processAuthError } from './auth';
+
+function deps() {
+  return {
+    clearStoredDeviceId: vi.fn(),
+    setStoredDeviceId: vi.fn(),
+    disconnect: vi.fn(),
+    connect: vi.fn(),
+    redirectToRelay: vi.fn(),
+  };
+}
+
+describe('processAuthError: credential wipe policy', () => {
+  beforeEach(() => { localStorageMock.clear(); });
+
+  it('KEEPS credentials on auth_unavailable (transient backend outage)', () => {
+    localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://r', deviceId: 'dev_x' }));
+    const d = deps();
+    processAuthError({ code: 'auth_unavailable', message: 'Authentication service unavailable' }, 'dev_x', d);
+    expect(d.clearStoredDeviceId).not.toHaveBeenCalled();
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('kraki_device');
+    // It reconnects to retry.
+    expect(d.disconnect).toHaveBeenCalled();
+    expect(d.connect).toHaveBeenCalled();
+  });
+
+  it('KEEPS credentials on a generic auth_rejected (may be transient)', () => {
+    localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://r', deviceId: 'dev_x' }));
+    const d = deps();
+    processAuthError({ code: 'auth_rejected', message: 'x' }, 'dev_x', d);
+    expect(d.clearStoredDeviceId).not.toHaveBeenCalled();
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('kraki_device');
+  });
+
+  it('CLEARS credentials on invalid_signature (deterministic)', () => {
+    localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://r', deviceId: 'dev_x' }));
+    const d = deps();
+    processAuthError({ code: 'invalid_signature', message: 'Invalid signature' }, 'dev_x', d);
+    expect(d.clearStoredDeviceId).toHaveBeenCalled();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('kraki_device');
+  });
+
+  it('CLEARS credentials on device_not_found (deterministic)', () => {
+    localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://r', deviceId: 'dev_x' }));
+    const d = deps();
+    processAuthError({ code: 'device_not_found', message: 'Device not found' }, 'dev_x', d);
+    expect(d.clearStoredDeviceId).toHaveBeenCalled();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('kraki_device');
+  });
+
+  it('CLEARS credentials on user_not_found (deterministic)', () => {
+    localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://r', deviceId: 'dev_x' }));
+    const d = deps();
+    processAuthError({ code: 'user_not_found', message: 'User not found' }, 'dev_x', d);
+    expect(d.clearStoredDeviceId).toHaveBeenCalled();
+  });
+
+  it('still redirects to the assigned region on wrong_region', () => {
+    localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://cn.relay', deviceId: 'dev_x' }));
+    const d = deps();
+    processAuthError({ code: 'wrong_region', redirect: 'wss://relay.kraki.chat', deviceId: 'dev_x' }, 'dev_x', d);
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+});

--- a/packages/arm/web/src/lib/auth.ts
+++ b/packages/arm/web/src/lib/auth.ts
@@ -151,16 +151,33 @@ export function processAuthError(
   }
 
   if (storedDeviceId) {
-    logger.warn('Auth failed for stored device, clearing credentials');
-    localStorage.removeItem(STORAGE_KEY);
-    deps.clearStoredDeviceId();
-    store.setLastError(
-      oauthAvailable
-        ? 'Authentication failed. Please sign in again or scan a new pairing QR code.'
-        : 'Authentication failed. Please scan a new pairing QR code.',
+    // Only destroy the persisted pairing on a DETERMINISTIC failure — a code
+    // that proves this device's credentials are actually invalid. A transient
+    // outage (auth backend unreachable/timed out → auth_unavailable, or a
+    // generic auth_rejected that may itself stem from a backend hiccup) must
+    // NOT clear the paired device: doing so turned a 15s account-service
+    // timeout into a permanent logout that required a fresh QR/GitHub pairing.
+    const fatal = authError.code === 'invalid_signature'
+      || authError.code === 'device_not_found'
+      || authError.code === 'unknown_device'
+      || authError.code === 'user_not_found';
+    if (fatal) {
+      logger.warn('Auth failed for stored device (fatal), clearing credentials', { code: authError.code });
+      localStorage.removeItem(STORAGE_KEY);
+      deps.clearStoredDeviceId();
+      store.setLastError(
+        oauthAvailable
+          ? 'Authentication failed. Please sign in again or scan a new pairing QR code.'
+          : 'Authentication failed. Please scan a new pairing QR code.',
       );
-      deps.disconnect();
-      deps.connect();
+    } else {
+      // Transient: keep the paired identity and just reconnect — the next
+      // challenge attempt succeeds once the backend recovers.
+      logger.warn('Auth failed for stored device (transient), keeping credentials', { code: authError.code });
+      store.setLastError('Authentication temporarily unavailable. Reconnecting…');
+    }
+    deps.disconnect();
+    deps.connect();
   } else {
     store.setReconnectState(0, null);
     store.setLastError(

--- a/packages/head/src/__tests__/auth-unavailable.test.ts
+++ b/packages/head/src/__tests__/auth-unavailable.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression: a thrown/rejected auth-backend verifyChallenge (network timeout,
+ * 5xx, abort) must surface as `auth_unavailable`, NOT `auth_rejected`.
+ *
+ * The old code mapped the `.catch` onto `auth_rejected`, which the arm treats
+ * as a generic failure. For a paired device that meant processAuthError()
+ * wiped the persisted deviceId — a 15s account-service timeout permanently
+ * logged the user out and forced a fresh QR/GitHub pairing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import { WebSocket } from 'ws';
+import type { AuthMethod, DeviceInfo } from '@kraki/protocol';
+import { Storage } from '../storage.js';
+import { HeadServer } from '../server.js';
+import type {
+  AuthBackend, AuthOutcome, ChallengeOutcome, AuthInfoConfig,
+} from '../auth-backend.js';
+
+class FlakyChallengeBackend implements AuthBackend {
+  /** When set, verifyChallenge rejects with this error (simulates timeout). */
+  verifyError: Error | null = null;
+
+  async authenticate(): Promise<AuthOutcome> {
+    throw new Error('not used');
+  }
+  async startChallenge(): Promise<ChallengeOutcome> {
+    return { ok: true, nonce: 'deadbeef', userId: 'u1', deviceId: 'dev_challenge' };
+  }
+  async verifyChallenge(): Promise<AuthOutcome> {
+    if (this.verifyError) throw this.verifyError;
+    return { ok: true, userId: 'u1', deviceId: 'dev_challenge', authMethod: 'challenge', user: { id: 'u1', login: 'x', provider: 'open' }, devices: [] };
+  }
+  createPairingToken() { return { token: 't', expiresIn: 900 }; }
+  async requestPairingToken() { return { ok: true as const, userId: 'u1', pairingToken: 't', expiresIn: 900 }; }
+  getAuthInfo(): AuthInfoConfig { return { methods: ['challenge'] }; }
+}
+
+async function createEnv() {
+  const storage = new Storage(':memory:');
+  const backend = new FlakyChallengeBackend();
+  const server = new HeadServer(storage, { authBackend: backend });
+  const httpServer = createServer();
+  server.attach(httpServer);
+  await new Promise<void>(r => httpServer.listen(0, r));
+  const port = (httpServer.address() as AddressInfo).port;
+  return {
+    port, backend,
+    cleanup: async () => { server.close(); await new Promise<void>(r => httpServer.close(() => r())); storage.close(); },
+  };
+}
+
+async function challengeAuth(port: number): Promise<Record<string, unknown>[]> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  const raw: Record<string, unknown>[] = [];
+  await new Promise<void>((resolve, reject) => { ws.on('open', resolve); ws.on('error', reject); });
+  ws.on('message', (d) => raw.push(JSON.parse(d.toString())));
+  // initiate challenge auth
+  ws.send(JSON.stringify({
+    type: 'auth',
+    auth: { method: 'challenge', deviceId: 'dev_challenge' },
+    device: { name: 'dev', role: 'app', deviceId: 'dev_challenge', publicKey: 'pub', encryptionKey: 'enc' },
+  }));
+  // wait for the challenge nonce
+  const nonce = await new Promise<string>((resolve, reject) => {
+    const to = setTimeout(() => reject(new Error('no challenge')), 2000);
+    const iv = setInterval(() => {
+      const c = raw.find(m => m.type === 'auth_challenge');
+      if (c) { clearTimeout(to); clearInterval(iv); resolve((c as { nonce: string }).nonce); }
+    }, 10);
+  });
+  // respond with a signature
+  ws.send(JSON.stringify({ type: 'auth_response', deviceId: 'dev_challenge', signature: 'sig-' + nonce }));
+  // collect the next auth_error / auth_ok
+  const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
+    const to = setTimeout(() => reject(new Error('no auth response')), 2000);
+    const iv = setInterval(() => {
+      const e = raw.find(m => m.type === 'auth_error' || m.type === 'auth_ok');
+      if (e) { clearTimeout(to); clearInterval(iv); resolve(e); }
+    }, 10);
+  });
+  ws.close();
+  return [result, ...raw];
+}
+
+describe('Challenge auth: transient backend outage → auth_unavailable (not auth_rejected)', () => {
+  let env: Awaited<ReturnType<typeof createEnv>>;
+  beforeEach(async () => { env = await createEnv(); });
+  afterEach(async () => { await env.cleanup(); });
+
+  it('reports auth_unavailable when verifyChallenge rejects (timeout/network)', async () => {
+    env.backend.verifyError = new Error('The operation was aborted due to timeout');
+    const messages = await challengeAuth(env.port);
+    const err = messages.find(m => m.type === 'auth_error') as { code?: string; message?: string } | undefined;
+    expect(err).toBeDefined();
+    expect(err!.code).toBe('auth_unavailable');
+    expect(err!.message).toContain('unavailable');
+  });
+
+  it('reports auth_unavailable on a 5xx backend error too', async () => {
+    env.backend.verifyError = new Error('500 internal');
+    const messages = await challengeAuth(env.port);
+    const err = messages.find(m => m.type === 'auth_error') as { code?: string } | undefined;
+    expect(err).toBeDefined();
+    expect(err!.code).toBe('auth_unavailable');
+  });
+});

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -1022,8 +1022,15 @@ export class HeadServer {
       ).then(result => {
         this.handleBackendAuthResult(ws, state, result);
       }).catch(err => {
+        // A thrown error means the auth backend itself was unreachable / timed
+        // out (network, 5xx, abort) — NOT that the signature was invalid. A
+        // deterministic auth failure comes back as a resolved AuthError outcome
+        // above. Reporting this as auth_rejected made the arm treat a transient
+        // backend outage as a permanent credential failure and wipe the paired
+        // device, forcing a full re-pair. Surface it as auth_unavailable so the
+        // client retries instead of destroying a valid session.
         logger.error('Auth backend verifyChallenge failed', { error: (err as Error).message });
-        this.sendAuthError(ws, 'auth_rejected', 'Internal auth error');
+        this.sendAuthError(ws, 'auth_unavailable', 'Authentication service unavailable');
       });
       return;
     }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1259,6 +1259,7 @@ export interface AuthOkMessage {
 
 export type AuthErrorCode =
   | 'auth_rejected'
+  | 'auth_unavailable'
   | 'unknown_auth_method'
   | 'pairing_disabled'
   | 'invalid_pairing_token'


### PR DESCRIPTION
fix(auth): don't wipe paired credentials on a transient backend outage

A paired Web device got permanently logged out whenever the account
service hiccuped during challenge verification.

Root cause (two layers):
1. Head: when verifyChallenge() rejected (account-service timeout / 5xx /
   abort), the .catch mapped it onto auth_rejected + "Internal auth error" —
   indistinguishable from a real rejection.
2. Arm: processAuthError() treated EVERY non-wrong_region auth_error on a
   paired device as a permanent credential failure — it wiped the persisted
   deviceId (localStorage) and reconnected as a brand-new device, which then
   stalled on the auth_info flow because the paired keys no longer matched.

So a 15s account-service timeout (observed in prod: "Account service request
failed /api/auth/verify aborted due to timeout") permanently forced a fresh
QR/GitHub re-pairing of an otherwise healthy browser.

Fix:
- protocol: add 'auth_unavailable' to AuthErrorCode.
- head: verifyChallenge() rejection (backend unreachable) now surfaces as
  auth_unavailable, not auth_rejected. A deterministic auth failure still
  comes back as a resolved AuthError outcome (invalid_signature / etc.).
- arm: processAuthError() only clears credentials on DETERMINISTIC failures
  (invalid_signature / device_not_found / unknown_device / user_not_found).
  auth_unavailable, auth_rejected, and other transient codes keep the paired
  identity and just reconnect — the next challenge succeeds once the backend
  recovers.

Validation:
- pnpm validate (lint + build + all unit) ✅
- Head: 245/245 (incl. 2 new auth-unavailable regressions)
- Arm: 406/406 (incl. 6 new processAuthError credential-policy regressions)
