### PR TITLE
chore(release): v0.31.8

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.7",
+  "version": "0.31.8",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

- `@kraki/tentacle`: `0.31.7 → 0.31.8`
- `@kraki/head`: `0.17.0 → 0.17.1`

Ships #198:

- Pulse unicast target authorization and array-bypass closure
- stale/replaced WebSocket cleanup
- endpoint GC/persistence/device-deletion hardening
- bigint SQLite seq binding
- `@coinfra/pulse@0.5.0` across all Pulse consumers

The Head patch bump is required so the npm publishing job does not skip the
relay package. The Tentacle bump owns the `v0.31.8` release tag and binary
assets.

## Validation

- `pnpm install --frozen-lockfile` ✅
- `pnpm validate` ✅
  - crypto 36
  - head 253
  - tentacle 821
  - integration 44
  - arm-web 411
- #198 CI ✅
- main CI for #198 merge commit ✅
- Real-stack Playwright using npm `@coinfra/pulse@0.5.0`: 53/53 ✅

This release intentionally follows v0.31.7 after waiting for the concurrent
release session to finish, so no tag/version collision occurs.
