### PR TITLE
chore(release): v0.31.10

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.9",
+  "version": "0.31.10",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump `@kraki/tentacle` from `0.31.9` to `0.31.10`
- includes PR #202 background-only daemon hardening and PR #204 portable Windows release tests

## Why 0.31.10

`0.31.9` reached npm, but the Windows binary test job failed due to Unix-only assumptions in macOS launchd tests, so GitHub Release assets were not published. `0.31.10` is the complete replacement release.

## Release safety

PR #204 also makes npm publication wait for all Tentacle binary jobs to succeed, preventing another partial npm-first release.
