### PR TITLE
fix(head): harden Pulse endpoint lifecycle and unicast authorization

### DIFF
--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -16,7 +16,7 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
-    "@coinfra/pulse": "^0.4.1",
+    "@coinfra/pulse": "^0.5.0",
     "@kraki/protocol": "workspace:*",
     "highlight.js": "^11.10.0",
     "idb": "^8.0.3",

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@coinfra/pulse": "^0.4.1",
+    "@coinfra/pulse": "^0.5.0",
     "@kraki/crypto": "workspace:*",
     "@kraki/protocol": "workspace:*",
     "better-sqlite3": "^11.0.0",

--- a/packages/head/src/__tests__/pulse-hub.test.ts
+++ b/packages/head/src/__tests__/pulse-hub.test.ts
@@ -363,4 +363,68 @@ describe('PulseHub GC (spec §11.4)', () => {
     const persistedSeqs = (s.outbox as Array<{ seq: string; durable: boolean }>).map((e) => e.seq).sort();
     expect(persistedSeqs).toEqual(['2']); // only the durable entry
   });
+
+  it('GC reclaims an endpoint that was only ever created while its device was OFFLINE', () => {
+    // Regression: a freshly-constructed Endpoint is Disconnected but reports
+    // disconnectedAtMs === null ("never disconnected in this run"), and the GC
+    // skips exactly that case. Endpoints minted by forward()-to-an-offline-
+    // device (and by recoverOnBoot) therefore became permanently immortal:
+    // never L1-purged, never L2-evicted. This is the common case in prod, where
+    // most registered arms are offline most of the time.
+    const w = new GcWorld(db, { purgeNonDurableAfterMs: 1_000, evictEndpointAfterMs: 5_000, intervalMs: 0 });
+    w.connectArm();
+    // Tentacle is never connected in this run — the hub mints its endpoint
+    // lazily on the first forward.
+    w.armSend(1, false);
+    w.advance(1_000);
+    expect(w.hub.endpointCount()).toBe(2); // arm + lazily-created tentacle
+
+    w.advance(10_000);
+    w.hub.gcTick();
+    // The never-connected tentacle endpoint must be evicted; arm stays.
+    expect(w.hub.endpointCount()).toBe(1);
+  });
+
+  it('GC does not re-snapshot devices that purged nothing', () => {
+    // Regression: gcTick tested the CUMULATIVE purged/evicted counters inside
+    // the per-device loop, so once any earlier device purged, every subsequent
+    // device in the scan got a redundant saveSnapshot() — reintroducing the
+    // per-message SQLite write storm the hub exists to avoid.
+    const w = new GcWorld(db, { purgeNonDurableAfterMs: 1_000, evictEndpointAfterMs: 0, intervalMs: 0 });
+    w.connectArm();
+    w.armSend(1, false); // creates + queues on the offline tentacle endpoint
+    w.advance(5_000);
+    w.hub.gcTick(); // purges the tentacle's non-durable queue
+
+    // Second scan: nothing left to purge anywhere, so no snapshot writes.
+    let writes = 0;
+    const realPrepare = db.prepare.bind(db);
+    (db as unknown as { prepare: typeof db.prepare }).prepare = ((sql: string) => {
+      if (sql.includes('INSERT OR REPLACE INTO pulse_meta')) writes++;
+      return realPrepare(sql);
+    }) as typeof db.prepare;
+    try {
+      w.hub.gcTick();
+    } finally {
+      (db as unknown as { prepare: typeof db.prepare }).prepare = realPrepare;
+    }
+    expect(writes).toBe(0);
+  });
+
+  it('forgetDevice drops in-memory endpoint and every persisted row', () => {
+    const w = new GcWorld(db, { intervalMs: 0 });
+    w.connectArm();
+    w.armSend(7, true); // durable → tentacle outbox + snapshot rows on disk
+    w.advance(1_000);
+    expect(w.hub.outboxCount(TENT)).toBeGreaterThan(0);
+
+    w.hub.forgetDevice(TENT);
+
+    expect(w.hub.outboxCount(TENT)).toBe(0);
+    const meta = db.prepare('SELECT COUNT(*) AS n FROM pulse_meta WHERE device = ?').get(TENT) as { n: number };
+    expect(meta.n).toBe(0);
+    // And a boot recovery must not resurrect an endpoint for it.
+    w.hub.recoverOnBoot();
+    expect(w.hub.endpointCount()).toBe(1); // arm only
+  });
 });

--- a/packages/head/src/__tests__/server.test.ts
+++ b/packages/head/src/__tests__/server.test.ts
@@ -347,6 +347,76 @@ describe('HeadServer (thin relay)', () => {
       await new Promise((r) => setTimeout(r, 200));
       expect(bobGot).toBe(false);
     });
+
+    it('rejects a pulse unicast addressed to another user\'s device', async () => {
+      // Regression: the pulse unicast branch passed `to` straight to the hub
+      // with no ownership check, so any authenticated device could address ANY
+      // device id. The hub would mint an endpoint for it and queue payloads on
+      // a stranger's outbox (persisting them for durable sends) — cross-user
+      // frame injection plus an unbounded endpoint/disk growth amplifier.
+      const fetcher = mockGitHubFetcher({
+        tok_alice: { id: 'alice', login: 'alice' },
+        tok_bob: { id: 'bob', login: 'bob' },
+      });
+      head = await createHead({ authProvider: new GitHubAuthProvider({ fetcher }) });
+
+      const { ws: aliceWs } = await authConnect(head.port, 'A-Laptop', 'tentacle', { token: 'tok_alice' });
+      const { authOk: bobAuth } = await authConnect(head.port, 'B-Phone', 'app', { token: 'tok_bob' });
+
+      const errors: string[] = [];
+      aliceWs.on('message', (d) => {
+        const m = JSON.parse(d.toString());
+        if (m.type === 'server_error') errors.push(m.message as string);
+      });
+
+      const hub = (head.server as unknown as { pulseHub: { endpointCount(): number } }).pulseHub;
+      const before = hub.endpointCount();
+
+      aliceWs.send(JSON.stringify({
+        type: 'unicast', to: bobAuth.deviceId, pulse: 'AAAA', blob: '', keys: {},
+      }));
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(errors.some((e) => /not reachable/i.test(e))).toBe(true);
+      // And no endpoint was minted for Bob's device on Alice's behalf.
+      expect(hub.endpointCount()).toBe(before);
+    });
+
+    it('rejects a pulse unicast whose `to` is an array (multicast-check bypass)', async () => {
+      // `to` as an array reached the hub's multicast branch, skipping every
+      // validation the real `multicast` handler performs (tentacle-only sender,
+      // same-user + role=app targets, target cap).
+      head = await createHead();
+      const { ws: app } = await authConnect(head.port, 'Phone', 'app');
+      const errors: string[] = [];
+      app.on('message', (d) => {
+        const m = JSON.parse(d.toString());
+        if (m.type === 'server_error') errors.push(m.message as string);
+      });
+
+      app.send(JSON.stringify({
+        type: 'unicast', to: ['a', 'b'], pulse: 'AAAA', blob: '', keys: {},
+      }));
+      await new Promise((r) => setTimeout(r, 200));
+      expect(errors.some((e) => /single string target/i.test(e))).toBe(true);
+    });
+
+    it('accepts a pulse unicast with an EMPTY `to` (pure control frame)', async () => {
+      // Load-bearing: hello/ack/heartbeat/reset carry no forward destination,
+      // so both arm and tentacle emit them as `to: ''`. Rejecting those breaks
+      // the pulse handshake itself — every session goes dead.
+      head = await createHead();
+      const { ws: app } = await authConnect(head.port, 'Phone', 'app');
+      const errors: string[] = [];
+      app.on('message', (d) => {
+        const m = JSON.parse(d.toString());
+        if (m.type === 'server_error') errors.push(m.message as string);
+      });
+
+      app.send(JSON.stringify({ type: 'unicast', to: '', pulse: 'AAAA', blob: '', keys: {} }));
+      await new Promise((r) => setTimeout(r, 200));
+      expect(errors).toEqual([]);
+    });
   });
 
   // ── Broadcast isolation ───────────────────────────────
@@ -562,6 +632,46 @@ describe('HeadServer (thin relay)', () => {
   // ── Edge cases ────────────────────────────────────────
 
   describe('edge cases', () => {
+    it('stale-kill notifies the pulse hub so the endpoint stays collectable', async () => {
+      // Regression: removeConnection() (the no-pong stale kill) deleted the
+      // map entries and closed the socket, but never told the hub. The close
+      // handler then hit its reconnect-guard (entry already gone) and skipped
+      // onDeviceDisconnected too — so the device's pulse endpoint stayed in
+      // link=connected with disconnectedAtMs=null FOREVER. Neither GC tier can
+      // touch such an endpoint, and every later forward() kept growing its
+      // outbox: an unbounded leak for every device the relay ever stale-kills.
+      head = await createHead();
+      const { authOk } = await authConnect(head.port, 'Phone', 'app');
+      const deviceId = authOk.deviceId as string;
+
+      const hub = (head.server as unknown as {
+        pulseHub: { devices: Map<string, { live: { link: string; disconnectedAtMs: number | null } }> };
+      }).pulseHub;
+      expect(hub.devices.get(deviceId)?.live.link).toBe('connected');
+
+      (head.server as unknown as { removeConnection(id: string): void }).removeConnection(deviceId);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const ep = hub.devices.get(deviceId);
+      expect(ep?.live.link).toBe('disconnected');
+      expect(ep?.live.disconnectedAtMs).not.toBeNull();
+    });
+
+    it('re-auth on a new socket tears down the previous socket', async () => {
+      // The old socket is dropped from `connections` by the new auth, so the
+      // ping timer never visits it and its close handler skips cleanup — it
+      // would linger in `clients` holding its ClientState until TCP gave up.
+      head = await createHead();
+      const { ws: first, authOk } = await authConnect(head.port, 'Laptop', 'tentacle', { deviceId: 'dev_dup' });
+      const closed = new Promise<void>((resolve) => first.on('close', () => resolve()));
+
+      await authConnect(head.port, 'Laptop', 'tentacle', { deviceId: authOk.deviceId as string });
+      await closed; // the first socket must be terminated by the server
+
+      const clients = (head.server as unknown as { clients: Map<unknown, unknown> }).clients;
+      expect(clients.size).toBe(1);
+    });
+
     it('should handle invalid JSON gracefully', async () => {
       head = await createHead();
       const ws = connect(head.port);

--- a/packages/head/src/pulse-hub.ts
+++ b/packages/head/src/pulse-hub.ts
@@ -195,21 +195,62 @@ export class PulseHub {
     // stream gets its own epoch so a RESET/burst on bulk cannot disturb the
     // live stream's cursor.
     const ts = this.host.now();
+    // `createdAtMs` is what keeps these endpoints collectable. An endpoint
+    // starts Disconnected, so its offline clock must start now: otherwise every
+    // endpoint created while its device is OFFLINE — boot restore
+    // (`recoverOnBoot`) and, far more commonly, `forward()` to an offline
+    // destination — reports "never disconnected", which both GC tiers skip, and
+    // is never purged or evicted. `onDeviceConnected` clears the mark.
+    //
+    // The option ships in @coinfra/pulse >= 0.5.0. Widen the type so this also
+    // compiles against 0.4.1, where the constructor ignores the unknown key —
+    // the runtime fallback below covers that version.
+    type EpOpts = ConstructorParameters<typeof Endpoint>[0] & { createdAtMs?: number };
     const live = new Endpoint({
       epoch: `head:${this.processEpoch}:${deviceId}:live:${ts}`,
       durable: { supported: true },
       streamId: STREAM_LIVE,
       restore: this.loadSnapshot(deviceId, STREAM_LIVE),
-    });
+      createdAtMs: ts,
+    } as EpOpts);
     const bulk = new Endpoint({
       epoch: `head:${this.processEpoch}:${deviceId}:bulk:${ts}`,
       durable: { supported: true },
       streamId: STREAM_BULK,
       restore: this.loadSnapshot(deviceId, STREAM_BULK),
-    });
+      createdAtMs: ts,
+    } as EpOpts);
     d = { streams: new StreamSet([live, bulk]), live, bulk };
+    // Fallback for pulse < 0.5.0, where `createdAtMs` is ignored and the clock
+    // stays null: stamp it via onDisconnected. Second choice, not first: it also
+    // bumps the reconnect attempt counter and arms `reconnectAt`, so the next
+    // tick emits an `open` effect — a request to dial that makes no sense for
+    // the passive side of the link. Our `run()` deliberately ignores `open`
+    // (connections are WS-driven), so it is inert here, just noise. On >= 0.5.0
+    // `disconnectedAtMs` is already non-null and this never engages.
+    if (!this.connectedDevices.has(deviceId) && live.disconnectedAtMs === null) {
+      live.onDisconnected(ts);
+      bulk.onDisconnected(ts);
+    }
     this.devices.set(deviceId, d);
     return d;
+  }
+
+  /** Drop every trace of a device: in-memory endpoints plus its persisted
+   *  outbox / snapshot / capability rows. Called when a device is deleted from
+   *  the account — otherwise its durable rows stay in SQLite forever and
+   *  `recoverOnBoot` keeps resurrecting an endpoint for a device that can never
+   *  reconnect. */
+  forgetDevice(deviceId: string): void {
+    this.devices.delete(deviceId);
+    this.connectedDevices.delete(deviceId);
+    this.bulkCapableEver.delete(deviceId);
+    this.bulkCapableNow.delete(deviceId);
+    this.pulseSeenNow.delete(deviceId);
+    if (this.closed || !this.db.open) return;
+    this.db.prepare('DELETE FROM pulse_outbox WHERE device = ?').run(deviceId);
+    this.db.prepare('DELETE FROM pulse_meta WHERE device = ?').run(deviceId);
+    this.db.prepare('DELETE FROM pulse_capabilities WHERE device = ?').run(deviceId);
   }
 
   /** A device connected — bring up its stream set (resume any persisted outbox). */
@@ -405,9 +446,13 @@ export class PulseHub {
   }
 
   private unstoreOutbox(device: string, stream: number, seqUpTo: bigint): void {
+    // `seq` is stored as TEXT, so it must be compared numerically. Bind the
+    // bound as TEXT and CAST it too: `Number(seqUpTo)` silently loses precision
+    // above 2^53 and would then delete rows it shouldn't (or miss rows it
+    // should) once a long-lived endpoint's seq space grows past that.
     this.db
-      .prepare('DELETE FROM pulse_outbox WHERE device = ? AND stream = ? AND CAST(seq AS INTEGER) <= ?')
-      .run(device, stream, Number(seqUpTo));
+      .prepare('DELETE FROM pulse_outbox WHERE device = ? AND stream = ? AND CAST(seq AS INTEGER) <= CAST(? AS INTEGER)')
+      .run(device, stream, seqUpTo.toString());
   }
 
   private saveSnapshot(device: string): void {
@@ -513,6 +558,7 @@ export class PulseHub {
         continue;
       }
       // L1: drop non-durable outbox entries on BOTH streams.
+      let devicePurged = 0;
       for (const ep of [d.live, d.bulk]) {
         if (
           this.gc.purgeNonDurableAfterMs > 0
@@ -521,12 +567,19 @@ export class PulseHub {
         ) {
           const { droppedSeqs } = ep.purgeNonDurable('gc-idle');
           if (droppedSeqs.length > 0) {
-            purged += droppedSeqs.length;
+            devicePurged += droppedSeqs.length;
             trace('GC-PURGE', { device: deviceId, stream: ep.stream, dropped: droppedSeqs.length, offlineMs });
           }
         }
       }
-      if (purged > 0 || evicted > 0) this.saveSnapshot(deviceId);
+      // Snapshot only when THIS device actually changed. The counters are
+      // cumulative across the whole scan, so testing them here re-wrote a
+      // snapshot for every remaining device once any earlier device purged —
+      // exactly the per-message SQLite write storm the hub is built to avoid.
+      if (devicePurged > 0) {
+        purged += devicePurged;
+        this.saveSnapshot(deviceId);
+      }
     }
     if (purged > 0 || evicted > 0) {
       getLogger().info('pulse-hub gc', {

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -479,9 +479,32 @@ export class HeadServer {
       // store-and-forward. The envelope MUST carry a pulse frame — the head is
       // pulse-only; there is no raw-WS relay path.
       if (typeof msg.pulse === 'string' && state.deviceId) {
+        // `to` MUST be a single string. An array here would reach the hub's
+        // multicast branch and bypass every check the `multicast` handler makes.
+        if (msg.to !== undefined && typeof msg.to !== 'string') {
+          this.sendError(ws, 'unicast requires a single string target');
+          return;
+        }
+        // An EMPTY `to` is legitimate and load-bearing: pure pulse control
+        // frames (hello/ack/heartbeat/reset) carry no forward destination, so
+        // both arm and tentacle emit them with `to: ''`. They ride the source
+        // endpoint only and are never forwarded — nothing to authorize.
+        const to = typeof msg.to === 'string' ? msg.to : '';
+        // Authorize a real destination. Without this any authenticated device
+        // could address ANY device id: the hub would mint an endpoint for it
+        // and queue (and, for durable sends, persist to SQLite) payloads on a
+        // stranger's outbox — cross-user frame injection plus an unbounded
+        // endpoint/disk-growth amplifier from a single client.
+        if (to !== '' && to !== HEAD_PULSE_TARGET) {
+          const target = this.storage.getDevice(to);
+          if (!target || target.userId !== state.userId) {
+            this.sendError(ws, 'unicast target is not reachable');
+            return;
+          }
+        }
         this.pulseHub.onPulseEnvelope(state.deviceId, {
           pulse: msg.pulse as string,
-          to: msg.to as string,
+          to,
         });
         return;
       }
@@ -832,8 +855,19 @@ export class HeadServer {
     this.connections.delete(deviceId);
     this.userByDevice.delete(deviceId);
     if (ws) {
-      try { ws.close(); } catch { /* best effort */ }
+      // The reason we are here is that the peer stopped answering pings, so a
+      // graceful `close()` (which waits for a close handshake that will never
+      // come) can leave the socket — and its ClientState — pinned for the full
+      // TCP timeout. Terminate outright.
+      try { ws.terminate(); } catch { /* best effort */ }
+      this.clients.delete(ws);
     }
+    // Tell the hub the link is down. The ws.on('close') handler cannot do it
+    // for us: its reconnect-guard sees the map entry already deleted and skips
+    // the whole cleanup block. Without this the device's pulse endpoint stays
+    // in link=connected with disconnectedAtMs=null forever, so neither GC tier
+    // can ever reclaim it and every later forward() keeps growing its outbox.
+    if (ws || userId) this.pulseHub.onDeviceDisconnected(deviceId);
     // Programmatic removal — the ws.on('close') handler's reconnect-guard
     // check will fail (we already deleted from the map), so notify other
     // devices ourselves. Idempotent: if the close handler does run later it
@@ -1070,6 +1104,7 @@ export class HeadServer {
     state.authenticatedAt = Date.now();
     state.deviceId = deviceId;
     state.userId = user.userId;
+    this.evictPreviousConnection(deviceId, ws);
     this.connections.set(deviceId, ws);
     this.userByDevice.set(deviceId, user.userId);
     trace('DEV-CONNECT', { device: deviceId, user: user.userId, auth: 'challenge' });
@@ -1108,6 +1143,7 @@ export class HeadServer {
     state.authenticatedAt = Date.now();
     state.deviceId = result.deviceId;
     state.userId = result.userId;
+    this.evictPreviousConnection(result.deviceId, ws);
     this.connections.set(result.deviceId, ws);
     this.userByDevice.set(result.deviceId, result.userId);
     trace('DEV-CONNECT', { device: result.deviceId, user: result.userId, auth: 'backend' });
@@ -1242,6 +1278,24 @@ export class HeadServer {
     this.broadcastDeviceJoined(params.userId, params.deviceId);
   }
 
+  /**
+   * A device is about to register `ws` as its connection. If the SAME device id
+   * already had a socket, that older socket is now orphaned: once we overwrite
+   * the map entry its close handler hits the reconnect-guard and skips cleanup,
+   * and the ping timer (which only walks `connections`) never visits it again.
+   * It would sit in `clients` holding its ClientState until TCP finally gives
+   * up. Terminate it explicitly.
+   *
+   * Must be called BEFORE `connections.set(deviceId, ws)`.
+   */
+  private evictPreviousConnection(deviceId: string, ws: WebSocket): void {
+    const previous = this.connections.get(deviceId);
+    if (!previous || previous === ws) return;
+    getLogger().info('Replacing existing connection for device', { deviceId });
+    this.clients.delete(previous);
+    try { previous.terminate(); } catch { /* best effort */ }
+  }
+
   private completeAuth(
     ws: WebSocket,
     state: ClientState,
@@ -1271,6 +1325,7 @@ export class HeadServer {
     state.authenticatedAt = Date.now();
     state.deviceId = deviceId;
     state.userId = user.id;
+    this.evictPreviousConnection(deviceId, ws);
     this.connections.set(deviceId, ws);
     this.userByDevice.set(deviceId, user.id);
     trace('DEV-CONNECT', { device: deviceId, user: user.id, auth: 'inline' });
@@ -1423,6 +1478,11 @@ export class HeadServer {
 
     this.storage.deleteDevice(targetDeviceId);
     this.storage.deletePushTokensForDevice(targetDeviceId);
+    // Drop the device's pulse endpoint + persisted outbox/snapshot/capability
+    // rows too. Otherwise they outlive the device record forever, and
+    // recoverOnBoot faithfully rebuilds an endpoint for a device that can
+    // never authenticate again.
+    this.pulseHub.forgetDevice(targetDeviceId);
     logger.info('Device removed', { deviceId: targetDeviceId, byDevice: state.deviceId });
 
     // Broadcast removal to all remaining user devices

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.156",
-    "@coinfra/pulse": "^0.4.1",
+    "@coinfra/pulse": "^0.5.0",
     "@earendil-works/pi-coding-agent": "0.80.2",
     "@github/copilot-sdk": "^1.0.1",
     "@inquirer/prompts": "^8.3.2",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -10,7 +10,7 @@
     "test:live": "vitest run --config vitest.live.config.ts"
   },
   "dependencies": {
-    "@coinfra/pulse": "^0.4.1",
+    "@coinfra/pulse": "^0.5.0",
     "@kraki/crypto": "workspace:*",
     "@kraki/head": "workspace:*",
     "@kraki/protocol": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   packages/arm/web:
     dependencies:
       '@coinfra/pulse':
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0
       '@kraki/protocol':
         specifier: workspace:*
         version: link:../../protocol
@@ -139,8 +139,8 @@ importers:
   packages/head:
     dependencies:
       '@coinfra/pulse':
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0
       '@kraki/crypto':
         specifier: workspace:*
         version: link:../crypto
@@ -200,8 +200,8 @@ importers:
         specifier: ^0.3.156
         version: 0.3.156(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@coinfra/pulse':
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.2
         version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
@@ -270,8 +270,8 @@ importers:
   packages/tests:
     dependencies:
       '@coinfra/pulse':
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0
       '@kraki/crypto':
         specifier: workspace:*
         version: link:../crypto
@@ -684,8 +684,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@coinfra/pulse@0.4.1':
-    resolution: {integrity: sha512-qSG4f/rG4LRqafahaqkC43laXyrfzh0+oiKZqnwYvJ4SMzs3UPOWO/RYMmPX4EonnTcVPBs6QhuSdqPodytW/w==}
+  '@coinfra/pulse@0.5.0':
+    resolution: {integrity: sha512-vbRrGJ8THroQm2jEf+yXFR+Bto/4xDLC0T7ur0vJ5JBA/GV8xkD6R0iC6tyIPG+rP/ApLPn55e9LE4fWCBiVOQ==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -4566,7 +4566,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.9':
     optional: true
 
-  '@coinfra/pulse@0.4.1': {}
+  '@coinfra/pulse@0.5.0': {}
 
   '@csstools/color-helpers@5.1.0': {}
 


### PR DESCRIPTION
## Summary

Production hardening found while reviewing the last month of WebSocket and
Pulse protocol work. This PR fixes seven concrete reliability/security defects
in `@kraki/head` and consumes the released `@coinfra/pulse@0.5.0` fix across all
Pulse users.

### Security / routing

- **Authorize Pulse unicast destinations.** A device could address any deviceId,
  including another user's, and the hub would lazily create an endpoint and
  queue/persist payloads for it. This enabled cross-user frame injection plus
  unbounded memory/SQLite growth.
- Require `unicast.to` to be one string; arrays previously fell into the hub's
  multicast branch and bypassed all checks in the real multicast handler.
- Preserve empty `to`, which is load-bearing for hello/ack/heartbeat/reset
  control frames that have no forward destination.

### Endpoint / socket lifecycle

- **Notify PulseHub on stale no-pong termination.** The stale path deleted the
  connection entry but skipped `onDeviceDisconnected`; the close handler's
  reconnect guard then skipped it too. The endpoint remained `connected`
  forever and was unreachable by either GC tier.
- Use `terminate()` for dead peers rather than waiting for graceful close on a
  dead TCP connection.
- **Evict a previous socket on same-device re-auth.** The overwritten socket was
  no longer pinged but could keep its ClientState and inject frames until TCP
  expiry. Applied to challenge, backend, and inline auth.

### Persistence / GC

- **Fix per-device GC snapshot accounting.** A cumulative purge counter caused
  every device after the first purge to be re-serialized and written to SQLite
  on every scan.
- **Add `forgetDevice()`.** Device deletion now removes in-memory endpoints and
  `pulse_meta`, `pulse_outbox`, and `pulse_capabilities`; otherwise boot restore
  resurrected a device that can never authenticate again.
- Bind bigint seq values to SQLite as decimal text rather than `Number()`, which
  silently loses precision above 2^53.
- Pass `createdAtMs` so endpoints minted for offline devices and endpoints
  restored on boot participate in the §11 GC policy. Keep a guarded compatibility
  fallback for Pulse 0.4.1.

### Pulse 0.5.0

Bump all four consumers (`head`, `tentacle`, `arm-web`, and integration tests) to
`@coinfra/pulse@^0.5.0`, which includes the offline-clock and purged-tail-gap
fixes from coinfra PR #7. This resolves one state-machine version workspace-wide.

## Regression coverage

New tests cover:

- cross-user, missing, and array unicast targets;
- empty-target Pulse control frames;
- stale socket endpoint cleanup;
- same-device reconnect eviction;
- offline-created endpoint GC and boot-restored endpoint collectability;
- per-device-only snapshot writes;
- deleted-device in-memory + SQLite cleanup;
- bigint seq binding.

## Verification

Verified after rebasing onto current `origin/main`, using the npm registry build
of `@coinfra/pulse@0.5.0` (not a local link):

- `pnpm install --frozen-lockfile` ✅
- `pnpm validate` ✅
  - lint ✅
  - build ✅
  - crypto: 36 tests ✅
  - head: 253 tests ✅
  - tentacle/web unit suites ✅
  - integration: 44 tests ✅
  - arm-web validation suite: 411 tests ✅
- Real-stack Playwright: **53/53 passed** ✅
  - real Head + real Tentacle + Chromium
  - conversation, streaming, reconnect, multistream, coalescing, subscriptions,
    attachment pulls, device presence, permissions/questions, terminal cards
- Test stack used isolated ports 4700/3700/4710 and left the existing Kraki
  process/ports untouched.
