### PR TITLE
chore(release): v0.31.9

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.8",
+  "version": "0.31.9",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump `@kraki/tentacle` from `0.31.8` to `0.31.9`
- release PR only; implementation is PR #202

## Release contents

- daemon never falls back to the interactive foreground process
- fix Launch Services environment inheritance
- explicit background readiness handshake
- fail-closed launchd/PID/update/stop handling
- installers delegate to `kraki start`

## Validation

- PR #202: 844/844 Tentacle tests
- Protocol/Crypto/Tentacle builds passed
- lint and diff checks passed
- GitHub Validate passed for PR #202
