### PR TITLE
fix(tentacle): harden v0.31.6 daemon and Pi discovery

### DIFF
--- a/packages/tentacle/src/__tests__/daemon-launch-tcc.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-launch-tcc.test.ts
@@ -80,13 +80,28 @@ describe('buildLaunchdPlist — bundled install (the TCC-critical path)', () => 
     expect(i + 2).toBe(args.length);
   });
 
-  it('forwards environment via --env, since LS-launched apps do not inherit it', () => {
-    // An app started through LaunchServices gets the launchd session
-    // environment, NOT the environment of the process that called `open`.
-    // Without --env the daemon would silently lose PATH, proxies and tokens.
+  it('forwards environment by name, never embedding values in argv', () => {
+    // `open --env NAME` copies NAME from open's environment. NAME=VALUE would
+    // expose proxy credentials/tokens in the long-lived `open -W` argv.
     expect(args).toContain('--env');
-    expect(args).toContain('NODE_ENV=production');
-    expect(args).toContain('LOG_LEVEL=info');
+    expect(args).toContain('NODE_ENV');
+    expect(args).toContain('LOG_LEVEL');
+    expect(args).not.toContain('NODE_ENV=production');
+    expect(args).not.toContain('LOG_LEVEL=info');
+  });
+
+  it('does not leak environment values into the long-lived open command line', () => {
+    const secret = 'github_pat_super_secret';
+    const secretPlist = buildLaunchdPlist({
+      ...BASE,
+      appBundle: BUNDLE,
+      envEntries: [['HTTPS_PROXY', 'http://user:pass@proxy'], ['GH_TOKEN', secret]],
+    });
+    const secretArgs = programArgs(secretPlist);
+    expect(secretArgs).toContain('HTTPS_PROXY');
+    expect(secretArgs).toContain('GH_TOKEN');
+    expect(secretArgs.join(' ')).not.toContain('user:pass');
+    expect(secretArgs.join(' ')).not.toContain(secret);
   });
 
   it('redirects the daemon stdio, which LaunchServices also does not inherit', () => {
@@ -134,7 +149,8 @@ describe('buildLaunchdPlist — general', () => {
     });
     expect(plist).toContain('/Apps/A &amp; B.app');
     expect(plist).toContain('x&lt;y&gt;z');
-    expect(plist).toContain('V=a&amp;b&lt;c&gt;d');
+    expect(plist).toContain('<key>V</key>');
+    expect(plist).toContain('<string>a&amp;b&lt;c&gt;d</string>');
     // No raw & survived (every & must be part of an entity).
     expect(plist).not.toMatch(/&(?!amp;|lt;|gt;)/);
   });

--- a/packages/tentacle/src/__tests__/daemon.test.ts
+++ b/packages/tentacle/src/__tests__/daemon.test.ts
@@ -12,9 +12,11 @@ import { resolve } from 'node:path';
 
 const mockSpawn = vi.fn();
 const mockExecSync = vi.fn();
+const mockExecFileSync = vi.fn();
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
   execSync: (...args: unknown[]) => mockExecSync(...args),
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 
 const mockSaveDaemonPid = vi.fn();
@@ -68,6 +70,7 @@ beforeEach(() => {
   vi.useRealTimers();
   mockLoadDaemonPid.mockReturnValue(null);
   mockOpenSync.mockReturnValue(99);
+  mockExecFileSync.mockReturnValue('/path/to/kraki __daemon-worker');
 });
 
 afterEach(() => {
@@ -239,6 +242,33 @@ describe('stopDaemon()', () => {
   it('returns false when no daemon is running (no PID file)', () => {
     mockLoadDaemonPid.mockReturnValue(null);
     expect(stopDaemon()).toBe(false);
+  });
+
+  it('does not signal a reused PID that belongs to another process', () => {
+    mockLoadDaemonPid.mockReturnValue(12345);
+    mockExecFileSync.mockReturnValue('/Applications/Safari.app/Contents/MacOS/Safari');
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    expect(stopDaemon()).toBe(true);
+
+    expect(killSpy).toHaveBeenCalledWith(12345, 0);
+    expect(killSpy).not.toHaveBeenCalledWith(12345, 'SIGTERM');
+    expect(killSpy).not.toHaveBeenCalledWith(12345, 'SIGKILL');
+    expect(mockClearDaemonPid).toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it('fails closed when a live PID cannot be inspected', () => {
+    mockLoadDaemonPid.mockReturnValue(12345);
+    mockExecFileSync.mockImplementation(() => { throw new Error('EPERM'); });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    expect(stopDaemon()).toBe(false);
+
+    expect(killSpy).toHaveBeenCalledWith(12345, 0);
+    expect(killSpy).not.toHaveBeenCalledWith(12345, 'SIGTERM');
+    expect(mockClearDaemonPid).not.toHaveBeenCalled();
+    killSpy.mockRestore();
   });
 
   it('sends SIGTERM, clears PID, and returns true', () => {

--- a/packages/tentacle/src/__tests__/daemon.test.ts
+++ b/packages/tentacle/src/__tests__/daemon.test.ts
@@ -61,6 +61,7 @@ import {
   getDaemonStatus,
   startDaemon,
   stopDaemon,
+  inspectDaemonProcess,
   resolveDaemonLaunch,
   getDaemonBootstrapLogPath,
 } from '../daemon.js';
@@ -90,6 +91,24 @@ function makeFakeChild(pid = 42) {
   };
   return { child, listeners };
 }
+
+// ── inspectDaemonProcess ─────────────────────────────────
+
+describe('inspectDaemonProcess()', () => {
+  it('accepts only a process carrying the daemon-worker marker', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    mockExecFileSync.mockReturnValue('/path/to/kraki __daemon-worker');
+    expect(inspectDaemonProcess(12345)).toBe('daemon');
+    killSpy.mockRestore();
+  });
+
+  it('rejects another kraki CLI process without the worker marker', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    mockExecFileSync.mockReturnValue('/path/to/kraki update');
+    expect(inspectDaemonProcess(12345)).toBe('other');
+    killSpy.mockRestore();
+  });
+});
 
 // ── isDaemonRunning ─────────────────────────────────────
 

--- a/packages/tentacle/src/__tests__/pi-catalog-rpc.test.ts
+++ b/packages/tentacle/src/__tests__/pi-catalog-rpc.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { queryPiCatalog, PiAdapter } from '../adapters/pi.js';
+
+const tempDirs: string[] = [];
+
+function fakePi(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kraki-pi-catalog-'));
+  tempDirs.push(dir);
+  const path = join(dir, 'pi');
+  writeFileSync(path, `#!/usr/bin/env node\n${source}\n`, 'utf8');
+  chmodSync(path, 0o755);
+  return path;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('queryPiCatalog — throwaway RPC lifecycle', () => {
+  it('sends get_available_models and returns the catalog', async () => {
+    const cli = fakePi(`
+      process.stdin.once('data', chunk => {
+        const command = JSON.parse(String(chunk));
+        if (command.type !== 'get_available_models') process.exit(2);
+        console.log(JSON.stringify({
+          id: command.id,
+          type: 'response',
+          command: 'get_available_models',
+          success: true,
+          data: { models: [{ id: 'opus', provider: 'anthropic', reasoning: true, thinkingLevelMap: { max: 'max' } }] },
+        }));
+      });
+    `);
+
+    await expect(queryPiCatalog(cli, 2000)).resolves.toEqual([
+      { id: 'opus', provider: 'anthropic', reasoning: true, thinkingLevelMap: { max: 'max' } },
+    ]);
+  });
+
+  it('rejects an explicit RPC error instead of treating it as an empty catalog', async () => {
+    const cli = fakePi(`
+      process.stdin.once('data', chunk => {
+        const command = JSON.parse(String(chunk));
+        console.log(JSON.stringify({ id: command.id, type: 'response', command: 'get_available_models', success: false, error: 'catalog unavailable' }));
+      });
+    `);
+
+    await expect(queryPiCatalog(cli, 2000)).rejects.toThrow('catalog unavailable');
+  });
+
+  it('rejects when pi exits before answering and includes stderr', async () => {
+    const cli = fakePi(`
+      console.error('provider init failed');
+      process.exit(7);
+    `);
+
+    await expect(queryPiCatalog(cli, 2000)).rejects.toThrow(/pi exited before answering: provider init failed/);
+  });
+
+  it('retries after a transient catalog failure instead of caching fallback forever', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kraki-pi-catalog-retry-'));
+    tempDirs.push(dir);
+    const marker = join(dir, 'attempted');
+    const cli = join(dir, 'pi');
+    writeFileSync(cli, `#!/usr/bin/env node
+      const fs = require('node:fs');
+      const marker = ${JSON.stringify(marker)};
+      if (process.argv.includes('--list-models')) {
+        console.log('provider   model   context   max-out   thinking   images');
+        console.log('anthropic  opus    200K      32K       yes        no');
+      } else {
+        process.stdin.once('data', chunk => {
+          const command = JSON.parse(String(chunk));
+          if (!fs.existsSync(marker)) {
+            fs.writeFileSync(marker, '1');
+            console.log(JSON.stringify({ id: command.id, type: 'response', command: 'get_available_models', success: false, error: 'temporary failure' }));
+          } else {
+            console.log(JSON.stringify({ id: command.id, type: 'response', command: 'get_available_models', success: true, data: { models: [{ id: 'opus', provider: 'anthropic', reasoning: true, thinkingLevelMap: { xhigh: 'xhigh', max: 'max' } }] } }));
+          }
+        });
+      }
+    `, 'utf8');
+    chmodSync(cli, 0o755);
+    const adapter = new PiAdapter({ cliPath: cli });
+
+    const first = await adapter.listModelDetails();
+    expect(first[0]?.supportedReasoningEfforts).toEqual(['high', 'xhigh']);
+
+    const second = await adapter.listModelDetails();
+    expect(second[0]?.supportedReasoningEfforts).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+  });
+
+  it('times out and terminates a non-responsive child', async () => {
+    const cli = fakePi(`
+      process.stdin.resume();
+      setInterval(() => {}, 1000);
+    `);
+    const started = Date.now();
+
+    await expect(queryPiCatalog(cli, 80)).rejects.toThrow('pi catalog query timed out');
+    expect(Date.now() - started).toBeLessThan(1500);
+  });
+});

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -557,6 +557,59 @@ interface PromptWatchdogOptions {
   idleStallMs: number;
 }
 
+export function queryPiCatalog(cliPath: string, timeoutMs = 15_000): Promise<PiCatalogModel[]> {
+  return new Promise((resolve, reject) => {
+    // --no-session: this process only answers one question, it must not leave a
+    // session file behind next to the user's real ones.
+    const child = spawn(cliPath, ['--mode', 'rpc', '--no-session'], {
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const rl = createInterface({ input: child.stdout });
+    let settled = false;
+    let lastStderr = '';
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      rl.close();
+      child.kill();
+      fn();
+    };
+    const fail = (reason: string) =>
+      finish(() => reject(new Error(lastStderr ? `${reason}: ${lastStderr}` : reason)));
+    const timer = setTimeout(() => fail('pi catalog query timed out'), timeoutMs);
+
+    rl.on('line', line => {
+      let msg: { type?: string; command?: string; success?: boolean; error?: string; data?: { models?: PiCatalogModel[] } };
+      try { msg = JSON.parse(line); } catch { return; }
+      if (msg.type !== 'response' || msg.command !== 'get_available_models') return;
+      if (msg.success === false) {
+        fail(msg.error || 'pi catalog query failed');
+        return;
+      }
+      finish(() => resolve(msg.data?.models ?? []));
+    });
+    // Drain stderr rather than leaving it piped and unread: a full pipe buffer
+    // would block pi mid-write and stall the query until the timeout. Keeping
+    // the last chunk also gives the rejection something to say.
+    child.stderr.on('data', d => { lastStderr = String(d).trim().slice(-200) || lastStderr; });
+    child.on('error', err => finish(() => reject(err)));
+    child.on('exit', () => fail('pi exited before answering'));
+    // An unhandled 'error' on stdin is a process-level crash, and this stream
+    // breaks whenever pi dies early — a degraded ladder is the acceptable
+    // outcome here, taking the daemon down with it is not.
+    child.stdin.on('error', () => fail('pi stdin closed before the query was sent'));
+    if (child.stdin.writable) {
+      child.stdin.write(`${JSON.stringify({ id: 'models', type: 'get_available_models' })}\n`);
+    }
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Section 5 — adapter public methods
+// ─────────────────────────────────────────────────────────────────────────────
+
 export class PiAdapter extends AgentAdapter {
   private cliPath: string;
   private readonly attachmentStore?: import('../attachment-store.js').AttachmentStore;
@@ -1636,68 +1689,26 @@ export class PiAdapter extends AgentAdapter {
    *  interface that exposes each model's thinkingLevelMap, and thus the only way
    *  to tell a model that genuinely has `max` (Opus 5, Fable 5, GLM 5.2) from one
    *  whose top rung is `low` (GPT-5.6 Luna). Best-effort: on any failure the
-   *  caller keeps the old fixed ladder rather than losing the model list. */
+   *  caller keeps the old fixed ladder rather than losing the model list. Failed
+   *  lookups are deliberately NOT cached, so a transient pi startup/RPC failure
+   *  heals on the next capabilities refresh instead of lasting until daemon
+   *  restart. */
   private async fetchEfforts(): Promise<Map<string, ReasoningEffort[]>> {
     if (this.cachedEfforts) return this.cachedEfforts;
-    const efforts = new Map<string, ReasoningEffort[]>();
     try {
-      const models = await this.queryCatalog();
+      const efforts = new Map<string, ReasoningEffort[]>();
+      const models = await queryPiCatalog(this.cliPath);
       for (const m of models) {
         if (!m?.id || !m?.provider) continue;
         efforts.set(`${m.provider}/${m.id}`, piThinkingLevelsFor(m));
       }
       logger.info({ count: efforts.size }, 'Fetched pi thinking levels');
+      this.cachedEfforts = efforts;
+      return efforts;
     } catch (err) {
       logger.warn({ err: (err as Error).message }, 'Could not fetch pi thinking levels, using default ladder');
+      return new Map();
     }
-    this.cachedEfforts = efforts;
-    return efforts;
-  }
-
-  private queryCatalog(timeoutMs = 15_000): Promise<PiCatalogModel[]> {
-    return new Promise((resolve, reject) => {
-      // --no-session: this process only answers one question, it must not leave a
-      // session file behind next to the user's real ones.
-      const child = spawn(this.cliPath, ['--mode', 'rpc', '--no-session'], {
-        env: process.env,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      const rl = createInterface({ input: child.stdout });
-      let settled = false;
-      let lastStderr = '';
-      const finish = (fn: () => void) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        rl.close();
-        child.kill();
-        fn();
-      };
-      const fail = (reason: string) =>
-        finish(() => reject(new Error(lastStderr ? `${reason}: ${lastStderr}` : reason)));
-      const timer = setTimeout(() => fail('pi catalog query timed out'), timeoutMs);
-
-      rl.on('line', line => {
-        let msg: { type?: string; command?: string; data?: { models?: PiCatalogModel[] } };
-        try { msg = JSON.parse(line); } catch { return; }
-        if (msg.type === 'response' && msg.command === 'get_available_models') {
-          finish(() => resolve(msg.data?.models ?? []));
-        }
-      });
-      // Drain stderr rather than leaving it piped and unread: a full pipe buffer
-      // would block pi mid-write and stall the query until the timeout. Keeping
-      // the last chunk also gives the rejection something to say.
-      child.stderr.on('data', d => { lastStderr = String(d).trim().slice(-200) || lastStderr; });
-      child.on('error', err => finish(() => reject(err)));
-      child.on('exit', () => fail('pi exited before answering'));
-      // An unhandled 'error' on stdin is a process-level crash, and this stream
-      // breaks whenever pi dies early — a degraded ladder is the acceptable
-      // outcome here, taking the daemon down with it is not.
-      child.stdin.on('error', () => fail('pi stdin closed before the query was sent'));
-      if (child.stdin.writable) {
-        child.stdin.write(`${JSON.stringify({ id: 'models', type: 'get_available_models' })}\n`);
-      }
-    });
   }
 
   async listModelDetails(): Promise<ModelDetail[]> {

--- a/packages/tentacle/src/cli.ts
+++ b/packages/tentacle/src/cli.ts
@@ -255,6 +255,11 @@ async function silentStart(config: KrakiConfig): Promise<void> {
  * downloaded SEA binaries (com.apple.provenance + CSM 2).
  */
 async function startDaemonInProcess(config: KrakiConfig): Promise<void> {
+  // Give the in-process CSM fallback the same inspectable identity marker as a
+  // normal daemon worker. stopDaemon() requires this before signalling a PID;
+  // accepting any process that merely runs the kraki executable would allow a
+  // stale PID reused by `kraki logs/update` to be killed.
+  process.title = `kraki ${INTERNAL_DAEMON_WORKER_COMMAND}`;
   // Ignore SIGHUP so the daemon survives terminal close
   process.on('SIGHUP', () => {});
 

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -12,7 +12,7 @@
  * to running the daemon worker in the current process.
  */
 
-import { spawn, execSync, type ChildProcess } from 'node:child_process';
+import { spawn, execSync, execFileSync, type ChildProcess } from 'node:child_process';
 import { closeSync, mkdirSync, openSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
 import { delimiter, join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
@@ -74,6 +74,55 @@ function cleanupLaunchdPlist(): void {
   if (existsSync(p)) unlinkSync(p);
 }
 export const INTERNAL_DAEMON_WORKER_COMMAND = '__daemon-worker';
+
+export type DaemonProcessIdentity = 'daemon' | 'other' | 'gone' | 'unknown';
+
+/**
+ * Verify that a PID still belongs to a Kraki daemon before signalling it.
+ *
+ * PID files can outlive their process, and operating systems eventually reuse
+ * the numeric PID. A liveness probe alone therefore cannot distinguish the real
+ * daemon from an unrelated process that inherited the same number. Query the
+ * process command line and require Kraki's internal worker marker. Fail closed
+ * (`unknown`) when the command cannot be inspected: it is safer to leave a hung
+ * daemon for manual diagnosis than to SIGKILL an arbitrary process.
+ */
+export function inspectDaemonProcess(pid: number): DaemonProcessIdentity {
+  try {
+    process.kill(pid, 0);
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM' ? 'unknown' : 'gone';
+  }
+
+  try {
+    const command = process.platform === 'win32'
+      ? execFileSync('powershell.exe', [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`,
+        ], { encoding: 'utf8', timeout: 5000, windowsHide: true })
+      : execFileSync('/bin/ps', ['-p', String(pid), '-o', 'command='], {
+          encoding: 'utf8',
+          timeout: 5000,
+        });
+    const trimmed = command.trim();
+    const marker = INTERNAL_DAEMON_WORKER_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (new RegExp(`(?:^|\\s)${marker}(?:\\s|$)`).test(trimmed)) return 'daemon';
+
+    // macOS CSM fallback runs the SEA daemon worker in the original CLI process,
+    // so its argv has no __daemon-worker marker. For SEA only, accept the exact
+    // installed executable path as a second identity proof. Never do this for a
+    // regular Node runtime, where process.execPath would merely identify "node"
+    // and could match an unrelated application.
+    if (isSea() && (trimmed === process.execPath || trimmed.startsWith(`${process.execPath} `))) {
+      return 'daemon';
+    }
+    return 'other';
+  } catch {
+    return 'unknown';
+  }
+}
 
 export interface DaemonLaunchSpec {
   runtime: string;
@@ -208,27 +257,26 @@ export interface DaemonStatus {
 export function isDaemonRunning(): boolean {
   const pid = loadDaemonPid();
   if (pid === null) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    // Process doesn't exist — stale PID file
+  const identity = inspectDaemonProcess(pid);
+  if (identity === 'gone' || identity === 'other') {
     clearDaemonPid();
     return false;
   }
+  // `unknown` means the PID is alive but the OS refused command inspection.
+  // Treat it as running to avoid launching a duplicate daemon; stopDaemon()
+  // still refuses to signal it until its identity can be established.
+  return true;
 }
 
 export function getDaemonStatus(): DaemonStatus {
   const pid = loadDaemonPid();
   if (pid === null) return { running: false, pid: null };
-
-  try {
-    process.kill(pid, 0);
-    return { running: true, pid };
-  } catch {
+  const identity = inspectDaemonProcess(pid);
+  if (identity === 'gone' || identity === 'other') {
     clearDaemonPid();
     return { running: false, pid: null };
   }
+  return { running: true, pid };
 }
 
 export class MacOSCodeSignatureError extends Error {
@@ -297,7 +345,12 @@ export function buildLaunchdPlist(opts: {
         '-a', appBundle,
         '--stdout', bootstrapLogPath,
         '--stderr', bootstrapLogPath,
-        ...envEntries.flatMap(([k, v]) => ['--env', `${k}=${v}`]),
+        // `open --env NAME` copies NAME from open's own environment without
+        // embedding its value in argv. launchd supplies that environment via
+        // EnvironmentVariables below. Passing NAME=VALUE here would expose
+        // GH_TOKEN, proxy credentials, etc. in the long-lived `open -W` process
+        // command line for the daemon's entire lifetime.
+        ...envEntries.flatMap(([k]) => ['--env', k]),
         '--args', INTERNAL_DAEMON_WORKER_COMMAND,
       ]
     : [execPath, INTERNAL_DAEMON_WORKER_COMMAND];
@@ -377,8 +430,10 @@ async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
   ];
   if (process.env.KRAKI_RELAY_URL) envEntries.push(['KRAKI_RELAY_URL', process.env.KRAKI_RELAY_URL]);
 
-  // Forward proxy and other relevant env vars so the daemon can reach
-  // external services (e.g. Copilot API behind a proxy).
+  // Forward proxy and GitHub auth variables so the daemon keeps the same
+  // credential behavior as before. buildLaunchdPlist passes only variable NAMES
+  // to `open --env` (values remain in launchd's EnvironmentVariables), avoiding
+  // the new long-lived argv exposure without breaking PAT-only installations.
   const forwardVars = [
     'HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy',
     'ALL_PROXY', 'all_proxy', 'NO_PROXY', 'no_proxy',
@@ -429,6 +484,11 @@ function escapeXml(s: string): string {
 
 export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): Promise<number> {
   stopDaemon();
+  // An alive PID whose identity could not be verified is deliberately left in
+  // place by stopDaemon(). Do not start a second daemon beside it.
+  if (loadDaemonPid() !== null) {
+    throw new Error('Refusing to start: the recorded daemon PID is alive but could not be verified. Remove the stale daemon.pid only after checking the process.');
+  }
 
   // On macOS SEA, use launchctl so launchd spawns the daemon in a clean
   // context that isn't blocked by CSM provenance tracking.
@@ -472,7 +532,21 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
 }
 
 export function stopDaemon(): boolean {
-  // Unload the launchd job BEFORE signalling the daemon. The bundled macOS job
+  const pid = loadDaemonPid();
+  if (pid === null) {
+    // A missing PID can coexist with a stale launchd job (e.g. crash before the
+    // worker saved its PID). Cleaning the home-scoped job is safe here.
+    if (process.platform === 'darwin') cleanupLaunchdPlist();
+    return false;
+  }
+
+  // Establish identity BEFORE unloading supervision. If process inspection is
+  // unavailable, fail closed and leave both the process and its launchd job
+  // untouched rather than stranding a real daemon unsupervised.
+  const identity = inspectDaemonProcess(pid);
+  if (identity === 'unknown') return false;
+
+  // Unload the launchd job BEFORE signalling a verified daemon. The bundled macOS job
   // runs with KeepAlive=true (see startDaemonLaunchctl), so killing first would
   // let launchd restart the daemon in the window before the job is unloaded and
   // `kraki stop` would appear to do nothing.
@@ -485,8 +559,12 @@ export function stopDaemon(): boolean {
   // succeed.
   if (process.platform === 'darwin') cleanupLaunchdPlist();
 
-  const pid = loadDaemonPid();
-  if (pid === null) return false;
+  if (identity === 'gone' || identity === 'other') {
+    // Stale/reused PID: clean the record but never signal the process currently
+    // holding that number.
+    clearDaemonPid();
+    return true;
+  }
 
   const alive = () => {
     try { process.kill(pid, 0); return true; } catch { return false; }
@@ -515,7 +593,14 @@ export function stopDaemon(): boolean {
     Atomics.wait(idle, 0, 0, 100);   // synchronous sleep; spawns nothing
   }
   if (alive()) {
-    try { process.kill(pid, 'SIGKILL'); } catch { /* raced us to exit */ }
+    // Re-check immediately before escalation. The daemon may have exited and
+    // its numeric PID may already have been reused during the grace window.
+    const finalIdentity = inspectDaemonProcess(pid);
+    if (finalIdentity === 'daemon') {
+      try { process.kill(pid, 'SIGKILL'); } catch { /* raced us to exit */ }
+    } else if (finalIdentity === 'unknown') {
+      return false;
+    }
   }
 
   clearDaemonPid();

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -108,17 +108,7 @@ export function inspectDaemonProcess(pid: number): DaemonProcessIdentity {
         });
     const trimmed = command.trim();
     const marker = INTERNAL_DAEMON_WORKER_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    if (new RegExp(`(?:^|\\s)${marker}(?:\\s|$)`).test(trimmed)) return 'daemon';
-
-    // macOS CSM fallback runs the SEA daemon worker in the original CLI process,
-    // so its argv has no __daemon-worker marker. For SEA only, accept the exact
-    // installed executable path as a second identity proof. Never do this for a
-    // regular Node runtime, where process.execPath would merely identify "node"
-    // and could match an unrelated application.
-    if (isSea() && (trimmed === process.execPath || trimmed.startsWith(`${process.execPath} `))) {
-      return 'daemon';
-    }
-    return 'other';
+    return new RegExp(`(?:^|\\s)${marker}(?:\\s|$)`).test(trimmed) ? 'daemon' : 'other';
   } catch {
     return 'unknown';
   }

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -360,7 +360,7 @@ export async function performUpdate(currentVersion: string): Promise<void> {
   spinner.text = `Updating ${currentVersion} → ${latest}…`;
 
   // Import daemon management upfront — needed for pre-update stop and post-update restart
-  const { isDaemonRunning, stopDaemon, startDaemon, MacOSCodeSignatureError } = await import('./daemon.js');
+  const { isDaemonRunning, stopDaemon, startDaemon, MacOSCodeSignatureError, INTERNAL_DAEMON_WORKER_COMMAND } = await import('./daemon.js');
   const daemonWasRunning = isDaemonRunning();
 
   // Probe FDA BEFORE the binary is replaced. After replacement the kernel
@@ -442,6 +442,7 @@ export async function performUpdate(currentVersion: string): Promise<void> {
             // Fall back to running the daemon in the current process
             // (already Gatekeeper-approved since the user invoked it).
             console.log(chalk.dim('  Starting in foreground (macOS code signature restriction)…'));
+            process.title = `kraki ${INTERNAL_DAEMON_WORKER_COMMAND}`;
             process.on('SIGHUP', () => {});
             const { saveDaemonPid, getLogVerbosity: getLogV } = await import('./config.js');
             saveDaemonPid(process.pid);


### PR DESCRIPTION
## Context

Follow-up hardening from a post-release review of the two Tentacle changes shipped in `v0.31.6`:

- #195 — Launch Services daemon identity / macOS TCC persistence
- #196 — per-model Pi thinking levels

Both changes have sound core mechanisms. This PR closes the concrete safety and resilience gaps found in review. It does **not** bump versions or trigger a release.

## Changes

### 1. Never signal an unverified/reused daemon PID

The PID file previously stored only a numeric PID. If the daemon crashed and the OS reused that number, `stopDaemon()` could send SIGTERM and (since #195) eventually SIGKILL to an unrelated process.

- Inspect the target process command before signalling.
- Require the internal `__daemon-worker` marker.
- Preserve the macOS CSM in-process SEA fallback by accepting the exact SEA executable path.
- Treat a reused/stale PID as non-daemon: clear the PID record, send no signal.
- Fail closed when inspection is unavailable: leave the process and launchd supervision untouched.
- Re-check identity immediately before SIGKILL to close the grace-window PID-reuse race.
- Refuse to start a duplicate daemon when a live recorded PID cannot be verified.

### 2. Keep environment values out of the long-lived `open -W` argv

#195 passed `--env NAME=VALUE`, which exposed tokens/proxy credentials in the command line of the `open -W` supervisor for the daemon's entire lifetime.

Now the launchd plist still carries the existing environment (preserving PAT-only and proxy setups), while `open` receives only `--env NAME`. Launch Services copies the value from `open`'s environment without embedding it in argv.

### 3. Recover from transient Pi catalog failures

#196 cached an empty effort map after one failed/timeout catalog RPC, so accurate per-model levels (including `max`) could not recover until daemon restart.

- Cache only successful catalog results.
- Retry on the next capabilities refresh after a failure.
- Treat explicit RPC `success:false` as an error rather than an empty catalog.
- Extract and test the throwaway child-process RPC lifecycle.

## Tests

- Tentacle full suite: **819/819**
- Focused daemon/TCC/Pi tests: **50/50**
- Added real fake-Pi child process tests for success, explicit RPC error, early exit + stderr, timeout/termination, and transient-failure retry.
- Build, Biome lint, and `git diff --check` pass.

## Scope

Only `@kraki/tentacle` source and tests are changed. No Head, Protocol, Web, iOS, production daemon, or monitor changes.
