### PR TITLE
fix(auth): use the real transient code service_unavailable

### DIFF
--- a/packages/arm/web/src/lib/auth.test.ts
+++ b/packages/arm/web/src/lib/auth.test.ts
@@ -54,6 +54,18 @@ describe('processAuthError: credential wipe policy', () => {
     expect(d.connect).toHaveBeenCalled();
   });
 
+  it('KEEPS credentials on service_unavailable (real RemoteAuthBackend timeout code)', () => {
+    // RemoteAuthBackend.post() catches fetch failures and returns
+    // { ok:false, code:'service_unavailable' }; Head forwards that code. The
+    // arm must treat it as transient and keep the paired identity.
+    localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://r', deviceId: 'dev_x' }));
+    const d = deps();
+    processAuthError({ code: 'service_unavailable', message: 'Account service unavailable' }, 'dev_x', d);
+    expect(d.clearStoredDeviceId).not.toHaveBeenCalled();
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('kraki_device');
+    expect(d.connect).toHaveBeenCalled();
+  });
+
   it('KEEPS credentials on a generic auth_rejected (may be transient)', () => {
     localStorageMock._seed('kraki_device', JSON.stringify({ relay: 'wss://r', deviceId: 'dev_x' }));
     const d = deps();

--- a/packages/head/src/__tests__/auth-unavailable.test.ts
+++ b/packages/head/src/__tests__/auth-unavailable.test.ts
@@ -89,20 +89,20 @@ describe('Challenge auth: transient backend outage → auth_unavailable (not aut
   beforeEach(async () => { env = await createEnv(); });
   afterEach(async () => { await env.cleanup(); });
 
-  it('reports auth_unavailable when verifyChallenge rejects (timeout/network)', async () => {
+  it('reports service_unavailable when verifyChallenge rejects (timeout/network)', async () => {
     env.backend.verifyError = new Error('The operation was aborted due to timeout');
     const messages = await challengeAuth(env.port);
     const err = messages.find(m => m.type === 'auth_error') as { code?: string; message?: string } | undefined;
     expect(err).toBeDefined();
-    expect(err!.code).toBe('auth_unavailable');
+    expect(err!.code).toBe('service_unavailable');
     expect(err!.message).toContain('unavailable');
   });
 
-  it('reports auth_unavailable on a 5xx backend error too', async () => {
+  it('reports service_unavailable on a 5xx backend error too', async () => {
     env.backend.verifyError = new Error('500 internal');
     const messages = await challengeAuth(env.port);
     const err = messages.find(m => m.type === 'auth_error') as { code?: string } | undefined;
     expect(err).toBeDefined();
-    expect(err!.code).toBe('auth_unavailable');
+    expect(err!.code).toBe('service_unavailable');
   });
 });

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -1030,7 +1030,7 @@ export class HeadServer {
         // device, forcing a full re-pair. Surface it as auth_unavailable so the
         // client retries instead of destroying a valid session.
         logger.error('Auth backend verifyChallenge failed', { error: (err as Error).message });
-        this.sendAuthError(ws, 'auth_unavailable', 'Authentication service unavailable');
+        this.sendAuthError(ws, 'service_unavailable', 'Authentication service unavailable');
       });
       return;
     }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1260,6 +1260,7 @@ export interface AuthOkMessage {
 export type AuthErrorCode =
   | 'auth_rejected'
   | 'auth_unavailable'
+  | 'service_unavailable'
   | 'unknown_auth_method'
   | 'pairing_disabled'
   | 'invalid_pairing_token'


### PR DESCRIPTION
fix(auth): use the real transient code service_unavailable

Follow-up to #185. The transient-outage code path actually emitted by
production is `service_unavailable`, not `auth_unavailable`:

RemoteAuthBackend.post() catches fetch failures (timeout / 5xx / abort) and
returns a resolved { ok:false, code:'service_unavailable' } outcome — it does
NOT throw. So Head's handleBackendAuthResult() forwards `service_unavailable`
straight to the client; #185's verifyChallenge .catch (which I pointed at
auth_unavailable) is only a defensive fallback for a future throw.

Observed in prod (China edge → Tokyo account service): a 15s
`/api/auth/verify aborted due to timeout` produced auth_error code
`service_unavailable`. That code was missing from the AuthErrorCode union, so
it was an untyped string on the wire.

Fix:
- protocol: add `service_unavailable` to AuthErrorCode (the real code in use).
- head: .catch fallback also emits `service_unavailable` (consistent with the
  resolved-outcome path).
- arm: processAuthError already treats service_unavailable as transient
  (keeps credentials) — #185's fatal list excludes it. Added an explicit unit
  test for it.

This is why a paired browser survived tonight's account-service timeouts and
recovered automatically instead of being forced to re-pair.

Validation: pnpm validate ✅ (Head 245/245 incl. updated regressions;
Arm 407/407 incl. new service_unavailable test).
