### PR TITLE
chore(release): v0.31.7

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.6",
+  "version": "0.31.7",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bump `@kraki/tentacle` from `0.31.6` to `0.31.7`.

Includes the post-release hardening from #199:

- verify daemon PID identity before TERM/KILL and fail closed on unknown processes
- prevent PID-reuse races, including before SIGKILL
- explicitly mark macOS in-process daemon fallbacks
- keep environment values out of the long-lived `open -W` argv
- retry transient Pi catalog failures and handle explicit RPC errors
- add real child-process catalog lifecycle tests

Validation on #199: Tentacle 821/821, build, lint, diff check, GitHub CI all pass.