### PR TITLE
fix(mac): give the daemon a Launch Services identity so TCC grants survive updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,28 +285,35 @@ jobs:
           </plist>
           PLIST
 
-          # Sign the bundle — this re-signs the executable inside too
-          codesign --force --deep --options runtime \
+          # Sign inside-out: the nested executable first, then the bundle.
+          # --deep is deprecated for signing and applies the OUTER entitlements to
+          # every nested binary, which silently mis-signs anything added to the
+          # bundle later.
+          codesign --force --options runtime \
+            --entitlements packages/tentacle/entitlements.plist \
+            --sign "${{ secrets.APPLE_SIGNING_IDENTITY }}" \
+            "$APP_DIR/Contents/MacOS/kraki"
+          codesign --force --options runtime \
             --entitlements packages/tentacle/entitlements.plist \
             --sign "${{ secrets.APPLE_SIGNING_IDENTITY }}" \
             "$APP_DIR"
 
-          # Create tar.gz for distribution
-          ARCH="${{ matrix.asset_name }}"
-          ARCH="${ARCH#kraki-cli-macos-}"
-          tar -czf "packages/tentacle/dist/sea/kraki-macos-${ARCH}.app.tar.gz" \
-            -C packages/tentacle/dist/sea Kraki.app
+          codesign --verify --strict --verbose=2 "$APP_DIR"
 
-          echo "Created kraki-macos-${ARCH}.app.tar.gz"
-          ls -lh "packages/tentacle/dist/sea/kraki-macos-${ARCH}.app.tar.gz"
+          # The distribution tarball is NOT built here. It has to be created after
+          # notarization + stapling, or it ships without the ticket and every user
+          # needs a successful online Gatekeeper check to launch. See the
+          # "Notarize" step below.
 
-      - name: Notarize binary (macOS)
+      - name: Notarize and staple (macOS)
         if: runner.os == 'macOS' && needs.prepare.outputs.publish_mode == 'publish'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          set -euo pipefail
+
           # Notarize the standalone binary
           zip $RUNNER_TEMP/binary.zip packages/tentacle/dist/sea/${{ matrix.asset_name }}
           xcrun notarytool submit $RUNNER_TEMP/binary.zip \
@@ -320,6 +327,29 @@ jobs:
           xcrun notarytool submit $RUNNER_TEMP/app-bundle.zip \
             --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" --wait
+
+          # Staple the ticket INTO the bundle. Unlike a bare Mach-O, an .app can
+          # and must be stapled: without it every launch depends on a successful
+          # online Gatekeeper check, so an offline or rate-limited machine sees
+          # "damaged app" — and an app Gatekeeper refuses to launch has no TCC
+          # grants at all.
+          xcrun stapler staple packages/tentacle/dist/sea/Kraki.app
+          xcrun stapler validate packages/tentacle/dist/sea/Kraki.app
+          spctl -a -vvv --type exec packages/tentacle/dist/sea/Kraki.app
+
+      - name: Package .app bundle (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          # Packaged only after notarization + stapling, so the tarball carries
+          # the ticket. Building it earlier is why the shipped bundle had no
+          # stapled ticket despite the release being notarized.
+          ARCH="${{ matrix.asset_name }}"
+          ARCH="${ARCH#kraki-cli-macos-}"
+          tar -czf "packages/tentacle/dist/sea/kraki-macos-${ARCH}.app.tar.gz" \
+            -C packages/tentacle/dist/sea Kraki.app
+          echo "Created kraki-macos-${ARCH}.app.tar.gz"
+          ls -lh "packages/tentacle/dist/sea/kraki-macos-${ARCH}.app.tar.gz"
 
       - name: Smoke test tentacle binary
         run: node packages/tentacle/scripts/smoke-test-binary.mjs packages/tentacle/dist/sea/${{ matrix.asset_name }}

--- a/docs/mac-tcc-permissions.md
+++ b/docs/mac-tcc-permissions.md
@@ -1,8 +1,14 @@
 # macOS TCC permissions — root-cause fix for "kraki keeps losing its permissions"
 
-> Status: fixed end-to-end. The recurring re-grant-on-every-update bug is
-> resolved by registering `Kraki.app` with Launch Services. This document
-> exists so nobody re-introduces the regression.
+> Status: fixed by changing how the daemon is **launched**.
+>
+> An earlier revision of this document declared the bug "fixed end-to-end by
+> registering `Kraki.app` with Launch Services". That was wrong, and it was the
+> seventh failed fix. `lsregister -f` makes Launch Services aware that the bundle
+> exists **on disk**; it has no effect on the **runtime identity** of a process
+> that launchd `execve()`d directly, and runtime identity is what TCC keys on.
+> Registration was necessary but never sufficient. See "What was actually
+> measured" below — the evidence, rather than the reasoning, is the point.
 
 ## Symptom
 
@@ -56,17 +62,105 @@ permanent — until now.
 
 ### Why the prior fixes kept relapsing
 
-`#123/#133/#138/#142` all attacked detection or packaging, never these
-two mechanisms. The `.app` wrap (#142) was the right instinct but (a) it
-doesn't change how launchd launches the binary, and (b) it never cleaned
-the Launch Services pollution, so the zombie problem kept growing.
+`#123/#133/#138/#142` all attacked detection or packaging, never these two
+mechanisms. The `.app` wrap (#142) was the right instinct but (a) it doesn't
+change how launchd launches the binary, and (b) it never cleaned the Launch
+Services pollution, so the zombie problem kept growing.
+
+`#182` then fixed Bug 2 properly — the zombie sweeper works and should stay. But
+it only *argued around* Bug 1, claiming the path-tracking risk was "addressed by
+keeping the canonical path stable and keeping Launch Services unambiguous". It
+is not. Keeping the path stable is precisely the case that breaks: TCC stores
+path **plus cdhash**, and every update rewrites the cdhash at that stable path.
+
+The deeper reason this recurred seven times is that **nothing ever measured the
+daemon's runtime identity**. Bundle registration and LS cleanliness are both easy
+to observe and both looked correct, so each fix appeared to work until a user
+updated again.
+
+## What was actually measured
+
+Run directly against the live install and a set of throwaway signed bundles on
+macOS 26.5. `lsappinfo info -only bundleid <pid>` and
+`NSRunningApplication(processIdentifier:)` agree in every case.
+
+| Bundle `Info.plist` | Launched by | Launch Services identity |
+|---|---|---|
+| `LSBackgroundOnly` + `LSUIElement` (kraki's exact config) | `execve` of `Contents/MacOS/…` | **none** |
+| `LSUIElement` only | `execve` of `Contents/MacOS/…` | **none** |
+| `LSBackgroundOnly` + `LSUIElement` | `open` | bundle id resolves |
+| `LSUIElement` only | `open` | bundle id resolves |
+| — | launchd job running `open -W -n -a` | bundle id resolves |
+
+The live kraki daemon reported `"CFBundleIdentifier"=[ NULL ]`, i.e. no bundle
+identity at all — so TCC had nothing to key on but the absolute path.
+
+Three conclusions follow, and they are what the fix rests on:
+
+1. **The launch method decides everything.** `Info.plist` flags are irrelevant;
+   `LSBackgroundOnly` is not the culprit and removing it changes nothing.
+2. **A plain non-AppKit CLI binary does get a full bundle identity** when started
+   through LaunchServices. Being a Node SEA binary is not an obstacle.
+3. **`lsregister -f` cannot fix this**, because it only describes the bundle on
+   disk and never touches the identity of a running process.
+
+Independently confirmed that grants do survive an update once the identity is
+right: a Developer-ID-signed bundle launched via LaunchServices kept Screen
+Recording, Accessibility, Input Monitoring and Microphone across a version bump
+that changed its cdhash.
 
 ## Fix
 
-Three things, all in `packages/tentacle/src/checks.ts` and wired into the
-install/update/daemon paths:
+### The load-bearing change — launch through LaunchServices
 
-1. **`registerKrakiAppBundle()`** — `lsregister -f <Kraki.app>`. Called on
+`buildLaunchdPlist()` in `packages/tentacle/src/daemon.ts` now emits, for any
+bundled install:
+
+```
+/usr/bin/open -W -n -a <Kraki.app>
+  --stdout <bootstrap.log> --stderr <bootstrap.log>
+  --env K=V …
+  --args __daemon-worker
+```
+
+instead of `execve`ing `Kraki.app/Contents/MacOS/kraki` directly. The daemon now
+has a real bundle identity, so TCC stores the grant against `chat.kraki.cli` and
+its cdhash-free Designated Requirement, which survives every update.
+
+Details that are load-bearing, each verified rather than assumed:
+
+- **`-W`** blocks for the app's lifetime, so launchd still supervises the daemon.
+  Without it `open` returns immediately and launchd loses the process entirely.
+- **`KeepAlive: true`**, not `SuccessfulExit: false`. `open -W` exits **0 even
+  when the app it waits on is SIGKILLed**, so the old exit-code condition would
+  never fire and a crashed daemon would stay dead. `ThrottleInterval: 10` keeps
+  an unlaunchable bundle from spinning.
+- **`--env`** is required: an app started through LaunchServices inherits the
+  launchd *session* environment, not the environment of whoever called `open`.
+  Without it the daemon silently loses `PATH`, proxy settings and tokens.
+- **`--stdout` / `--stderr`** for the same reason — the launchd job's
+  `StandardOutPath` now captures `open` itself, not the daemon.
+- **`--args` must come last**; `open` treats everything after it as app `argv`.
+  Verified the daemon receives a clean `argv[1] == "__daemon-worker"` with no
+  `-psn_…` argument injected.
+- **`stopDaemon()` now unloads the launchd job *before* signalling the daemon.**
+  With `KeepAlive: true`, killing first lets launchd resurrect the daemon in the
+  window before the job is unloaded, and `kraki stop` appears to do nothing.
+- Non-bundled installs keep the old direct-`execve` behaviour and its original
+  `SuccessfulExit: false` semantics, where exit status is still meaningful.
+
+`buildLaunchdPlist()` is exported and pure specifically so the launch mechanism
+is asserted in CI (`src/__tests__/daemon-launch-tcc.test.ts`, 13 tests). That is
+the actual regression guard: this bug relapsed six times because nothing ever
+tested *how* the daemon was launched.
+
+### Supporting changes (necessary, not sufficient)
+
+Three things in `packages/tentacle/src/checks.ts`, wired into the
+install/update/daemon paths. These keep System Settings showing one unambiguous
+"Kraki" entry; they do **not** by themselves preserve grants:
+
+1. **`registerKrakiAppBundle(path?)`** — `lsregister -f <Kraki.app>`. Called on
    install, after every self-update, and on every daemon start, so the
    canonical bundle-id binding Launch Services needs is always current.
 
@@ -99,25 +193,57 @@ Wiring:
 | `daemon-worker.ts` `startWorker()` | register + sweep on every daemon start (self-heal) |
 | `cli.ts` `cmdPermissions(--clean)` + `cmdDoctor()` | user-driven / observable |
 
-Because the Developer ID Team ID (`3A83X5JZ3S`) never changes between
-releases, once the Launch Services state is clean and the bundle is
-registered, the bundle-id path through TCC is stable and a granted
-permission survives updates. The path-tracked risk (Bug 1) is addressed
-by keeping the canonical path stable (it is) and keeping Launch Services
-unambiguous (Bug 2 fix) so the resolver consistently lands on the
-bundle-id-tracked record.
+The Developer ID Team ID (`3A83X5JZ3S`) never changes between releases, so the
+Designated Requirement is stable and cdhash-free. Combined with a daemon that
+actually has a bundle identity, a granted permission now survives updates.
+
+Two further corrections shipped with this change:
+
+- `registerKrakiAppBundle()` now takes an explicit path, and `update.ts` passes
+  the **new** `targetAppDir`. The no-argument form derived the bundle from the
+  running process's `execPath`, which at that point is the old bundle just
+  renamed to `.bak` — and in the standalone-to-bundle migration it returned
+  `null`, so the freshly installed bundle was never registered at all.
+- `unregisterAppBundlePath()` now only fabricates its eviction stub at a path
+  that is **completely absent**. It previously wrote a stub into any directory
+  lacking `Contents/Info.plist` and then `rmSync`'d the whole tree — which would
+  delete a half-extracted update, or an unrelated directory that merely shared
+  the name. An uncollected Launch Services record is recoverable; a deleted
+  directory is not.
+
+### Diagnosing it next time
+
+`kraki doctor` now reports `tcc.identity`:
+
+```json
+{ "bundled": true, "bundlePath": "…/Kraki.app",
+  "daemonPid": 6856, "daemonBundleId": null, "healthy": false }
+```
+
+`daemonBundleId: null` with `bundled: true` is the exact broken state — a
+correctly signed, correctly registered bundle whose daemon was nonetheless
+started by absolute path. That single field is what was missing for seven
+attempts. When healthy it reads `"daemonBundleId": "chat.kraki.cli"`.
 
 ### Verified
 
-- `vitest run` — 748/748 pass (incl. 19 new tests covering bundle
-  detection, lsregister calls, the vanished-path stub eviction, and
-  `cleanupStaleBundleEntries`).
+- `vitest run` — 792/792 pass, including 13 new tests in
+  `src/__tests__/daemon-launch-tcc.test.ts` asserting the launch mechanism
+  itself: `open` as `argv[0]`, `-W`, `-n`, `-a <bundle>`, `--args` last,
+  `--env`/`--stdout`/`--stderr` forwarding, `KeepAlive: true`, and the
+  direct-`execve` fallback for non-bundled installs.
 - `tsc --noEmit` — 0 errors across the whole tentacle package.
-- Sandbox (`/tmp/kraki-tcc-sandbox-test.sh`) — registers, survives a
-  simulated update, never touches the real `chat.kraki.cli`.
-- Direct eviction probe (`/tmp/evict-probe.mjs`, against the real compiled
-  `dist/checks.js`) — a deleted-path zombie (3 entries) is reduced to 0 by
-  `unregisterAppBundlePath()`.
+- Launch identity measured live on macOS 26.5 across four bundle/launch
+  combinations plus a real launchd job (see "What was actually measured").
+- End-to-end under real launchd: a job running `open -W -n -a <bundle>` produced
+  a process with a resolved bundle id, stayed supervised, and was **restarted
+  ~1s after `kill -9` with its identity intact**.
+- Grant survival across a cdhash-changing update confirmed on a Developer-ID
+  signed bundle launched through LaunchServices.
+
+Not verified here, and the one thing left to confirm on a real install: that a
+freshly granted Full Disk Access on the updated kraki survives the *next* real
+release. The mechanism is proven; the production round-trip needs one user grant.
 
 ## Granting the permissions (user)
 
@@ -156,6 +282,18 @@ kraki fda [--json|--watch]   # unchanged, retained for compatibility
   Team ID resets every grant.
 - **Never** strip the `.app` wrapping. A raw Mach-O executed directly has
   no bundle identity to track.
+- **Never** point the launchd job back at `Contents/MacOS/kraki`. That single
+  change silently reintroduces the entire bug — the daemon keeps running, the
+  bundle stays signed and registered, and grants quietly stop surviving updates.
+  `daemon-launch-tcc.test.ts` fails if you do; do not "fix" that test.
+- **Never** launch the daemon through the `~/.local/bin/kraki` symlink either.
+  It has the same effect: no bundle identity, path-tracked grant. (`install.sh`
+  and the web installer still do this for their initial post-install start — it
+  is the remaining known gap, tracked below.)
+- Keep the notarization ticket **stapled** and staple *before* building the
+  distribution tarball. An unstapled app needs a successful online Gatekeeper
+  check on every launch; if Gatekeeper refuses to launch it, its TCC grants are
+  irrelevant.
 - If you ship a second bundle (e.g. the Tauri toolbar,
   `cloud.corelli.kraki.toolbar`), register **that** bundle with
   `lsregister` too — its TCC grants are tracked under its own bundle id.
@@ -172,6 +310,18 @@ kraki fda [--json|--watch]   # unchanged, retained for compatibility
 | `3efb194d` (#133) | robust multi-path FDA probe | fixed *detection*, not *persistence* |
 | `ad7b9c2d` (#138) | probe FDA before binary replace | worked around the post-replace probe, not the grant loss |
 | `9da93153` (#142) | wrap CLI in `.app` to "preserve FDA" | correct theory — but never registered the bundle with Launch Services, so TCC still used cdhash |
+| `12ddf3c2` (#182) | `lsregister -f` + zombie eviction + real app icon | fixed Bug 2 for good, but only argued around Bug 1; the daemon was still `execve`'d by path, so it still had no bundle identity |
+| *this change* | launch the daemon via `open -W -n -a <bundle>` | gives the daemon a real Launch Services identity — the thing every previous fix left untouched |
+
+### Known remaining gap
+
+`install.sh:208` and `packages/arm/web/public/install.sh:188` still start the
+daemon with `nohup "${INSTALL_DIR}/kraki" __daemon-worker`, i.e. through the
+symlink. That first post-install daemon therefore has no bundle identity until
+something restarts it via the launchd job. It self-heals on the next
+`kraki start`/restart or reboot, but the installers should be switched to the
+same `open`-based launch. The two installers also disagree on `INSTALL_DIR`
+(`~/.local/bin` vs `/usr/local/bin`), which is worth unifying at the same time.
 | **this change** | **`lsregister` on install + after every update** | **closes the gap #142 left open** |
 
 ## The trigger we actually hit on the live install

--- a/docs/mac-tcc-permissions.md
+++ b/docs/mac-tcc-permissions.md
@@ -313,15 +313,30 @@ kraki fda [--json|--watch]   # unchanged, retained for compatibility
 | `12ddf3c2` (#182) | `lsregister -f` + zombie eviction + real app icon | fixed Bug 2 for good, but only argued around Bug 1; the daemon was still `execve`'d by path, so it still had no bundle identity |
 | *this change* | launch the daemon via `open -W -n -a <bundle>` | gives the daemon a real Launch Services identity — the thing every previous fix left untouched |
 
-### Known remaining gap
+### Installers
 
-`install.sh:208` and `packages/arm/web/public/install.sh:188` still start the
-daemon with `nohup "${INSTALL_DIR}/kraki" __daemon-worker`, i.e. through the
-symlink. That first post-install daemon therefore has no bundle identity until
-something restarts it via the launchd job. It self-heals on the next
-`kraki start`/restart or reboot, but the installers should be switched to the
-same `open`-based launch. The two installers also disagree on `INSTALL_DIR`
-(`~/.local/bin` vs `/usr/local/bin`), which is worth unifying at the same time.
+Both `install.sh` and `packages/arm/web/public/install.sh` previously started
+the first daemon with `nohup "${INSTALL_DIR}/kraki" __daemon-worker` — through
+the symlink, so that very first daemon had no bundle identity either. If the
+user granted Full Disk Access to *that* process, the grant was path-tracked from
+the outset and died on the next update.
+
+Both now launch the bundle through LaunchServices on macOS:
+
+```sh
+open -n -a "$HOME/.local/share/kraki/Kraki.app" \
+  --stdout "$BOOTSTRAP_LOG" --stderr "$BOOTSTRAP_LOG" \
+  --env "PATH=$PATH" --env "HOME=$HOME" \
+  --args __daemon-worker
+```
+
+with the original `nohup` retained for non-macOS and for the non-bundled
+fallback. Because `open` returns as soon as the app is launched, the liveness
+check matches on process name instead of a PID the shell never owned.
+
+Still open, and not a TCC issue: the two installers disagree on `INSTALL_DIR`
+(`~/.local/bin` vs `/usr/local/bin`), so the symlink location differs by install
+channel. Worth unifying separately.
 | **this change** | **`lsregister` on install + after every update** | **closes the gap #142 left open** |
 
 ## The trigger we actually hit on the live install

--- a/install.sh
+++ b/install.sh
@@ -203,18 +203,41 @@ main() {
   # shell can launch it just fine.
   KRAKI_INSTALL=1 "${INSTALL_DIR}/${BINARY_NAME}" </dev/tty
 
-  # Start daemon in background from the shell
+  # Start daemon in background from the shell.
   mkdir -p "${HOME}/.kraki/logs"
-  nohup "${INSTALL_DIR}/${BINARY_NAME}" __daemon-worker \
-    </dev/null >"${HOME}/.kraki/logs/daemon-bootstrap.log" 2>&1 &
-  DAEMON_PID=$!
+  BOOTSTRAP_LOG="${HOME}/.kraki/logs/daemon-bootstrap.log"
 
-  # Brief check that daemon survived startup
-  sleep 1
-  if kill -0 "$DAEMON_PID" 2>/dev/null; then
-    echo "  🦑 Kraki daemon started (PID $DAEMON_PID)"
+  # On macOS the daemon MUST be started through LaunchServices, not through the
+  # ${INSTALL_DIR}/kraki symlink. A binary exec'd by path gets no Launch Services
+  # application identity, so TCC keys its grants to the absolute path + cdhash
+  # and every future update silently revokes Full Disk Access. Launching the
+  # bundle with `open` gives the process its real bundle id (chat.kraki.cli),
+  # whose Developer ID Designated Requirement is cdhash-free and stable.
+  # See docs/mac-tcc-permissions.md.
+  APP_PATH="${HOME}/.local/share/kraki/Kraki.app"
+  if [ "$(uname -s)" = "Darwin" ] && [ -d "$APP_PATH" ]; then
+    open -n -a "$APP_PATH" \
+      --stdout "$BOOTSTRAP_LOG" --stderr "$BOOTSTRAP_LOG" \
+      --env "PATH=${PATH}" --env "HOME=${HOME}" \
+      --args __daemon-worker
+    # `open` returns as soon as the app is launched, so confirm by process name
+    # rather than by a PID we never owned.
+    sleep 2
+    if pgrep -f "Kraki.app/Contents/MacOS/kraki __daemon-worker" >/dev/null 2>&1; then
+      echo "  🦑 Kraki daemon started (via LaunchServices)"
+    else
+      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
+    fi
   else
-    echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
+    nohup "${INSTALL_DIR}/${BINARY_NAME}" __daemon-worker \
+      </dev/null >"$BOOTSTRAP_LOG" 2>&1 &
+    DAEMON_PID=$!
+    sleep 1
+    if kill -0 "$DAEMON_PID" 2>/dev/null; then
+      echo "  🦑 Kraki daemon started (PID $DAEMON_PID)"
+    else
+      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
+    fi
   fi
   echo ""
 }

--- a/packages/arm/web/public/install.sh
+++ b/packages/arm/web/public/install.sh
@@ -183,18 +183,41 @@ main() {
   # shell can launch it just fine.
   KRAKI_INSTALL=1 "${INSTALL_DIR}/${BINARY_NAME}" </dev/tty
 
-  # Start daemon in background from the shell
+  # Start daemon in background from the shell.
   mkdir -p "${HOME}/.kraki/logs"
-  nohup "${INSTALL_DIR}/${BINARY_NAME}" __daemon-worker \
-    </dev/null >"${HOME}/.kraki/logs/daemon-bootstrap.log" 2>&1 &
-  DAEMON_PID=$!
+  BOOTSTRAP_LOG="${HOME}/.kraki/logs/daemon-bootstrap.log"
 
-  # Brief check that daemon survived startup
-  sleep 1
-  if kill -0 "$DAEMON_PID" 2>/dev/null; then
-    echo "  🦑 Kraki daemon started (PID $DAEMON_PID)"
+  # On macOS the daemon MUST be started through LaunchServices, not through the
+  # ${INSTALL_DIR}/kraki symlink. A binary exec'd by path gets no Launch Services
+  # application identity, so TCC keys its grants to the absolute path + cdhash
+  # and every future update silently revokes Full Disk Access. Launching the
+  # bundle with `open` gives the process its real bundle id (chat.kraki.cli),
+  # whose Developer ID Designated Requirement is cdhash-free and stable.
+  # See docs/mac-tcc-permissions.md.
+  APP_PATH="${HOME}/.local/share/kraki/Kraki.app"
+  if [ "$(uname -s)" = "Darwin" ] && [ -d "$APP_PATH" ]; then
+    open -n -a "$APP_PATH" \
+      --stdout "$BOOTSTRAP_LOG" --stderr "$BOOTSTRAP_LOG" \
+      --env "PATH=${PATH}" --env "HOME=${HOME}" \
+      --args __daemon-worker
+    # `open` returns as soon as the app is launched, so confirm by process name
+    # rather than by a PID we never owned.
+    sleep 2
+    if pgrep -f "Kraki.app/Contents/MacOS/kraki __daemon-worker" >/dev/null 2>&1; then
+      echo "  🦑 Kraki daemon started (via LaunchServices)"
+    else
+      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
+    fi
   else
-    echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
+    nohup "${INSTALL_DIR}/${BINARY_NAME}" __daemon-worker \
+      </dev/null >"$BOOTSTRAP_LOG" 2>&1 &
+    DAEMON_PID=$!
+    sleep 1
+    if kill -0 "$DAEMON_PID" 2>/dev/null; then
+      echo "  🦑 Kraki daemon started (PID $DAEMON_PID)"
+    else
+      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
+    fi
   fi
   echo ""
 }

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/daemon-launch-tcc.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-launch-tcc.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression tests for the macOS TCC launch mechanism.
+ *
+ * "TCC permissions reset on every update" was diagnosed and fixed six times
+ * (#123, #133, #138, #142, and two TCC-warmup commits) and relapsed every time.
+ * The reason it kept coming back is that the thing that actually causes it — HOW
+ * the daemon process is launched — was never asserted anywhere.
+ *
+ * Measured behaviour these tests lock in (verified on macOS 26.5):
+ *
+ *   bundle launched by execve of Contents/MacOS/<bin>
+ *     -> NSRunningApplication(processIdentifier:) == nil
+ *     -> lsappinfo info -only bundleid <pid> == NULL
+ *     -> no Launch Services identity, so TCC keys the grant by absolute path
+ *        (client_type=1) and revalidates cdhash -> every update breaks it
+ *
+ *   same bundle launched via `open`
+ *     -> NSRunningApplication resolves, lsappinfo reports the bundle id
+ *     -> TCC keys the grant by bundle id against a cdhash-free Designated
+ *        Requirement -> the grant survives updates
+ *
+ * Info.plist flags do NOT change this: LSBackgroundOnly and LSUIElement both
+ * behave identically under each launch method.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildLaunchdPlist, INTERNAL_DAEMON_WORKER_COMMAND } from '../daemon.js';
+
+const BASE = {
+  label: 'cloud.corelli.kraki',
+  execPath: '/Users/u/.local/share/kraki/Kraki.app/Contents/MacOS/kraki',
+  bootstrapLogPath: '/Users/u/.kraki/logs/daemon-bootstrap.log',
+  workingDirectory: '/Users/u',
+  envEntries: [
+    ['NODE_ENV', 'production'],
+    ['LOG_LEVEL', 'info'],
+  ] as [string, string][],
+};
+const BUNDLE = '/Users/u/.local/share/kraki/Kraki.app';
+
+/** Extract ProgramArguments in order. */
+function programArgs(plist: string): string[] {
+  const block = plist.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/);
+  if (!block) return [];
+  return [...block[1].matchAll(/<string>([\s\S]*?)<\/string>/g)].map(m => m[1]);
+}
+
+describe('buildLaunchdPlist — bundled install (the TCC-critical path)', () => {
+  const plist = buildLaunchdPlist({ ...BASE, appBundle: BUNDLE });
+  const args = programArgs(plist);
+
+  it('launches through LaunchServices, not by execve of the raw Mach-O', () => {
+    expect(args[0]).toBe('/usr/bin/open');
+    // The regression to guard against: the executable path appearing as argv[0],
+    // which is what leaves the daemon without a Launch Services identity.
+    expect(args[0]).not.toBe(BASE.execPath);
+  });
+
+  it('targets the .app bundle with -a so the process inherits the bundle id', () => {
+    const i = args.indexOf('-a');
+    expect(i).toBeGreaterThan(0);
+    expect(args[i + 1]).toBe(BUNDLE);
+  });
+
+  it('passes -W so launchd still supervises the daemon lifetime', () => {
+    // Without -W, `open` returns immediately and launchd loses track of the
+    // daemon entirely — it would never notice a crash.
+    expect(args).toContain('-W');
+  });
+
+  it('passes -n so a stale instance is never silently reactivated', () => {
+    expect(args).toContain('-n');
+  });
+
+  it('still reaches the daemon-worker entry point', () => {
+    const i = args.indexOf('--args');
+    expect(i).toBeGreaterThan(0);
+    expect(args[i + 1]).toBe(INTERNAL_DAEMON_WORKER_COMMAND);
+    // --args must come last: `open` treats everything after it as app argv.
+    expect(i + 2).toBe(args.length);
+  });
+
+  it('forwards environment via --env, since LS-launched apps do not inherit it', () => {
+    // An app started through LaunchServices gets the launchd session
+    // environment, NOT the environment of the process that called `open`.
+    // Without --env the daemon would silently lose PATH, proxies and tokens.
+    expect(args).toContain('--env');
+    expect(args).toContain('NODE_ENV=production');
+    expect(args).toContain('LOG_LEVEL=info');
+  });
+
+  it('redirects the daemon stdio, which LaunchServices also does not inherit', () => {
+    const o = args.indexOf('--stdout');
+    const e = args.indexOf('--stderr');
+    expect(o).toBeGreaterThan(0);
+    expect(e).toBeGreaterThan(0);
+    expect(args[o + 1]).toBe(BASE.bootstrapLogPath);
+    expect(args[e + 1]).toBe(BASE.bootstrapLogPath);
+  });
+
+  it('uses KeepAlive=true because `open -W` exits 0 even on SIGKILL', () => {
+    // Verified: `open -W` returns status 0 when the app it waits on is killed,
+    // so KeepAlive/SuccessfulExit=false would never restart a crashed daemon.
+    expect(plist).toMatch(/<key>KeepAlive<\/key>\s*<true\/>/);
+    expect(plist).not.toMatch(/<key>SuccessfulExit<\/key>/);
+  });
+
+  it('throttles restarts so an unlaunchable bundle cannot spin', () => {
+    expect(plist).toMatch(/<key>ThrottleInterval<\/key>\s*<integer>10<\/integer>/);
+  });
+});
+
+describe('buildLaunchdPlist — non-bundled install (fallback)', () => {
+  const plist = buildLaunchdPlist({ ...BASE, appBundle: null });
+  const args = programArgs(plist);
+
+  it('execs the binary directly when there is no bundle to launch', () => {
+    expect(args).toEqual([BASE.execPath, INTERNAL_DAEMON_WORKER_COMMAND]);
+  });
+
+  it('keeps the original exit-code KeepAlive semantics', () => {
+    // Here the job really is the daemon, so exit status is meaningful again.
+    expect(plist).toMatch(/<key>SuccessfulExit<\/key>\s*<false\/>/);
+  });
+});
+
+describe('buildLaunchdPlist — general', () => {
+  it('is well-formed and escapes XML metacharacters in every interpolated field', () => {
+    const plist = buildLaunchdPlist({
+      ...BASE,
+      appBundle: '/Apps/A & B.app',
+      label: 'x<y>z',
+      envEntries: [['V', 'a&b<c>d']],
+    });
+    expect(plist).toContain('/Apps/A &amp; B.app');
+    expect(plist).toContain('x&lt;y&gt;z');
+    expect(plist).toContain('V=a&amp;b&lt;c&gt;d');
+    // No raw & survived (every & must be part of an entity).
+    expect(plist).not.toMatch(/&(?!amp;|lt;|gt;)/);
+  });
+
+  it('sets RunAtLoad so the daemon comes back after a reboot', () => {
+    const plist = buildLaunchdPlist({ ...BASE, appBundle: BUNDLE });
+    expect(plist).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
+  });
+});

--- a/packages/tentacle/src/__tests__/daemon.test.ts
+++ b/packages/tentacle/src/__tests__/daemon.test.ts
@@ -242,6 +242,29 @@ describe('stopDaemon()', () => {
   });
 
   it('sends SIGTERM, clears PID, and returns true', () => {
+    // Model a daemon that honours SIGTERM: the signal lands, and the
+    // liveness probe (signal 0) then reports it gone.
+    let terminated = false;
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((_pid: number, sig?: string | number) => {
+      if (sig === 'SIGTERM') { terminated = true; return true; }
+      if (sig === 0 && terminated) throw new Error('ESRCH');
+      return true;
+    }) as typeof process.kill);
+    mockLoadDaemonPid.mockReturnValue(12345);
+
+    const result = stopDaemon();
+
+    expect(result).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(12345, 'SIGTERM');
+    expect(killSpy).not.toHaveBeenCalledWith(12345, 'SIGKILL');
+    expect(mockClearDaemonPid).toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it('escalates to SIGKILL when the daemon ignores SIGTERM', () => {
+    // Unloading the launchd job no longer kills the daemon — the job is `open`
+    // and the daemon belongs to LaunchServices — so this escalation is the only
+    // backstop left for a hung daemon.
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
     mockLoadDaemonPid.mockReturnValue(12345);
 
@@ -249,9 +272,10 @@ describe('stopDaemon()', () => {
 
     expect(result).toBe(true);
     expect(killSpy).toHaveBeenCalledWith(12345, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(12345, 'SIGKILL');
     expect(mockClearDaemonPid).toHaveBeenCalled();
     killSpy.mockRestore();
-  });
+  }, 10_000);
 
   it('clears PID even if process is already gone', () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -421,8 +421,21 @@ export function getKrakiAppBundlePath(): string | null {
 }
 
 /**
- * Register (or re-register) the installed Kraki.app bundle with Launch
- * Services so TCC tracks permissions by bundle id instead of cdhash.
+ * Register (or re-register) the installed Kraki.app bundle with Launch Services.
+ *
+ * This makes Launch Services aware that the bundle exists ON DISK — which is
+ * what lets System Settings show it with its name and icon, and what keeps the
+ * bundle-id lookup unambiguous. It does NOT by itself make TCC track the daemon
+ * by bundle id.
+ *
+ * TCC's choice between bundle-id and path tracking follows the RUNTIME identity
+ * of the process, which is decided by how the process was launched, not by what
+ * is registered on disk. A binary `execve()`d out of Contents/MacOS has no
+ * Launch Services application identity at all (verified: NSRunningApplication
+ * returns nil for it, and resolves the bundle id for the same bundle started via
+ * `open`), so TCC path-tracks it and the grant dies with the next cdhash change.
+ * The daemon is therefore launched through LaunchServices — see the launch
+ * comment in startDaemonLaunchctl() (daemon.ts), which is the actual fix.
  *
  * Safe to call repeatedly and on every platform:
  *   - non-darwin -> no-op, returns true
@@ -431,9 +444,14 @@ export function getKrakiAppBundlePath(): string | null {
  *
  * Returns true when the bundle looks registered.
  */
-export function registerKrakiAppBundle(): boolean {
+export function registerKrakiAppBundle(appBundlePath?: string): boolean {
   if (platform() !== 'darwin') return true;
-  const appPath = getKrakiAppBundlePath();
+  // An explicit path is required after an update: the bundle directory has just
+  // been replaced, and deriving it from the still-running process's execPath
+  // either points at the old (now renamed) bundle or, when migrating a
+  // standalone binary to a bundle for the first time, resolves to null — in
+  // which case the freshly installed bundle was never registered at all.
+  const appPath = appBundlePath ?? getKrakiAppBundlePath();
   if (!appPath) return false;
 
   try {
@@ -449,6 +467,68 @@ export function registerKrakiAppBundle(): boolean {
     // bundle id once the user adds it in System Settings.
     return false;
   }
+}
+
+/**
+ * Whether a running process has a Launch Services application identity, i.e.
+ * whether TCC has a bundle id to key its grants on.
+ *
+ * This is the signal that was missing while "permissions reset on every update"
+ * was misdiagnosed six times. Registering the bundle on disk and cleaning zombie
+ * Launch Services entries are both visible and both looked correct, while the
+ * thing that actually decides bundle-id vs path tracking — the runtime identity
+ * of the daemon process — was never measured.
+ *
+ * `lsappinfo` answers it without a compiled helper. A process launched through
+ * LaunchServices reports its bundle id; one `execve()`d straight out of
+ * Contents/MacOS reports NULL, and NULL means TCC is path-tracking it and the
+ * grant will not survive the next update.
+ *
+ * Returns the bundle id, or null when the process has no LS identity (or on any
+ * lookup failure — this is a diagnostic and must never throw).
+ */
+export function getProcessBundleIdentity(pid: number): string | null {
+  if (platform() !== 'darwin') return null;
+  try {
+    const out = execSync(`/usr/bin/lsappinfo info -only bundleid ${pid}`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    // Present:  "CFBundleIdentifier"="chat.kraki.cli"
+    // Absent:   "CFBundleIdentifier"=[ NULL ]
+    const m = out.match(/"CFBundleIdentifier"\s*=\s*"([^"]+)"/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Report whether the daemon is launched in a way TCC can track by bundle id.
+ *
+ * `healthy: false` with `bundled: true` is the exact state that caused the
+ * recurring permission loss: a correctly signed, correctly registered bundle
+ * whose daemon was nonetheless started by absolute path.
+ */
+export function getDaemonTccIdentity(daemonPid: number | null): {
+  bundled: boolean;
+  bundlePath: string | null;
+  daemonPid: number | null;
+  daemonBundleId: string | null;
+  healthy: boolean;
+} {
+  const bundlePath = getKrakiAppBundlePath();
+  const bundled = bundlePath !== null;
+  const daemonBundleId = daemonPid !== null ? getProcessBundleIdentity(daemonPid) : null;
+  return {
+    bundled,
+    bundlePath,
+    daemonPid,
+    daemonBundleId,
+    // Only meaningful while the daemon is actually running.
+    healthy: daemonPid === null ? bundled : daemonBundleId === KRAKI_BUNDLE_ID,
+  };
 }
 
 /** Ensure the bundle is registered. Convenience wrapper for setup/update. */
@@ -482,8 +562,18 @@ export function unregisterAppBundlePath(appPath: string): void {
   // bundle at the same path (same CFBundleIdentifier), run `-u`, then delete
   // the stub. That is the only reliable way to evict an orphan Launch Services
   // record without a destructive `-kill` db reset.
+  // Only fabricate a stub at a path that is COMPLETELY absent. A directory that
+  // exists but has no Contents/Info.plist is not necessarily ours — it can be a
+  // half-extracted update, or an unrelated directory that merely shares the name.
+  // Writing a stub into it would make the rmSync below delete the whole tree, so
+  // in that case do the plain `-u` and leave the directory alone even if the
+  // zombie entry survives. An uncollected LS record is recoverable; deleting a
+  // user's directory is not.
+  const alreadyExists = existsSync(appPath);
+  const isIntactBundle = existsSync(join(appPath, 'Contents', 'Info.plist'));
   let createdStub = false;
-  if (!existsSync(join(appPath, 'Contents', 'Info.plist'))) {
+
+  if (!alreadyExists) {
     safeTry(() => {
       mkdirSync(join(appPath, 'Contents', 'MacOS'), { recursive: true });
       writeFileSync(join(appPath, 'Contents', 'MacOS', 'kraki'), '#!/bin/sh\n', { mode: 0o755 });
@@ -507,9 +597,9 @@ export function unregisterAppBundlePath(appPath: string): void {
     });
   });
 
-  // Tear down any stub we created (best-effort; never the real bundle, which
-  // always had an Info.plist and so never triggered stub creation).
-  if (createdStub) {
+  // Remove only a stub this call created at a path that did not previously
+  // exist. Never touch a pre-existing directory, intact bundle or not.
+  if (createdStub && !alreadyExists && !isIntactBundle) {
     safeTry(() => rmSync(appPath, { recursive: true, force: true }));
   }
 }

--- a/packages/tentacle/src/cli.ts
+++ b/packages/tentacle/src/cli.ts
@@ -784,7 +784,9 @@ async function cmdPermissions(args: string[]): Promise<void> {
 async function cmdDoctor(): Promise<void> {
   const {
     checkGhAuth, checkCopilotCli, checkClaudeCli, checkAnthropicCreds, probeFda, getKrakiAppBundlePath,
+    getDaemonTccIdentity,
   } = await import('./checks.js');
+  const { loadDaemonPid } = await import('./config.js');
   // `kraki doctor` must emit a single clean JSON line on stdout. The
   // multi-adapter logger (created at module load) defaults to info-level
   // stdout (dev) which would interleave pino lines into the output, so
@@ -829,6 +831,13 @@ async function cmdDoctor(): Promise<void> {
       bundlePath: getKrakiAppBundlePath(),
       // Read-only hint: run `kraki permissions` to (re)register + clean.
       // We intentionally do NOT mutate LS from a status query.
+      //
+      // identity.healthy answers the question that actually predicts whether a
+      // grant survives the next update: does the RUNNING daemon have a Launch
+      // Services bundle identity? A bundled, registered, correctly signed app
+      // still reports healthy:false when its daemon was started by absolute
+      // path — that combination is what made this bug recur six times.
+      identity: getDaemonTccIdentity(loadDaemonPid()),
     },
     ghAuth: ghAuth.authenticated,
     ghUser: ghAuth.username ?? null,

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -27,6 +27,7 @@ import {
   loadDaemonPid,
   clearDaemonPid,
 } from './config.js';
+import { getKrakiAppBundlePath } from './checks.js';
 
 // How long to wait for a regular spawned child to finish bootstrapping
 // before declaring success. No signature verification involved.
@@ -247,6 +248,109 @@ export class MacOSCodeSignatureError extends Error {
  * launchd spawns the process in a clean context, bypassing CSM restrictions.
  * The daemon-worker saves its own PID; we poll for it here.
  */
+/**
+ * Build the launchd job that starts the daemon.
+ *
+ * Exported and pure so the launch mechanism is assertable in CI. That matters
+ * more than it looks: "TCC permissions reset on every update" was diagnosed and
+ * "fixed" six times, and every one of those fixes left the launch mechanism
+ * untested, so each regression was invisible until a user hit it again.
+ *
+ * @param appBundle absolute path to the enclosing .app, or null for a raw binary
+ * @param execPath  the daemon executable, used only in the non-bundled fallback
+ */
+export function buildLaunchdPlist(opts: {
+  label: string;
+  appBundle: string | null;
+  execPath: string;
+  bootstrapLogPath: string;
+  workingDirectory: string;
+  envEntries: [string, string][];
+}): string {
+  const { label, appBundle, execPath, bootstrapLogPath, workingDirectory, envEntries } = opts;
+
+  // How the daemon is launched decides how TCC identifies it, and that decision
+  // is what made Full Disk Access evaporate on every update.
+  //
+  // launchd `execve()`ing Kraki.app/Contents/MacOS/kraki gives the process NO
+  // Launch Services application identity — verified directly: for a bundle
+  // launched that way, NSRunningApplication(processIdentifier:) returns nil and
+  // `lsappinfo info -only bundleid <pid>` reports NULL, while the same bundle
+  // started via `open` resolves to its bundle id. With no bundle identity to key
+  // on, TCC falls back to client_type=1 (absolute path) and, since the macOS 11.4
+  // fix for CVE-2021-30713, revalidates the binary at that path against the
+  // cdhash captured at grant time. Every update writes a new cdhash, so a
+  // path-tracked grant cannot survive one.
+  //
+  // `lsregister -f` does not fix this. It only teaches Launch Services that the
+  // bundle exists ON DISK; it has no effect on the runtime identity of a process
+  // that was exec'd directly. That is why registering the bundle and clearing
+  // zombie LS entries reduced the symptom without ever ending it.
+  //
+  // Launching through LaunchServices is the fix: `open` gives the process a real
+  // bundle identity, so TCC stores the grant against chat.kraki.cli, whose
+  // Designated Requirement is cdhash-free and stable across updates.
+  //   -W  block for the app's lifetime so launchd still supervises the daemon
+  //   -n  always start a fresh instance rather than reactivating a stale one
+  // Info.plist flags are irrelevant here: LSBackgroundOnly and LSUIElement both
+  // resolve fine under `open`, and neither rescues a path-exec'd process.
+  const programArgs: string[] = appBundle
+    ? [
+        '/usr/bin/open',
+        '-W',
+        '-n',
+        '-a', appBundle,
+        '--stdout', bootstrapLogPath,
+        '--stderr', bootstrapLogPath,
+        ...envEntries.flatMap(([k, v]) => ['--env', `${k}=${v}`]),
+        '--args', INTERNAL_DAEMON_WORKER_COMMAND,
+      ]
+    : [execPath, INTERNAL_DAEMON_WORKER_COMMAND];
+
+  // `open -W` returns 0 even when the app it is waiting on is SIGKILLed, so
+  // KeepAlive/SuccessfulExit=false would never fire and a crashed daemon would
+  // stay dead. Supervise unconditionally instead, throttled so a bundle that
+  // refuses to launch cannot spin. The direct-exec fallback keeps the original
+  // exit-code semantics, where they still work.
+  const keepAliveXml = appBundle
+    ? '    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>10</integer>'
+    : '    <key>KeepAlive</key>\n    <dict>\n        <key>SuccessfulExit</key>\n        <false/>\n    </dict>';
+
+  const programArgsXml = programArgs
+    .map(a => `        <string>${escapeXml(a)}</string>`)
+    .join('\n');
+
+  const envXml = envEntries
+    .map(([k, v]) => `        <key>${k}</key>\n        <string>${escapeXml(v)}</string>`)
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${escapeXml(label)}</string>
+    <key>ProgramArguments</key>
+    <array>
+${programArgsXml}
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+${keepAliveXml}
+    <key>EnvironmentVariables</key>
+    <dict>
+${envXml}
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${escapeXml(bootstrapLogPath)}</string>
+    <key>StandardErrorPath</key>
+    <string>${escapeXml(bootstrapLogPath)}</string>
+    <key>WorkingDirectory</key>
+    <string>${escapeXml(workingDirectory)}</string>
+</dict>
+</plist>`;
+}
+
 async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
   const logLevel = getLogVerbosity(config) === 'verbose' ? 'debug' : 'info';
   const bootstrapLogPath = getDaemonBootstrapLogPath();
@@ -278,40 +382,14 @@ async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
     if (process.env[key]) envEntries.push([key, process.env[key]!]);
   }
 
-  const envXml = envEntries
-    .map(([k, v]) => `        <key>${k}</key>\n        <string>${escapeXml(v)}</string>`)
-    .join('\n');
-
-  const plist = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>${getLaunchdLabel()}</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>${escapeXml(process.execPath)}</string>
-        <string>${INTERNAL_DAEMON_WORKER_COMMAND}</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
-    <key>EnvironmentVariables</key>
-    <dict>
-${envXml}
-    </dict>
-    <key>StandardOutPath</key>
-    <string>${escapeXml(bootstrapLogPath)}</string>
-    <key>StandardErrorPath</key>
-    <string>${escapeXml(bootstrapLogPath)}</string>
-    <key>WorkingDirectory</key>
-    <string>${escapeXml(homedir())}</string>
-</dict>
-</plist>`;
+  const plist = buildLaunchdPlist({
+    label: getLaunchdLabel(),
+    appBundle: getKrakiAppBundlePath(),
+    execPath: process.execPath,
+    bootstrapLogPath,
+    workingDirectory: homedir(),
+    envEntries,
+  });
 
   const plistPath = getLaunchdPlistPath();
   writeFileSync(plistPath, plist);
@@ -388,6 +466,12 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
 }
 
 export function stopDaemon(): boolean {
+  // Unload the launchd job BEFORE signalling the daemon. The bundled macOS job
+  // runs with KeepAlive=true (see startDaemonLaunchctl), so killing first would
+  // let launchd restart the daemon in the window before the job is unloaded and
+  // `kraki stop` would appear to do nothing.
+  if (process.platform === 'darwin') cleanupLaunchdPlist();
+
   const pid = loadDaemonPid();
   if (pid !== null) {
     try {
@@ -397,9 +481,6 @@ export function stopDaemon(): boolean {
     }
     clearDaemonPid();
   }
-
-  // On macOS, also clean up launchd agent
-  if (process.platform === 'darwin') cleanupLaunchdPlist();
 
   return pid !== null;
 }

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -244,11 +244,6 @@ export class MacOSCodeSignatureError extends Error {
 // ── Start / Stop ────────────────────────────────────────
 
 /**
- * Start the daemon via launchctl on macOS SEA.
- * launchd spawns the process in a clean context, bypassing CSM restrictions.
- * The daemon-worker saves its own PID; we poll for it here.
- */
-/**
  * Build the launchd job that starts the daemon.
  *
  * Exported and pure so the launch mechanism is assertable in CI. That matters
@@ -351,6 +346,17 @@ ${envXml}
 </plist>`;
 }
 
+/**
+ * Start the daemon via launchctl on macOS SEA.
+ *
+ * launchd spawns the job in a clean context, bypassing CSM restrictions. For a
+ * bundled install the job is `open`, which hands the actual launch to
+ * LaunchServices so the daemon gets a real bundle identity — see
+ * buildLaunchdPlist() for why that is load-bearing.
+ *
+ * Either way the daemon-worker saves its own PID, so the poll below reads the
+ * daemon's PID and not the PID of whatever launched it.
+ */
 async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
   const logLevel = getLogVerbosity(config) === 'verbose' ? 'debug' : 'info';
   const bootstrapLogPath = getDaemonBootstrapLogPath();
@@ -470,17 +476,48 @@ export function stopDaemon(): boolean {
   // runs with KeepAlive=true (see startDaemonLaunchctl), so killing first would
   // let launchd restart the daemon in the window before the job is unloaded and
   // `kraki stop` would appear to do nothing.
+  //
+  // Unloading is no longer sufficient on its own, either. The job is now `open`,
+  // and the daemon it launches belongs to LaunchServices rather than to launchd
+  // — verified: after `launchctl unload` the daemon is still running. Before, the
+  // daemon WAS the job process and the unload killed it. So the PID-based signal
+  // below is now the only thing that actually stops the daemon, and it has to
+  // succeed.
   if (process.platform === 'darwin') cleanupLaunchdPlist();
 
   const pid = loadDaemonPid();
-  if (pid !== null) {
-    try {
-      process.kill(pid, 'SIGTERM');
-    } catch {
-      // Process already gone
-    }
+  if (pid === null) return false;
+
+  const alive = () => {
+    try { process.kill(pid, 0); return true; } catch { return false; }
+  };
+
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    // Process already gone.
     clearDaemonPid();
+    return true;
   }
 
-  return pid !== null;
+  // Escalate if it ignores SIGTERM. Only ever targets the PID recorded under
+  // THIS Kraki home, so a dev instance can never take down the global daemon
+  // (the reason the launchd label is KRAKI_HOME-scoped in the first place) —
+  // which is also why there is deliberately no pkill-by-name fallback here: with
+  // no PID file there is no way to tell whose daemon a process is.
+  // 5s: the daemon's SIGTERM handler disconnects the relay and stops the
+  // adapter before exiting, so cutting it off too early truncates a real
+  // shutdown. It exits well inside this window when healthy, so `kraki stop`
+  // still returns promptly.
+  const deadline = Date.now() + 5000;
+  const idle = new Int32Array(new SharedArrayBuffer(4));
+  while (Date.now() < deadline && alive()) {
+    Atomics.wait(idle, 0, 0, 100);   // synchronous sleep; spawns nothing
+  }
+  if (alive()) {
+    try { process.kill(pid, 'SIGKILL'); } catch { /* raced us to exit */ }
+  }
+
+  clearDaemonPid();
+  return true;
 }

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -677,14 +677,19 @@ async function updateViaAppBundle(
     // Clean up backup
     rmSync(backupDir, { recursive: true, force: true });
 
-    // Re-register the new bundle with Launch Services. This is THE fix
-    // for the recurring "kraki lost its permissions after update" bug:
-    // it refreshes TCC's bundle-id -> path binding so every previously
-    // granted TCC service (FDA / Accessibility / Screen Recording / ...)
-    // continues to resolve to the new binary via the stable Developer ID
-    // Designated Requirement, instead of being invalidated by the cdhash
-    // change. Best-effort; never fatal if lsregister is unavailable.
-    registerKrakiAppBundle();
+    // Re-register the new bundle with Launch Services so System Settings keeps
+    // showing it by name and icon and the bundle-id lookup stays unambiguous.
+    //
+    // Pass targetAppDir explicitly. The no-argument form derives the bundle from
+    // the RUNNING process's execPath, which at this point is the old bundle that
+    // was just renamed to <target>.bak — and in the standalone-to-bundle
+    // migration it resolves to null, so the newly installed bundle was never
+    // registered at all.
+    //
+    // Registration alone does NOT preserve TCC grants across an update; only the
+    // launch mechanism does that (see buildLaunchdPlist in daemon.ts). Best-effort;
+    // never fatal if lsregister is unavailable.
+    registerKrakiAppBundle(targetAppDir);
     // Purge zombie Launch Services entries left by prior updates / test
     // builds (paths that no longer exist under /private/tmp, DerivedData,
     // etc.). Without this, TCC can mis-resolve the daemon's bundle and


### PR DESCRIPTION
## The bug, and why it came back seven times

"kraki loses Full Disk Access on every update" has now been fixed seven times (#123, #133, #138, #142, #182, plus two earlier TCC-warmup commits). Every one of those fixed something real. None of them fixed the mechanism, because **the mechanism was never measured**.

The launchd job `execve()`s `Kraki.app/Contents/MacOS/kraki` directly. A process launched that way has **no Launch Services application identity at all**. Measured against the live install:

```
lsappinfo info -only bundleid 6856  ->  "CFBundleIdentifier"=[ NULL ]
```

With no bundle identity to key on, TCC falls back to `client_type=1` (absolute path) and — since the macOS 11.4 fix for CVE-2021-30713 — revalidates the binary at that path against the cdhash captured at grant time. Every update rewrites that cdhash, so a path-tracked grant *cannot* survive one. Keeping the path stable does not help; it is precisely the case that breaks.

#182 diagnosed this as "Bug 1" but only argued around it, claiming it was "addressed by keeping the canonical path stable and keeping Launch Services unambiguous". `lsregister -f` only tells Launch Services the bundle exists **on disk**; it has no effect on the runtime identity of a process that was already exec'd directly.

## Measured, not assumed

Four bundle/launch combinations plus a real launchd job, on macOS 26.5:

| `Info.plist` | Launched by | LS identity |
|---|---|---|
| `LSBackgroundOnly` + `LSUIElement` (our config) | `execve` | **none** |
| `LSUIElement` only | `execve` | **none** |
| `LSBackgroundOnly` + `LSUIElement` | `open` | bundle id resolves |
| `LSUIElement` only | `open` | bundle id resolves |
| — | launchd job running `open -W -n -a` | bundle id resolves |

So: the **launch method decides everything**, `Info.plist` flags are irrelevant, and a plain non-AppKit Node SEA binary *does* get a full bundle identity under `open`.

## The fix

`buildLaunchdPlist()` now emits, for any bundled install:

```
/usr/bin/open -W -n -a <Kraki.app> --stdout <log> --stderr <log> --env K=V … --args __daemon-worker
```

Three details that are load-bearing, each verified rather than assumed:

- **`open -W` exits 0 even when the app is SIGKILLed**, so `KeepAlive/SuccessfulExit=false` would never fire and a crashed daemon would stay dead. Now `KeepAlive: true` + `ThrottleInterval: 10`.
- **LS-launched apps inherit the launchd session environment, not the caller's.** Without `--env` the daemon silently loses `PATH`, proxies and tokens. Same for stdio.
- **`stopDaemon()` now unloads the job *before* signalling the daemon** — under `KeepAlive: true`, killing first lets launchd resurrect it in the gap and `kraki stop` appears to do nothing.

Both installers were doing the same thing wrong (`nohup "${INSTALL_DIR}/kraki" __daemon-worker` through the symlink), so even the *first* daemon a user granted FDA to was path-tracked. Both now launch via `open` on macOS.

Non-bundled installs keep direct `execve` and the original exit-code semantics.

## Regression guard

`buildLaunchdPlist()` is exported and pure specifically so the launch mechanism is asserted in CI. **This is the actual fix for the recurrence** — the bug relapsed six times because nothing ever tested *how* the daemon was launched. 13 new tests in `daemon-launch-tcc.test.ts`.

New diagnostic: `kraki doctor` reports `tcc.identity.daemonBundleId`. `null` with `bundled: true` is the broken state, and is the single field whose absence let this recur.

## Also fixed (same code path)

- `registerKrakiAppBundle()` now takes an explicit path; `update.ts` passes the new `targetAppDir`. The no-arg form derived the bundle from the running process's `execPath` — the old bundle, already renamed to `.bak` — and returned `null` during standalone→bundle migration, so the new bundle was never registered at all.
- `unregisterAppBundlePath()` only fabricates its eviction stub at a path that is **completely absent**. It previously wrote a stub into any directory lacking `Contents/Info.plist` then `rmSync`'d the whole tree — which would delete a half-extracted update or an unrelated same-named directory.
- `release.yml`: sign inside-out instead of `--deep` (deprecated; applies outer entitlements to nested binaries), **staple** the notarization ticket, and build the tarball **after** stapling — it was built before notarization, so shipped bundles carried no ticket and needed an online Gatekeeper check.

## Verified

- `pnpm validate` — exit 0 (lint + build + tentacle 797/797 + arm-web 411/411)
- Under real launchd: bundle id resolves, job stays supervised, daemon restarts ~1s after `kill -9` with identity intact
- A Developer-ID bundle launched via LaunchServices kept Screen Recording, Accessibility, Input Monitoring and Microphone across a cdhash-changing version bump
- Emitted plist passes `plutil -lint`

**Not verified, and the one thing left:** that a freshly granted FDA on the updated kraki survives the *next* real release. The mechanism is proven; the production round-trip needs one user grant after installing 0.31.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)