### PR TITLE
fix(tentacle): never fall back to foreground daemon

### DIFF
--- a/docs/mac-tcc-permissions.md
+++ b/docs/mac-tcc-permissions.md
@@ -119,7 +119,6 @@ bundled install:
 ```
 /usr/bin/open -W -n -a <Kraki.app>
   --stdout <bootstrap.log> --stderr <bootstrap.log>
-  --env K=V …
   --args __daemon-worker
 ```
 
@@ -135,9 +134,12 @@ Details that are load-bearing, each verified rather than assumed:
   when the app it waits on is SIGKILLed**, so the old exit-code condition would
   never fire and a crashed daemon would stay dead. `ThrottleInterval: 10` keeps
   an unlaunchable bundle from spinning.
-- **`--env`** is required: an app started through LaunchServices inherits the
-  launchd *session* environment, not the environment of whoever called `open`.
-  Without it the daemon silently loses `PATH`, proxy settings and tokens.
+- **No `open --env` arguments.** The launched app already inherits `open`'s
+  environment, and launchd supplies the required values through its
+  `EnvironmentVariables` dictionary. `open --env NAME` does **not** copy the
+  existing value — it overwrites it with an empty string. `NAME=VALUE` would
+  work but would expose proxy credentials and tokens in the long-lived
+  `open -W` command line.
 - **`--stdout` / `--stderr`** for the same reason — the launchd job's
   `StandardOutPath` now captures `open` itself, not the daemon.
 - **`--args` must come last**; `open` treats everything after it as app `argv`.
@@ -227,11 +229,13 @@ attempts. When healthy it reads `"daemonBundleId": "chat.kraki.cli"`.
 
 ### Verified
 
-- `vitest run` — 792/792 pass, including 13 new tests in
-  `src/__tests__/daemon-launch-tcc.test.ts` asserting the launch mechanism
-  itself: `open` as `argv[0]`, `-W`, `-n`, `-a <bundle>`, `--args` last,
-  `--env`/`--stdout`/`--stderr` forwarding, `KeepAlive: true`, and the
-  direct-`execve` fallback for non-bundled installs.
+- `vitest run` — 844/844 pass, including launch mechanism, background-only
+  failure behavior, explicit readiness handshake, launchd-without-PID authority,
+  failed-worker TERM/KILL/PID-reuse handling, updater stop gates, installer
+  delegation and PID hardening tests. The TCC suite asserts `open` as `argv[0]`,
+  `-W`, `-n`, `-a <bundle>`, `--args` last, no `--env` argv entries,
+  redirected stdio,
+  `KeepAlive: true`, and the direct-`execve` path for non-bundled installs.
 - `tsc --noEmit` — 0 errors across the whole tentacle package.
 - Launch identity measured live on macOS 26.5 across four bundle/launch
   combinations plus a real launchd job (see "What was actually measured").
@@ -286,10 +290,10 @@ kraki fda [--json|--watch]   # unchanged, retained for compatibility
   change silently reintroduces the entire bug — the daemon keeps running, the
   bundle stays signed and registered, and grants quietly stop surviving updates.
   `daemon-launch-tcc.test.ts` fails if you do; do not "fix" that test.
-- **Never** launch the daemon through the `~/.local/bin/kraki` symlink either.
-  It has the same effect: no bundle identity, path-tracked grant. (`install.sh`
-  and the web installer still do this for their initial post-install start — it
-  is the remaining known gap, tracked below.)
+- **Never** launch the daemon through the `~/.local/bin/kraki` symlink or a
+  hand-written installer `open`/`nohup` command. Installers must delegate to
+  `kraki start`, which owns launchd supervision, readiness validation and
+  Launch Services identity checks.
 - Keep the notarization ticket **stapled** and staple *before* building the
   distribution tarball. An unstapled app needs a successful online Gatekeeper
   check on every launch; if Gatekeeper refuses to launch it, its TCC grants are
@@ -321,18 +325,17 @@ the symlink, so that very first daemon had no bundle identity either. If the
 user granted Full Disk Access to *that* process, the grant was path-tracked from
 the outset and died on the next update.
 
-Both now launch the bundle through LaunchServices on macOS:
+Both installers now finish setup by invoking the public daemon manager:
 
 ```sh
-open -n -a "$HOME/.local/share/kraki/Kraki.app" \
-  --stdout "$BOOTSTRAP_LOG" --stderr "$BOOTSTRAP_LOG" \
-  --env "PATH=$PATH" --env "HOME=$HOME" \
-  --args __daemon-worker
+KRAKI_INSTALL=1 "${INSTALL_DIR}/kraki" </dev/tty
+"${INSTALL_DIR}/kraki" start
 ```
 
-with the original `nohup` retained for non-macOS and for the non-bundled
-fallback. Because `open` returns as soon as the app is launched, the liveness
-check matches on process name instead of a PID the shell never owned.
+They no longer invoke `open`, `nohup`, or `__daemon-worker` directly. This gives
+first install the same background-only policy, launchd supervision, explicit
+readiness handshake, Launch Services identity validation and non-zero failure
+path as `kraki start` and `kraki restart`.
 
 Still open, and not a TCC issue: the two installers disagree on `INSTALL_DIR`
 (`~/.local/bin` vs `/usr/local/bin`), so the symlink location differs by install

--- a/install.sh
+++ b/install.sh
@@ -196,49 +196,15 @@ main() {
   echo "  ✓ Kraki ${VERSION} installed"
   echo ""
 
-  # Auto-run interactive setup. KRAKI_INSTALL=1 tells kraki to show the
-  # setup wizard + pairing QR but exit without starting the daemon.
-  # The daemon is started below from the shell — on macOS 26+, kraki
-  # cannot fork+exec itself (CSM provenance tracking), but the user's
-  # shell can launch it just fine.
+  # Auto-run interactive setup. KRAKI_INSTALL=1 tells kraki to complete
+  # configuration but exit before daemon startup or pairing output. The
+  # subsequent `kraki start` uses the same background-only daemon manager,
+  # manager, readiness handshake, Launch Services validation, and error path as
+  # `kraki start` / `kraki restart`.
   KRAKI_INSTALL=1 "${INSTALL_DIR}/${BINARY_NAME}" </dev/tty
 
-  # Start daemon in background from the shell.
-  mkdir -p "${HOME}/.kraki/logs"
-  BOOTSTRAP_LOG="${HOME}/.kraki/logs/daemon-bootstrap.log"
-
-  # On macOS the daemon MUST be started through LaunchServices, not through the
-  # ${INSTALL_DIR}/kraki symlink. A binary exec'd by path gets no Launch Services
-  # application identity, so TCC keys its grants to the absolute path + cdhash
-  # and every future update silently revokes Full Disk Access. Launching the
-  # bundle with `open` gives the process its real bundle id (chat.kraki.cli),
-  # whose Developer ID Designated Requirement is cdhash-free and stable.
-  # See docs/mac-tcc-permissions.md.
-  APP_PATH="${HOME}/.local/share/kraki/Kraki.app"
-  if [ "$(uname -s)" = "Darwin" ] && [ -d "$APP_PATH" ]; then
-    open -n -a "$APP_PATH" \
-      --stdout "$BOOTSTRAP_LOG" --stderr "$BOOTSTRAP_LOG" \
-      --env "PATH=${PATH}" --env "HOME=${HOME}" \
-      --args __daemon-worker
-    # `open` returns as soon as the app is launched, so confirm by process name
-    # rather than by a PID we never owned.
-    sleep 2
-    if pgrep -f "Kraki.app/Contents/MacOS/kraki __daemon-worker" >/dev/null 2>&1; then
-      echo "  🦑 Kraki daemon started (via LaunchServices)"
-    else
-      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
-    fi
-  else
-    nohup "${INSTALL_DIR}/${BINARY_NAME}" __daemon-worker \
-      </dev/null >"$BOOTSTRAP_LOG" 2>&1 &
-    DAEMON_PID=$!
-    sleep 1
-    if kill -0 "$DAEMON_PID" 2>/dev/null; then
-      echo "  🦑 Kraki daemon started (PID $DAEMON_PID)"
-    else
-      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
-    fi
-  fi
+  echo "  Starting Kraki daemon..."
+  "${INSTALL_DIR}/${BINARY_NAME}" start
   echo ""
 }
 

--- a/packages/arm/web/public/install.sh
+++ b/packages/arm/web/public/install.sh
@@ -176,49 +176,15 @@ main() {
   echo "  ✓ Kraki ${VERSION} installed"
   echo ""
 
-  # Auto-run interactive setup. KRAKI_INSTALL=1 tells kraki to show the
-  # setup wizard + pairing QR but exit without starting the daemon.
-  # The daemon is started below from the shell — on macOS 26+, kraki
-  # cannot fork+exec itself (CSM provenance tracking), but the user's
-  # shell can launch it just fine.
+  # Auto-run interactive setup. KRAKI_INSTALL=1 tells kraki to complete
+  # configuration but exit before daemon startup or pairing output. The
+  # subsequent `kraki start` uses the same background-only daemon manager,
+  # manager, readiness handshake, Launch Services validation, and error path as
+  # `kraki start` / `kraki restart`.
   KRAKI_INSTALL=1 "${INSTALL_DIR}/${BINARY_NAME}" </dev/tty
 
-  # Start daemon in background from the shell.
-  mkdir -p "${HOME}/.kraki/logs"
-  BOOTSTRAP_LOG="${HOME}/.kraki/logs/daemon-bootstrap.log"
-
-  # On macOS the daemon MUST be started through LaunchServices, not through the
-  # ${INSTALL_DIR}/kraki symlink. A binary exec'd by path gets no Launch Services
-  # application identity, so TCC keys its grants to the absolute path + cdhash
-  # and every future update silently revokes Full Disk Access. Launching the
-  # bundle with `open` gives the process its real bundle id (chat.kraki.cli),
-  # whose Developer ID Designated Requirement is cdhash-free and stable.
-  # See docs/mac-tcc-permissions.md.
-  APP_PATH="${HOME}/.local/share/kraki/Kraki.app"
-  if [ "$(uname -s)" = "Darwin" ] && [ -d "$APP_PATH" ]; then
-    open -n -a "$APP_PATH" \
-      --stdout "$BOOTSTRAP_LOG" --stderr "$BOOTSTRAP_LOG" \
-      --env "PATH=${PATH}" --env "HOME=${HOME}" \
-      --args __daemon-worker
-    # `open` returns as soon as the app is launched, so confirm by process name
-    # rather than by a PID we never owned.
-    sleep 2
-    if pgrep -f "Kraki.app/Contents/MacOS/kraki __daemon-worker" >/dev/null 2>&1; then
-      echo "  🦑 Kraki daemon started (via LaunchServices)"
-    else
-      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
-    fi
-  else
-    nohup "${INSTALL_DIR}/${BINARY_NAME}" __daemon-worker \
-      </dev/null >"$BOOTSTRAP_LOG" 2>&1 &
-    DAEMON_PID=$!
-    sleep 1
-    if kill -0 "$DAEMON_PID" 2>/dev/null; then
-      echo "  🦑 Kraki daemon started (PID $DAEMON_PID)"
-    else
-      echo "  ⚠  Daemon didn't start automatically. Run: kraki start"
-    fi
-  fi
+  echo "  Starting Kraki daemon..."
+  "${INSTALL_DIR}/${BINARY_NAME}" start
   echo ""
 }
 

--- a/packages/tentacle/src/__tests__/cli.test.ts
+++ b/packages/tentacle/src/__tests__/cli.test.ts
@@ -123,6 +123,7 @@ let stdoutOutput: string[];
 let stderrOutput: string[];
 let originalArgv: string[];
 let originalMetaFile: string | undefined;
+let originalInstallMode: string | undefined;
 const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
 
 beforeEach(() => {
@@ -146,7 +147,9 @@ beforeEach(() => {
   }) as never);
   originalArgv = process.argv;
   originalMetaFile = process.env.KRAKI_META_FILE;
+  originalInstallMode = process.env.KRAKI_INSTALL;
   delete process.env.KRAKI_META_FILE;
+  delete process.env.KRAKI_INSTALL;
   // Reset mock defaults
   mockGetConfigDir.mockReturnValue('/tmp/fake-kraki');
   mockGetConfigPath.mockReturnValue('/tmp/fake-kraki/config.json');
@@ -159,6 +162,8 @@ afterEach(() => {
   process.argv = originalArgv;
   if (originalMetaFile === undefined) delete process.env.KRAKI_META_FILE;
   else process.env.KRAKI_META_FILE = originalMetaFile;
+  if (originalInstallMode === undefined) delete process.env.KRAKI_INSTALL;
+  else process.env.KRAKI_INSTALL = originalInstallMode;
 });
 
 /**
@@ -252,6 +257,23 @@ describe('CLI stop', () => {
   });
 });
 
+describe('CLI install mode', () => {
+  it('finishes setup without starting a worker or issuing a pairing token', async () => {
+    process.env.KRAKI_INSTALL = '1';
+    mockLoadConfig.mockReturnValue({
+      relay: 'wss://relay.test',
+      authMethod: 'github',
+      device: { name: 'laptop' },
+    });
+
+    await runCli(['start']);
+
+    expect(mockStartDaemon).not.toHaveBeenCalled();
+    expect(mockStartWorker).not.toHaveBeenCalled();
+    expect(mockShowPairingQr).not.toHaveBeenCalled();
+  });
+});
+
 describe('CLI restart', () => {
   it('starts from existing config when the daemon is stopped', async () => {
     const config = { relay: 'wss://relay.test', authMethod: 'github', device: { name: 'laptop' } };
@@ -263,6 +285,21 @@ describe('CLI restart', () => {
 
     expect(mockStopDaemon).not.toHaveBeenCalled();
     expect(mockStartDaemon).toHaveBeenCalledWith(config);
+  });
+
+  it('reports a background start failure and never runs the worker in the CLI process', async () => {
+    const config = { relay: 'wss://relay.test', authMethod: 'github', device: { name: 'laptop' } };
+    mockLoadConfig.mockReturnValue(config);
+    mockGetDaemonStatus.mockReturnValue({ running: false, pid: null });
+    mockStartDaemon.mockRejectedValue(new Error('background launch failed'));
+
+    await runCli(['restart']);
+
+    expect(mockStartDaemon).toHaveBeenCalledWith(config);
+    expect(mockStartWorker).not.toHaveBeenCalled();
+    expect(consoleOutput.join('\n')).toContain('Fatal error:');
+    expect(consoleOutput.join('\n')).toContain('background launch failed');
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('stops a running daemon before starting it again', async () => {

--- a/packages/tentacle/src/__tests__/config.test.ts
+++ b/packages/tentacle/src/__tests__/config.test.ts
@@ -218,6 +218,30 @@ describe('saveDaemonPid() / loadDaemonPid() / clearDaemonPid()', () => {
   });
 });
 
+// ── Daemon readiness ───────────────────────────────────
+
+describe('saveDaemonReady() / loadDaemonReady() / clearDaemonReady()', () => {
+  it('uses a separate readiness file and round-trips the worker PID', () => {
+    expect(config.getDaemonReadyPath()).toBe(join(tempHome, '.kraki', 'daemon.ready'));
+    expect(config.loadDaemonReady()).toBeNull();
+
+    config.saveDaemonReady(54321);
+    expect(config.loadDaemonReady()).toBe(54321);
+    expect(config.loadDaemonPid()).toBeNull();
+
+    config.clearDaemonReady();
+    expect(config.loadDaemonReady()).toBeNull();
+  });
+
+  it('returns null for stale or malformed readiness data', () => {
+    mkdirSync(join(tempHome, '.kraki'), { recursive: true });
+    writeFileSync(join(tempHome, '.kraki', 'daemon.ready'), 'not-a-pid', 'utf8');
+    expect(config.loadDaemonReady()).toBeNull();
+    expect(() => config.clearDaemonReady()).not.toThrow();
+    expect(() => config.clearDaemonReady()).not.toThrow();
+  });
+});
+
 describe('getOrCreateDeviceId()', () => {
   it('generates a new device ID on first call', () => {
     const id = config.getOrCreateDeviceId();

--- a/packages/tentacle/src/__tests__/daemon-launch-tcc.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-launch-tcc.test.ts
@@ -80,17 +80,18 @@ describe('buildLaunchdPlist — bundled install (the TCC-critical path)', () => 
     expect(i + 2).toBe(args.length);
   });
 
-  it('forwards environment by name, never embedding values in argv', () => {
-    // `open --env NAME` copies NAME from open's environment. NAME=VALUE would
-    // expose proxy credentials/tokens in the long-lived `open -W` argv.
-    expect(args).toContain('--env');
-    expect(args).toContain('NODE_ENV');
-    expect(args).toContain('LOG_LEVEL');
-    expect(args).not.toContain('NODE_ENV=production');
-    expect(args).not.toContain('LOG_LEVEL=info');
+  it('inherits launchd environment without using open --env', () => {
+    // `open --env NAME` sets NAME to an empty string; it does not copy the
+    // existing value. The launched app already inherits open's environment,
+    // which launchd provides through EnvironmentVariables.
+    expect(args).not.toContain('--env');
+    expect(args).not.toContain('NODE_ENV');
+    expect(args).not.toContain('LOG_LEVEL');
+    expect(plist).toMatch(/<key>NODE_ENV<\/key>\s*<string>production<\/string>/);
+    expect(plist).toMatch(/<key>LOG_LEVEL<\/key>\s*<string>info<\/string>/);
   });
 
-  it('does not leak environment values into the long-lived open command line', () => {
+  it('does not leak environment names or values into the long-lived open command line', () => {
     const secret = 'github_pat_super_secret';
     const secretPlist = buildLaunchdPlist({
       ...BASE,
@@ -98,10 +99,15 @@ describe('buildLaunchdPlist — bundled install (the TCC-critical path)', () => 
       envEntries: [['HTTPS_PROXY', 'http://user:pass@proxy'], ['GH_TOKEN', secret]],
     });
     const secretArgs = programArgs(secretPlist);
-    expect(secretArgs).toContain('HTTPS_PROXY');
-    expect(secretArgs).toContain('GH_TOKEN');
+    expect(secretArgs).not.toContain('--env');
+    expect(secretArgs).not.toContain('HTTPS_PROXY');
+    expect(secretArgs).not.toContain('GH_TOKEN');
     expect(secretArgs.join(' ')).not.toContain('user:pass');
     expect(secretArgs.join(' ')).not.toContain(secret);
+    expect(secretPlist).toContain('<key>HTTPS_PROXY</key>');
+    expect(secretPlist).toContain('<string>http://user:pass@proxy</string>');
+    expect(secretPlist).toContain('<key>GH_TOKEN</key>');
+    expect(secretPlist).toContain(`<string>${secret}</string>`);
   });
 
   it('redirects the daemon stdio, which LaunchServices also does not inherit', () => {

--- a/packages/tentacle/src/__tests__/daemon-worker.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-worker.test.ts
@@ -101,6 +101,10 @@ vi.mock('../logger.js', () => ({
 let mockConfig: Record<string, unknown> | null = null;
 let mockChannelKey: string | null = null;
 
+const mockSaveDaemonPid = vi.fn();
+const mockSaveDaemonReady = vi.fn();
+const mockClearDaemonReady = vi.fn();
+
 vi.mock('../config.js', () => ({
   loadConfig: vi.fn(() => mockConfig),
   loadChannelKey: vi.fn(() => mockChannelKey),
@@ -110,7 +114,9 @@ vi.mock('../config.js', () => ({
   getChannelKeyPath: vi.fn(() => '/tmp/fake-kraki/channel.key'),
   getConfigDir: vi.fn(() => '/tmp/fake-kraki'),
   getVersion: vi.fn(() => '0.0.0-test'),
-  saveDaemonPid: vi.fn(),
+  saveDaemonPid: (...args: unknown[]) => mockSaveDaemonPid(...args),
+  saveDaemonReady: (...args: unknown[]) => mockSaveDaemonReady(...args),
+  clearDaemonReady: (...args: unknown[]) => mockClearDaemonReady(...args),
 }));
 
 let mockExecSyncReturn = 'fake-token\n';
@@ -166,9 +172,11 @@ describe('daemon-worker: startWorker()', () => {
     expect(mockLoggerFns.debug).toHaveBeenCalledWith(expect.stringContaining('Resolved GitHub token'));
     expect(mockAdapter.start).toHaveBeenCalled();
     expect(mockRelay.connect).toHaveBeenCalled();
+    expect(mockSaveDaemonReady).toHaveBeenCalledWith(process.pid);
     expect(process.env.GITHUB_TOKEN).toBe('fake-token');
 
     await shutdown();
+    expect(mockClearDaemonReady).toHaveBeenCalled();
     expect(mockRelay.disconnect).toHaveBeenCalled();
     expect(mockAdapter.stop).toHaveBeenCalled();
   });

--- a/packages/tentacle/src/__tests__/daemon.test.ts
+++ b/packages/tentacle/src/__tests__/daemon.test.ts
@@ -13,6 +13,9 @@ import { resolve } from 'node:path';
 const mockSpawn = vi.fn();
 const mockExecSync = vi.fn();
 const mockExecFileSync = vi.fn();
+const mockIsSea = vi.fn(() => false);
+const mockGetKrakiAppBundlePath = vi.fn((): string | null => null);
+const mockGetProcessBundleIdentity = vi.fn((): string | null => null);
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
   execSync: (...args: unknown[]) => mockExecSync(...args),
@@ -22,12 +25,15 @@ vi.mock('node:child_process', () => ({
 const mockSaveDaemonPid = vi.fn();
 const mockLoadDaemonPid = vi.fn();
 const mockClearDaemonPid = vi.fn();
+const mockLoadDaemonReady = vi.fn();
+const mockClearDaemonReady = vi.fn();
 const mockMkdirSync = vi.fn();
 const mockOpenSync = vi.fn();
 const mockCloseSync = vi.fn();
 const mockExistsSync = vi.fn(() => false);
 const mockUnlinkSync = vi.fn();
 const mockWriteFileSync = vi.fn();
+const mockChmodSync = vi.fn();
 
 vi.mock('node:fs', () => ({
   mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
@@ -36,15 +42,21 @@ vi.mock('node:fs', () => ({
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
   unlinkSync: (...args: unknown[]) => mockUnlinkSync(...args),
   writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  chmodSync: (...args: unknown[]) => mockChmodSync(...args),
 }));
 
 vi.mock('node:os', () => ({
   homedir: vi.fn(() => '/tmp/fake-home'),
 }));
 
-// Force isSea() → false so startDaemon tests use the spawn path (not launchctl)
 vi.mock('node:sea', () => ({
-  isSea: vi.fn(() => false),
+  isSea: (...args: unknown[]) => mockIsSea(...args),
+}));
+
+vi.mock('../checks.js', () => ({
+  getKrakiAppBundlePath: (...args: unknown[]) => mockGetKrakiAppBundlePath(...args),
+  getProcessBundleIdentity: (...args: unknown[]) => mockGetProcessBundleIdentity(...args),
+  KRAKI_BUNDLE_ID: 'chat.kraki.cli',
 }));
 
 vi.mock('../config.js', () => ({
@@ -54,15 +66,20 @@ vi.mock('../config.js', () => ({
   saveDaemonPid: (...args: unknown[]) => mockSaveDaemonPid(...args),
   loadDaemonPid: (...args: unknown[]) => mockLoadDaemonPid(...args),
   clearDaemonPid: (...args: unknown[]) => mockClearDaemonPid(...args),
+  loadDaemonReady: (...args: unknown[]) => mockLoadDaemonReady(...args),
+  clearDaemonReady: (...args: unknown[]) => mockClearDaemonReady(...args),
 }));
 
 import {
+  assertNoUntrackedLaunchdDaemon,
   isDaemonRunning,
   getDaemonStatus,
   startDaemon,
+  startDaemonLaunchctl,
   stopDaemon,
   inspectDaemonProcess,
   resolveDaemonLaunch,
+  DaemonStartupError,
   getDaemonBootstrapLogPath,
 } from '../daemon.js';
 
@@ -71,7 +88,14 @@ beforeEach(() => {
   vi.useRealTimers();
   mockLoadDaemonPid.mockReturnValue(null);
   mockOpenSync.mockReturnValue(99);
-  mockExecFileSync.mockReturnValue('/path/to/kraki __daemon-worker');
+  mockExecFileSync.mockImplementation((command: string) => {
+    if (command === '/bin/launchctl') throw new Error('not loaded');
+    return '/path/to/kraki __daemon-worker';
+  });
+  mockIsSea.mockReturnValue(false);
+  mockGetKrakiAppBundlePath.mockReturnValue(null);
+  mockGetProcessBundleIdentity.mockReturnValue(null);
+  mockLoadDaemonReady.mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -110,9 +134,68 @@ describe('inspectDaemonProcess()', () => {
   });
 });
 
+describe('launchd job without a verified worker PID', () => {
+  it('fails closed instead of unloading a loaded job', () => {
+    mockLoadDaemonPid.mockReturnValue(null);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      return '/path/to/kraki __daemon-worker';
+    });
+
+    expect(stopDaemon('darwin')).toBe(false);
+    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('refuses to start a duplicate beside a loaded untracked job', () => {
+    mockLoadDaemonPid.mockReturnValue(null);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      return '/path/to/kraki __daemon-worker';
+    });
+
+    expect(() => assertNoUntrackedLaunchdDaemon('darwin')).toThrow('will not risk starting a duplicate daemon');
+  });
+
+  it('allows stale plist cleanup when launchctl confirms no job is loaded', () => {
+    mockLoadDaemonPid.mockReturnValue(null);
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') throw new Error('not loaded');
+      return '/path/to/kraki __daemon-worker';
+    });
+
+    expect(stopDaemon('darwin')).toBe(false);
+    expect(mockExecSync).toHaveBeenCalled();
+    expect(mockUnlinkSync).toHaveBeenCalled();
+  });
+});
+
 // ── isDaemonRunning ─────────────────────────────────────
 
 describe('isDaemonRunning()', () => {
+  it('treats a loaded launchd job without a PID as running', () => {
+    mockLoadDaemonPid.mockReturnValue(null);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      return '/path/to/kraki __daemon-worker';
+    });
+
+    expect(isDaemonRunning('darwin')).toBe(true);
+    expect(getDaemonStatus('darwin')).toEqual({ running: true, pid: null });
+  });
+
+  it('does not discard a stale PID while its launchd job remains loaded', () => {
+    mockLoadDaemonPid.mockReturnValue(999999999);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      return '/path/to/kraki __daemon-worker';
+    });
+
+    expect(isDaemonRunning('darwin')).toBe(true);
+    expect(mockClearDaemonPid).not.toHaveBeenCalled();
+  });
+
   it('returns false when no PID file exists', () => {
     mockLoadDaemonPid.mockReturnValue(null);
     expect(isDaemonRunning()).toBe(false);
@@ -133,6 +216,16 @@ describe('isDaemonRunning()', () => {
 // ── getDaemonStatus ─────────────────────────────────────
 
 describe('getDaemonStatus()', () => {
+  it('reports a loaded launchd job without a PID as running with unknown PID', () => {
+    mockLoadDaemonPid.mockReturnValue(null);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      return '/path/to/kraki __daemon-worker';
+    });
+
+    expect(getDaemonStatus('darwin')).toEqual({ running: true, pid: null });
+  });
+
   it('returns running=false and pid=null when no PID file', () => {
     mockLoadDaemonPid.mockReturnValue(null);
     expect(getDaemonStatus()).toEqual({ running: false, pid: null });
@@ -197,10 +290,97 @@ describe('startDaemon()', () => {
     expect(launch.workerPath).toBe(process.execPath);
   });
 
+  it('rejects a bundled macOS launch whose PID lacks the required Launch Services identity', async () => {
+    vi.useFakeTimers();
+    mockIsSea.mockReturnValue(true);
+    mockGetKrakiAppBundlePath.mockReturnValue('/Applications/Kraki.app');
+    mockGetProcessBundleIdentity.mockReturnValue(null);
+    mockLoadDaemonReady.mockReturnValue(4242);
+    mockExistsSync.mockReturnValue(true);
+    // stopDaemon() sees no previous PID; the duplicate-start guard also sees
+    // none; then the new worker writes PID 4242 during the launch poll.
+    mockLoadDaemonPid
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValue(4242);
+    let terminated = false;
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((_pid: number, signal?: string | number) => {
+      if (signal === 'SIGTERM') { terminated = true; return true; }
+      if (signal === 0 && terminated) throw new Error('ESRCH');
+      return true;
+    }) as typeof process.kill);
+
+    const startPromise = startDaemonLaunchctl(fakeConfig);
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      '/tmp/fake-home/Library/LaunchAgents/cloud.corelli.kraki.plist',
+      expect.any(String),
+      { mode: 0o600 },
+    );
+    expect(mockChmodSync).toHaveBeenCalledWith(
+      '/tmp/fake-home/Library/LaunchAgents/cloud.corelli.kraki.plist',
+      0o600,
+    );
+    const rejection = expect(startPromise).rejects.toBeInstanceOf(DaemonStartupError);
+    await vi.advanceTimersByTimeAsync(35_300);
+
+    await rejection;
+    expect(mockGetProcessBundleIdentity).toHaveBeenCalledWith(4242);
+    expect(mockUnlinkSync).toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it('fails closed without removing supervision when startup identity cannot be inspected', async () => {
+    vi.useFakeTimers();
+    mockIsSea.mockReturnValue(true);
+    mockGetKrakiAppBundlePath.mockReturnValue('/Applications/Kraki.app');
+    mockLoadDaemonReady.mockReturnValue(4243);
+    mockLoadDaemonPid
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValue(4243);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      throw new Error('EPERM');
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const startPromise = startDaemonLaunchctl(fakeConfig);
+    const readyClearsBeforeTimeout = mockClearDaemonReady.mock.calls.length;
+    const rejection = expect(startPromise).rejects.toBeInstanceOf(DaemonStartupError);
+    await vi.advanceTimersByTimeAsync(30_200);
+
+    await rejection;
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+    expect(mockClearDaemonPid).not.toHaveBeenCalled();
+    expect(mockClearDaemonReady).toHaveBeenCalledTimes(readyClearsBeforeTimeout);
+    expect(killSpy).not.toHaveBeenCalledWith(4243, 'SIGTERM');
+    killSpy.mockRestore();
+  });
+
+  it('preserves a loaded launchd job when startup times out before any PID is available', async () => {
+    vi.useFakeTimers();
+    mockGetKrakiAppBundlePath.mockReturnValue('/Applications/Kraki.app');
+    mockLoadDaemonPid.mockReturnValue(null);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      throw new Error('unexpected process inspection');
+    });
+
+    const startPromise = startDaemonLaunchctl(fakeConfig);
+    const rejection = expect(startPromise).rejects.toBeInstanceOf(DaemonStartupError);
+    await vi.advanceTimersByTimeAsync(30_200);
+
+    await rejection;
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+    expect(mockClearDaemonPid).not.toHaveBeenCalled();
+    expect(mockClearDaemonReady).toHaveBeenCalledTimes(1);
+  });
+
   it('waits for bootstrap before saving the PID', async () => {
     vi.useFakeTimers();
     const { child } = makeFakeChild(42);
     mockSpawn.mockReturnValue(child);
+    mockLoadDaemonReady.mockReturnValue(42);
 
     const startPromise = startDaemon(fakeConfig);
 
@@ -217,7 +397,7 @@ describe('startDaemon()', () => {
     expect(mockCloseSync).toHaveBeenCalledWith(99);
     expect(mockSaveDaemonPid).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(1500);
+    await vi.advanceTimersByTimeAsync(100);
 
     await expect(startPromise).resolves.toBe(42);
     expect(mockSaveDaemonPid).toHaveBeenCalledWith(42);
@@ -228,6 +408,7 @@ describe('startDaemon()', () => {
     vi.useFakeTimers();
     const { child } = makeFakeChild(55);
     mockSpawn.mockReturnValue(child);
+    mockLoadDaemonReady.mockReturnValue(55);
 
     const startPromise = startDaemon({
       ...fakeConfig,
@@ -237,8 +418,82 @@ describe('startDaemon()', () => {
     const [, , opts] = mockSpawn.mock.calls[0];
     expect(opts.env.LOG_LEVEL).toBe('debug');
 
-    await vi.advanceTimersByTimeAsync(1500);
+    await vi.advanceTimersByTimeAsync(100);
     await expect(startPromise).resolves.toBe(55);
+  });
+
+  it('fails instead of reporting success when a background worker never publishes readiness', async () => {
+    vi.useFakeTimers();
+    const { child } = makeFakeChild(77);
+    mockSpawn.mockReturnValue(child);
+    mockLoadDaemonReady.mockReturnValue(null);
+    let terminated = false;
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((_pid: number, signal?: string | number) => {
+      if (signal === 'SIGTERM') { terminated = true; return true; }
+      if (signal === 0 && terminated) throw new Error('ESRCH');
+      return true;
+    }) as typeof process.kill);
+
+    const startPromise = startDaemon(fakeConfig);
+    const rejection = expect(startPromise).rejects.toThrow('did not become ready');
+    await vi.advanceTimersByTimeAsync(35_200);
+
+    await rejection;
+    expect(child.unref).not.toHaveBeenCalled();
+    expect(mockSaveDaemonPid).not.toHaveBeenCalled();
+    expect(killSpy).toHaveBeenCalledWith(77, 'SIGTERM');
+    killSpy.mockRestore();
+  });
+
+  it('does not SIGKILL a PID reused after the failed worker exits', async () => {
+    vi.useFakeTimers();
+    const { child } = makeFakeChild(78);
+    mockSpawn.mockReturnValue(child);
+    mockLoadDaemonReady.mockReturnValue(null);
+    let psInspections = 0;
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') throw new Error('not loaded');
+      psInspections += 1;
+      return psInspections === 1
+        ? '/path/to/kraki __daemon-worker'
+        : '/Applications/Safari.app/Contents/MacOS/Safari';
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const startPromise = startDaemon(fakeConfig);
+    const rejection = expect(startPromise).rejects.toThrow('did not become ready');
+    await vi.advanceTimersByTimeAsync(30_300);
+
+    await rejection;
+    expect(mockSaveDaemonPid).not.toHaveBeenCalled();
+    expect(mockClearDaemonPid).toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalledWith(78, 'SIGKILL');
+    killSpy.mockRestore();
+  });
+
+  it('preserves the PID when failed-worker identity becomes unknown', async () => {
+    vi.useFakeTimers();
+    const { child } = makeFakeChild(79);
+    mockSpawn.mockReturnValue(child);
+    mockLoadDaemonReady.mockReturnValue(null);
+    let psInspections = 0;
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') throw new Error('not loaded');
+      psInspections += 1;
+      if (psInspections === 1) return '/path/to/kraki __daemon-worker';
+      throw new Error('EPERM');
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const startPromise = startDaemon(fakeConfig);
+    const rejection = expect(startPromise).rejects.toThrow('could not be safely terminated');
+    await vi.advanceTimersByTimeAsync(30_300);
+
+    await rejection;
+    expect(mockSaveDaemonPid).toHaveBeenCalledWith(79);
+    expect(mockClearDaemonPid).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalledWith(79, 'SIGKILL');
+    killSpy.mockRestore();
   });
 
   it('fails fast when the child exits during bootstrap', async () => {
@@ -265,7 +520,10 @@ describe('stopDaemon()', () => {
 
   it('does not signal a reused PID that belongs to another process', () => {
     mockLoadDaemonPid.mockReturnValue(12345);
-    mockExecFileSync.mockReturnValue('/Applications/Safari.app/Contents/MacOS/Safari');
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') throw new Error('not loaded');
+      return '/Applications/Safari.app/Contents/MacOS/Safari';
+    });
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
     expect(stopDaemon()).toBe(true);
@@ -314,7 +572,12 @@ describe('stopDaemon()', () => {
     // Unloading the launchd job no longer kills the daemon — the job is `open`
     // and the daemon belongs to LaunchServices — so this escalation is the only
     // backstop left for a hung daemon.
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    let killed = false;
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((_pid: number, signal?: string | number) => {
+      if (signal === 'SIGKILL') { killed = true; return true; }
+      if (signal === 0 && killed) throw new Error('ESRCH');
+      return true;
+    }) as typeof process.kill);
     mockLoadDaemonPid.mockReturnValue(12345);
 
     const result = stopDaemon();
@@ -325,6 +588,18 @@ describe('stopDaemon()', () => {
     expect(mockClearDaemonPid).toHaveBeenCalled();
     killSpy.mockRestore();
   }, 10_000);
+
+  it('keeps the PID and reports failure when SIGKILL does not terminate the daemon', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    mockLoadDaemonPid.mockReturnValue(12345);
+
+    const result = stopDaemon();
+
+    expect(result).toBe(false);
+    expect(killSpy).toHaveBeenCalledWith(12345, 'SIGKILL');
+    expect(mockClearDaemonPid).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  }, 12_000);
 
   it('clears PID even if process is already gone', () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {

--- a/packages/tentacle/src/__tests__/installer-contract.test.ts
+++ b/packages/tentacle/src/__tests__/installer-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const installerPaths = [
+  resolve(import.meta.dirname, '../../../../install.sh'),
+  resolve(import.meta.dirname, '../../../arm/web/public/install.sh'),
+];
+
+for (const installerPath of installerPaths) {
+  const installer = readFileSync(installerPath, 'utf8');
+
+  describe(`daemon startup contract: ${installerPath}`, () => {
+    it('delegates startup to the background-only CLI daemon manager', () => {
+      expect(installer).toContain('"${INSTALL_DIR}/${BINARY_NAME}" start');
+      expect(installer).not.toMatch(/\bnohup\b/);
+      expect(installer).not.toMatch(/\bopen\s+-n\s+-a\b/);
+      expect(installer).not.toContain('__daemon-worker');
+    });
+  });
+}

--- a/packages/tentacle/src/__tests__/update.test.ts
+++ b/packages/tentacle/src/__tests__/update.test.ts
@@ -20,7 +20,7 @@ vi.mock('node:https', async () => {
   };
 });
 
-import { fetchLatestVersion, formatBytes, getProxyForUrl, shouldBypassProxy } from '../update.js';
+import { fetchLatestVersion, formatBytes, getProxyForUrl, shouldBypassProxy, stopDaemonForUpdate } from '../update.js';
 
 function createMockResponse(statusCode: number, body: string, headers: Record<string, string> = {}) {
   const res = new PassThrough() as PassThrough & {
@@ -122,6 +122,36 @@ describe('update proxy support', () => {
     await expect(fetchLatestVersion()).resolves.toBe('0.12.0');
     expect(mockHttpRequest).toHaveBeenCalledOnce();
     expect(mockHttpsRequest).toHaveBeenCalledOnce();
+  });
+});
+
+describe('update daemon stop gate', () => {
+  it('does nothing when the daemon is already stopped', async () => {
+    const stopDaemon = vi.fn();
+    await stopDaemonForUpdate({ isDaemonRunning: () => false, stopDaemon }, 1, 1);
+    expect(stopDaemon).not.toHaveBeenCalled();
+  });
+
+  it('refuses the update when daemon identity cannot be safely stopped', async () => {
+    await expect(stopDaemonForUpdate({
+      isDaemonRunning: () => true,
+      stopDaemon: () => false,
+    }, 1, 1)).rejects.toThrow('could not be safely identified and stopped');
+  });
+
+  it('refuses the update when the daemon remains alive after the stop window', async () => {
+    await expect(stopDaemonForUpdate({
+      isDaemonRunning: () => true,
+      stopDaemon: () => true,
+    }, 1, 2)).rejects.toThrow('did not exit');
+  });
+
+  it('continues only after the daemon is confirmed gone', async () => {
+    let probes = 0;
+    await expect(stopDaemonForUpdate({
+      isDaemonRunning: () => probes++ < 2,
+      stopDaemon: () => true,
+    }, 1, 3)).resolves.toBeUndefined();
   });
 });
 

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -389,7 +389,7 @@ export const LSREGISTER_PATH =
   'LaunchServices.framework/Versions/A/Support/lsregister';
 
 /** Bundle id of the signed Kraki CLI/daemon .app (must never change). */
-const KRAKI_BUNDLE_ID = 'chat.kraki.cli';
+export const KRAKI_BUNDLE_ID = 'chat.kraki.cli';
 
 /**
  * Resolve the .app bundle that contains the current executable, if any.

--- a/packages/tentacle/src/cli.ts
+++ b/packages/tentacle/src/cli.ts
@@ -21,7 +21,7 @@ import { readFileSync, existsSync, unlinkSync } from 'node:fs';
 import { select } from '@inquirer/prompts';
 
 import { loadConfig, saveConfig, getConfigPath, getKrakiHome, getLogVerbosity, getVersion, loadChannelKey, type KrakiConfig } from './config.js';
-import { INTERNAL_DAEMON_WORKER_COMMAND, isDaemonRunning, getDaemonStatus, startDaemon, stopDaemon, MacOSCodeSignatureError } from './daemon.js';
+import { INTERNAL_DAEMON_WORKER_COMMAND, isDaemonRunning, getDaemonStatus, startDaemon, stopDaemon } from './daemon.js';
 import { runSetup } from './setup.js';
 import { requestPairingToken, buildPairingUrl, renderQrToTerminal } from './pair.js';
 import { printStaticBanner } from './banner.js';
@@ -210,30 +210,14 @@ async function cmdStart(): Promise<void> {
 // ── Shared start logic ──────────────────────────────────
 
 async function silentStart(config: KrakiConfig): Promise<void> {
-  // In install mode, the install script handles daemon startup from the
-  // shell (needed on macOS where kraki can't fork+exec itself due to CSM).
+  // In install mode, finish configuration but leave startup to the install
+  // script's subsequent `kraki start`. That command uses the normal background
+  // daemon manager and shows the pairing QR only after readiness succeeds.
   if (process.env.KRAKI_INSTALL === '1') {
-    const { showPairingQr } = await import('./setup.js');
-    await showPairingQr(config);
-    console.log(chalk.dim('  Commands:'));
-    console.log(chalk.dim('    kraki connect   Generate a new connect code'));
-    console.log(chalk.dim('    kraki status    Show connection status'));
-    console.log(chalk.dim('    kraki logs -f   Follow logs'));
-    console.log(chalk.dim('    kraki stop      Stop Kraki'));
-    console.log('');
     return;
   }
 
-  let pid: number;
-  try {
-    pid = await startDaemon(config);
-  } catch (err) {
-    if (err instanceof MacOSCodeSignatureError) {
-      return startDaemonInProcess(config);
-    }
-    console.log(chalk.red(`  Failed to start Kraki: ${(err as Error).message}`));
-    return;
-  }
+  const pid = await startDaemon(config);
   console.log(chalk.green(`  🦑 Kraki started (PID ${pid})`));
 
   // Show pairing QR code
@@ -247,42 +231,6 @@ async function silentStart(config: KrakiConfig): Promise<void> {
   console.log(chalk.dim('    kraki logs -f   Follow logs'));
   console.log(chalk.dim('    kraki stop      Stop Kraki'));
   console.log('');
-}
-
-/**
- * Run the daemon worker in the current process.
- * Used on macOS when the kernel blocks child process spawning of
- * downloaded SEA binaries (com.apple.provenance + CSM 2).
- */
-async function startDaemonInProcess(config: KrakiConfig): Promise<void> {
-  // Give the in-process CSM fallback the same inspectable identity marker as a
-  // normal daemon worker. stopDaemon() requires this before signalling a PID;
-  // accepting any process that merely runs the kraki executable would allow a
-  // stale PID reused by `kraki logs/update` to be killed.
-  process.title = `kraki ${INTERNAL_DAEMON_WORKER_COMMAND}`;
-  // Ignore SIGHUP so the daemon survives terminal close
-  process.on('SIGHUP', () => {});
-
-  const { saveDaemonPid, getLogVerbosity: getLogV } = await import('./config.js');
-  saveDaemonPid(process.pid);
-  process.env.LOG_LEVEL = getLogV(config) === 'verbose' ? 'debug' : 'info';
-
-  // Force production logging so pino writes to files, not stdout.
-  // (The spawned-daemon path doesn't need this because stdio is 'ignore'.)
-  process.env.NODE_ENV = 'production';
-
-  console.log(chalk.green(`  🦑 Kraki started (PID ${process.pid})`));
-
-  // Show pairing QR code
-  const { showPairingQr } = await import('./setup.js');
-  await showPairingQr(config);
-
-  console.log(chalk.dim('  Running in foreground — press Ctrl+C or run `kraki stop` to quit'));
-  console.log('');
-
-  const { startWorker } = await import('./daemon-worker.js');
-  await startWorker();
-  // This never returns — the process is now the daemon
 }
 
 function cmdStop(): void {

--- a/packages/tentacle/src/config.ts
+++ b/packages/tentacle/src/config.ts
@@ -219,3 +219,32 @@ export function clearDaemonPid(): void {
     // File may not exist — that's fine
   }
 }
+
+// ── Daemon readiness ───────────────────────────────────
+
+export function getDaemonReadyPath(): string {
+  return join(getKrakiHome(), 'daemon.ready');
+}
+
+export function saveDaemonReady(pid: number): void {
+  getConfigDir();
+  writeFileSync(getDaemonReadyPath(), String(pid), 'utf8');
+}
+
+export function loadDaemonReady(): number | null {
+  try {
+    const raw = readFileSync(getDaemonReadyPath(), 'utf8').trim();
+    const pid = parseInt(raw, 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDaemonReady(): void {
+  try {
+    unlinkSync(getDaemonReadyPath());
+  } catch {
+    // File may not exist — that's fine
+  }
+}

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -15,7 +15,7 @@
 
 import { execSync } from 'node:child_process';
 import { platform } from 'node:os';
-import { loadConfig, loadChannelKey, getOrCreateDeviceId, getConfigPath, getChannelKeyPath, getVersion, saveDaemonPid } from './config.js';
+import { loadConfig, loadChannelKey, getOrCreateDeviceId, getConfigPath, getChannelKeyPath, getVersion, saveDaemonPid, saveDaemonReady, clearDaemonReady } from './config.js';
 import { ensureWindowsSystemPath, probeFda, ensureTccBundleRegistered, cleanupStaleBundleEntries } from './checks.js';
 import { MultiAgentAdapter } from './adapters/multi.js';
 
@@ -67,7 +67,9 @@ export interface WorkerResult {
 }
 
 export async function startWorker(): Promise<WorkerResult> {
-  // Write PID immediately so the launcher (launchctl or CLI) can find us
+  // Clear any stale readiness before publishing this process's PID. This order
+  // prevents a reused numeric PID from momentarily matching an old ready file.
+  clearDaemonReady();
   saveDaemonPid(process.pid);
   logger.info('Daemon starting…');
   if (_ensuredWindowsPathDirs.length > 0) {
@@ -256,7 +258,8 @@ export async function startWorker(): Promise<WorkerResult> {
   relay.connect();
   logger.info({ relay: config.relay, device: config.device.name }, 'Daemon running');
 
-  // Write initial status file so toolbar can detect the daemon
+  // Write initial status file so toolbar can detect the daemon. Readiness is
+  // published only after the lifecycle handlers below are installed.
   initStatusFile(process.env.KRAKI_RELAY_URL ?? config.relay, config.device.name);
 
   // 6. Graceful shutdown
@@ -265,6 +268,7 @@ export async function startWorker(): Promise<WorkerResult> {
     if (shuttingDown) return;
     shuttingDown = true;
     logger.info('Shutting down…');
+    clearDaemonReady();
     clearStatusFile();
     relay.disconnect();
     await adapter.stop();
@@ -282,6 +286,11 @@ export async function startWorker(): Promise<WorkerResult> {
     logger.fatal({ err }, 'Uncaught exception — attempting graceful shutdown');
     shutdown().catch(() => {}).finally(() => process.exit(1));
   });
+
+  // Publish readiness only after every startup-critical component and graceful
+  // lifecycle handler is installed. The launcher must not report success before
+  // this point.
+  saveDaemonReady(process.pid);
 
   return { adapter, relay, sessionManager, shutdown };
 }

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -8,12 +8,12 @@
  * cannot be removed. macOS 26+ CSM 2 blocks direct fork()+execve() of
  * such binaries from child processes. To bypass this, macOS SEA builds
  * use launchctl to have launchd spawn the daemon in a completely
- * independent context. If launchctl also fails, the caller falls back
- * to running the daemon worker in the current process.
+ * independent context. A launch failure is fatal: Kraki never runs the
+ * daemon inside the interactive CLI process.
  */
 
 import { spawn, execSync, execFileSync, type ChildProcess } from 'node:child_process';
-import { closeSync, mkdirSync, openSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
+import { closeSync, mkdirSync, openSync, writeFileSync, existsSync, unlinkSync, chmodSync } from 'node:fs';
 import { delimiter, join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { isSea } from 'node:sea';
@@ -26,19 +26,18 @@ import {
   saveDaemonPid,
   loadDaemonPid,
   clearDaemonPid,
+  loadDaemonReady,
+  clearDaemonReady,
 } from './config.js';
-import { getKrakiAppBundlePath } from './checks.js';
+import { getKrakiAppBundlePath, getProcessBundleIdentity, KRAKI_BUNDLE_ID } from './checks.js';
 
-// How long to wait for a regular spawned child to finish bootstrapping
-// before declaring success. No signature verification involved.
-const SPAWN_GRACE_MS = 1500;
+// How long to wait for any background daemon to publish readiness. Agent
+// discovery and capability loading can be slow on a cold machine; the explicit
+// ready file prevents this larger timeout from accepting a half-started worker.
+const DAEMON_READY_TIMEOUT_MS = 30_000;
 
-// How long to wait for a launchctl-spawned daemon to write its PID file.
-// Cold-launching a freshly-installed SEA binary on macOS takes ~2s for
-// signature verification + Node SEA bundle parse. Empirically a fresh
-// binary's first launch is ~1.9s, so we keep comfortable headroom for
-// slower machines / busy disks. After this, a CSM block is plausible.
-const LAUNCHCTL_GRACE_MS = 8000;
+// macOS LaunchServices uses the same readiness contract.
+const LAUNCHCTL_GRACE_MS = DAEMON_READY_TIMEOUT_MS;
 const LAUNCHD_LABEL_BASE = 'cloud.corelli.kraki';
 
 /**
@@ -68,11 +67,41 @@ function unloadLaunchdAgent(): void {
   } catch { /* not loaded */ }
 }
 
+function isLaunchdAgentLoaded(platform = process.platform): boolean {
+  if (platform !== 'darwin') return false;
+  const uid = process.getuid?.();
+  if (uid === undefined) return false;
+  try {
+    execFileSync('/bin/launchctl', ['print', `gui/${uid}/${getLaunchdLabel()}`], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function cleanupLaunchdPlist(): void {
   unloadLaunchdAgent();
   const p = getLaunchdPlistPath();
   if (existsSync(p)) unlinkSync(p);
 }
+export function hasUntrackedLaunchdDaemon(
+  pid: number | null = loadDaemonPid(),
+  platform = process.platform,
+): boolean {
+  return pid === null && isLaunchdAgentLoaded(platform);
+}
+
+export function assertNoUntrackedLaunchdDaemon(platform = process.platform): void {
+  if (!hasUntrackedLaunchdDaemon(loadDaemonPid(), platform)) return;
+  throw new Error(
+    'Refusing to start: the launchd job is still loaded but no verified daemon PID is available. ' +
+    'Inspect the existing job before removing it; Kraki will not risk starting a duplicate daemon.',
+  );
+}
+
 export const INTERNAL_DAEMON_WORKER_COMMAND = '__daemon-worker';
 
 export type DaemonProcessIdentity = 'daemon' | 'other' | 'gone' | 'unknown';
@@ -204,11 +233,13 @@ export function resolveDaemonLaunch(
 function waitForDaemonBootstrap(
   child: ChildProcess,
   bootstrapLogPath: string,
-  timeoutMs = SPAWN_GRACE_MS,
+  timeoutMs = DAEMON_READY_TIMEOUT_MS,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
+    let poll: NodeJS.Timeout | undefined;
     const cleanup = () => {
       clearTimeout(timer);
+      if (poll) clearInterval(poll);
       child.off('error', onError);
       child.off('exit', onExit);
     };
@@ -229,12 +260,59 @@ function waitForDaemonBootstrap(
 
     const timer = setTimeout(() => {
       cleanup();
-      resolve();
+      reject(new Error(`Kraki did not become ready within ${timeoutMs}ms. Check ${bootstrapLogPath}`));
     }, timeoutMs);
+
+    poll = setInterval(() => {
+      if (child.pid && loadDaemonReady() === child.pid) {
+        cleanup();
+        resolve();
+      }
+    }, 100);
 
     child.once('error', onError);
     child.once('exit', onExit);
   });
+}
+
+async function waitForProcessIdentityToChange(
+  pid: number,
+  timeoutMs: number,
+): Promise<DaemonProcessIdentity> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const identity = inspectDaemonProcess(pid);
+    if (identity !== 'daemon') return identity;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return inspectDaemonProcess(pid);
+}
+
+async function terminateFailedDaemon(pid: number): Promise<boolean> {
+  const initialIdentity = inspectDaemonProcess(pid);
+  if (initialIdentity === 'gone' || initialIdentity === 'other') return true;
+  if (initialIdentity !== 'daemon') return false;
+
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    return true;
+  }
+
+  const afterTerm = await waitForProcessIdentityToChange(pid, 5000);
+  if (afterTerm === 'gone' || afterTerm === 'other') return true;
+  if (afterTerm !== 'daemon') return false;
+
+  // Re-check immediately before escalation to cover PID reuse during the wait.
+  if (inspectDaemonProcess(pid) !== 'daemon') return true;
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    return true;
+  }
+
+  const afterKill = await waitForProcessIdentityToChange(pid, 1000);
+  return afterKill === 'gone' || afterKill === 'other';
 }
 
 // ── Status ──────────────────────────────────────────────
@@ -244,12 +322,14 @@ export interface DaemonStatus {
   pid: number | null;
 }
 
-export function isDaemonRunning(): boolean {
+export function isDaemonRunning(platform = process.platform): boolean {
   const pid = loadDaemonPid();
-  if (pid === null) return false;
+  if (pid === null) return isLaunchdAgentLoaded(platform);
   const identity = inspectDaemonProcess(pid);
   if (identity === 'gone' || identity === 'other') {
+    if (isLaunchdAgentLoaded(platform)) return true;
     clearDaemonPid();
+    clearDaemonReady();
     return false;
   }
   // `unknown` means the PID is alive but the OS refused command inspection.
@@ -258,24 +338,30 @@ export function isDaemonRunning(): boolean {
   return true;
 }
 
-export function getDaemonStatus(): DaemonStatus {
+export function getDaemonStatus(platform = process.platform): DaemonStatus {
   const pid = loadDaemonPid();
-  if (pid === null) return { running: false, pid: null };
+  if (pid === null) {
+    return isLaunchdAgentLoaded(platform)
+      ? { running: true, pid: null }
+      : { running: false, pid: null };
+  }
   const identity = inspectDaemonProcess(pid);
   if (identity === 'gone' || identity === 'other') {
+    if (isLaunchdAgentLoaded(platform)) return { running: true, pid: null };
     clearDaemonPid();
+    clearDaemonReady();
     return { running: false, pid: null };
   }
   return { running: true, pid };
 }
 
-export class MacOSCodeSignatureError extends Error {
+export class DaemonStartupError extends Error {
   constructor(bootstrapLogPath: string) {
     super(
-      `Daemon did not start within ${LAUNCHCTL_GRACE_MS}ms (CSM block or slow first-launch verify). ` +
-      `Falling back to in-process daemon. Check ${bootstrapLogPath}`,
+      `Daemon did not become ready within ${LAUNCHCTL_GRACE_MS}ms. ` +
+      `Kraki was not started. Check ${bootstrapLogPath}`,
     );
-    this.name = 'MacOSCodeSignatureError';
+    this.name = 'DaemonStartupError';
   }
 }
 
@@ -335,12 +421,14 @@ export function buildLaunchdPlist(opts: {
         '-a', appBundle,
         '--stdout', bootstrapLogPath,
         '--stderr', bootstrapLogPath,
-        // `open --env NAME` copies NAME from open's own environment without
-        // embedding its value in argv. launchd supplies that environment via
-        // EnvironmentVariables below. Passing NAME=VALUE here would expose
-        // GH_TOKEN, proxy credentials, etc. in the long-lived `open -W` process
-        // command line for the daemon's entire lifetime.
-        ...envEntries.flatMap(([k]) => ['--env', k]),
+        // Do not pass `open --env` at all. The app launched by `open` already
+        // inherits open's environment, which launchd supplies through the
+        // EnvironmentVariables dictionary below. Contrary to the previous
+        // implementation's assumption, `open --env NAME` sets NAME to an empty
+        // string; it does not copy the existing value. NAME=VALUE would work but
+        // would expose tokens and proxy credentials in the long-lived `open -W`
+        // argv. Inheriting the launchd environment preserves values without
+        // putting secrets on the command line.
         '--args', INTERNAL_DAEMON_WORKER_COMMAND,
       ]
     : [execPath, INTERNAL_DAEMON_WORKER_COMMAND];
@@ -400,7 +488,7 @@ ${envXml}
  * Either way the daemon-worker saves its own PID, so the poll below reads the
  * daemon's PID and not the PID of whatever launched it.
  */
-async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
+export async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
   const logLevel = getLogVerbosity(config) === 'verbose' ? 'debug' : 'info';
   const bootstrapLogPath = getDaemonBootstrapLogPath();
   mkdirSync(dirname(bootstrapLogPath), { recursive: true });
@@ -421,9 +509,9 @@ async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
   if (process.env.KRAKI_RELAY_URL) envEntries.push(['KRAKI_RELAY_URL', process.env.KRAKI_RELAY_URL]);
 
   // Forward proxy and GitHub auth variables so the daemon keeps the same
-  // credential behavior as before. buildLaunchdPlist passes only variable NAMES
-  // to `open --env` (values remain in launchd's EnvironmentVariables), avoiding
-  // the new long-lived argv exposure without breaking PAT-only installations.
+  // credential behavior as before. Values live only in launchd's
+  // EnvironmentVariables dictionary; `open` and the app it launches inherit
+  // them without exposing them in the long-lived command line.
   const forwardVars = [
     'HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy',
     'ALL_PROXY', 'all_proxy', 'NO_PROXY', 'no_proxy',
@@ -433,9 +521,10 @@ async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
     if (process.env[key]) envEntries.push([key, process.env[key]!]);
   }
 
+  const appBundle = getKrakiAppBundlePath();
   const plist = buildLaunchdPlist({
     label: getLaunchdLabel(),
-    appBundle: getKrakiAppBundlePath(),
+    appBundle,
     execPath: process.execPath,
     bootstrapLogPath,
     workingDirectory: homedir(),
@@ -443,7 +532,9 @@ async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
   });
 
   const plistPath = getLaunchdPlistPath();
-  writeFileSync(plistPath, plist);
+  clearDaemonReady();
+  writeFileSync(plistPath, plist, { mode: 0o600 });
+  chmodSync(plistPath, 0o600);
   unloadLaunchdAgent();
   execSync(`launchctl load "${plistPath}"`, { stdio: 'ignore' });
 
@@ -455,17 +546,52 @@ async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
     if (pid !== null) {
       try {
         process.kill(pid, 0);
-        return pid;
       } catch {
-        // PID saved but process already dead → CSM or crash
+        // PID saved but process already dead → startup crash / CSM block.
         break;
       }
+
+      // A PID file is written at the beginning of worker startup, before all
+      // imports and adapters have finished initializing. Do not report success
+      // merely because that early PID is alive: the process can still crash a
+      // moment later (the v0.31.8 `open --env NAME` regression did exactly
+      // this). Require the real worker marker, and for a bundled install require
+      // the Launch Services identity that makes the TCC fix meaningful.
+      const readinessPublished = loadDaemonReady() === pid;
+      if (!readinessPublished) continue;
+
+      const workerReady = inspectDaemonProcess(pid) === 'daemon';
+      const launchServicesReady = appBundle === null || getProcessBundleIdentity(pid) === KRAKI_BUNDLE_ID;
+      if (workerReady && launchServicesReady) return pid;
     }
   }
 
-  // Daemon didn't start or died immediately
+  // Daemon did not become ready. Inspect before removing supervision. If the OS
+  // refuses process inspection, fail closed: keep the launchd job and PID files
+  // intact so a potentially real daemon remains supervised and a later command
+  // cannot start a duplicate beside it.
+  const failedPid = loadDaemonPid();
+  const failedIdentity = failedPid === null ? 'gone' : inspectDaemonProcess(failedPid);
+  if (failedPid === null || failedIdentity !== 'daemon') {
+    // Without a verified worker PID, unloading `open -W` could leave its
+    // LaunchServices-owned child alive and unsupervised. Preserve the loaded job
+    // and state so later commands refuse to start a duplicate. If launchctl says
+    // the job is already gone, stale files are safe to clean.
+    if (isLaunchdAgentLoaded('darwin')) {
+      throw new DaemonStartupError(bootstrapLogPath);
+    }
+    cleanupLaunchdPlist();
+    clearDaemonPid();
+    clearDaemonReady();
+    throw new DaemonStartupError(bootstrapLogPath);
+  }
+
   cleanupLaunchdPlist();
-  throw new MacOSCodeSignatureError(bootstrapLogPath);
+  const terminated = await terminateFailedDaemon(failedPid);
+  if (!terminated) throw new DaemonStartupError(bootstrapLogPath);
+  clearDaemonPid();
+  clearDaemonReady();
+  throw new DaemonStartupError(bootstrapLogPath);
 }
 
 function escapeXml(s: string): string {
@@ -474,11 +600,13 @@ function escapeXml(s: string): string {
 
 export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): Promise<number> {
   stopDaemon();
+  assertNoUntrackedLaunchdDaemon();
   // An alive PID whose identity could not be verified is deliberately left in
   // place by stopDaemon(). Do not start a second daemon beside it.
   if (loadDaemonPid() !== null) {
     throw new Error('Refusing to start: the recorded daemon PID is alive but could not be verified. Remove the stale daemon.pid only after checking the process.');
   }
+  clearDaemonReady();
 
   // On macOS SEA, use launchctl so launchd spawns the daemon in a clean
   // context that isn't blocked by CSM provenance tracking.
@@ -508,11 +636,16 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
   try {
     await waitForDaemonBootstrap(child, bootstrapLogPath);
   } catch (err) {
-    try {
-      process.kill(child.pid, 'SIGTERM');
-    } catch {
-      // Child may already be gone
+    const terminated = await terminateFailedDaemon(child.pid);
+    if (!terminated) {
+      saveDaemonPid(child.pid);
+      throw new Error(
+        `Kraki failed to become ready and the background worker could not be safely terminated. ` +
+        `PID ${child.pid} remains recorded for manual diagnosis. Check ${bootstrapLogPath}`,
+      );
     }
+    clearDaemonPid();
+    clearDaemonReady();
     throw err;
   }
 
@@ -521,12 +654,17 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
   return child.pid;
 }
 
-export function stopDaemon(): boolean {
+export function stopDaemon(platform = process.platform): boolean {
   const pid = loadDaemonPid();
   if (pid === null) {
-    // A missing PID can coexist with a stale launchd job (e.g. crash before the
-    // worker saved its PID). Cleaning the home-scoped job is safe here.
-    if (process.platform === 'darwin') cleanupLaunchdPlist();
+    // A loaded launchd job without a PID is ambiguous: LaunchServices may still
+    // own a child process that cannot be safely identified. Fail closed and
+    // preserve supervision rather than unloading the job and risking a duplicate
+    // daemon on the next start. Only remove a stale plist when launchctl confirms
+    // the job itself is not loaded.
+    if (hasUntrackedLaunchdDaemon(pid, platform)) return false;
+    if (platform === 'darwin') cleanupLaunchdPlist();
+    clearDaemonReady();
     return false;
   }
 
@@ -535,6 +673,9 @@ export function stopDaemon(): boolean {
   // untouched rather than stranding a real daemon unsupervised.
   const identity = inspectDaemonProcess(pid);
   if (identity === 'unknown') return false;
+  if ((identity === 'gone' || identity === 'other') && isLaunchdAgentLoaded(platform)) {
+    return false;
+  }
 
   // Unload the launchd job BEFORE signalling a verified daemon. The bundled macOS job
   // runs with KeepAlive=true (see startDaemonLaunchctl), so killing first would
@@ -547,12 +688,13 @@ export function stopDaemon(): boolean {
   // daemon WAS the job process and the unload killed it. So the PID-based signal
   // below is now the only thing that actually stops the daemon, and it has to
   // succeed.
-  if (process.platform === 'darwin') cleanupLaunchdPlist();
+  if (platform === 'darwin') cleanupLaunchdPlist();
 
   if (identity === 'gone' || identity === 'other') {
     // Stale/reused PID: clean the record but never signal the process currently
     // holding that number.
     clearDaemonPid();
+    clearDaemonReady();
     return true;
   }
 
@@ -565,6 +707,7 @@ export function stopDaemon(): boolean {
   } catch {
     // Process already gone.
     clearDaemonPid();
+    clearDaemonReady();
     return true;
   }
 
@@ -588,11 +731,21 @@ export function stopDaemon(): boolean {
     const finalIdentity = inspectDaemonProcess(pid);
     if (finalIdentity === 'daemon') {
       try { process.kill(pid, 'SIGKILL'); } catch { /* raced us to exit */ }
+
+      const killDeadline = Date.now() + 1000;
+      while (Date.now() < killDeadline) {
+        const afterKill = inspectDaemonProcess(pid);
+        if (afterKill === 'gone' || afterKill === 'other') break;
+        if (afterKill === 'unknown') return false;
+        Atomics.wait(idle, 0, 0, 50);
+      }
+      if (inspectDaemonProcess(pid) === 'daemon') return false;
     } else if (finalIdentity === 'unknown') {
       return false;
     }
   }
 
   clearDaemonPid();
+  clearDaemonReady();
   return true;
 }

--- a/packages/tentacle/src/update.ts
+++ b/packages/tentacle/src/update.ts
@@ -330,15 +330,21 @@ function isNewer(latest: string, current: string): boolean {
 
 // ── Update command ──────────────────────────────────────
 
-/**
- * Wait for the daemon process to fully exit so file locks are released.
- * Polls `isDaemonRunning()` at the given interval, up to maxAttempts.
- */
-async function waitForProcessExit(intervalMs: number, maxAttempts: number): Promise<void> {
-  const { isDaemonRunning } = await import('./daemon.js');
+export async function stopDaemonForUpdate(
+  deps: { isDaemonRunning: () => boolean; stopDaemon: () => boolean },
+  intervalMs = 500,
+  maxAttempts = 10,
+): Promise<void> {
+  if (!deps.isDaemonRunning()) return;
+  if (!deps.stopDaemon()) {
+    throw new Error('Refusing to update: the running daemon could not be safely identified and stopped');
+  }
   for (let i = 0; i < maxAttempts; i++) {
-    if (!isDaemonRunning()) return;
+    if (!deps.isDaemonRunning()) return;
     await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  if (deps.isDaemonRunning()) {
+    throw new Error(`Refusing to update: the daemon did not exit within ${(intervalMs * maxAttempts) / 1000} seconds`);
   }
 }
 
@@ -360,7 +366,7 @@ export async function performUpdate(currentVersion: string): Promise<void> {
   spinner.text = `Updating ${currentVersion} → ${latest}…`;
 
   // Import daemon management upfront — needed for pre-update stop and post-update restart
-  const { isDaemonRunning, stopDaemon, startDaemon, MacOSCodeSignatureError, INTERNAL_DAEMON_WORKER_COMMAND } = await import('./daemon.js');
+  const { isDaemonRunning, stopDaemon, startDaemon } = await import('./daemon.js');
   const daemonWasRunning = isDaemonRunning();
 
   // Probe FDA BEFORE the binary is replaced. After replacement the kernel
@@ -384,10 +390,15 @@ export async function performUpdate(currentVersion: string): Promise<void> {
   // Wait briefly for the process to release locks / finish flushing.
   if (daemonWasRunning) {
     spinner.text = `Stopping daemon before update…`;
-    stopDaemon();
-    await waitForProcessExit(500, 10);
+    try {
+      await stopDaemonForUpdate({ isDaemonRunning, stopDaemon });
+    } catch (err) {
+      spinner.fail((err as Error).message);
+      throw err;
+    }
   }
 
+  let installCompleted = false;
   try {
     switch (method) {
       case 'npm':
@@ -409,6 +420,7 @@ export async function performUpdate(currentVersion: string): Promise<void> {
     }
 
     spinner.succeed(`Updated ${chalk.dim(currentVersion)} → ${chalk.green(latest)}`);
+    installCompleted = true;
     writeCache(latest);
 
     // Show FDA guidance if it was denied before the update. We don't re-probe
@@ -433,42 +445,26 @@ export async function performUpdate(currentVersion: string): Promise<void> {
       const { loadConfig } = await import('./config.js');
       const config = loadConfig();
       if (config) {
-        try {
-          await startDaemon(config);
-          console.log(chalk.green('  ✔ Daemon restarted'));
-        } catch (restartErr) {
-          if (restartErr instanceof MacOSCodeSignatureError) {
-            // startDaemon spawns a child process, which CSM blocks.
-            // Fall back to running the daemon in the current process
-            // (already Gatekeeper-approved since the user invoked it).
-            console.log(chalk.dim('  Starting in foreground (macOS code signature restriction)…'));
-            process.title = `kraki ${INTERNAL_DAEMON_WORKER_COMMAND}`;
-            process.on('SIGHUP', () => {});
-            const { saveDaemonPid, getLogVerbosity: getLogV } = await import('./config.js');
-            saveDaemonPid(process.pid);
-            process.env.LOG_LEVEL = getLogV(config) === 'verbose' ? 'debug' : 'info';
-            process.env.NODE_ENV = 'production';
-            console.log(chalk.green(`  🦑 Kraki started (PID ${process.pid})`));
-            console.log(chalk.dim('  Running in foreground — press Ctrl+C or run `kraki stop` to quit'));
-            const { startWorker } = await import('./daemon-worker.js');
-            await startWorker();
-            return;
-          }
-          console.log(chalk.red(`  Failed to restart daemon: ${(restartErr as Error).message}`));
-        }
+        await startDaemon(config);
+        console.log(chalk.green('  ✔ Daemon restarted'));
+      } else {
+        throw new Error('Update installed, but daemon restart failed because the Kraki config could not be loaded');
       }
     }
   } catch (err) {
-    // If we stopped the daemon for the update but it failed, restart so the
-    // user isn't left with a stopped daemon.
-    if (daemonWasRunning && !isDaemonRunning()) {
+    // If installation itself failed after stopping the old daemon, make one
+    // best-effort BACKGROUND recovery attempt. Once installation completed,
+    // however, a restart failure is final and must remain visible — never retry
+    // ambiguously and never run the worker in this interactive updater process.
+    if (!installCompleted && daemonWasRunning && !isDaemonRunning()) {
       try {
         const { loadConfig } = await import('./config.js');
         const config = loadConfig();
         if (config) await startDaemon(config);
-      } catch { /* best effort */ }
+      } catch { /* preserve the original update/restart failure below */ }
     }
     spinner.fail(`Update failed: ${(err as Error).message}`);
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

- remove every CLI/updater foreground daemon fallback; background launch failure now exits non-zero
- fix macOS Launch Services environment inheritance by removing `open --env NAME` (which clears values)
- add an explicit `daemon.ready` handshake and require worker identity + `chat.kraki.cli` LS identity before reporting success
- make startup timeout cleanup fail closed and keep launchd supervision when PID identity cannot be verified
- route both Unix installers through `kraki start` instead of direct `open`/`nohup __daemon-worker`
- keep launchd environment values out of argv and lock the plist to mode `0600`

## Production incident

`v0.31.8` generated a correct `open -W -n -a Kraki.app` launchd job, but passed environment variable names using `open --env NAME`. macOS `open` defines that form as an empty-string assignment, not inheritance. The worker received empty `LOG_LEVEL`, `NODE_ENV`, `PATH`, and `HOME`, crashed during startup, and the CLI silently switched into the interactive process. This PR removes that fallback entirely.

Verified directly on macOS:

- without `--env`, the launched app inherited the parent/launchd environment value
- with `--env NAME`, the launched app received an empty string

## Validation

- Tentacle: `829/829`
- focused daemon/installer tests: `39/39`
- Protocol build
- Crypto build
- Tentacle build
- `pnpm lint`
- `git diff --check`
- `sh -n install.sh`
- `sh -n packages/arm/web/public/install.sh`
- repository search confirms no production `startDaemonInProcess`, `Running in foreground`, direct installer `nohup __daemon-worker`, or direct installer `open -n -a Kraki` path remains

## Operational note

No production daemon, Head, Web monitor, or running session was stopped or modified while developing and validating this fix.
