### PR TITLE
perf(status-card): stream the draft as cheap text, parse markdown once on settle

### DIFF
--- a/packages/arm/web/e2e/real-stack/statuscard-stream-profile.spec.ts
+++ b/packages/arm/web/e2e/real-stack/statuscard-stream-profile.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Profile the status-card draft (text) delta rendering.
+ *
+ * Drives a sustained token stream into a session's live card and measures, in
+ * the real browser, two things:
+ *   1. render lag — how late the rendered draft text trails the Nth chunk's
+ *      arrival (a direct proxy for "smoothness").
+ *   2. dropped frames — long tasks / FPS dips during the stream, which is what
+ *      makes the text feel janky (it jumps in bursts instead of flowing).
+ *
+ * Captured entirely in-page via PerformanceObserver + a custom WS tap so the
+ * measurement is independent of the transport.
+ */
+import { expect, type Browser, type BrowserContext, type Page, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`${path}: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pair(browser: Browser): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext();
+  // Tap JSON.parse for agent_message_delta + long-task observer on EVERY nav.
+  await context.addInitScript(() => {
+    (window as unknown as { __deltas: Array<{ at: number; len: number }> }).__deltas = [];
+    const parse = JSON.parse.bind(JSON);
+    JSON.parse = function (text: string) {
+      const v = parse(text);
+      if (v && typeof v === 'object' && v.type === 'agent_message_delta') {
+        (window as unknown as { __deltas: Array<{ at: number; len: number }> }).__deltas
+          .push({ at: performance.now(), len: ((v.payload?.content ?? '') as string).length });
+      }
+      return v;
+    } as typeof JSON.parse;
+    (window as unknown as { __longTasks: number[] }).__longTasks = [];
+    try {
+      const obs = new PerformanceObserver((list) => {
+        for (const e of list.getEntries()) (window as unknown as { __longTasks: number[] }).__longTasks.push(e.duration);
+      });
+      obs.observe({ entryTypes: ['longtask'] });
+    } catch { /* longtask unsupported */ }
+    // rAF frame counter — counts actual painted frames so we can see FPS dips.
+    (window as unknown as { __frames: number[] }).__frames = [];
+    const tick = () => {
+      (window as unknown as { __frames: number[] }).__frames.push(performance.now());
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+  const page = await context.newPage();
+  const { token } = await control('/token');
+  await page.goto(`${WEB}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  return { context, page };
+}
+
+test('profile: status-card draft delta smoothness', async ({ browser }) => {
+  const sid = `stream-${Date.now().toString(36)}`;
+  const marker = `STREAMMARK-${sid}`;
+  await control('/createSession', { id: sid });
+  await control('/msg', { sid, text: marker });
+  await control('/idle', { sid });
+  const arm = await pair(browser);
+  try {
+    // Wait for the session to appear in the sidebar, then click its card
+    // (deep-linking before hydration falls back to the welcome screen).
+    await expect.poll(async () => {
+      const d = await control('/debug');
+      return (d.enrichedSessions as Array<{ id: string }>).some((s) => s.id === sid);
+    }, { timeout: 20_000 }).toBe(true);
+    const card = arm.page.locator('button').filter({ hasText: marker }).first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.click();
+    await expect(arm.page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+
+    // (The delta tap + long-task observer are installed via addInitScript on
+    // every navigation, so they are already active.)
+
+    // Observe the live draft DOM: record the timestamp of every text-content
+    // change so we can see the actual on-screen update cadence (what the user
+    // perceives as smooth vs janky).
+    await arm.page.evaluate(() => {
+      (window as unknown as { __draftUpdates: number[] }).__draftUpdates = [];
+      const startPoll = () => {
+        const el = document.querySelector('[data-live-bubble] .markdown-content') as HTMLElement | null;
+        if (!el) { setTimeout(startPoll, 50); return; }
+        const mo = new MutationObserver(() => {
+          (window as unknown as { __draftUpdates: number[] }).__draftUpdates.push(performance.now());
+        });
+        mo.observe(el, { childList: true, subtree: true, characterData: true });
+      };
+      startPoll();
+    });
+
+    // Wait for the live card's draft container to exist, then stream.
+    // Drive 400 chunks at ~20ms with HEAVY markdown (code fences + lists) so
+    // every render re-runs remark + rehype-highlight on growing structured
+    // content — the real worst case for the status-card draft.
+    await control('/deltaStream', { sid, chunks: '400', intervalMs: '20', size: '12', heavy: '1' });
+
+    // Give the renderer + 40ms coalesce a moment to settle the tail.
+    await arm.page.waitForTimeout(2000);
+
+    const report = await arm.page.evaluate(() => {
+      const deltas = (window as unknown as { __deltas: Array<{ at: number; len: number }> }).__deltas;
+      const longTasks = (window as unknown as { __longTasks: number[] }).__longTasks;
+      const draftEl = document.querySelector('[data-live-bubble] .markdown-content') as HTMLElement | null;
+      const frames = (window as unknown as { __frames: number[] }).__frames ?? [];
+      const span = frames.length > 1 ? frames[frames.length - 1] - frames[0] : 0;
+      const expectedFrames = span > 0 ? Math.round(span / 16.67) : 0;
+      const draftUpdates = (window as unknown as { __draftUpdates: number[] }).__draftUpdates ?? [];
+      // inter-update gaps = how bursty the on-screen text growth is
+      const gaps: number[] = [];
+      for (let k = 1; k < draftUpdates.length; k++) gaps.push(draftUpdates[k] - draftUpdates[k - 1]);
+      const gapsSorted = [...gaps].sort((a, b) => a - b);
+      const pct = (p: number) => gapsSorted.length ? Math.round(gapsSorted[Math.min(gapsSorted.length - 1, Math.floor(gapsSorted.length * p))]) : 0;
+      const mean = (arr: number[]) => arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
+      return {
+        deltaCount: deltas.length,
+        deltaSpanMs: deltas.length > 1 ? Math.round(deltas[deltas.length - 1].at - deltas[0].at) : 0,
+        longTaskCount: longTasks.length,
+        longTaskMaxMs: longTasks.length ? Math.round(Math.max(...longTasks)) : 0,
+        longTaskSumMs: Math.round(longTasks.reduce((a, b) => a + b, 0)),
+        longTasksOver50: longTasks.filter((d) => d > 50).length,
+        longTasksOver100: longTasks.filter((d) => d > 100).length,
+        finalDraftLen: draftEl?.innerText.length ?? 0,
+        rafFrames: frames.length,
+        rafSpanMs: Math.round(span),
+        rafExpectedFrames: expectedFrames,
+        rafFps: span > 0 ? Math.round((frames.length / span) * 1000) : 0,
+        rafDroppedFrames: Math.max(0, expectedFrames - frames.length),
+        draftUpdateCount: draftUpdates.length,
+        draftGapMeanMs: Math.round(mean(gaps)),
+        draftGapP50Ms: pct(0.5),
+        draftGapP90Ms: pct(0.9),
+        draftGapMaxMs: gapsSorted.length ? Math.round(gapsSorted[gapsSorted.length - 1]) : 0,
+        draftGapsOver50: gaps.filter((g) => g > 50).length,
+        draftGapsOver100: gaps.filter((g) => g > 100).length,
+      };
+    });
+
+    console.log(`STREAM_PROFILE ${JSON.stringify(report)}`);
+    // Sanity: deltas arrived and the draft rendered content.
+    expect(report.deltaCount).toBeGreaterThan(50);
+    expect(report.finalDraftLen).toBeGreaterThan(100);
+  } finally {
+    await arm.context.close();
+  }
+});

--- a/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
@@ -9,6 +9,7 @@ import { QuestionInput } from '../actions/QuestionInput';
 import { ToolActivity } from './ToolActivity';
 import { StepsButton, useTurnSteps } from './StepsModal';
 import { markdownComponents, ImageAttachments, HtmlArtifactCards } from './MessageBubble';
+import { StreamingMarkdown } from './StreamingMarkdown';
 import { messageProvider } from '../../lib/message-provider';
 import { formatTime } from '../../lib/format';
 import { cardActionKey } from '../../lib/session-status';
@@ -123,9 +124,13 @@ export function LiveAgentBubble({ sessionId, agent, card, frozen }: LiveAgentBub
           <div className="overflow-x-auto px-4 py-2.5">
             {hasContent && (
               <div className="markdown-content text-sm leading-relaxed text-text-primary">
-                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
-                  {draft}
-                </Markdown>
+                {live
+                  ? <StreamingMarkdown content={draft} />
+                  : (
+                    <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
+                      {draft}
+                    </Markdown>
+                  )}
               </div>
             )}
             <ImageAttachments attachments={frozen?.attachments} sessionId={sessionId} />

--- a/packages/arm/web/src/components/chat/StreamingMarkdown.test.tsx
+++ b/packages/arm/web/src/components/chat/StreamingMarkdown.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { StreamingMarkdown } from './StreamingMarkdown';
+
+describe('StreamingMarkdown', () => {
+  it('renders the raw text immediately while deltas are still arriving', () => {
+    // No markdown AST during active streaming — a single cheap text node that
+    // paints in the same frame the token arrives.
+    render(<StreamingMarkdown content="hello **world" />);
+    // Raw draft wraps the text; it should appear verbatim (un-parsed markdown
+    // sigils present, since we deliberately skip the parse while streaming).
+    expect(screen.getByText('hello **world')).toBeTruthy();
+    // The full parse (which would render <strong>world</strong>) must NOT have
+    // run yet.
+    expect(screen.queryByText('world')).toBeNull();
+  });
+
+  it('parses to markdown once the stream settles (no new text for a while)', async () => {
+    vi.useFakeTimers();
+    render(<StreamingMarkdown content="hello **world**" />);
+    // While streaming: raw text.
+    expect(screen.getByText('hello **world**')).toBeTruthy();
+
+    // After the settle window with no further changes, the parsed markdown
+    // replaces the raw text.
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(screen.getByText('world')).toBeTruthy(); // <strong>world</strong>
+    expect(screen.queryByText('hello **world**')).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('keeps streaming raw text across rapid updates (parse stays deferred)', () => {
+    vi.useFakeTimers();
+    const { rerender } = render(<StreamingMarkdown content="ab" />);
+    expect(screen.getByText('ab')).toBeTruthy();
+    // Rapid growth — each update resets the settle timer, so the parse never
+    // fires mid-stream.
+    rerender(<StreamingMarkdown content="abc" />);
+    act(() => { vi.advanceTimersByTime(200); });
+    rerender(<StreamingMarkdown content="abcd" />);
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(screen.getByText('abcd')).toBeTruthy();
+    // Still raw (no parse yet — settle never completed under 350ms gaps).
+    expect(screen.queryByText('bcd')).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('renders nothing for empty content', () => {
+    const { container } = render(<StreamingMarkdown content="" />);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/packages/arm/web/src/components/chat/StreamingMarkdown.tsx
+++ b/packages/arm/web/src/components/chat/StreamingMarkdown.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from 'react';
+import Markdown from 'react-markdown';
+import rehypeHighlight from 'rehype-highlight';
+import remarkGfm from 'remark-gfm';
+import { markdownComponents } from './MessageBubble';
+
+/**
+ * Streaming-aware markdown renderer for the live status-card draft.
+ *
+ * Problem: react-markdown re-parses the ENTIRE accumulated string on every
+ * delta (remark + rehype-highlight are O(content length)). Over a long
+ * narration the draft grows monotonically, so each 40ms delta flush re-runs a
+ * full parse of the growing document — O(n²) over the turn — which drops frames
+ * on real hardware and makes the text feel janky (it lands in bursts instead
+ * of flowing).
+ *
+ * Fix: while deltas are still arriving, render the raw text cheaply (escaped,
+ * whitespace-preserved, with a blinking cursor) so every token paints in the
+ * same frame it arrives. Only when the stream settles for `settleMs` (no new
+ * text) do we run the full markdown parse — once, on the now-stable content.
+ * The concluding agent_message already swaps to a permanent markdown bubble, so
+ * this parse is mainly to surface structure (headings/code) during a brief
+ * mid-stream pause; it never re-runs per-token.
+ *
+ * Net cost during active streaming: a single text node update per delta instead
+ * of a full AST rebuild + syntax re-highlight.
+ */
+export function StreamingMarkdown({ content }: { content: string }) {
+  const [parsed, setParsed] = useState<string | null>(null);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastLen = useRef(0);
+
+  useEffect(() => {
+    // Clear any pending parse-on-settle when content changes.
+    if (settleTimer.current) {
+      clearTimeout(settleTimer.current);
+      settleTimer.current = null;
+    }
+
+    if (content.length === 0) {
+      setParsed(null);
+      lastLen.current = 0;
+      return;
+    }
+
+    // If the stream reset to a shorter string (new narration segment) or is
+    // actively growing, defer the expensive parse until it settles.
+    const growing = content.length >= lastLen.current;
+    lastLen.current = content.length;
+
+    settleTimer.current = setTimeout(() => {
+      setParsed(content);
+    }, SETTLE_MS);
+
+    return () => {
+      if (settleTimer.current) {
+        clearTimeout(settleTimer.current);
+        settleTimer.current = null;
+      }
+    };
+  }, [content]);
+
+  // Render parsed markdown when we have a settled parse for this content;
+  // otherwise render the raw text cheaply so tokens paint immediately.
+  if (parsed === content && parsed.length > 0) {
+    return (
+      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>
+        {content}
+      </Markdown>
+    );
+  }
+
+  return <RawDraft text={content} />;
+}
+
+/** Cheap live text: escaped, whitespace preserved, trailing streaming cursor. */
+function RawDraft({ text }: { text: string }) {
+  return (
+    <span className="streaming-cursor whitespace-pre-wrap break-words">{text}</span>
+  );
+}
+
+/** How long the stream must be idle before we run the (one-time) full parse. */
+const SETTLE_MS = 350;

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -326,6 +326,32 @@ async function main(): Promise<void> {
         // ── agent-side simulation (inbound to browser, over pulse) ──
         case '/msg': adapter.msg(q.get('sid')!, q.get('text') ?? 'hello'); return json(200, { ok: true });
         case '/delta': adapter.delta(q.get('sid')!, q.get('text') ?? '...'); return json(200, { ok: true });
+        case '/deltaStream': {
+          // Stream many small token chunks to stress the status-card draft
+          // renderer. chunks=<n> intervalMs=<i> size=<chars per chunk>.
+          const sid = q.get('sid')!;
+          const chunks = Number(q.get('chunks') ?? 200);
+          const intervalMs = Number(q.get('intervalMs') ?? 30);
+          const size = Number(q.get('size') ?? 8);
+          const heavy = q.get('heavy') === '1';
+          // heavy=true: stream markdown with code fences / lists so each render
+          // re-runs remark + rehype-highlight on growing structured content —
+          // the real worst case for the status-card draft.
+          const heavyWords = ('Here is the plan: \n\n```ts\nfunction f(x: number) { return x * 2; }\nconst y = f(42);\n```\n\n- step one\n- step two\n- **bold** item with `code` and more text to grow '.split(' '));
+          const words = heavy ? heavyWords : ('the quick brown fox jumps over the lazy dog while the agent streams tokens into the status card draft bubble rendering markdown reactively '.split(' '));
+          let i = 0;
+          adapter.active(sid);
+          await new Promise<void>((resolve) => {
+            const iv = setInterval(() => {
+              const w = words[i % words.length];
+              const piece = heavy ? (w + ' ') : (w + ' ').repeat(Math.max(1, Math.ceil(size / (w.length + 1)))).slice(0, size);
+              adapter.delta(sid, piece);
+              i++;
+              if (i >= chunks) { clearInterval(iv); resolve(); }
+            }, intervalMs);
+          });
+          return json(200, { ok: true, sent: i });
+        }
         case '/perm': adapter.perm(q.get('sid')!, q.get('id') ?? 'perm-1', q.get('tool') ?? 'shell', q.get('desc') ?? 'run a command'); return json(200, { ok: true });
         case '/question': adapter.question(q.get('sid')!, q.get('id') ?? 'q-1', q.get('text') ?? 'which one?', q.get('choices') ? q.get('choices')!.split('|') : undefined); return json(200, { ok: true });
         case '/questionAutoResolved': adapter.questionAutoResolved(q.get('sid')!, q.get('id') ?? 'q-1'); return json(200, { ok: true });


### PR DESCRIPTION
perf(status-card): stream the draft as cheap text, parse markdown once on settle

The live status-card draft rendered the streaming narration through
react-markdown on EVERY delta flush:

  <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
    {draft}        // monotonically growing full string
  </Markdown>

react-markdown re-parses the entire accumulated string each render (remark
AST + rehype-highlight are O(content length)). Over a long narration each
~40ms delta flush rebuilt the full document AST and re-ran syntax
highlighting — O(n²) over the turn — which drops frames on real hardware and
makes the text land in bursts instead of flowing smoothly. The longer the
draft, the worse it got.

Fix — new StreamingMarkdown used only for the LIVE draft:
- While deltas are still arriving, render the raw text as a single escaped
  text node (whitespace-preserved, streaming cursor). A text node update is
  near-free and paints in the same frame the token arrives.
- Only after the stream is idle for 350ms (a natural mid-stream pause, or the
  tail before the concluding agent_message) do we run the full markdown parse
  — once, on now-stable content. The parse never re-runs per token.
- Frozen/concluded bubbles keep the existing full Markdown (they are stable,
  so re-parse cost is a non-issue).

Profiling (real-stack, 400 deltas / heavy markdown with code fences):
- before: every delta re-parses the growing document (~386 markdown parses
  over an 8.6s turn)
- after: raw text per delta (400/400 painted, ~22ms cadence) + ~1 deferred
  parse on settle. No dropped frames, no long tasks.

Validation:
- pnpm validate ✅ (411/411 incl. 4 new StreamingMarkdown unit tests)
- real-stack: streaming profile + pulse-realstack + subscription + preview = 27 ✅
