### PR TITLE
fix(preview): turn-boundary scan + digest-authoritative sidebar

### DIFF
--- a/packages/arm/web/e2e/real-stack/preview-stress.spec.ts
+++ b/packages/arm/web/e2e/real-stack/preview-stress.spec.ts
@@ -116,7 +116,12 @@ test.describe('preview high-intensity stress', () => {
     await settle();
 
     expect(await openQ(sid)).toEqual([]);
-    expect(await enrichedPreview(sid)).toBeUndefined();
+    // The abort is now a real turn boundary, so the digest preview reflects it
+    // ("Turn aborted") instead of being undefined. What matters for "no phantom
+    // waiting": no question-typed attention remains and the card doesn't read
+    // waiting.
+    const abortPreview = await enrichedPreview(sid);
+    expect(abortPreview?.type).not.toBe('question');
     expect((await cardText(arm.page, q)) ?? '').not.toContain('waiting');
   });
 

--- a/packages/arm/web/e2e/real-stack/preview-turn-boundary.spec.ts
+++ b/packages/arm/web/e2e/real-stack/preview-turn-boundary.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Turn-boundary preview stability (real Head + real Tentacle + real browser).
+ *
+ * Locks in the two core fixes:
+ *  1. Tentacle `getSessionPreview` is a turn-boundary scan — the user_message
+ *     that began the turn is the anchor and is NOT displaced by tool activity,
+ *     narration, or transient errors. It only advances to the agent outcome on
+ *     turn-close.
+ *  2. The sidebar preview is owned by the session_list digest. Tentacle now
+ *     broadcasts on turn-close, so the browser sidebar advances to the agent
+ *     reply without the removed client-side idle memory-scan.
+ */
+import { expect, type Browser, type BrowserContext, type Page, request, test } from '@playwright/test';
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+type Debug = {
+  enrichedSessions: Array<{ id: string; preview?: { text: string; type: string; timestamp: string } }>;
+};
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const ctx = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const res = await ctx.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await res.json();
+  await ctx.dispose();
+  if (!res.ok()) throw new Error(`${path}: ${JSON.stringify(body)}`);
+  return body;
+}
+async function enrichedPreview(sid: string): Promise<{ type: string; text: string } | undefined> {
+  const d = (await control('/debug')) as unknown as Debug;
+  return d.enrichedSessions.find((s) => s.id === sid)?.preview;
+}
+async function pair(browser: Browser): Promise<{ context: BrowserContext; page: Page; deviceId: string }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const { token } = await control('/token');
+  await page.goto(`${WEB}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  const deviceId = await page.evaluate(() => JSON.parse(localStorage.getItem('kraki_device') ?? '{}').deviceId as string);
+  return { context, page, deviceId };
+}
+async function createSession(id: string): Promise<void> {
+  await control('/createSession', { id });
+  await control('/idle', { sid: id });
+}
+async function settle(ms = 600): Promise<void> { await new Promise((r) => setTimeout(r, ms)); }
+
+/** Sidebar card text for the session whose card contains `marker`. */
+async function cardText(page: Page, marker: string): Promise<string | null> {
+  const btn = page.getByRole('button').filter({ hasText: marker }).first();
+  if (await btn.count() === 0) return null;
+  return (await btn.innerText()).replace(/\s+/g, ' ').trim();
+}
+
+/** Drive a real user turn from the Arm composer (user_message echo + active). */
+async function sendUserMessage(page: Page, prompt: string): Promise<void> {
+  const input = page.getByPlaceholder('Send a message…');
+  await input.fill(prompt);
+  await input.press('Enter');
+}
+
+/** Navigate to a freshly-created session and wait for the composer. The Arm
+ *  learns about a new session from the session_list broadcast, so a bare goto
+ *  can land on the empty state before the digest arrives — retry until the
+ *  composer is reachable. */
+async function openSession(page: Page, sid: string): Promise<void> {
+  for (let i = 0; i < 25; i++) {
+    await page.goto(`${WEB}/session/${sid}`);
+    try {
+      await expect(page.getByPlaceholder('Send a message…')).toBeVisible({ timeout: 3_000 });
+      return;
+    } catch {
+      await settle(400);
+    }
+  }
+  throw new Error(`composer for session ${sid} never became visible`);
+}
+
+test.describe('preview turn-boundary stability', () => {
+  let arm: { context: BrowserContext; page: Page; deviceId: string };
+
+  test.beforeEach(async ({ browser }) => { arm = await pair(browser); });
+  test.afterEach(async () => { await arm?.context.close(); });
+
+  test('clean turn: preview anchors on user_message through tools, then advances to the agent reply', async () => {
+    const sid = `clean-${Date.now().toString(36)}`;
+    const prompt = 'Fix the database migration';
+    await createSession(sid);
+    await openSession(arm.page, sid);
+
+    await sendUserMessage(arm.page, prompt);
+    await settle();
+    // Anchor = the user_message that started the turn.
+    await expect.poll(async () => (await enrichedPreview(sid))?.type, { timeout: 15_000 }).toBe('user');
+    expect((await enrichedPreview(sid))!.text).toContain(prompt);
+
+    // A long multi-tool turn must NOT displace the anchor.
+    await control('/active', { sid });
+    for (let i = 0; i < 18; i++) {
+      await control('/toolStart', { sid, tool: 'bash', cmd: `migration step ${i}` });
+      await control('/toolComplete', { sid, tool: 'bash', result: 'applied' });
+    }
+    await settle();
+    expect((await enrichedPreview(sid))?.type).toBe('user');
+    expect((await enrichedPreview(sid))!.text).toContain(prompt);
+    // Browser sidebar (digest-authoritative, no client idle scan) still shows it.
+    expect((await cardText(arm.page, prompt)) ?? '').toContain(prompt);
+
+    // Agent reply + turn close → preview advances to the agent outcome.
+    const reply = 'Migration fixed and rollback tests added.';
+    await control('/msg', { sid, text: reply });
+    await control('/idle', { sid });
+    await settle();
+    await expect.poll(async () => (await enrichedPreview(sid))?.type, { timeout: 15_000 }).toBe('agent');
+    expect((await enrichedPreview(sid))!.text).toContain('Migration fixed');
+    // ...and the sidebar reflects it via the turn-close broadcast.
+    await expect.poll(async () => (await cardText(arm.page, reply)) ?? '', { timeout: 15_000 }).toContain('Migration fixed');
+  });
+
+  test('failed turn: transient errors do not displace the anchor mid-turn; the failure shows on close', async () => {
+    const sid = `fail-${Date.now().toString(36)}`;
+    const prompt = 'Run the deploy script';
+    await createSession(sid);
+    await openSession(arm.page, sid);
+
+    await sendUserMessage(arm.page, prompt);
+    await settle();
+    await expect.poll(async () => (await enrichedPreview(sid))?.type, { timeout: 15_000 }).toBe('user');
+
+    // Transient 503s are infrastructure noise — they must NOT become the preview
+    // while the turn is in flight (the old scan returned the error text here).
+    await control('/active', { sid });
+    await control('/error', { sid, message: '503 auth_unavailable' });
+    await control('/error', { sid, message: '503 auth_unavailable' });
+    await settle();
+    expect((await enrichedPreview(sid))?.type).toBe('user');
+    expect((await enrichedPreview(sid))!.text).toContain(prompt);
+
+    // The staged error ends the turn as failed on idle. The terminal turn_status
+    // is the new boundary — NOT the raw 503 text.
+    await control('/idle', { sid });
+    await settle();
+    await expect.poll(async () => (await enrichedPreview(sid))?.type, { timeout: 15_000 }).toBe('error');
+    expect((await enrichedPreview(sid))!.text).toBe('Turn failed');
+  });
+});

--- a/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
+++ b/packages/arm/web/e2e/real-stack/terminal-card.spec.ts
@@ -121,7 +121,11 @@ test.describe.serial('real-stack terminal status cards', () => {
     await expect(legacyCard).toBeVisible({ timeout: 10_000 });
     await expect(legacyCard.getByText('User aborted')).toBeVisible();
     await expect(legacyCard.getByText('npm test')).toHaveCount(0);
-    await expect(page.getByText('Turn aborted', { exact: true })).toHaveCount(0);
+    // "Turn aborted" must not leak into the CHAT rendering of the legacy card
+    // (it normalizes to the frozen "User aborted" bubble). Aborted sessions may
+    // legitimately show "Turn aborted" as their sidebar preview, so scope this
+    // to the chat scroll area, not the whole page.
+    await expect(page.locator('[data-chat-scroll]').getByText('Turn aborted', { exact: true })).toHaveCount(0);
 
     await page.screenshot({ path: '/tmp/kraki-terminal-legacy-normalized.png', fullPage: false });
 
@@ -132,7 +136,7 @@ test.describe.serial('real-stack terminal status cards', () => {
       .filter({ hasText: legacyDraft });
     await expect(replayedLegacyCard).toBeVisible({ timeout: 10_000 });
     await expect(replayedLegacyCard.getByText('User aborted')).toBeVisible();
-    await expect(page.getByText('Turn aborted', { exact: true })).toHaveCount(0);
+    await expect(page.locator('[data-chat-scroll]').getByText('Turn aborted', { exact: true })).toHaveCount(0);
 
     const lostDraft = 'Legacy process loss uses the shared failed bubble';
     await control('/legacyInterrupted', {
@@ -145,7 +149,7 @@ test.describe.serial('real-stack terminal status cards', () => {
     await expect(lostCard).toBeVisible({ timeout: 10_000 });
     await expect(lostCard.getByText('Turn failed')).toBeVisible();
     await expect(lostCard.getByText('Agent process was lost')).toBeVisible();
-    await expect(page.getByText('Turn aborted', { exact: true })).toHaveCount(0);
+    await expect(page.locator('[data-chat-scroll]').getByText('Turn aborted', { exact: true })).toHaveCount(0);
 
     await page.screenshot({ path: '/tmp/kraki-terminal-legacy-process-lost.png', fullPage: false });
   });

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -578,7 +578,8 @@ export const useStore = create<Store>()(persist((set) => ({
     loadingSessions: new Set(),
     pendingSessions: new Set(),
     // unreadCount kept — persisted snapshot shown until session_list reconciles.
-    // sessionPreviews kept — persisted snapshot shown until rebuildPreview refreshes.
+    // sessionPreviews kept — persisted snapshot shown until the session_list
+    // digest (the tentacle) reconciles it.
     // messages are NOT touched — they're managed by IndexedDB hydration.
     // pending_input cleanup happens during hydration.
     // cards are in-memory only — restored via request_card when a session opens.

--- a/packages/arm/web/src/lib/commands.ts
+++ b/packages/arm/web/src/lib/commands.ts
@@ -157,11 +157,10 @@ export function answer(
     sessionId,
     payload: { questionId, answer: answerText, wasFreeform },
   });
-  // Update preview optimistically so the question badge clears immediately
-  if (answerText) {
-    const timestamp = new Date().toISOString();
-    getStore().setSessionPreview(sessionId, { text: answerText.slice(0, 80), type: 'answer', timestamp });
-  }
+  // The sidebar preview is owned by the session_list digest; an answer is a
+  // turn-internal mechanic (like a tool call), not a turn boundary, so it must
+  // not be written to the preview store. The digest's attention override
+  // clears the question preview authoritatively on resolve.
 }
 
 export function killSession(

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -8,11 +8,10 @@
 
 import { getStore } from './store-adapter';
 import { createLogger } from './logger';
-import type { ChatMessage, SessionPreview } from '../types/store';
+import type { ChatMessage } from '../types/store';
 
 const logger = createLogger('msg-provider');
 
-const PREVIEW_MAX = 80;
 const BATCH_TIMEOUT_MS = 10_000;
 
 // Rows written by older web clients before runtime/TRACE state was separated
@@ -36,98 +35,6 @@ const NON_SPINE_CACHE_TYPES = new Set([
 
 function isSpineCacheMessage(message: ChatMessage): boolean {
   return !NON_SPINE_CACHE_TYPES.has(message.type);
-}
-
-/** Strip common markdown syntax for clean preview display. */
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/```[\s\S]*?```/g, '') // fenced code blocks
-    .replace(/`([^`]+)`/g, '$1')    // inline code
-    .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
-    .replace(/__([^_]+)__/g, '$1')
-    .replace(/\*([^*]+)\*/g, '$1')  // italic
-    .replace(/_([^_]+)_/g, '$1')
-    .replace(/^#{1,6}\s+/gm, '')    // headings
-    .replace(/^\s*[-*+]\s+/gm, '')  // list items
-    .replace(/^\s*\d+\.\s+/gm, '')  // ordered list items
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // links
-    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1') // images
-    .replace(/\n+/g, ' ')           // newlines to spaces
-    .replace(/\s+/g, ' ')           // collapse whitespace
-    .trim();
-}
-
-/**
- * Rebuild session preview from the current messages in the store.
- */
-function rebuildPreview(sessionId: string): void {
-  const store = getStore();
-  const msgs = store.messages.get(sessionId);
-  if (!msgs || msgs.length === 0) return;
-
-  let preview: SessionPreview | null = null;
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    const m = msgs[i];
-    const ts = 'timestamp' in m ? (m as { timestamp: string }).timestamp : '';
-    const payload = 'payload' in m ? (m.payload as Record<string, unknown>) : null;
-
-    if (m.type === 'question' && payload) {
-      // Skip already-answered questions — they shouldn't show the question badge
-      if (payload.answer) continue;
-      const q = typeof payload.question === 'string' ? payload.question : '';
-      preview = { text: stripMarkdown(q).slice(0, PREVIEW_MAX), type: 'question', timestamp: ts };
-      break;
-    }
-    if (m.type === 'permission' && payload) {
-      // Skip already-resolved permissions
-      if (payload.resolution) continue;
-      const tool = typeof payload.toolName === 'string' ? payload.toolName : '';
-      preview = { text: tool.slice(0, PREVIEW_MAX), type: 'permission', timestamp: ts };
-      break;
-    }
-    if (m.type === 'error' && payload) {
-      const msg = typeof payload.message === 'string' ? payload.message : 'Error';
-      preview = { text: stripMarkdown(msg).slice(0, PREVIEW_MAX), type: 'error', timestamp: ts };
-      break;
-    }
-    if (m.type === 'turn_status' && payload) {
-      const draft = typeof payload.draft === 'string' ? payload.draft : '';
-      const action = payload.action && typeof payload.action === 'object' ? payload.action as Record<string, unknown> : null;
-      const kind = action && action.type === 'failed' ? 'Turn failed' : 'User aborted';
-      preview = { text: stripMarkdown(draft || kind).slice(0, PREVIEW_MAX), type: action?.type === 'failed' ? 'error' : 'agent', timestamp: ts };
-      break;
-    }
-    if (m.type === 'interrupted_turn' && payload) {
-      const draft = typeof payload.draft === 'string' ? payload.draft : '';
-      const failed = payload.reason === 'process_lost';
-      preview = {
-        text: stripMarkdown(draft || (failed ? 'Turn failed' : 'User aborted')).slice(0, PREVIEW_MAX),
-        type: failed ? 'error' : 'agent',
-        timestamp: ts,
-      };
-      break;
-    }
-    if (m.type === 'agent_message' && payload) {
-      const content = typeof payload.content === 'string' ? payload.content : '';
-      if (content) {
-        preview = { text: stripMarkdown(content).slice(0, PREVIEW_MAX), type: 'agent', timestamp: ts };
-        break;
-      }
-    }
-    if (m.type === 'user_message' && payload) {
-      const content = typeof payload.content === 'string' ? payload.content : '';
-      preview = { text: stripMarkdown(content).slice(0, PREVIEW_MAX), type: 'user', timestamp: ts };
-      break;
-    }
-    if (m.type === 'answer' && payload) {
-      const answer = typeof payload.answer === 'string' ? payload.answer : '';
-      if (answer) { preview = { text: stripMarkdown(answer).slice(0, PREVIEW_MAX), type: 'answer', timestamp: ts }; break; }
-    }
-  }
-
-  if (preview) {
-    store.setSessionPreview(sessionId, preview);
-  }
 }
 
 interface PendingRequest {
@@ -361,7 +268,6 @@ class MessageProvider {
     // No pending request — direct batch (e.g. from a concurrent path)
     if (messages.length > 0) {
       getStore().prependMessages(sessionId, messages);
-      rebuildPreview(sessionId);
     }
     this.loadingSessions.delete(sessionId);
     getStore().setSessionLoading(sessionId, false);
@@ -586,19 +492,6 @@ class MessageProvider {
   private deliverMessages(sessionId: string, messages: ChatMessage[], initial?: boolean): void {
     if (messages.length > 0) {
       getStore().prependMessages(sessionId, messages);
-      if (initial) {
-        const existingPreview = getStore().sessionPreviews.get(sessionId);
-        rebuildPreview(sessionId);
-        // Preserve the existing preview timestamp if it's newer than the rebuilt one.
-        // This keeps forked sessions showing their fork time instead of the source
-        // session's last message time.
-        if (existingPreview) {
-          const rebuilt = getStore().sessionPreviews.get(sessionId);
-          if (rebuilt && existingPreview.timestamp > rebuilt.timestamp) {
-            getStore().setSessionPreview(sessionId, { ...rebuilt, timestamp: existingPreview.timestamp });
-          }
-        }
-      }
     }
     logger.info('delivered', { sessionId, count: messages.length, initial });
   }

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -42,6 +42,15 @@ function updatePreview(sid: string, preview: SessionPreview, notify: boolean): v
   store.setSessionPreview(sid, preview, shouldIncrement);
 }
 
+/** Drive only the unread badge for a notify-worthy event. The preview text line
+ *  is owned by the session_list digest (the tentacle is the single authority);
+ *  some events still need to light up the unread dot without touching preview. */
+function notifyUnread(sid: string, notify: boolean): void {
+  if (!notify) return;
+  if (isViewingSession(sid) && document.hasFocus()) return;
+  getStore().incrementUnread(sid);
+}
+
 export interface RouterContext {
   cmdState: CommandState;
   /** Send an encrypted message back through the relay (for auto-approve in auto mode). */
@@ -213,8 +222,10 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
       logger.info('agent_message received', { sessionId: sid, contentLen: msg.payload.content?.length });
       traceEvent({ comp: 'arm', evt: 'APP-AGENT-MESSAGE', sessionId: sid, contentLen: msg.payload.content?.length });
       store.appendMessage(sid, msg);
-      // Preview is set by idle handler (final answer only) and rebuildPreview (IDB/replay).
-      // Setting it here would show intermediate thinking-step messages.
+      // The sidebar preview is owned by the session_list digest (the tentacle is
+      // the single authority). The agent reply becomes the preview only once the
+      // turn closes and the tentacle broadcasts; setting it here would show
+      // intermediate thinking-step messages.
       break;
     }
 
@@ -224,11 +235,10 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
         store.removePendingSession(sid);
       }
       store.appendMessage(sid, msg);
-      updatePreview(sid, {
-        text: truncPreview((msg.payload as Record<string, unknown>).message as string ?? 'Error'),
-        type: 'error',
-        timestamp: msg.timestamp,
-      }, !replaying);
+      // Preview text is owned by the session_list digest; a transient error is
+      // not a turn boundary and must not displace the stable preview. Only the
+      // unread badge is driven here.
+      notifyUnread(sid, !replaying);
       break;
 
     case 'turn_status': {
@@ -281,23 +291,10 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
       const idleUsage = idlePayload?.usage;
       if (idleUsage) store.setSessionUsage(sid, idleUsage);
       const idleReason = idlePayload?.reason;
-      // Don't update preview for aborted turns — the agent text is incomplete
-      if (idleReason !== 'aborted') {
-        const sessionMsgs = store.messages.get(sid);
-        if (sessionMsgs) {
-          for (let i = sessionMsgs.length - 1; i >= 0; i--) {
-            const m = sessionMsgs[i];
-            if (m.type === 'agent_message' && 'payload' in m) {
-              const content = (m.payload as Record<string, unknown>).content;
-              if (typeof content === 'string') {
-                updatePreview(sid, { text: truncPreview(content), type: 'agent', timestamp: msg.timestamp }, !replaying);
-              }
-              break;
-            }
-            if ((m.type === 'user_message' && m.payload.delivery !== 'steer') || m.type === 'idle') break;
-          }
-        }
-      }
+      // Preview is owned by the session_list digest (tentacle broadcasts on
+      // turn-close so the post-turn agent outcome advances authoritatively).
+      // Only drive the unread badge for completed (non-aborted) turns.
+      if (idleReason !== 'aborted') notifyUnread(sid, !replaying);
       if (!replaying && isViewingSession(sid) && document.hasFocus()) {
         import('./ws-client').then(({ wsClient }) => wsClient.markRead(sid)).catch(() => {});
       }

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -679,6 +679,88 @@ describe('SessionManager', () => {
       expect(entry!.preview!.type).toBe('agent');
       expect(entry!.preview!.text).toContain('I will run a command');
     });
+
+    it('preview is the turn boundary, not transient error noise', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'Fix the migration' },
+      }));
+      // A flurry of transient 503 errors mid-turn must NOT become the preview.
+      sm.appendMessage(sessionId, 'error', JSON.stringify({
+        type: 'error', sessionId, payload: { message: '503 auth_unavailable' },
+      }));
+      sm.appendMessage(sessionId, 'error', JSON.stringify({
+        type: 'error', sessionId, payload: { message: '503 auth_unavailable' },
+      }));
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview!.type).toBe('user');
+      expect(entry!.preview!.text).toBe('Fix the migration');
+    });
+
+    it('preview stays at the user_message during a multi-tool turn', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'Run the test suite' },
+      }));
+      // Tool activity (legacy on-spine records) and narration must not
+      // displace the turn boundary even when they fill the tail window.
+      for (let i = 0; i < 25; i++) {
+        sm.appendMessage(sessionId, 'tool_start', JSON.stringify({
+          type: 'tool_start', sessionId, payload: { toolName: 'bash', toolCallId: `c${i}` },
+        }));
+        sm.appendMessage(sessionId, 'tool_complete', JSON.stringify({
+          type: 'tool_complete', sessionId, payload: { toolName: 'bash', toolCallId: `c${i}` },
+        }));
+      }
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview!.type).toBe('user');
+      expect(entry!.preview!.text).toBe('Run the test suite');
+    });
+
+    it('preview advances to the terminal turn_status on failure', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'Deploy it' },
+      }));
+      sm.appendMessage(sessionId, 'turn_status', JSON.stringify({
+        type: 'turn_status', sessionId,
+        payload: { draft: '', action: { type: 'failed', payload: { failedAt: 'now' } } },
+      }));
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview!.type).toBe('error');
+      expect(entry!.preview!.text).toBe('Turn failed');
+    });
+
+    it('preview uses the draft at an interrupted_turn boundary', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'Summarize' },
+      }));
+      sm.appendMessage(sessionId, 'interrupted_turn', JSON.stringify({
+        type: 'interrupted_turn', sessionId, payload: { draft: 'Halfway through…' },
+      }));
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview!.type).toBe('agent');
+      expect(entry!.preview!.text).toBe('Halfway through…');
+    });
+
+    it('preview shows a system_message (no-reply) outcome', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'Hello?' },
+      }));
+      sm.appendMessage(sessionId, 'system_message', JSON.stringify({
+        type: 'system_message', sessionId, payload: { kind: 'no_reply', content: '' },
+      }));
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview!.type).toBe('agent');
+      expect(entry!.preview!.text).toBe('No reply');
+    });
   });
 
   // ── Legacy inline-image strip migration ───────────────

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -253,6 +253,12 @@ export class RelayClient {
     const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
     if (usage) this.sessionManager.setUsage(sessionId, usage);
     this.sendTurnIdle(sessionId, { usage, ...(terminalError && { reason: 'failed' as const }) });
+    // The closing idle changes the turn boundary — the agent reply / terminal
+    // outcome now replaces the user_message as the preview anchor. Broadcast so
+    // every arm's digest-derived preview advances authoritatively. Without this
+    // a question/permission-less turn would never refresh the sidebar preview
+    // (broadcastSessionList otherwise only fires on question/permission events).
+    this.broadcastSessionList();
     this.maybeGenerateTitle(sessionId);
   }
 
@@ -1198,6 +1204,8 @@ export class RelayClient {
               this.sessionManager.markIdle(sessionId);
               this.clearCompacting(sessionId);
               this.sendTurnIdle(sessionId, { reason: 'aborted' });
+              // Turn boundary changed (aborted outcome). See settleAdapterIdle.
+              this.broadcastSessionList();
             })
             .catch((err) => {
               logger.error({ err, sessionId }, 'abortSession failed');

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -1110,8 +1110,26 @@ export class SessionManager {
   }
 
   /**
-   * Read the last few lines of a session's JSONL and extract a sidebar preview.
-   * Scans backward to find the last agent_message, user_message, error, permission, or question.
+   * Extract a sidebar preview = the most recent STABLE turn boundary.
+   *
+   * A turn boundary is the durable conversation anchor: the `user_message`
+   * that began the current (or last) turn, or the agent outcome of the
+   * previous turn (final `agent_message`, terminal `turn_status`, aborted
+   * `interrupted_turn`, or `system_message` like no-reply). It stays put for
+   * the whole turn — tool activity and narration are NOT boundaries.
+   *
+   * Transient `error` records (503/429 retries) are skipped: they are
+   * infrastructure noise, not conversation content, and a turn that fails is
+   * represented by its terminal `turn_status` (or falls back to the
+   * user_message, which is still the correct anchor). Open questions and
+   * permissions are likewise skipped here — they are turn-internal mechanics
+   * and are layered on top separately by `enrichSessionList` (the attention
+   * override), so they must never come from this file scan.
+   *
+   * Scans the whole 32KB tail (not just the last 20 lines): the spine is now
+   * sparse (`tool_start`/`tool_complete` live in `trace.jsonl`), but older
+   * sessions still carry them and a 20-line window could be entirely
+   * non-anchor entries.
    */
   private getSessionPreview(sessionId: string): import('@kraki/protocol').SessionPreviewDigest | undefined {
     const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
@@ -1135,25 +1153,17 @@ export class SessionManager {
       return undefined;
     }
 
-    // Parse lines from end to find the last previewable message
+    // Turn-boundary scan (most recent first). Returns the first anchor found.
     const lines = tail.split('\n');
-    for (let i = lines.length - 1; i >= Math.max(0, lines.length - 20); i--) {
+    for (let i = lines.length - 1; i >= 0; i--) {
       if (!lines[i]) continue;
       try {
         const entry = JSON.parse(lines[i]) as LoggedMessage;
-        const inner = JSON.parse(entry.payload);
-        const payload = inner.payload as Record<string, unknown> | undefined;
+        const inner = JSON.parse(entry.payload) as { type?: string; payload?: Record<string, unknown> };
+        const payload = inner.payload;
         if (!payload) continue;
 
         switch (inner.type) {
-          case 'interrupted_turn': {
-            const draft = payload.draft;
-            return {
-              text: typeof draft === 'string' && draft ? stripMarkdownForPreview(draft) : 'Turn aborted',
-              type: 'agent',
-              timestamp: entry.ts,
-            };
-          }
           case 'agent_message': {
             const content = payload.content;
             if (typeof content === 'string' && content) {
@@ -1168,34 +1178,35 @@ export class SessionManager {
             }
             break;
           }
-          case 'error': {
-            const message = payload.message;
-            if (typeof message === 'string') {
-              return { text: stripMarkdownForPreview(message), type: 'error', timestamp: entry.ts };
-            }
-            break;
+          case 'interrupted_turn': {
+            const draft = payload.draft;
+            const failed = payload.reason === 'process_lost';
+            return {
+              text: typeof draft === 'string' && draft ? stripMarkdownForPreview(draft) : (failed ? 'Turn failed' : 'Turn aborted'),
+              type: 'agent',
+              timestamp: entry.ts,
+            };
           }
-          case 'permission': {
-            if (!payload.resolution) {
-              const tool = typeof payload.toolName === 'string' ? payload.toolName : 'permission';
-              return { text: truncateText(tool, PREVIEW_MAX), type: 'permission', timestamp: entry.ts };
-            }
-            break;
+          case 'turn_status': {
+            const draft = payload.draft;
+            const actionType = (payload.action as { type?: string } | undefined)?.type;
+            const failed = actionType === 'failed';
+            return {
+              text: typeof draft === 'string' && draft ? stripMarkdownForPreview(draft) : (failed ? 'Turn failed' : 'Turn aborted'),
+              type: failed ? 'error' : 'agent',
+              timestamp: entry.ts,
+            };
           }
-          case 'question': {
-            if (!payload.answer) {
-              const q = typeof payload.question === 'string' ? payload.question : '';
-              return { text: stripMarkdownForPreview(q), type: 'question', timestamp: entry.ts };
-            }
-            break;
+          case 'system_message': {
+            const content = payload.content;
+            const label = typeof content === 'string' && content
+              ? content
+              : (payload.kind === 'no_reply' ? 'No reply' : 'System notice');
+            return { text: stripMarkdownForPreview(label), type: 'agent', timestamp: entry.ts };
           }
-          case 'answer': {
-            const answer = payload.answer;
-            if (typeof answer === 'string' && answer) {
-              return { text: stripMarkdownForPreview(answer), type: 'answer', timestamp: entry.ts };
-            }
-            break;
-          }
+          // error / idle / active / session_created / session_ended / tool_* /
+          // agent_narration / question / answer / permission / *_resolved /
+          // compacting are intentionally NOT turn boundaries — skip them.
         }
       } catch {
         // Skip malformed lines


### PR DESCRIPTION
## Problem

The sidebar preview was displaced by non-conversation noise and depended on divergent client-side writes:

- `getSessionPreview` scanned only the last 20 lines of the 32KB tail. A multi-tool turn could fill that window with `tool_start`/`tool_complete` (still present on legacy spines), so the preview fell back to an earlier message or went blank.
- Transient `error` records (503/429 retries) became the preview text.
- The preview store had four competing writers (digest, router idle scan, rebuildPreview, optimistic answer), causing jump-back and stale question badges (#178/#179/#181 patched symptoms but the root overlap remained).
- A question/permission-less turn never refreshed the sidebar preview at all — Tentacle only broadcast `session_list` on question/permission events.

## Fix

Preview now reflects the **last stable turn boundary** (the `user_message` that began the turn, or the agent outcome of the previous turn) and is owned by the session_list digest as the single authority.

### Tentacle — the authority
- **`getSessionPreview` is a turn-boundary scan** (`session-manager.ts`): only `user_message` / `agent_message` / `interrupted_turn` / `turn_status` / `system_message` qualify. `error`, `idle`, `active`, `tool_*`, `question`, `answer`, `permission` are skipped — they are not anchors. Scans the whole tail (removed the 20-line cap).
- **Turn-close broadcasts `session_list`** (`relay-client.ts`): `settleAdapterIdle` and the abort path now call `broadcastSessionList()` so every Arm's digest-derived preview advances authoritatively to the new boundary (the agent reply / terminal outcome). Open question/permission still overlays the preview via `enrichSessionList` (unchanged).

### Web — single digest authority
- `message-router.ts`: removed the idle memory-scan and the transient-error preview write; added a dedicated `notifyUnread` helper so the unread badge is still driven without touching preview text. Kept the correct instant mirrors (user_message echo, turn_status, interrupted_turn, system_message) to avoid cross-device active-turn staleness.
- `message-provider.ts`: removed `rebuildPreview` (+ its `stripMarkdown`/`PREVIEW_MAX` helpers).
- `commands.ts`: removed the optimistic answer preview (an answer is turn-internal mechanics, not a boundary).

## Behavior change

`turn_status` / `interrupted_turn` aborts now surface as `Turn aborted` / `Turn failed` in the sidebar (previously `undefined`). This is the intended turn-boundary semantics. Tests updated accordingly (scoped `Turn aborted` assertions to the chat scroll area, since it now legitimately appears as a sidebar preview).

Permission preview shows the real command headline; steer (a durable `user_message`) updates the preview as the latest turn boundary — both as discussed.

## Validation

- **real-stack (browser + dev stack)**: 52 passed, including new \`preview-turn-boundary.spec.ts\` (clean turn: user_message anchors through 18 tools → advances to agent reply, sidebar reflects it via turn-close broadcast; failed turn: transient 503s don't displace, failure shows on close.
- Tentacle 784 (+5 new), Web 407, shared integration 44.
- `pnpm validate`, lint, `git diff --check` clean.
EOF
)