### PR TITLE
fix(tentacle): source pi thinking levels per model so max effort is reachable

### DIFF
--- a/packages/tentacle/src/__tests__/pi-thinking-levels.test.ts
+++ b/packages/tentacle/src/__tests__/pi-thinking-levels.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the pi adapter's thinking-level ladder.
+ *
+ * pi's ladder is off|minimal|low|medium|high|xhigh|max and `max` is a rung of its
+ * own — on Anthropic's adaptive-thinking models it is the only one that reaches
+ * the top effort. The adapter used to fold `max` into `xhigh` and advertise one
+ * fixed ladder for every model, so the top rung was unreachable and models were
+ * credited with rungs pi then clamped away. These tests pin the per-model
+ * derivation (a mirror of pi-ai's `getSupportedThinkingLevels`) and the mapping.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  defaultEffortFor,
+  effortToThinking,
+  FALLBACK_EFFORTS,
+  piThinkingLevelsFor,
+  type PiCatalogModel,
+} from '../adapters/pi.js';
+
+const model = (over: Partial<PiCatalogModel>): PiCatalogModel => ({
+  id: 'm', provider: 'p', reasoning: true, ...over,
+});
+
+describe('effortToThinking — Kraki effort → pi ThinkingLevel', () => {
+  it('passes every rung through by name', () => {
+    expect(effortToThinking('low')).toBe('low');
+    expect(effortToThinking('medium')).toBe('medium');
+    expect(effortToThinking('high')).toBe('high');
+    expect(effortToThinking('xhigh')).toBe('xhigh');
+  });
+
+  it('keeps max as its own rung rather than folding it into xhigh', () => {
+    expect(effortToThinking('max')).toBe('max');
+  });
+
+  it('returns undefined for an unset or unknown effort', () => {
+    expect(effortToThinking(undefined)).toBeUndefined();
+    expect(effortToThinking('ultra')).toBeUndefined();
+  });
+});
+
+describe('piThinkingLevelsFor — per-model rungs from the catalog', () => {
+  it('offers nothing for a non-reasoning model', () => {
+    expect(piThinkingLevelsFor(model({ reasoning: false }))).toEqual([]);
+  });
+
+  it('treats xhigh and max as opt-in — absent from the map means absent', () => {
+    // e.g. anthropic/claude-haiku-4-5: reasoning, but no map at all.
+    expect(piThinkingLevelsFor(model({}))).toEqual(['low', 'medium', 'high']);
+  });
+
+  it('grants xhigh and max only when the map declares them', () => {
+    // e.g. anthropic/claude-opus-5 and claude-fable-5.
+    expect(piThinkingLevelsFor(model({
+      thinkingLevelMap: { xhigh: 'xhigh', max: 'max' },
+    }))).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+  });
+
+  it('honours a max-without-xhigh model', () => {
+    // e.g. zai/glm-5.2: adaptive max, no native xhigh.
+    expect(piThinkingLevelsFor(model({
+      thinkingLevelMap: { minimal: null, low: 'high', medium: 'high', high: 'high', max: 'max' },
+    }))).toEqual(['low', 'medium', 'high', 'max']);
+  });
+
+  it('drops rungs the map nulls out', () => {
+    // e.g. 1yuan-gpt/gpt-5.6-luna: everything above low is unavailable.
+    expect(piThinkingLevelsFor(model({
+      thinkingLevelMap: { off: 'low', minimal: 'low', low: 'low', medium: null, high: null, xhigh: null },
+    }))).toEqual(['low']);
+  });
+
+  it('never surfaces off or minimal — Kraki has no such rung', () => {
+    const levels = piThinkingLevelsFor(model({ thinkingLevelMap: { off: null } }));
+    expect(levels).not.toContain('off');
+    expect(levels).not.toContain('minimal');
+  });
+});
+
+describe('defaultEffortFor', () => {
+  it('defaults to high when the model has it', () => {
+    expect(defaultEffortFor(['low', 'medium', 'high', 'xhigh', 'max'])).toBe('high');
+  });
+
+  it('walks down to the strongest available rung below high', () => {
+    expect(defaultEffortFor(['low'])).toBe('low');
+    expect(defaultEffortFor(['low', 'medium'])).toBe('medium');
+  });
+
+  it('is undefined when the model has no rungs at all', () => {
+    expect(defaultEffortFor([])).toBeUndefined();
+  });
+
+  it('keeps the pre-existing default for the fallback ladder', () => {
+    expect(defaultEffortFor(FALLBACK_EFFORTS)).toBe('high');
+  });
+});

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -76,7 +76,8 @@ export interface PiRpcOptions {
   /** Resume an existing on-disk session file. */
   sessionFile?: string;
   appendSystemPrompt?: string;
-  /** Thinking level: off|minimal|low|medium|high|xhigh (xhigh = max). */
+  /** Thinking level: off|minimal|low|medium|high|xhigh|max — `max` is pi's own
+   *  top rung, above xhigh, not an alias for it. */
   thinking?: string;
   /** Path to a pi extension loaded via `--extension`. Kraki always loads its
    *  tools extension (finalize_reply / ask_user + permission gate). */
@@ -305,14 +306,17 @@ export function parsePiPermission(toolName: string, inputJson: string): { toolAr
   }
 }
 
-/** Kraki ReasoningEffort → pi ThinkingLevel. pi tops out at xhigh; "max" maps there. */
-function effortToThinking(effort?: string): string | undefined {
+/** Kraki ReasoningEffort → pi ThinkingLevel. The names line up 1:1 — pi's ladder
+ *  is off|minimal|low|medium|high|xhigh|max, so `max` is a rung of its own and
+ *  must not be folded into xhigh. On Anthropic's adaptive-thinking models each
+ *  rung becomes an effort value and only `max` reaches the top one. */
+export function effortToThinking(effort?: string): string | undefined {
   switch (effort) {
     case 'low': return 'low';
     case 'medium': return 'medium';
     case 'high': return 'high';
-    case 'xhigh':
-    case 'max': return 'xhigh';
+    case 'xhigh': return 'xhigh';
+    case 'max': return 'max';
     default: return undefined;
   }
 }
@@ -440,6 +444,50 @@ function resolveDefaultModel(models: PiModelRow[]): string {
   // Prefer a pro/large model as default, then the first model
   const preferred = models.find(m => m.model.includes('pro') || m.model.includes('opus')) ?? models[0];
   return `${preferred.provider}/${preferred.model}`;
+}
+
+// ── Per-model thinking levels via the `get_available_models` RPC ───
+
+/** The slice of a pi catalog entry we need. `--list-models` reports thinking as
+ *  a bare yes/no, so the thinkingLevelMap — the thing that says which rungs a
+ *  model actually has — is only reachable over RPC. */
+export interface PiCatalogModel {
+  id: string;
+  provider: string;
+  reasoning?: boolean;
+  thinkingLevelMap?: Record<string, string | null>;
+}
+
+/** pi's ladder, weakest first. Kraki has no `off`/`minimal` rung. */
+const PI_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+const KRAKI_EFFORTS: ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+/** Ladder to fall back on when the catalog is unreachable: what the adapter
+ *  offered for every reasoning model before it could ask per model. */
+export const FALLBACK_EFFORTS: ReasoningEffort[] = ['high', 'xhigh'];
+
+/** Mirrors pi-ai's `getSupportedThinkingLevels`. off/minimal/low/medium/high are
+ *  available unless the model's map nulls them out; xhigh and max are opt-in —
+ *  a model only has them if its map declares them. Anything else would advertise
+ *  rungs pi then silently clamps away. */
+export function piThinkingLevelsFor(model: PiCatalogModel): ReasoningEffort[] {
+  if (!model.reasoning) return [];
+  return PI_THINKING_LEVELS.filter(level => {
+    const mapped = model.thinkingLevelMap?.[level];
+    if (mapped === null) return false;
+    if (level === 'xhigh' || level === 'max') return mapped !== undefined;
+    return true;
+  }).filter((level): level is ReasoningEffort =>
+    (KRAKI_EFFORTS as readonly string[]).includes(level));
+}
+
+/** `high` when the model has it, else the strongest rung below it — the same
+ *  direction pi's own clamp walks. */
+export function defaultEffortFor(efforts: ReasoningEffort[]): ReasoningEffort | undefined {
+  for (let i = KRAKI_EFFORTS.indexOf('high'); i >= 0; i--) {
+    if (efforts.includes(KRAKI_EFFORTS[i])) return KRAKI_EFFORTS[i];
+  }
+  return efforts[0];
 }
 
 /** Minimal shape of pi's streamed `assistantMessageEvent` (message_update RPC).
@@ -1582,16 +1630,80 @@ export class PiAdapter extends AgentAdapter {
     return this.fetchModels().map(m => `${m.provider}/${m.model}`);
   }
 
+  private cachedEfforts: Map<string, ReasoningEffort[]> | null = null;
+
+  /** Ask pi for its catalog over a throwaway rpc process. This is the only
+   *  interface that exposes each model's thinkingLevelMap, and thus the only way
+   *  to tell a model that genuinely has `max` (Opus 5, Fable 5, GLM 5.2) from one
+   *  whose top rung is `low` (GPT-5.6 Luna). Best-effort: on any failure the
+   *  caller keeps the old fixed ladder rather than losing the model list. */
+  private async fetchEfforts(): Promise<Map<string, ReasoningEffort[]>> {
+    if (this.cachedEfforts) return this.cachedEfforts;
+    const efforts = new Map<string, ReasoningEffort[]>();
+    try {
+      const models = await this.queryCatalog();
+      for (const m of models) {
+        if (!m?.id || !m?.provider) continue;
+        efforts.set(`${m.provider}/${m.id}`, piThinkingLevelsFor(m));
+      }
+      logger.info({ count: efforts.size }, 'Fetched pi thinking levels');
+    } catch (err) {
+      logger.warn({ err: (err as Error).message }, 'Could not fetch pi thinking levels, using default ladder');
+    }
+    this.cachedEfforts = efforts;
+    return efforts;
+  }
+
+  private queryCatalog(timeoutMs = 15_000): Promise<PiCatalogModel[]> {
+    return new Promise((resolve, reject) => {
+      // --no-session: this process only answers one question, it must not leave a
+      // session file behind next to the user's real ones.
+      const child = spawn(this.cliPath, ['--mode', 'rpc', '--no-session'], {
+        env: process.env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const rl = createInterface({ input: child.stdout });
+      let settled = false;
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        rl.close();
+        child.kill();
+        fn();
+      };
+      const timer = setTimeout(
+        () => finish(() => reject(new Error('pi catalog query timed out'))),
+        timeoutMs,
+      );
+
+      rl.on('line', line => {
+        let msg: { type?: string; command?: string; data?: { models?: PiCatalogModel[] } };
+        try { msg = JSON.parse(line); } catch { return; }
+        if (msg.type === 'response' && msg.command === 'get_available_models') {
+          finish(() => resolve(msg.data?.models ?? []));
+        }
+      });
+      child.on('error', err => finish(() => reject(err)));
+      child.on('exit', () => finish(() => reject(new Error('pi exited before answering'))));
+      child.stdin.write(`${JSON.stringify({ id: 'models', type: 'get_available_models' })}\n`);
+    });
+  }
+
   async listModelDetails(): Promise<ModelDetail[]> {
-    const efforts: ReasoningEffort[] = ['high', 'xhigh'];
-    return this.fetchModels().map(m => ({
-      id: `${m.provider}/${m.model}`,
-      name: `${m.provider.charAt(0).toUpperCase() + m.provider.slice(1)} ${m.model}`,
-      supportsReasoningEffort: m.reasoning,
-      supportedReasoningEfforts: m.reasoning ? efforts : undefined,
-      defaultReasoningEffort: m.reasoning ? 'high' as const : undefined,
-      contextWindow: m.contextWindow,
-    }));
+    const byModel = await this.fetchEfforts();
+    return this.fetchModels().map(m => {
+      const id = `${m.provider}/${m.model}`;
+      const efforts = byModel.get(id) ?? (m.reasoning ? FALLBACK_EFFORTS : []);
+      return {
+        id,
+        name: `${m.provider.charAt(0).toUpperCase() + m.provider.slice(1)} ${m.model}`,
+        supportsReasoningEffort: m.reasoning && efforts.length > 0,
+        supportedReasoningEfforts: efforts.length > 0 ? efforts : undefined,
+        defaultReasoningEffort: defaultEffortFor(efforts),
+        contextWindow: m.contextWindow,
+      };
+    });
   }
 
   getSessionUsage(sessionId: string): SessionUsage | null {

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -1664,6 +1664,7 @@ export class PiAdapter extends AgentAdapter {
       });
       const rl = createInterface({ input: child.stdout });
       let settled = false;
+      let lastStderr = '';
       const finish = (fn: () => void) => {
         if (settled) return;
         settled = true;
@@ -1672,10 +1673,9 @@ export class PiAdapter extends AgentAdapter {
         child.kill();
         fn();
       };
-      const timer = setTimeout(
-        () => finish(() => reject(new Error('pi catalog query timed out'))),
-        timeoutMs,
-      );
+      const fail = (reason: string) =>
+        finish(() => reject(new Error(lastStderr ? `${reason}: ${lastStderr}` : reason)));
+      const timer = setTimeout(() => fail('pi catalog query timed out'), timeoutMs);
 
       rl.on('line', line => {
         let msg: { type?: string; command?: string; data?: { models?: PiCatalogModel[] } };
@@ -1684,9 +1684,19 @@ export class PiAdapter extends AgentAdapter {
           finish(() => resolve(msg.data?.models ?? []));
         }
       });
+      // Drain stderr rather than leaving it piped and unread: a full pipe buffer
+      // would block pi mid-write and stall the query until the timeout. Keeping
+      // the last chunk also gives the rejection something to say.
+      child.stderr.on('data', d => { lastStderr = String(d).trim().slice(-200) || lastStderr; });
       child.on('error', err => finish(() => reject(err)));
-      child.on('exit', () => finish(() => reject(new Error('pi exited before answering'))));
-      child.stdin.write(`${JSON.stringify({ id: 'models', type: 'get_available_models' })}\n`);
+      child.on('exit', () => fail('pi exited before answering'));
+      // An unhandled 'error' on stdin is a process-level crash, and this stream
+      // breaks whenever pi dies early — a degraded ladder is the acceptable
+      // outcome here, taking the daemon down with it is not.
+      child.stdin.on('error', () => fail('pi stdin closed before the query was sent'));
+      if (child.stdin.writable) {
+        child.stdin.write(`${JSON.stringify({ id: 'models', type: 'get_available_models' })}\n`);
+      }
     });
   }
 


### PR DESCRIPTION
## Problem

The pi adapter advertised one hardcoded ladder — `['high','xhigh']` — for **every** reasoning-capable model, and `effortToThinking` folded `max` into `xhigh`. Two consequences:

- **pi's top rung was unreachable.** On Anthropic's adaptive-thinking models (Opus 5, Fable 5, Sonnet 5) each rung becomes an `output_config.effort` value, and only `max` reaches the top one — so Kraki could never ask for it.
- **Models were credited with rungs they don't have.** GPT-5.6 Luna tops out at `low` and Haiku 4.5 has no xhigh, yet both were offered xhigh; pi silently clamped, so the picker showed choices that did nothing.

## Fix

`pi --list-models` reports thinking as a bare yes/no — which is why the ladder was hardcoded. The `get_available_models` RPC *does* carry each model's `thinkingLevelMap`, so ask that instead over a throwaway rpc process and mirror pi-ai's own `getSupportedThinkingLevels` rule: `off/minimal/low/medium/high` are available unless the map nulls them out, while `xhigh` and `max` are opt-in.

Best-effort by design — if the query fails the old fixed ladder still applies, so a pi that can't answer costs the top rung, never the model list.

## Verified live against pi 0.80.10

| model | efforts offered | default |
|---|---|---|
| `anthropic/claude-opus-5` | low, medium, high, xhigh, **max** | high |
| `anthropic/claude-fable-5` | low, medium, high, xhigh, **max** | high |
| `zai/glm-5.2` | low, medium, high, **max** (no native xhigh) | high |
| `anthropic/claude-haiku-4-5` | low, medium, high | high |
| `1yuan-gpt/gpt-5.6-luna` | low | low |

The arm UI already labels and renders `max` (`EFFORT_LABELS`, `SessionInfoPanel`), so no web change is needed.

`pnpm validate` passes; 13 new unit tests pin the derivation rule and the effort→ThinkingLevel mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)