### PR TITLE
chore(release): v0.31.6

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release bump for **v0.31.6**.

Ships #196 — the pi adapter now sources each model's thinking-level ladder from pi's own catalog (`get_available_models`) instead of advertising one hardcoded `['high','xhigh']` for everything, so `max` is reachable and models no longer get credited with rungs pi silently clamps away.

| model | efforts offered |
|---|---|
| `anthropic/claude-opus-5`, `claude-fable-5` | low, medium, high, xhigh, **max** |
| `zai/glm-5.2` | low, medium, high, **max** |
| `anthropic/claude-haiku-4-5` | low, medium, high |
| `1yuan-gpt/gpt-5.6-luna` | low |

🤖 Generated with [Claude Code](https://claude.com/claude-code)