### PR TITLE
fix(release): make daemon tests portable across platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,12 +430,17 @@ jobs:
     name: Publish npm Packages
     needs:
       - prepare
+      - build-binary
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: |
       always() &&
       needs.prepare.result == 'success' &&
-      needs.prepare.outputs.publish_mode == 'publish'
+      needs.prepare.outputs.publish_mode == 'publish' &&
+      (
+        (startsWith(needs.prepare.outputs.release_tag, 'head-v') && needs.build-binary.result == 'skipped')
+        || (!startsWith(needs.prepare.outputs.release_tag, 'head-v') && needs.build-binary.result == 'success')
+      )
     permissions:
       contents: write
       id-token: write

--- a/packages/tentacle/src/__tests__/daemon.test.ts
+++ b/packages/tentacle/src/__tests__/daemon.test.ts
@@ -6,7 +6,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
+
+const TEST_UID = 501;
+const expectedPlistPath = join('/tmp/fake-home', 'Library', 'LaunchAgents', 'cloud.corelli.kraki.plist');
 
 // ── Mocks ───────────────────────────────────────────────
 
@@ -142,7 +145,7 @@ describe('launchd job without a verified worker PID', () => {
       return '/path/to/kraki __daemon-worker';
     });
 
-    expect(stopDaemon('darwin')).toBe(false);
+    expect(stopDaemon('darwin', TEST_UID)).toBe(false);
     expect(mockExecSync).not.toHaveBeenCalled();
     expect(mockUnlinkSync).not.toHaveBeenCalled();
   });
@@ -154,7 +157,7 @@ describe('launchd job without a verified worker PID', () => {
       return '/path/to/kraki __daemon-worker';
     });
 
-    expect(() => assertNoUntrackedLaunchdDaemon('darwin')).toThrow('will not risk starting a duplicate daemon');
+    expect(() => assertNoUntrackedLaunchdDaemon('darwin', TEST_UID)).toThrow('will not risk starting a duplicate daemon');
   });
 
   it('allows stale plist cleanup when launchctl confirms no job is loaded', () => {
@@ -165,7 +168,7 @@ describe('launchd job without a verified worker PID', () => {
       return '/path/to/kraki __daemon-worker';
     });
 
-    expect(stopDaemon('darwin')).toBe(false);
+    expect(stopDaemon('darwin', TEST_UID)).toBe(false);
     expect(mockExecSync).toHaveBeenCalled();
     expect(mockUnlinkSync).toHaveBeenCalled();
   });
@@ -181,8 +184,8 @@ describe('isDaemonRunning()', () => {
       return '/path/to/kraki __daemon-worker';
     });
 
-    expect(isDaemonRunning('darwin')).toBe(true);
-    expect(getDaemonStatus('darwin')).toEqual({ running: true, pid: null });
+    expect(isDaemonRunning('darwin', TEST_UID)).toBe(true);
+    expect(getDaemonStatus('darwin', TEST_UID)).toEqual({ running: true, pid: null });
   });
 
   it('does not discard a stale PID while its launchd job remains loaded', () => {
@@ -192,7 +195,7 @@ describe('isDaemonRunning()', () => {
       return '/path/to/kraki __daemon-worker';
     });
 
-    expect(isDaemonRunning('darwin')).toBe(true);
+    expect(isDaemonRunning('darwin', TEST_UID)).toBe(true);
     expect(mockClearDaemonPid).not.toHaveBeenCalled();
   });
 
@@ -223,7 +226,7 @@ describe('getDaemonStatus()', () => {
       return '/path/to/kraki __daemon-worker';
     });
 
-    expect(getDaemonStatus('darwin')).toEqual({ running: true, pid: null });
+    expect(getDaemonStatus('darwin', TEST_UID)).toEqual({ running: true, pid: null });
   });
 
   it('returns running=false and pid=null when no PID file', () => {
@@ -310,14 +313,14 @@ describe('startDaemon()', () => {
       return true;
     }) as typeof process.kill);
 
-    const startPromise = startDaemonLaunchctl(fakeConfig);
+    const startPromise = startDaemonLaunchctl(fakeConfig, TEST_UID);
     expect(mockWriteFileSync).toHaveBeenCalledWith(
-      '/tmp/fake-home/Library/LaunchAgents/cloud.corelli.kraki.plist',
+      expectedPlistPath,
       expect.any(String),
       { mode: 0o600 },
     );
     expect(mockChmodSync).toHaveBeenCalledWith(
-      '/tmp/fake-home/Library/LaunchAgents/cloud.corelli.kraki.plist',
+      expectedPlistPath,
       0o600,
     );
     const rejection = expect(startPromise).rejects.toBeInstanceOf(DaemonStartupError);
@@ -344,7 +347,7 @@ describe('startDaemon()', () => {
     });
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
-    const startPromise = startDaemonLaunchctl(fakeConfig);
+    const startPromise = startDaemonLaunchctl(fakeConfig, TEST_UID);
     const readyClearsBeforeTimeout = mockClearDaemonReady.mock.calls.length;
     const rejection = expect(startPromise).rejects.toBeInstanceOf(DaemonStartupError);
     await vi.advanceTimersByTimeAsync(30_200);
@@ -366,7 +369,7 @@ describe('startDaemon()', () => {
       throw new Error('unexpected process inspection');
     });
 
-    const startPromise = startDaemonLaunchctl(fakeConfig);
+    const startPromise = startDaemonLaunchctl(fakeConfig, TEST_UID);
     const rejection = expect(startPromise).rejects.toBeInstanceOf(DaemonStartupError);
     await vi.advanceTimersByTimeAsync(30_200);
 

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -67,10 +67,11 @@ function unloadLaunchdAgent(): void {
   } catch { /* not loaded */ }
 }
 
-function isLaunchdAgentLoaded(platform = process.platform): boolean {
-  if (platform !== 'darwin') return false;
-  const uid = process.getuid?.();
-  if (uid === undefined) return false;
+function isLaunchdAgentLoaded(
+  platform = process.platform,
+  uid: number | undefined = process.getuid?.(),
+): boolean {
+  if (platform !== 'darwin' || uid === undefined) return false;
   try {
     execFileSync('/bin/launchctl', ['print', `gui/${uid}/${getLaunchdLabel()}`], {
       stdio: ['ignore', 'ignore', 'ignore'],
@@ -90,12 +91,16 @@ function cleanupLaunchdPlist(): void {
 export function hasUntrackedLaunchdDaemon(
   pid: number | null = loadDaemonPid(),
   platform = process.platform,
+  uid: number | undefined = process.getuid?.(),
 ): boolean {
-  return pid === null && isLaunchdAgentLoaded(platform);
+  return pid === null && isLaunchdAgentLoaded(platform, uid);
 }
 
-export function assertNoUntrackedLaunchdDaemon(platform = process.platform): void {
-  if (!hasUntrackedLaunchdDaemon(loadDaemonPid(), platform)) return;
+export function assertNoUntrackedLaunchdDaemon(
+  platform = process.platform,
+  uid: number | undefined = process.getuid?.(),
+): void {
+  if (!hasUntrackedLaunchdDaemon(loadDaemonPid(), platform, uid)) return;
   throw new Error(
     'Refusing to start: the launchd job is still loaded but no verified daemon PID is available. ' +
     'Inspect the existing job before removing it; Kraki will not risk starting a duplicate daemon.',
@@ -322,12 +327,15 @@ export interface DaemonStatus {
   pid: number | null;
 }
 
-export function isDaemonRunning(platform = process.platform): boolean {
+export function isDaemonRunning(
+  platform = process.platform,
+  uid: number | undefined = process.getuid?.(),
+): boolean {
   const pid = loadDaemonPid();
-  if (pid === null) return isLaunchdAgentLoaded(platform);
+  if (pid === null) return isLaunchdAgentLoaded(platform, uid);
   const identity = inspectDaemonProcess(pid);
   if (identity === 'gone' || identity === 'other') {
-    if (isLaunchdAgentLoaded(platform)) return true;
+    if (isLaunchdAgentLoaded(platform, uid)) return true;
     clearDaemonPid();
     clearDaemonReady();
     return false;
@@ -338,16 +346,19 @@ export function isDaemonRunning(platform = process.platform): boolean {
   return true;
 }
 
-export function getDaemonStatus(platform = process.platform): DaemonStatus {
+export function getDaemonStatus(
+  platform = process.platform,
+  uid: number | undefined = process.getuid?.(),
+): DaemonStatus {
   const pid = loadDaemonPid();
   if (pid === null) {
-    return isLaunchdAgentLoaded(platform)
+    return isLaunchdAgentLoaded(platform, uid)
       ? { running: true, pid: null }
       : { running: false, pid: null };
   }
   const identity = inspectDaemonProcess(pid);
   if (identity === 'gone' || identity === 'other') {
-    if (isLaunchdAgentLoaded(platform)) return { running: true, pid: null };
+    if (isLaunchdAgentLoaded(platform, uid)) return { running: true, pid: null };
     clearDaemonPid();
     clearDaemonReady();
     return { running: false, pid: null };
@@ -488,7 +499,10 @@ ${envXml}
  * Either way the daemon-worker saves its own PID, so the poll below reads the
  * daemon's PID and not the PID of whatever launched it.
  */
-export async function startDaemonLaunchctl(config: KrakiConfig): Promise<number> {
+export async function startDaemonLaunchctl(
+  config: KrakiConfig,
+  uid: number | undefined = process.getuid?.(),
+): Promise<number> {
   const logLevel = getLogVerbosity(config) === 'verbose' ? 'debug' : 'info';
   const bootstrapLogPath = getDaemonBootstrapLogPath();
   mkdirSync(dirname(bootstrapLogPath), { recursive: true });
@@ -577,7 +591,7 @@ export async function startDaemonLaunchctl(config: KrakiConfig): Promise<number>
     // LaunchServices-owned child alive and unsupervised. Preserve the loaded job
     // and state so later commands refuse to start a duplicate. If launchctl says
     // the job is already gone, stale files are safe to clean.
-    if (isLaunchdAgentLoaded('darwin')) {
+    if (isLaunchdAgentLoaded('darwin', uid)) {
       throw new DaemonStartupError(bootstrapLogPath);
     }
     cleanupLaunchdPlist();
@@ -654,7 +668,10 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
   return child.pid;
 }
 
-export function stopDaemon(platform = process.platform): boolean {
+export function stopDaemon(
+  platform = process.platform,
+  uid: number | undefined = process.getuid?.(),
+): boolean {
   const pid = loadDaemonPid();
   if (pid === null) {
     // A loaded launchd job without a PID is ambiguous: LaunchServices may still
@@ -662,7 +679,7 @@ export function stopDaemon(platform = process.platform): boolean {
     // preserve supervision rather than unloading the job and risking a duplicate
     // daemon on the next start. Only remove a stale plist when launchctl confirms
     // the job itself is not loaded.
-    if (hasUntrackedLaunchdDaemon(pid, platform)) return false;
+    if (hasUntrackedLaunchdDaemon(pid, platform, uid)) return false;
     if (platform === 'darwin') cleanupLaunchdPlist();
     clearDaemonReady();
     return false;
@@ -673,7 +690,7 @@ export function stopDaemon(platform = process.platform): boolean {
   // untouched rather than stranding a real daemon unsupervised.
   const identity = inspectDaemonProcess(pid);
   if (identity === 'unknown') return false;
-  if ((identity === 'gone' || identity === 'other') && isLaunchdAgentLoaded(platform)) {
+  if ((identity === 'gone' || identity === 'other') && isLaunchdAgentLoaded(platform, uid)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- inject a deterministic UID into macOS launchd authority checks so the same logic executes on Windows CI instead of depending on `process.getuid()`
- use platform-native paths in daemon tests
- make npm publishing wait for all Tentacle binary jobs to succeed; head-only releases still allow the binary job to be skipped

## Incident

`v0.31.9` published npm successfully, but the Windows binary job failed because macOS launchd tests depended on Unix-only process/path behavior. GitHub Release assets were therefore not published.

## Validation

- Tentacle: 844/844
- focused daemon/CLI/logger: 75/75
- Protocol/Crypto/Tentacle builds
- lint, diff check, workflow YAML parse

The Windows release runner will provide the final cross-platform proof before `v0.31.10` npm publication because npm now depends on all binary jobs succeeding.
