### PR TITLE
chore(release): v0.31.5

### DIFF
--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kraki/arm-web",
-  "version": "0.16.0",
-  "description": "Kraki web receiver — view and control your agents from any browser",
+  "version": "0.16.1",
+  "description": "Kraki web receiver \u2014 view and control your agents from any browser",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.4",
-  "description": "Kraki agent bridge — the arm that connects your coding agent to the head",
+  "version": "0.31.5",
+  "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",
     "url": "https://github.com/corelli18512/kraki",


### PR DESCRIPTION
Release v0.31.5 — ships **fix(preview): turn-boundary scan + digest-authoritative sidebar (#189)**.

## Versions
- \`@kraki/tentacle\`: 0.31.4 → **0.31.5**
- \`@kraki/arm-web\`: 0.16.0 → **0.16.1**
- \`@kraki/protocol\`: 0.21.0 (unchanged)
- \`@kraki/head\`: 0.17.0 (unchanged)

## What ships
The sidebar preview now reflects the last stable **turn boundary** (the user_message that began the turn, or the agent outcome of the previous turn) and is owned by the session_list digest as the single authority. It is no longer displaced by tool activity, narration, or transient errors; open questions/permissions still overlay it while pending.

## Validation
- \`pnpm validate\` green (lint + build + crypto/head/tentacle/tests + web 409).
- Real-stack (browser + dev stack) 52 passed incl. new \`preview-turn-boundary.spec.ts\`.
- Tentacle 784, Web 407, shared integration 44 all green.

## Post-merge rollout
- Tag \`v0.31.5\` → triggers release.yml (npm publish, CLI bundles, GitHub Release).
- Web is a private package: \`app.kraki.chat\` requires a separate production deploy of the built bundle.
- Head/Relay unchanged (0.17.0) — no Head/Relay deployment needed.