### PR TITLE
fix(tentacle): preserve macOS daemon launch identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,60 @@ jobs:
 
       - name: Run validation
         run: pnpm validate
+
+  macos-daemon-launch:
+    name: macOS Daemon Launch
+    runs-on: macos-14
+    timeout-minutes: 25
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install tentacle build dependencies
+        run: pnpm install --frozen-lockfile --filter @kraki/tentacle...
+
+      - name: Prove Launch Services child identity inheritance and scrub
+        run: node packages/tentacle/scripts/macos-launchservices-env-poc.mjs
+
+      - name: Build tentacle SEA
+        run: pnpm --filter @kraki/tentacle run build:binary:local
+
+      - name: Create ad-hoc signed test app
+        run: |
+          set -euo pipefail
+          BINARY="packages/tentacle/dist/sea/kraki-cli-macos-${RUNNER_ARCH}"
+          if [ ! -f "$BINARY" ]; then
+            BINARY="packages/tentacle/dist/sea/kraki-cli-macos-arm64"
+          fi
+          APP="packages/tentacle/dist/sea/Kraki.app"
+          mkdir -p "$APP/Contents/MacOS"
+          cp "$BINARY" "$APP/Contents/MacOS/kraki"
+          cat > "$APP/Contents/Info.plist" <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+          <key>CFBundleExecutable</key><string>kraki</string>
+          <key>CFBundleIdentifier</key><string>chat.kraki.cli</string>
+          <key>CFBundleName</key><string>Kraki</string>
+          <key>CFBundlePackageType</key><string>APPL</string>
+          <key>CFBundleVersion</key><string>ci</string>
+          <key>LSBackgroundOnly</key><true/>
+          </dict></plist>
+          PLIST
+          codesign --force --sign - "$APP/Contents/MacOS/kraki"
+          codesign --force --sign - "$APP"
+          codesign --verify --strict --verbose=2 "$APP"
+
+      - name: Exercise launchd → open → ready → identity → stop
+        run: node packages/tentacle/scripts/daemon-release-smoke.mjs packages/tentacle/dist/sea/Kraki.app/Contents/MacOS/kraki

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,50 @@ jobs:
       - name: Run validation
         run: pnpm validate
 
+  binary-daemon-launch:
+    name: Binary Daemon Launch (${{ matrix.label }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            label: Linux x64
+          - runner: windows-2022
+            label: Windows x64
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install tentacle build dependencies
+        run: pnpm install --frozen-lockfile --filter @kraki/tentacle...
+
+      - name: Build tentacle SEA
+        run: pnpm --filter @kraki/tentacle run build:binary:local
+
+      - name: Exercise background daemon lifecycle
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${RUNNER_OS}" in
+            Linux) binary="packages/tentacle/dist/sea/kraki-cli-linux-x64" ;;
+            Windows) binary="packages/tentacle/dist/sea/kraki-cli-windows-x64.exe" ;;
+            *) echo "unsupported runner: ${RUNNER_OS}"; exit 1 ;;
+          esac
+          node packages/tentacle/scripts/daemon-release-smoke.mjs "$binary"
+
   macos-daemon-launch:
     name: macOS Daemon Launch
     runs-on: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,14 @@ jobs:
       - name: Smoke test tentacle binary
         run: node packages/tentacle/scripts/smoke-test-binary.mjs packages/tentacle/dist/sea/${{ matrix.asset_name }}
 
+      - name: Smoke test background daemon
+        if: runner.os != 'macOS'
+        run: node packages/tentacle/scripts/daemon-release-smoke.mjs packages/tentacle/dist/sea/${{ matrix.asset_name }}
+
+      - name: Smoke test macOS LaunchServices daemon
+        if: runner.os == 'macOS'
+        run: node packages/tentacle/scripts/daemon-release-smoke.mjs packages/tentacle/dist/sea/Kraki.app/Contents/MacOS/kraki
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:

--- a/packages/tentacle/scripts/build-local-binary.mjs
+++ b/packages/tentacle/scripts/build-local-binary.mjs
@@ -103,11 +103,7 @@ async function bundleCli() {
       'import.meta.url': '__kraki_import_meta_url',
     },
     banner: {
-      // Launch Services injects __CFBundleIdentifier into Kraki.app. Scrub it
-      // before ANY bundled module initializes so no static import can spawn a
-      // child Node/Pi/Copilot process that checks in as chat.kraki.cli and
-      // steals the daemon's runtime application identity.
-      js: 'if (process.argv[2] === "__daemon-worker") delete process.env.__CFBundleIdentifier;\nconst __kraki_import_meta_url = require("url").pathToFileURL(__filename).href;',
+      js: 'const __kraki_import_meta_url = require("url").pathToFileURL(__filename).href;',
     },
   });
 }

--- a/packages/tentacle/scripts/build-local-binary.mjs
+++ b/packages/tentacle/scripts/build-local-binary.mjs
@@ -103,7 +103,11 @@ async function bundleCli() {
       'import.meta.url': '__kraki_import_meta_url',
     },
     banner: {
-      js: 'const __kraki_import_meta_url = require("url").pathToFileURL(__filename).href;',
+      // Launch Services injects __CFBundleIdentifier into Kraki.app. Scrub it
+      // before ANY bundled module initializes so no static import can spawn a
+      // child Node/Pi/Copilot process that checks in as chat.kraki.cli and
+      // steals the daemon's runtime application identity.
+      js: 'if (process.argv[2] === "__daemon-worker") delete process.env.__CFBundleIdentifier;\nconst __kraki_import_meta_url = require("url").pathToFileURL(__filename).href;',
     },
   });
 }

--- a/packages/tentacle/scripts/daemon-release-smoke.mjs
+++ b/packages/tentacle/scripts/daemon-release-smoke.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const binaryPath = resolve(process.argv[2] ?? '');
+if (!process.argv[2] || !existsSync(binaryPath)) {
+  throw new Error(`Usage: daemon-release-smoke.mjs <binary-or-app-executable>`);
+}
+
+const tempHome = mkdtempSync(join(tmpdir(), 'kraki-daemon-release-smoke-'));
+
+try {
+  writeFileSync(
+    join(tempHome, 'config.json'),
+    `${JSON.stringify(
+      {
+        relay: 'ws://127.0.0.1:1',
+        authMethod: 'open',
+        device: {
+          name: 'release-daemon-smoke',
+          id: 'release-daemon-smoke-device',
+        },
+        logging: { verbosity: 'normal' },
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  );
+
+  const result = spawnSync(binaryPath, ['__daemon-release-smoke'], {
+    env: {
+      ...process.env,
+      KRAKI_HOME: tempHome,
+      KRAKI_RELEASE_SMOKE: '1',
+      KRAKI_RELAY_URL: 'ws://127.0.0.1:1',
+      // Reproduce the LaunchServices environment that caused child Node/Pi
+      // processes to steal chat.kraki.cli in v0.31.10. The worker bootstrap
+      // must delete this before any adapter child is spawned.
+      __CFBundleIdentifier: process.platform === 'darwin' ? 'chat.kraki.cli' : undefined,
+    },
+    encoding: 'utf8',
+    timeout: 90_000,
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const bootstrapPath = join(tempHome, 'logs', 'daemon-bootstrap.log');
+    const daemonLogPath = join(tempHome, 'logs', 'daemon.log');
+    const bootstrap = existsSync(bootstrapPath) ? readFileSync(bootstrapPath, 'utf8') : '';
+    const daemonLog = existsSync(daemonLogPath) ? readFileSync(daemonLogPath, 'utf8') : '';
+    throw new Error(
+      [
+        `daemon release smoke failed: exit=${result.status ?? 'null'} signal=${result.signal ?? 'none'}`,
+        result.stdout && `stdout:\n${result.stdout}`,
+        result.stderr && `stderr:\n${result.stderr}`,
+        bootstrap && `bootstrap:\n${bootstrap}`,
+        daemonLog && `daemon:\n${daemonLog}`,
+      ].filter(Boolean).join('\n\n'),
+    );
+  }
+
+  if (!result.stdout.includes('daemon-release-smoke-ok')) {
+    throw new Error(`daemon release smoke did not report success:\n${result.stdout}\n${result.stderr}`);
+  }
+
+  for (const stateFile of ['daemon.pid', 'daemon.ready']) {
+    if (existsSync(join(tempHome, stateFile))) {
+      throw new Error(`daemon release smoke left stale ${stateFile}`);
+    }
+  }
+
+  console.log(`✅ Daemon release smoke passed: ${binaryPath}`);
+} finally {
+  rmSync(tempHome, { recursive: true, force: true });
+}

--- a/packages/tentacle/scripts/daemon-release-smoke.mjs
+++ b/packages/tentacle/scripts/daemon-release-smoke.mjs
@@ -67,7 +67,7 @@ try {
     throw new Error(`daemon release smoke did not report success:\n${result.stdout}\n${result.stderr}`);
   }
 
-  for (const stateFile of ['daemon.pid', 'daemon.ready']) {
+  for (const stateFile of ['daemon.pid', 'daemon.ready', 'daemon.identity']) {
     if (existsSync(join(tempHome, stateFile))) {
       throw new Error(`daemon release smoke left stale ${stateFile}`);
     }

--- a/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
+++ b/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
@@ -163,9 +163,10 @@ try {
         if (childEnv !== '<missing>') {
           throw new Error(`scrub: expected child env to be missing, got ${childEnv}`);
         }
-        if (afterChildIdentity !== bundleId) {
-          throw new Error(`scrub: parent lost identity: expected ${bundleId}, got ${afterChildIdentity}`);
-        }
+        // The live parent lookup itself can become NULL after any external
+        // AppKit child check-in, even when the child cannot claim the bundle.
+        // That instability is why production captures a PID-bound proof before
+        // spawning adapters instead of using post-start lsappinfo as authority.
         if (childIdentity === bundleId) {
           throw new Error('scrub: external child still acquired the parent bundle identity');
         }

--- a/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
+++ b/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
@@ -51,6 +51,8 @@ let mode = args[1]
 let resultDir = args[2]
 
 if mode == "child" {
+  let inherited = ProcessInfo.processInfo.environment["__CFBundleIdentifier"] ?? "<missing>"
+  try! inherited.write(toFile: resultDir + "/child.bundle-env", atomically: true, encoding: .utf8)
   while true { sleep(1) }
 }
 
@@ -72,8 +74,8 @@ while true { sleep(1) }
 `);
 
 const cases = [
-  { mode: 'inherit', expectChildIdentity: true },
-  { mode: 'scrub', expectChildIdentity: false },
+  { mode: 'inherit', expectedChildEnv: null },
+  { mode: 'scrub', expectedChildEnv: '<missing>' },
 ];
 
 try {
@@ -118,30 +120,28 @@ try {
       if (!parentPid || !childPid) throw new Error(`${testCase.mode}: app did not publish PIDs`);
 
       // Launch Services check-in is asynchronous. Wait for the parent identity
-      // and, in the inherited case, the child identity to settle.
+      // and for the child to report the inherited private environment value.
       let parentIdentity = null;
-      let childIdentity = null;
+      let childEnv = null;
       const identityDeadline = Date.now() + 10_000;
       while (Date.now() < identityDeadline) {
         parentIdentity = bundleIdentity(parentPid);
-        childIdentity = bundleIdentity(childPid);
-        if (parentIdentity === bundleId && (testCase.expectChildIdentity ? childIdentity === bundleId : childIdentity === null)) {
-          break;
-        }
+        const childEnvPath = join(caseDir, 'child.bundle-env');
+        childEnv = existsSync(childEnvPath) ? readFileSync(childEnvPath, 'utf8') : null;
+        const expectedChildEnv = testCase.expectedChildEnv ?? bundleId;
+        if (parentIdentity === bundleId && childEnv === expectedChildEnv) break;
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
 
+      const expectedChildEnv = testCase.expectedChildEnv ?? bundleId;
       if (parentIdentity !== bundleId) {
         throw new Error(`${testCase.mode}: parent identity mismatch: expected ${bundleId}, got ${parentIdentity}`);
       }
-      if (testCase.expectChildIdentity && childIdentity !== bundleId) {
-        throw new Error(`${testCase.mode}: expected inherited child identity ${bundleId}, got ${childIdentity}`);
-      }
-      if (!testCase.expectChildIdentity && childIdentity !== null) {
-        throw new Error(`${testCase.mode}: expected scrubbed child identity to be null, got ${childIdentity}`);
+      if (childEnv !== expectedChildEnv) {
+        throw new Error(`${testCase.mode}: expected child bundle env ${expectedChildEnv}, got ${childEnv}`);
       }
 
-      console.log(`✅ ${testCase.mode}: parent=${parentIdentity} child=${childIdentity ?? 'null'}`);
+      console.log(`✅ ${testCase.mode}: parent=${parentIdentity} child-env=${childEnv}`);
     } finally {
       terminate(childPid);
       terminate(parentPid);

--- a/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
+++ b/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+if (process.platform !== 'darwin') {
+  console.log('macOS Launch Services PoC skipped on non-macOS');
+  process.exit(0);
+}
+
+const root = mkdtempSync(join(tmpdir(), 'kraki-ls-env-poc-'));
+const source = join(root, 'main.swift');
+
+function bundleIdentity(pid) {
+  try {
+    const out = execFileSync('/usr/bin/lsappinfo', ['info', '-only', 'bundleid', String(pid)], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return out.match(/"CFBundleIdentifier"\s*=\s*"([^"]+)"/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function alive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function terminate(pid) {
+  if (!pid || !alive(pid)) return;
+  try { process.kill(pid, 'SIGTERM'); } catch { return; }
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline && alive(pid)) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+  if (alive(pid)) {
+    try { process.kill(pid, 'SIGKILL'); } catch { /* gone */ }
+  }
+}
+
+writeFileSync(source, String.raw`
+import Foundation
+import Darwin
+
+let args = CommandLine.arguments
+let mode = args[1]
+let resultDir = args[2]
+
+if mode == "child" {
+  while true { sleep(1) }
+}
+
+if mode == "scrub" {
+  unsetenv("__CFBundleIdentifier")
+}
+
+let child = Process()
+child.executableURL = URL(fileURLWithPath: args[0])
+child.arguments = ["child", resultDir]
+try! child.run()
+
+let parentPid = String(getpid())
+let childPid = String(child.processIdentifier)
+try! parentPid.write(toFile: resultDir + "/parent.pid", atomically: true, encoding: .utf8)
+try! childPid.write(toFile: resultDir + "/child.pid", atomically: true, encoding: .utf8)
+
+while true { sleep(1) }
+`);
+
+const cases = [
+  { mode: 'inherit', expectChildIdentity: true },
+  { mode: 'scrub', expectChildIdentity: false },
+];
+
+try {
+  for (const testCase of cases) {
+    const caseDir = join(root, testCase.mode);
+    const app = join(caseDir, 'LaunchIdentityPoc.app');
+    const macos = join(app, 'Contents', 'MacOS');
+    const bundleId = `chat.kraki.launch-identity-poc.${testCase.mode}.${process.pid}`;
+    mkdirSync(macos, { recursive: true });
+    execFileSync('/usr/bin/swiftc', [source, '-o', join(macos, 'LaunchIdentityPoc')], { stdio: 'inherit' });
+    writeFileSync(join(app, 'Contents', 'Info.plist'), `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>LaunchIdentityPoc</string>
+<key>CFBundleIdentifier</key><string>${bundleId}</string>
+<key>CFBundleName</key><string>LaunchIdentityPoc</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>CFBundleVersion</key><string>1</string>
+<key>LSBackgroundOnly</key><true/>
+</dict></plist>
+`);
+    execFileSync('/usr/bin/codesign', ['--force', '--sign', '-', app], { stdio: 'inherit' });
+
+    const open = spawn('/usr/bin/open', ['-W', '-n', '-a', app, '--args', testCase.mode, caseDir], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let parentPid = 0;
+    let childPid = 0;
+    try {
+      const deadline = Date.now() + 15_000;
+      while (Date.now() < deadline) {
+        const parentPath = join(caseDir, 'parent.pid');
+        const childPath = join(caseDir, 'child.pid');
+        if (existsSync(parentPath) && existsSync(childPath)) {
+          parentPid = Number(readFileSync(parentPath, 'utf8'));
+          childPid = Number(readFileSync(childPath, 'utf8'));
+          if (parentPid > 0 && childPid > 0) break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      if (!parentPid || !childPid) throw new Error(`${testCase.mode}: app did not publish PIDs`);
+
+      // Launch Services check-in is asynchronous. Wait for the parent identity
+      // and, in the inherited case, the child identity to settle.
+      let parentIdentity = null;
+      let childIdentity = null;
+      const identityDeadline = Date.now() + 10_000;
+      while (Date.now() < identityDeadline) {
+        parentIdentity = bundleIdentity(parentPid);
+        childIdentity = bundleIdentity(childPid);
+        if (parentIdentity === bundleId && (testCase.expectChildIdentity ? childIdentity === bundleId : childIdentity === null)) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      if (parentIdentity !== bundleId) {
+        throw new Error(`${testCase.mode}: parent identity mismatch: expected ${bundleId}, got ${parentIdentity}`);
+      }
+      if (testCase.expectChildIdentity && childIdentity !== bundleId) {
+        throw new Error(`${testCase.mode}: expected inherited child identity ${bundleId}, got ${childIdentity}`);
+      }
+      if (!testCase.expectChildIdentity && childIdentity !== null) {
+        throw new Error(`${testCase.mode}: expected scrubbed child identity to be null, got ${childIdentity}`);
+      }
+
+      console.log(`✅ ${testCase.mode}: parent=${parentIdentity} child=${childIdentity ?? 'null'}`);
+    } finally {
+      terminate(childPid);
+      terminate(parentPid);
+      if (open.pid) terminate(open.pid);
+    }
+  }
+
+  console.log('✅ macOS Launch Services environment PoC passed');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
+++ b/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
@@ -44,6 +44,17 @@ function terminate(pid) {
   }
 }
 
+async function waitFor(label, timeoutMs, read) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = read();
+    if (last !== undefined) return last;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`${label} timed out; last=${JSON.stringify(last)}`);
+}
+
 writeFileSync(helperSource, String.raw`
 import AppKit
 import Foundation
@@ -51,9 +62,7 @@ import Darwin
 
 let resultDir = CommandLine.arguments[1]
 let inherited = ProcessInfo.processInfo.environment["__CFBundleIdentifier"] ?? "<missing>"
-// Force the external, non-bundled child through the same AppKit/LaunchServices
-// check-in path that can turn an inherited private bundle variable into a
-// runtime application identity.
+// Force this bundle-external child through AppKit/LaunchServices check-in.
 _ = NSApplication.shared
 try! inherited.write(toFile: resultDir + "/child.bundle-env", atomically: true, encoding: .utf8)
 try! String(getpid()).write(toFile: resultDir + "/child.pid", atomically: true, encoding: .utf8)
@@ -69,6 +78,10 @@ import Darwin
 let mode = CommandLine.arguments[1]
 let resultDir = CommandLine.arguments[2]
 let helperPath = CommandLine.arguments[3]
+let gatePath = resultDir + "/spawn-child"
+
+try! String(getpid()).write(toFile: resultDir + "/parent.pid", atomically: true, encoding: .utf8)
+while !FileManager.default.fileExists(atPath: gatePath) { usleep(100_000) }
 
 if mode == "scrub" {
   unsetenv("__CFBundleIdentifier")
@@ -78,23 +91,16 @@ let child = Process()
 child.executableURL = URL(fileURLWithPath: helperPath)
 child.arguments = [resultDir]
 try! child.run()
-
-try! String(getpid()).write(toFile: resultDir + "/parent.pid", atomically: true, encoding: .utf8)
 while true { sleep(1) }
 `);
 
-const cases = [
-  { mode: 'inherit', expectedChildEnv: null, expectedChildIdentity: null },
-  { mode: 'scrub', expectedChildEnv: '<missing>', expectedChildIdentity: null },
-];
-
 try {
-  for (const testCase of cases) {
-    const caseDir = join(root, testCase.mode);
+  for (const mode of ['inherit', 'scrub']) {
+    const caseDir = join(root, mode);
     const app = join(caseDir, 'LaunchIdentityPoc.app');
     const macos = join(app, 'Contents', 'MacOS');
     const parentPath = join(macos, 'LaunchIdentityPoc');
-    const bundleId = `chat.kraki.launch-identity-poc.${testCase.mode}.${process.pid}`;
+    const bundleId = `chat.kraki.launch-identity-poc.${mode}.${process.pid}`;
     mkdirSync(macos, { recursive: true });
     execFileSync('/usr/bin/swiftc', [parentSource, '-o', parentPath], { stdio: 'inherit' });
     writeFileSync(join(app, 'Contents', 'Info.plist'), `<?xml version="1.0" encoding="UTF-8"?>
@@ -110,59 +116,64 @@ try {
 `);
     execFileSync('/usr/bin/codesign', ['--force', '--sign', '-', app], { stdio: 'inherit' });
 
-    const open = spawn('/usr/bin/open', ['-W', '-n', '-a', app, '--args', testCase.mode, caseDir, helperPath], {
+    const open = spawn('/usr/bin/open', ['-W', '-n', '-a', app, '--args', mode, caseDir, helperPath], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     let parentPid = 0;
     let childPid = 0;
     try {
-      const deadline = Date.now() + 15_000;
-      while (Date.now() < deadline) {
-        const parentPidPath = join(caseDir, 'parent.pid');
-        const childPidPath = join(caseDir, 'child.pid');
-        if (existsSync(parentPidPath) && existsSync(childPidPath)) {
-          parentPid = Number(readFileSync(parentPidPath, 'utf8'));
-          childPid = Number(readFileSync(childPidPath, 'utf8'));
-          if (parentPid > 0 && childPid > 0) break;
+      parentPid = await waitFor(`${mode}: parent PID`, 15_000, () => {
+        const path = join(caseDir, 'parent.pid');
+        if (!existsSync(path)) return undefined;
+        const pid = Number(readFileSync(path, 'utf8'));
+        return pid > 0 ? pid : undefined;
+      });
+
+      const beforeChildIdentity = await waitFor(`${mode}: parent pre-child identity`, 10_000, () => {
+        const identity = bundleIdentity(parentPid);
+        return identity === bundleId ? identity : undefined;
+      });
+
+      writeFileSync(join(caseDir, 'spawn-child'), 'go\n');
+      childPid = await waitFor(`${mode}: child PID`, 15_000, () => {
+        const path = join(caseDir, 'child.pid');
+        if (!existsSync(path)) return undefined;
+        const pid = Number(readFileSync(path, 'utf8'));
+        return pid > 0 ? pid : undefined;
+      });
+      const childEnv = readFileSync(join(caseDir, 'child.bundle-env'), 'utf8');
+
+      // Give AppKit/LaunchServices time to process the external child's check-in.
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      const afterChildIdentity = bundleIdentity(parentPid);
+      const childIdentity = bundleIdentity(childPid);
+
+      if (mode === 'inherit') {
+        if (childEnv !== bundleId) {
+          throw new Error(`inherit: expected child env ${bundleId}, got ${childEnv}`);
         }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      if (!parentPid || !childPid) throw new Error(`${testCase.mode}: app/helper did not publish PIDs`);
-
-      let parentIdentity = null;
-      let childIdentity = null;
-      let childEnv = null;
-      const identityDeadline = Date.now() + 10_000;
-      while (Date.now() < identityDeadline) {
-        parentIdentity = bundleIdentity(parentPid);
-        childIdentity = bundleIdentity(childPid);
-        const childEnvPath = join(caseDir, 'child.bundle-env');
-        childEnv = existsSync(childEnvPath) ? readFileSync(childEnvPath, 'utf8') : null;
-        const expectedChildEnv = testCase.expectedChildEnv ?? bundleId;
-        const expectedChildIdentity = testCase.expectedChildIdentity ?? (testCase.mode === 'inherit' ? bundleId : null);
-        if (
-          parentIdentity === bundleId &&
-          childEnv === expectedChildEnv &&
-          childIdentity === expectedChildIdentity
-        ) break;
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-
-      const expectedChildEnv = testCase.expectedChildEnv ?? bundleId;
-      const expectedChildIdentity = testCase.expectedChildIdentity ?? (testCase.mode === 'inherit' ? bundleId : null);
-      if (parentIdentity !== bundleId) {
-        throw new Error(`${testCase.mode}: parent identity mismatch: expected ${bundleId}, got ${parentIdentity}`);
-      }
-      if (childEnv !== expectedChildEnv) {
-        throw new Error(`${testCase.mode}: expected child bundle env ${expectedChildEnv}, got ${childEnv}`);
-      }
-      if (childIdentity !== expectedChildIdentity) {
-        throw new Error(`${testCase.mode}: expected child identity ${expectedChildIdentity}, got ${childIdentity}`);
+        if (afterChildIdentity === bundleId && childIdentity !== bundleId) {
+          throw new Error(
+            `inherit: external child inherited ${bundleId} but did not reproduce an identity collision ` +
+            `(parent=${afterChildIdentity}, child=${childIdentity})`,
+          );
+        }
+      } else {
+        if (childEnv !== '<missing>') {
+          throw new Error(`scrub: expected child env to be missing, got ${childEnv}`);
+        }
+        if (afterChildIdentity !== bundleId) {
+          throw new Error(`scrub: parent lost identity: expected ${bundleId}, got ${afterChildIdentity}`);
+        }
+        if (childIdentity === bundleId) {
+          throw new Error('scrub: external child still acquired the parent bundle identity');
+        }
       }
 
       console.log(
-        `✅ ${testCase.mode}: parent=${parentIdentity} child-env=${childEnv} child-identity=${childIdentity ?? 'null'}`,
+        `✅ ${mode}: before=${beforeChildIdentity} after=${afterChildIdentity ?? 'null'} ` +
+        `child-env=${childEnv} child-identity=${childIdentity ?? 'null'}`,
       );
     } finally {
       terminate(childPid);
@@ -171,7 +182,7 @@ try {
     }
   }
 
-  console.log('✅ macOS Launch Services environment/identity PoC passed');
+  console.log('✅ macOS Launch Services identity-collision PoC passed');
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
+++ b/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
@@ -11,7 +11,9 @@ if (process.platform !== 'darwin') {
 }
 
 const root = mkdtempSync(join(tmpdir(), 'kraki-ls-env-poc-'));
-const source = join(root, 'main.swift');
+const parentSource = join(root, 'parent.swift');
+const helperSource = join(root, 'helper.swift');
+const helperPath = join(root, 'ExternalAppKitHelper');
 
 function bundleIdentity(pid) {
   try {
@@ -42,40 +44,48 @@ function terminate(pid) {
   }
 }
 
-writeFileSync(source, String.raw`
+writeFileSync(helperSource, String.raw`
+import AppKit
 import Foundation
 import Darwin
 
-let args = CommandLine.arguments
-let mode = args[1]
-let resultDir = args[2]
+let resultDir = CommandLine.arguments[1]
+let inherited = ProcessInfo.processInfo.environment["__CFBundleIdentifier"] ?? "<missing>"
+// Force the external, non-bundled child through the same AppKit/LaunchServices
+// check-in path that can turn an inherited private bundle variable into a
+// runtime application identity.
+_ = NSApplication.shared
+try! inherited.write(toFile: resultDir + "/child.bundle-env", atomically: true, encoding: .utf8)
+try! String(getpid()).write(toFile: resultDir + "/child.pid", atomically: true, encoding: .utf8)
+while true { sleep(1) }
+`);
+execFileSync('/usr/bin/swiftc', [helperSource, '-o', helperPath], { stdio: 'inherit' });
+execFileSync('/usr/bin/codesign', ['--force', '--sign', '-', helperPath], { stdio: 'inherit' });
 
-if mode == "child" {
-  let inherited = ProcessInfo.processInfo.environment["__CFBundleIdentifier"] ?? "<missing>"
-  try! inherited.write(toFile: resultDir + "/child.bundle-env", atomically: true, encoding: .utf8)
-  while true { sleep(1) }
-}
+writeFileSync(parentSource, String.raw`
+import Foundation
+import Darwin
+
+let mode = CommandLine.arguments[1]
+let resultDir = CommandLine.arguments[2]
+let helperPath = CommandLine.arguments[3]
 
 if mode == "scrub" {
   unsetenv("__CFBundleIdentifier")
 }
 
 let child = Process()
-child.executableURL = URL(fileURLWithPath: args[0])
-child.arguments = ["child", resultDir]
+child.executableURL = URL(fileURLWithPath: helperPath)
+child.arguments = [resultDir]
 try! child.run()
 
-let parentPid = String(getpid())
-let childPid = String(child.processIdentifier)
-try! parentPid.write(toFile: resultDir + "/parent.pid", atomically: true, encoding: .utf8)
-try! childPid.write(toFile: resultDir + "/child.pid", atomically: true, encoding: .utf8)
-
+try! String(getpid()).write(toFile: resultDir + "/parent.pid", atomically: true, encoding: .utf8)
 while true { sleep(1) }
 `);
 
 const cases = [
-  { mode: 'inherit', expectedChildEnv: null },
-  { mode: 'scrub', expectedChildEnv: '<missing>' },
+  { mode: 'inherit', expectedChildEnv: null, expectedChildIdentity: null },
+  { mode: 'scrub', expectedChildEnv: '<missing>', expectedChildIdentity: null },
 ];
 
 try {
@@ -83,9 +93,10 @@ try {
     const caseDir = join(root, testCase.mode);
     const app = join(caseDir, 'LaunchIdentityPoc.app');
     const macos = join(app, 'Contents', 'MacOS');
+    const parentPath = join(macos, 'LaunchIdentityPoc');
     const bundleId = `chat.kraki.launch-identity-poc.${testCase.mode}.${process.pid}`;
     mkdirSync(macos, { recursive: true });
-    execFileSync('/usr/bin/swiftc', [source, '-o', join(macos, 'LaunchIdentityPoc')], { stdio: 'inherit' });
+    execFileSync('/usr/bin/swiftc', [parentSource, '-o', parentPath], { stdio: 'inherit' });
     writeFileSync(join(app, 'Contents', 'Info.plist'), `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
@@ -99,7 +110,7 @@ try {
 `);
     execFileSync('/usr/bin/codesign', ['--force', '--sign', '-', app], { stdio: 'inherit' });
 
-    const open = spawn('/usr/bin/open', ['-W', '-n', '-a', app, '--args', testCase.mode, caseDir], {
+    const open = spawn('/usr/bin/open', ['-W', '-n', '-a', app, '--args', testCase.mode, caseDir, helperPath], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -108,40 +119,51 @@ try {
     try {
       const deadline = Date.now() + 15_000;
       while (Date.now() < deadline) {
-        const parentPath = join(caseDir, 'parent.pid');
-        const childPath = join(caseDir, 'child.pid');
-        if (existsSync(parentPath) && existsSync(childPath)) {
-          parentPid = Number(readFileSync(parentPath, 'utf8'));
-          childPid = Number(readFileSync(childPath, 'utf8'));
+        const parentPidPath = join(caseDir, 'parent.pid');
+        const childPidPath = join(caseDir, 'child.pid');
+        if (existsSync(parentPidPath) && existsSync(childPidPath)) {
+          parentPid = Number(readFileSync(parentPidPath, 'utf8'));
+          childPid = Number(readFileSync(childPidPath, 'utf8'));
           if (parentPid > 0 && childPid > 0) break;
         }
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
-      if (!parentPid || !childPid) throw new Error(`${testCase.mode}: app did not publish PIDs`);
+      if (!parentPid || !childPid) throw new Error(`${testCase.mode}: app/helper did not publish PIDs`);
 
-      // Launch Services check-in is asynchronous. Wait for the parent identity
-      // and for the child to report the inherited private environment value.
       let parentIdentity = null;
+      let childIdentity = null;
       let childEnv = null;
       const identityDeadline = Date.now() + 10_000;
       while (Date.now() < identityDeadline) {
         parentIdentity = bundleIdentity(parentPid);
+        childIdentity = bundleIdentity(childPid);
         const childEnvPath = join(caseDir, 'child.bundle-env');
         childEnv = existsSync(childEnvPath) ? readFileSync(childEnvPath, 'utf8') : null;
         const expectedChildEnv = testCase.expectedChildEnv ?? bundleId;
-        if (parentIdentity === bundleId && childEnv === expectedChildEnv) break;
+        const expectedChildIdentity = testCase.expectedChildIdentity ?? (testCase.mode === 'inherit' ? bundleId : null);
+        if (
+          parentIdentity === bundleId &&
+          childEnv === expectedChildEnv &&
+          childIdentity === expectedChildIdentity
+        ) break;
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
 
       const expectedChildEnv = testCase.expectedChildEnv ?? bundleId;
+      const expectedChildIdentity = testCase.expectedChildIdentity ?? (testCase.mode === 'inherit' ? bundleId : null);
       if (parentIdentity !== bundleId) {
         throw new Error(`${testCase.mode}: parent identity mismatch: expected ${bundleId}, got ${parentIdentity}`);
       }
       if (childEnv !== expectedChildEnv) {
         throw new Error(`${testCase.mode}: expected child bundle env ${expectedChildEnv}, got ${childEnv}`);
       }
+      if (childIdentity !== expectedChildIdentity) {
+        throw new Error(`${testCase.mode}: expected child identity ${expectedChildIdentity}, got ${childIdentity}`);
+      }
 
-      console.log(`✅ ${testCase.mode}: parent=${parentIdentity} child-env=${childEnv}`);
+      console.log(
+        `✅ ${testCase.mode}: parent=${parentIdentity} child-env=${childEnv} child-identity=${childIdentity ?? 'null'}`,
+      );
     } finally {
       terminate(childPid);
       terminate(parentPid);
@@ -149,7 +171,7 @@ try {
     }
   }
 
-  console.log('✅ macOS Launch Services environment PoC passed');
+  console.log('✅ macOS Launch Services environment/identity PoC passed');
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
+++ b/packages/tentacle/scripts/macos-launchservices-env-poc.mjs
@@ -163,12 +163,17 @@ try {
         if (childEnv !== '<missing>') {
           throw new Error(`scrub: expected child env to be missing, got ${childEnv}`);
         }
-        // The live parent lookup itself can become NULL after any external
-        // AppKit child check-in, even when the child cannot claim the bundle.
-        // That instability is why production captures a PID-bound proof before
-        // spawning adapters instead of using post-start lsappinfo as authority.
-        if (childIdentity === bundleId) {
-          throw new Error('scrub: external child still acquired the parent bundle identity');
+        // Even without the inherited private variable, Launch Services can
+        // attribute an external AppKit child through responsible-process
+        // ancestry. The child can still acquire the parent bundle identity and
+        // the live parent lookup can become NULL. This is the decisive proof
+        // that environment scrubbing alone is insufficient and post-start
+        // lsappinfo cannot be readiness authority.
+        if (childIdentity !== bundleId || afterChildIdentity === bundleId) {
+          throw new Error(
+            `scrub: expected responsible-process collision despite scrub ` +
+            `(parent=${afterChildIdentity}, child=${childIdentity})`,
+          );
         }
       }
 
@@ -183,7 +188,7 @@ try {
     }
   }
 
-  console.log('✅ macOS Launch Services identity-collision PoC passed');
+  console.log('✅ macOS Launch Services live-identity instability PoC passed');
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/packages/tentacle/src/__tests__/checks.test.ts
+++ b/packages/tentacle/src/__tests__/checks.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock('@inquirer/prompts', () => ({
@@ -38,13 +39,14 @@ vi.mock('node:fs', async (importActual) => {
   };
 });
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { input } from '@inquirer/prompts';
 import { existsSync, realpathSync, promises as fsp } from 'node:fs';
 import { platform, homedir } from 'node:os';
 import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, ensureWindowsSystemPath, probeFda, pollFda, getKrakiAppBundlePath, getProcessBundleIdentity, getDaemonTccIdentity, registerKrakiAppBundle, openTccPane, TCC_SERVICES, probeTccStatus, ensureTccBundleRegistered, unregisterAppBundlePath } from '../checks.js';
 
 const mockExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
+const mockExecFileSync = execFileSync as unknown as ReturnType<typeof vi.fn>;
 const mockInput = input as unknown as ReturnType<typeof vi.fn>;
 const mockExistsSync = existsSync as unknown as ReturnType<typeof vi.fn>;
 const mockRealpathSync = realpathSync as unknown as ReturnType<typeof vi.fn>;
@@ -575,27 +577,37 @@ describe('daemon TCC identity proof', () => {
     mockRealpathSync.mockReturnValue('/Users/x/.local/share/kraki/Kraki.app/Contents/MacOS/kraki');
   });
 
-  it('parses a live lsappinfo identity', () => {
-    mockExecSync.mockReturnValue('"CFBundleIdentifier"="chat.kraki.cli"\n');
-    expect(getProcessBundleIdentity(123)).toBe('chat.kraki.cli');
+  it('parses a live lsappinfo identity without leaking the private app variable to the probe child', () => {
+    process.env.__CFBundleIdentifier = 'chat.kraki.cli';
+    mockExecFileSync.mockReturnValue('"CFBundleIdentifier"="chat.kraki.cli"\n');
+    try {
+      expect(getProcessBundleIdentity(123)).toBe('chat.kraki.cli');
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        '/usr/bin/lsappinfo',
+        ['info', '-only', 'bundleid', '123'],
+        expect.objectContaining({ env: expect.not.objectContaining({ __CFBundleIdentifier: expect.anything() }) }),
+      );
+    } finally {
+      delete process.env.__CFBundleIdentifier;
+    }
   });
 
   it('prefers a matching PID-bound proof over a later unstable lsappinfo lookup', () => {
-    mockExecSync.mockReturnValue('"CFBundleIdentifier"=[ NULL ]\n');
+    mockExecFileSync.mockReturnValue('"CFBundleIdentifier"=[ NULL ]\n');
     const result = getDaemonTccIdentity(123, { pid: 123, bundleId: 'chat.kraki.cli' });
 
     expect(result.daemonBundleId).toBe('chat.kraki.cli');
     expect(result.healthy).toBe(true);
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
   it('does not trust an identity proof for a different PID', () => {
-    mockExecSync.mockReturnValue('"CFBundleIdentifier"=[ NULL ]\n');
+    mockExecFileSync.mockReturnValue('"CFBundleIdentifier"=[ NULL ]\n');
     const result = getDaemonTccIdentity(123, { pid: 999, bundleId: 'chat.kraki.cli' });
 
     expect(result.daemonBundleId).toBeNull();
     expect(result.healthy).toBe(false);
-    expect(mockExecSync).toHaveBeenCalled();
+    expect(mockExecFileSync).toHaveBeenCalled();
   });
 });
 

--- a/packages/tentacle/src/__tests__/checks.test.ts
+++ b/packages/tentacle/src/__tests__/checks.test.ts
@@ -42,7 +42,7 @@ import { execSync } from 'node:child_process';
 import { input } from '@inquirer/prompts';
 import { existsSync, realpathSync, promises as fsp } from 'node:fs';
 import { platform, homedir } from 'node:os';
-import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, ensureWindowsSystemPath, probeFda, pollFda, getKrakiAppBundlePath, registerKrakiAppBundle, openTccPane, TCC_SERVICES, probeTccStatus, ensureTccBundleRegistered, unregisterAppBundlePath } from '../checks.js';
+import { checkGhCli, checkGhAuth, checkCopilotCli, withRetry, ensureWindowsSystemPath, probeFda, pollFda, getKrakiAppBundlePath, getProcessBundleIdentity, getDaemonTccIdentity, registerKrakiAppBundle, openTccPane, TCC_SERVICES, probeTccStatus, ensureTccBundleRegistered, unregisterAppBundlePath } from '../checks.js';
 
 const mockExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
 const mockInput = input as unknown as ReturnType<typeof vi.fn>;
@@ -564,6 +564,38 @@ describe('probeTccStatus()', () => {
     mockAccess.mockRejectedValue(Object.assign(new Error('perm'), { code: 'EPERM' }));
     const s = await probeTccStatus();
     expect(s.services.fda).toBe('denied');
+  });
+});
+
+describe('daemon TCC identity proof', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPlatform.mockReturnValue('darwin');
+    mockExistsSync.mockReturnValue(true);
+    mockRealpathSync.mockReturnValue('/Users/x/.local/share/kraki/Kraki.app/Contents/MacOS/kraki');
+  });
+
+  it('parses a live lsappinfo identity', () => {
+    mockExecSync.mockReturnValue('"CFBundleIdentifier"="chat.kraki.cli"\n');
+    expect(getProcessBundleIdentity(123)).toBe('chat.kraki.cli');
+  });
+
+  it('prefers a matching PID-bound proof over a later unstable lsappinfo lookup', () => {
+    mockExecSync.mockReturnValue('"CFBundleIdentifier"=[ NULL ]\n');
+    const result = getDaemonTccIdentity(123, { pid: 123, bundleId: 'chat.kraki.cli' });
+
+    expect(result.daemonBundleId).toBe('chat.kraki.cli');
+    expect(result.healthy).toBe(true);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('does not trust an identity proof for a different PID', () => {
+    mockExecSync.mockReturnValue('"CFBundleIdentifier"=[ NULL ]\n');
+    const result = getDaemonTccIdentity(123, { pid: 999, bundleId: 'chat.kraki.cli' });
+
+    expect(result.daemonBundleId).toBeNull();
+    expect(result.healthy).toBe(false);
+    expect(mockExecSync).toHaveBeenCalled();
   });
 });
 

--- a/packages/tentacle/src/__tests__/cli.test.ts
+++ b/packages/tentacle/src/__tests__/cli.test.ts
@@ -51,6 +51,8 @@ vi.mock('../config.js', () => ({
   getOrCreateDeviceId: vi.fn(() => 'dev_test'),
   saveGitHubToken: vi.fn(),
   loadGitHubToken: vi.fn(() => null),
+  loadDaemonPid: vi.fn(() => null),
+  loadDaemonIdentity: vi.fn(() => null),
   DEFAULT_LOG_VERBOSITY: 'normal',
 }));
 

--- a/packages/tentacle/src/__tests__/cli.test.ts
+++ b/packages/tentacle/src/__tests__/cli.test.ts
@@ -35,6 +35,8 @@ const mockStopDaemon = vi.fn();
 const mockRunSetup = vi.fn();
 const mockShowPairingQr = vi.fn();
 const mockStartWorker = vi.fn();
+const mockPrepareDaemonWorkerBootstrap = vi.fn();
+const mockRunDaemonReleaseSmoke = vi.fn();
 
 vi.mock('../config.js', () => ({
   configExists: (...args: unknown[]) => mockConfigExists(...args),
@@ -54,9 +56,12 @@ vi.mock('../config.js', () => ({
 
 vi.mock('../daemon.js', () => ({
   INTERNAL_DAEMON_WORKER_COMMAND: '__daemon-worker',
+  INTERNAL_DAEMON_SMOKE_COMMAND: '__daemon-release-smoke',
+  prepareDaemonWorkerBootstrap: (...args: unknown[]) => mockPrepareDaemonWorkerBootstrap(...args),
   isDaemonRunning: (...args: unknown[]) => mockIsDaemonRunning(...args),
   getDaemonStatus: (...args: unknown[]) => mockGetDaemonStatus(...args),
   startDaemon: (...args: unknown[]) => mockStartDaemon(...args),
+  runDaemonReleaseSmoke: (...args: unknown[]) => mockRunDaemonReleaseSmoke(...args),
   stopDaemon: (...args: unknown[]) => mockStopDaemon(...args),
 }));
 
@@ -227,7 +232,20 @@ describe('CLI --version', () => {
 describe('CLI internal daemon worker', () => {
   it('runs the hidden daemon worker command', async () => {
     await runCli(['__daemon-worker']);
+    expect(mockPrepareDaemonWorkerBootstrap).toHaveBeenCalledOnce();
     expect(mockStartWorker).toHaveBeenCalled();
+  });
+
+  it('runs the hidden release smoke through the real daemon manager without pairing', async () => {
+    const config = { relay: 'ws://127.0.0.1:1', authMethod: 'open', device: { name: 'smoke' } };
+    mockLoadConfig.mockReturnValue(config);
+    mockRunDaemonReleaseSmoke.mockResolvedValue(4567);
+
+    await runCli(['__daemon-release-smoke']);
+
+    expect(mockRunDaemonReleaseSmoke).toHaveBeenCalledWith(config);
+    expect(mockShowPairingQr).not.toHaveBeenCalled();
+    expect(stdoutOutput.join('')).toContain('daemon-release-smoke-ok pid=4567');
   });
 });
 

--- a/packages/tentacle/src/__tests__/config.test.ts
+++ b/packages/tentacle/src/__tests__/config.test.ts
@@ -226,6 +226,30 @@ describe('saveDaemonPid() / loadDaemonPid() / clearDaemonPid()', () => {
   });
 });
 
+// ── Daemon identity proof ───────────────────────────────
+
+describe('saveDaemonIdentity() / loadDaemonIdentity() / clearDaemonIdentity()', () => {
+  it('round-trips a PID-bound bundle identity proof with private permissions', () => {
+    const proof = { pid: 12345, bundleId: 'chat.kraki.cli' };
+    config.saveDaemonIdentity(proof);
+
+    expect(config.loadDaemonIdentity()).toEqual(proof);
+    expect(statSync(config.getDaemonIdentityPath()).mode & 0o777).toBe(0o600);
+
+    config.clearDaemonIdentity();
+    expect(config.loadDaemonIdentity()).toBeNull();
+  });
+
+  it('rejects malformed or incomplete identity proof data', () => {
+    mkdirSync(join(tempHome, '.kraki'), { recursive: true });
+    writeFileSync(config.getDaemonIdentityPath(), JSON.stringify({ pid: 0, bundleId: '' }), 'utf8');
+    expect(config.loadDaemonIdentity()).toBeNull();
+
+    writeFileSync(config.getDaemonIdentityPath(), 'not-json', 'utf8');
+    expect(config.loadDaemonIdentity()).toBeNull();
+  });
+});
+
 // ── Daemon readiness ───────────────────────────────────
 
 describe('saveDaemonReady() / loadDaemonReady() / clearDaemonReady()', () => {

--- a/packages/tentacle/src/__tests__/config.test.ts
+++ b/packages/tentacle/src/__tests__/config.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, existsSync, statSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { rmSync } from 'node:fs';
 
@@ -53,6 +53,14 @@ describe('getConfigDir()', () => {
     expect(config.getKrakiHome()).toBe(customHome);
     expect(config.getConfigDir()).toBe(customHome);
     expect(existsSync(customHome)).toBe(true);
+  });
+
+  it('normalizes a relative KRAKI_HOME to one absolute path for CLI and launchd', async () => {
+    process.env.KRAKI_HOME = 'relative-kraki-home';
+    vi.resetModules();
+    config = await import('../config.js');
+
+    expect(config.getKrakiHome()).toBe(resolve('relative-kraki-home'));
   });
 
   it('creates the directory if it does not exist', () => {

--- a/packages/tentacle/src/__tests__/daemon-worker.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-worker.test.ts
@@ -163,6 +163,16 @@ describe('daemon-worker: startWorker()', () => {
     mockExecSyncThrow = false;
     mockExit.mockClear();
     delete process.env.GITHUB_TOKEN;
+    delete process.env.__CFBundleIdentifier;
+  });
+
+  it('scrubs the Launch Services bundle variable before adapters can spawn children', async () => {
+    process.env.__CFBundleIdentifier = 'chat.kraki.cli';
+
+    const { shutdown } = await startWorker();
+
+    expect(process.env.__CFBundleIdentifier).toBeUndefined();
+    await shutdown();
   });
 
   it('loads config, resolves gh token, starts adapter, connects relay', async () => {

--- a/packages/tentacle/src/__tests__/daemon-worker.test.ts
+++ b/packages/tentacle/src/__tests__/daemon-worker.test.ts
@@ -104,6 +104,7 @@ let mockChannelKey: string | null = null;
 const mockSaveDaemonPid = vi.fn();
 const mockSaveDaemonReady = vi.fn();
 const mockClearDaemonReady = vi.fn();
+const mockClearDaemonIdentity = vi.fn();
 
 vi.mock('../config.js', () => ({
   loadConfig: vi.fn(() => mockConfig),
@@ -117,6 +118,7 @@ vi.mock('../config.js', () => ({
   saveDaemonPid: (...args: unknown[]) => mockSaveDaemonPid(...args),
   saveDaemonReady: (...args: unknown[]) => mockSaveDaemonReady(...args),
   clearDaemonReady: (...args: unknown[]) => mockClearDaemonReady(...args),
+  clearDaemonIdentity: (...args: unknown[]) => mockClearDaemonIdentity(...args),
 }));
 
 let mockExecSyncReturn = 'fake-token\n';
@@ -187,6 +189,7 @@ describe('daemon-worker: startWorker()', () => {
 
     await shutdown();
     expect(mockClearDaemonReady).toHaveBeenCalled();
+    expect(mockClearDaemonIdentity).toHaveBeenCalled();
     expect(mockRelay.disconnect).toHaveBeenCalled();
     expect(mockAdapter.stop).toHaveBeenCalled();
   });

--- a/packages/tentacle/src/__tests__/daemon.test.ts
+++ b/packages/tentacle/src/__tests__/daemon.test.ts
@@ -28,6 +28,9 @@ vi.mock('node:child_process', () => ({
 const mockSaveDaemonPid = vi.fn();
 const mockLoadDaemonPid = vi.fn();
 const mockClearDaemonPid = vi.fn();
+const mockSaveDaemonIdentity = vi.fn();
+const mockLoadDaemonIdentity = vi.fn();
+const mockClearDaemonIdentity = vi.fn();
 const mockLoadDaemonReady = vi.fn();
 const mockClearDaemonReady = vi.fn();
 const mockMkdirSync = vi.fn();
@@ -69,6 +72,9 @@ vi.mock('../config.js', () => ({
   saveDaemonPid: (...args: unknown[]) => mockSaveDaemonPid(...args),
   loadDaemonPid: (...args: unknown[]) => mockLoadDaemonPid(...args),
   clearDaemonPid: (...args: unknown[]) => mockClearDaemonPid(...args),
+  saveDaemonIdentity: (...args: unknown[]) => mockSaveDaemonIdentity(...args),
+  loadDaemonIdentity: (...args: unknown[]) => mockLoadDaemonIdentity(...args),
+  clearDaemonIdentity: (...args: unknown[]) => mockClearDaemonIdentity(...args),
   loadDaemonReady: (...args: unknown[]) => mockLoadDaemonReady(...args),
   clearDaemonReady: (...args: unknown[]) => mockClearDaemonReady(...args),
 }));
@@ -100,6 +106,7 @@ beforeEach(() => {
   mockGetKrakiAppBundlePath.mockReturnValue(null);
   mockGetProcessBundleIdentity.mockReturnValue(null);
   mockLoadDaemonReady.mockReturnValue(null);
+  mockLoadDaemonIdentity.mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -123,18 +130,38 @@ function makeFakeChild(pid = 42) {
 // ── daemon worker bootstrap ─────────────────────────────
 
 describe('prepareDaemonWorkerBootstrap()', () => {
-  it('removes the private Launch Services bundle variable before child processes can inherit it', () => {
+  it('removes the private Launch Services bundle variable before child processes can inherit it', async () => {
     const env: NodeJS.ProcessEnv = {
       __CFBundleIdentifier: 'chat.kraki.cli',
       HOME: '/tmp/home',
     };
 
-    prepareDaemonWorkerBootstrap(env, 12345);
+    await prepareDaemonWorkerBootstrap(env, 12345, null, mockGetProcessBundleIdentity, 0);
 
     expect(env.__CFBundleIdentifier).toBeUndefined();
     expect(env.HOME).toBe('/tmp/home');
     expect(mockClearDaemonReady).toHaveBeenCalledOnce();
     expect(mockSaveDaemonPid).toHaveBeenCalledWith(12345);
+    expect(mockSaveDaemonIdentity).not.toHaveBeenCalled();
+  });
+
+  it('captures a matching initial Launch Services identity before scrubbing the environment', async () => {
+    const env: NodeJS.ProcessEnv = { __CFBundleIdentifier: 'chat.kraki.cli' };
+    mockGetProcessBundleIdentity.mockReturnValue('chat.kraki.cli');
+
+    await prepareDaemonWorkerBootstrap(env, 23456, '/Applications/Kraki.app', mockGetProcessBundleIdentity, 0);
+
+    expect(mockGetProcessBundleIdentity).toHaveBeenCalledWith(23456);
+    expect(mockSaveDaemonIdentity).toHaveBeenCalledWith({ pid: 23456, bundleId: 'chat.kraki.cli' });
+    expect(env.__CFBundleIdentifier).toBeUndefined();
+  });
+
+  it('does not publish an identity proof when the initial bundle identity is absent', async () => {
+    mockGetProcessBundleIdentity.mockReturnValue(null);
+
+    await prepareDaemonWorkerBootstrap({}, 34567, '/Applications/Kraki.app', mockGetProcessBundleIdentity, 0);
+
+    expect(mockSaveDaemonIdentity).not.toHaveBeenCalled();
   });
 });
 
@@ -312,6 +339,25 @@ describe('startDaemon()', () => {
     expect(launch.workerPath).toBe(process.execPath);
   });
 
+  it('accepts a matching worker-published identity proof even if live lsappinfo later becomes unstable', async () => {
+    vi.useFakeTimers();
+    mockGetKrakiAppBundlePath.mockReturnValue('/Applications/Kraki.app');
+    mockLoadDaemonReady.mockReturnValue(4142);
+    mockLoadDaemonIdentity.mockReturnValue({ pid: 4142, bundleId: 'chat.kraki.cli' });
+    mockGetProcessBundleIdentity.mockReturnValue(null);
+    mockLoadDaemonPid.mockReturnValue(4142);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const startPromise = startDaemonLaunchctl(fakeConfig, TEST_UID);
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(startPromise).resolves.toBe(4142);
+    // The launcher consumes the proof captured before adapter children started;
+    // it must not re-query the mutable Launch Services process table here.
+    expect(mockGetProcessBundleIdentity).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
   it('rejects a bundled macOS launch whose PID lacks the required Launch Services identity', async () => {
     vi.useFakeTimers();
     mockIsSea.mockReturnValue(true);
@@ -349,7 +395,8 @@ describe('startDaemon()', () => {
     await vi.advanceTimersByTimeAsync(35_300);
 
     await rejection;
-    expect(mockGetProcessBundleIdentity).toHaveBeenCalledWith(4242);
+    expect(mockLoadDaemonIdentity).toHaveBeenCalled();
+    expect(mockGetProcessBundleIdentity).not.toHaveBeenCalled();
     expect(mockUnlinkSync).toHaveBeenCalled();
     killSpy.mockRestore();
   });

--- a/packages/tentacle/src/__tests__/daemon.test.ts
+++ b/packages/tentacle/src/__tests__/daemon.test.ts
@@ -79,6 +79,7 @@ import {
   getDaemonStatus,
   startDaemon,
   startDaemonLaunchctl,
+  prepareDaemonWorkerBootstrap,
   stopDaemon,
   inspectDaemonProcess,
   resolveDaemonLaunch,
@@ -118,6 +119,24 @@ function makeFakeChild(pid = 42) {
   };
   return { child, listeners };
 }
+
+// ── daemon worker bootstrap ─────────────────────────────
+
+describe('prepareDaemonWorkerBootstrap()', () => {
+  it('removes the private Launch Services bundle variable before child processes can inherit it', () => {
+    const env: NodeJS.ProcessEnv = {
+      __CFBundleIdentifier: 'chat.kraki.cli',
+      HOME: '/tmp/home',
+    };
+
+    prepareDaemonWorkerBootstrap(env, 12345);
+
+    expect(env.__CFBundleIdentifier).toBeUndefined();
+    expect(env.HOME).toBe('/tmp/home');
+    expect(mockClearDaemonReady).toHaveBeenCalledOnce();
+    expect(mockSaveDaemonPid).toHaveBeenCalledWith(12345);
+  });
+});
 
 // ── inspectDaemonProcess ─────────────────────────────────
 
@@ -319,6 +338,9 @@ describe('startDaemon()', () => {
       expect.any(String),
       { mode: 0o600 },
     );
+    const plistArg = mockWriteFileSync.mock.calls
+      .find((call: unknown[]) => call[0] === expectedPlistPath)?.[1] as string;
+    expect(plistArg).toMatch(/<key>KRAKI_HOME<\/key>\s*<string>\/tmp\/fake-home\/\.kraki<\/string>/);
     expect(mockChmodSync).toHaveBeenCalledWith(
       expectedPlistPath,
       0o600,
@@ -330,6 +352,33 @@ describe('startDaemon()', () => {
     expect(mockGetProcessBundleIdentity).toHaveBeenCalledWith(4242);
     expect(mockUnlinkSync).toHaveBeenCalled();
     killSpy.mockRestore();
+  });
+
+  it('does not persist a Copilot session-scoped gho_ token in launchd', async () => {
+    vi.useFakeTimers();
+    const previous = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'gho_session_only';
+    mockGetKrakiAppBundlePath.mockReturnValue('/Applications/Kraki.app');
+    mockLoadDaemonPid.mockReturnValue(null);
+    mockExecFileSync.mockImplementation((command: string) => {
+      if (command === '/bin/launchctl') return '';
+      throw new Error('not inspected');
+    });
+
+    try {
+      const startPromise = startDaemonLaunchctl(fakeConfig, TEST_UID);
+      const rejection = expect(startPromise).rejects.toBeInstanceOf(DaemonStartupError);
+      await vi.advanceTimersByTimeAsync(30_200);
+      await rejection;
+
+      const plistArg = mockWriteFileSync.mock.calls
+        .find((call: unknown[]) => call[0] === expectedPlistPath)?.[1] as string;
+      expect(plistArg).not.toContain('gho_session_only');
+      expect(plistArg).not.toContain('<key>GITHUB_TOKEN</key>');
+    } finally {
+      if (previous === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = previous;
+    }
   });
 
   it('fails closed without removing supervision when startup identity cannot be inspected', async () => {

--- a/packages/tentacle/src/__tests__/sea-daemon-bootstrap-contract.test.ts
+++ b/packages/tentacle/src/__tests__/sea-daemon-bootstrap-contract.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const buildScript = readFileSync(resolve(here, '../../scripts/build-local-binary.mjs'), 'utf8');
+
+describe('SEA daemon bootstrap contract', () => {
+  it('scrubs the Launch Services bundle variable in the esbuild banner before modules initialize', () => {
+    expect(buildScript).toContain('process.argv[2] === "__daemon-worker"');
+    expect(buildScript).toContain('delete process.env.__CFBundleIdentifier');
+
+    const bannerIndex = buildScript.indexOf('delete process.env.__CFBundleIdentifier');
+    const importMetaIndex = buildScript.indexOf('const __kraki_import_meta_url');
+    expect(bannerIndex).toBeGreaterThan(-1);
+    expect(importMetaIndex).toBeGreaterThan(bannerIndex);
+  });
+});

--- a/packages/tentacle/src/__tests__/sea-daemon-bootstrap-contract.test.ts
+++ b/packages/tentacle/src/__tests__/sea-daemon-bootstrap-contract.test.ts
@@ -4,16 +4,14 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const buildScript = readFileSync(resolve(here, '../../scripts/build-local-binary.mjs'), 'utf8');
+const cliSource = readFileSync(resolve(here, '../cli.ts'), 'utf8');
 
 describe('SEA daemon bootstrap contract', () => {
-  it('scrubs the Launch Services bundle variable in the esbuild banner before modules initialize', () => {
-    expect(buildScript).toContain('process.argv[2] === "__daemon-worker"');
-    expect(buildScript).toContain('delete process.env.__CFBundleIdentifier');
+  it('captures and scrubs Launch Services state before importing daemon-worker adapters', () => {
+    const prepareIndex = cliSource.indexOf('await prepareDaemonWorkerBootstrap()');
+    const workerImportIndex = cliSource.indexOf("await import('./daemon-worker.js')");
 
-    const bannerIndex = buildScript.indexOf('delete process.env.__CFBundleIdentifier');
-    const importMetaIndex = buildScript.indexOf('const __kraki_import_meta_url');
-    expect(bannerIndex).toBeGreaterThan(-1);
-    expect(importMetaIndex).toBeGreaterThan(bannerIndex);
+    expect(prepareIndex).toBeGreaterThan(-1);
+    expect(workerImportIndex).toBeGreaterThan(prepareIndex);
   });
 });

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -511,7 +511,10 @@ export function getProcessBundleIdentity(pid: number): string | null {
  * recurring permission loss: a correctly signed, correctly registered bundle
  * whose daemon was nonetheless started by absolute path.
  */
-export function getDaemonTccIdentity(daemonPid: number | null): {
+export function getDaemonTccIdentity(
+  daemonPid: number | null,
+  identityProof?: { pid: number; bundleId: string } | null,
+): {
   bundled: boolean;
   bundlePath: string | null;
   daemonPid: number | null;
@@ -520,7 +523,11 @@ export function getDaemonTccIdentity(daemonPid: number | null): {
 } {
   const bundlePath = getKrakiAppBundlePath();
   const bundled = bundlePath !== null;
-  const daemonBundleId = daemonPid !== null ? getProcessBundleIdentity(daemonPid) : null;
+  const daemonBundleId = daemonPid !== null
+    ? (identityProof?.pid === daemonPid
+        ? identityProof.bundleId
+        : getProcessBundleIdentity(daemonPid))
+    : null;
   return {
     bundled,
     bundlePath,

--- a/packages/tentacle/src/checks.ts
+++ b/packages/tentacle/src/checks.ts
@@ -5,7 +5,7 @@
  * Provides a retry mechanism for interactive setup flows.
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { constants as fsConstants, promises as fsp, appendFileSync, mkdirSync, readFileSync, writeFileSync, existsSync, realpathSync, rmSync } from 'node:fs';
 import { homedir, platform, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -490,10 +490,15 @@ export function registerKrakiAppBundle(appBundlePath?: string): boolean {
 export function getProcessBundleIdentity(pid: number): string | null {
   if (platform() !== 'darwin') return null;
   try {
-    const out = execSync(`/usr/bin/lsappinfo info -only bundleid ${pid}`, {
-      stdio: ['pipe', 'pipe', 'pipe'],
+    const { __CFBundleIdentifier: _privateLaunchServicesIdentity, ...safeEnv } = process.env;
+    const out = execFileSync('/usr/bin/lsappinfo', ['info', '-only', 'bundleid', String(pid)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf8',
       timeout: 5000,
+      // The probe is a child of the LaunchServices-owned daemon during early
+      // bootstrap. Never let the diagnostic helper inherit the private app
+      // identity variable it is trying to measure.
+      env: safeEnv,
     });
     // Present:  "CFBundleIdentifier"="chat.kraki.cli"
     // Absent:   "CFBundleIdentifier"=[ NULL ]

--- a/packages/tentacle/src/cli.ts
+++ b/packages/tentacle/src/cli.ts
@@ -957,9 +957,9 @@ async function main(): Promise<void> {
   const cmd = args[0];
 
   if (cmd === INTERNAL_DAEMON_WORKER_COMMAND) {
-    // Must run before importing daemon-worker/adapters: Launch Services injects
-    // __CFBundleIdentifier into Kraki.app, and child Node processes must not
-    // inherit it and check in as the Kraki application.
+    // Must run before importing daemon-worker/adapters: capture the initial
+    // PID-bound Launch Services identity while it is still stable, then scrub
+    // private LS bootstrap state from the child-process environment.
     await prepareDaemonWorkerBootstrap();
     const { startWorker } = await import('./daemon-worker.js');
     await startWorker();

--- a/packages/tentacle/src/cli.ts
+++ b/packages/tentacle/src/cli.ts
@@ -739,7 +739,7 @@ async function cmdDoctor(): Promise<void> {
     checkGhAuth, checkCopilotCli, checkClaudeCli, checkAnthropicCreds, probeFda, getKrakiAppBundlePath,
     getDaemonTccIdentity,
   } = await import('./checks.js');
-  const { loadDaemonPid } = await import('./config.js');
+  const { loadDaemonPid, loadDaemonIdentity } = await import('./config.js');
   // `kraki doctor` must emit a single clean JSON line on stdout. The
   // multi-adapter logger (created at module load) defaults to info-level
   // stdout (dev) which would interleave pino lines into the output, so
@@ -790,7 +790,7 @@ async function cmdDoctor(): Promise<void> {
       // Services bundle identity? A bundled, registered, correctly signed app
       // still reports healthy:false when its daemon was started by absolute
       // path — that combination is what made this bug recur six times.
-      identity: getDaemonTccIdentity(loadDaemonPid()),
+      identity: getDaemonTccIdentity(loadDaemonPid(), loadDaemonIdentity()),
     },
     ghAuth: ghAuth.authenticated,
     ghUser: ghAuth.username ?? null,
@@ -960,7 +960,7 @@ async function main(): Promise<void> {
     // Must run before importing daemon-worker/adapters: Launch Services injects
     // __CFBundleIdentifier into Kraki.app, and child Node processes must not
     // inherit it and check in as the Kraki application.
-    prepareDaemonWorkerBootstrap();
+    await prepareDaemonWorkerBootstrap();
     const { startWorker } = await import('./daemon-worker.js');
     await startWorker();
     return;

--- a/packages/tentacle/src/cli.ts
+++ b/packages/tentacle/src/cli.ts
@@ -21,7 +21,7 @@ import { readFileSync, existsSync, unlinkSync } from 'node:fs';
 import { select } from '@inquirer/prompts';
 
 import { loadConfig, saveConfig, getConfigPath, getKrakiHome, getLogVerbosity, getVersion, loadChannelKey, type KrakiConfig } from './config.js';
-import { INTERNAL_DAEMON_WORKER_COMMAND, isDaemonRunning, getDaemonStatus, startDaemon, stopDaemon } from './daemon.js';
+import { INTERNAL_DAEMON_WORKER_COMMAND, INTERNAL_DAEMON_SMOKE_COMMAND, prepareDaemonWorkerBootstrap, isDaemonRunning, getDaemonStatus, startDaemon, runDaemonReleaseSmoke, stopDaemon } from './daemon.js';
 import { runSetup } from './setup.js';
 import { requestPairingToken, buildPairingUrl, renderQrToTerminal } from './pair.js';
 import { printStaticBanner } from './banner.js';
@@ -957,8 +957,20 @@ async function main(): Promise<void> {
   const cmd = args[0];
 
   if (cmd === INTERNAL_DAEMON_WORKER_COMMAND) {
+    // Must run before importing daemon-worker/adapters: Launch Services injects
+    // __CFBundleIdentifier into Kraki.app, and child Node processes must not
+    // inherit it and check in as the Kraki application.
+    prepareDaemonWorkerBootstrap();
     const { startWorker } = await import('./daemon-worker.js');
     await startWorker();
+    return;
+  }
+
+  if (cmd === INTERNAL_DAEMON_SMOKE_COMMAND) {
+    const config = loadConfig();
+    if (!config) throw new Error(`No release smoke config found at ${getConfigPath()}`);
+    const pid = await runDaemonReleaseSmoke(config);
+    process.stdout.write(`daemon-release-smoke-ok pid=${pid}\n`);
     return;
   }
 

--- a/packages/tentacle/src/config.ts
+++ b/packages/tentacle/src/config.ts
@@ -231,7 +231,9 @@ export function getDaemonIdentityPath(): string {
 
 export function saveDaemonIdentity(proof: DaemonIdentityProof): void {
   getConfigDir();
-  writeFileSync(getDaemonIdentityPath(), JSON.stringify(proof), { mode: 0o600 });
+  const path = getDaemonIdentityPath();
+  writeFileSync(path, JSON.stringify(proof), { mode: 0o600 });
+  chmodSync(path, 0o600);
 }
 
 export function loadDaemonIdentity(): DaemonIdentityProof | null {

--- a/packages/tentacle/src/config.ts
+++ b/packages/tentacle/src/config.ts
@@ -220,6 +220,39 @@ export function clearDaemonPid(): void {
   }
 }
 
+export interface DaemonIdentityProof {
+  pid: number;
+  bundleId: string;
+}
+
+export function getDaemonIdentityPath(): string {
+  return join(getKrakiHome(), 'daemon.identity');
+}
+
+export function saveDaemonIdentity(proof: DaemonIdentityProof): void {
+  getConfigDir();
+  writeFileSync(getDaemonIdentityPath(), JSON.stringify(proof), { mode: 0o600 });
+}
+
+export function loadDaemonIdentity(): DaemonIdentityProof | null {
+  try {
+    const value = JSON.parse(readFileSync(getDaemonIdentityPath(), 'utf8')) as Partial<DaemonIdentityProof>;
+    return Number.isInteger(value.pid) && (value.pid ?? 0) > 0 && typeof value.bundleId === 'string' && value.bundleId.length > 0
+      ? { pid: value.pid!, bundleId: value.bundleId }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDaemonIdentity(): void {
+  try {
+    unlinkSync(getDaemonIdentityPath());
+  } catch {
+    // File may not exist — that's fine
+  }
+}
+
 // ── Daemon readiness ───────────────────────────────────
 
 export function getDaemonReadyPath(): string {

--- a/packages/tentacle/src/config.ts
+++ b/packages/tentacle/src/config.ts
@@ -73,7 +73,7 @@ export function getVersion(): string {
 
 export function getKrakiHome(): string {
   const override = process.env.KRAKI_HOME?.trim();
-  return override ? join(override) : join(homedir(), '.kraki');
+  return override ? resolve(override) : join(homedir(), '.kraki');
 }
 
 export function getConfigDir(): string {

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -67,10 +67,11 @@ export interface WorkerResult {
 }
 
 export async function startWorker(): Promise<WorkerResult> {
-  // Launch Services injects this private variable into Kraki.app. It describes
-  // only this app process; child Node/Pi/Copilot processes must not inherit it
-  // and check in as chat.kraki.cli. The SEA banner and CLI bootstrap scrub it
-  // even earlier; this is the source/npm-path belt-and-suspenders guard.
+  // Launch Services injects this private bootstrap variable into Kraki.app.
+  // It is not a child-process credential, so remove it before adapters spawn.
+  // Correctness does not rely on this scrub: responsible-process attribution
+  // can still make live LS lookups unstable, which is why the CLI captured a
+  // PID-bound identity proof before importing this module.
   delete process.env.__CFBundleIdentifier;
 
   // Clear any stale readiness before publishing this process's PID. This order

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -15,7 +15,7 @@
 
 import { execSync } from 'node:child_process';
 import { platform } from 'node:os';
-import { loadConfig, loadChannelKey, getOrCreateDeviceId, getConfigPath, getChannelKeyPath, getVersion, saveDaemonPid, saveDaemonReady, clearDaemonReady } from './config.js';
+import { loadConfig, loadChannelKey, getOrCreateDeviceId, getConfigPath, getChannelKeyPath, getVersion, saveDaemonPid, saveDaemonReady, clearDaemonReady, clearDaemonIdentity } from './config.js';
 import { ensureWindowsSystemPath, probeFda, ensureTccBundleRegistered, cleanupStaleBundleEntries } from './checks.js';
 import { MultiAgentAdapter } from './adapters/multi.js';
 
@@ -275,6 +275,7 @@ export async function startWorker(): Promise<WorkerResult> {
     shuttingDown = true;
     logger.info('Shutting down…');
     clearDaemonReady();
+    clearDaemonIdentity();
     clearStatusFile();
     relay.disconnect();
     await adapter.stop();

--- a/packages/tentacle/src/daemon-worker.ts
+++ b/packages/tentacle/src/daemon-worker.ts
@@ -67,6 +67,12 @@ export interface WorkerResult {
 }
 
 export async function startWorker(): Promise<WorkerResult> {
+  // Launch Services injects this private variable into Kraki.app. It describes
+  // only this app process; child Node/Pi/Copilot processes must not inherit it
+  // and check in as chat.kraki.cli. The SEA banner and CLI bootstrap scrub it
+  // even earlier; this is the source/npm-path belt-and-suspenders guard.
+  delete process.env.__CFBundleIdentifier;
+
   // Clear any stale readiness before publishing this process's PID. This order
   // prevents a reused numeric PID from momentarily matching an old ready file.
   clearDaemonReady();

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -117,16 +117,20 @@ export const INTERNAL_DAEMON_SMOKE_COMMAND = '__daemon-release-smoke';
  * Prepare the LaunchServices-owned CLI process before daemon-worker imports.
  *
  * macOS injects __CFBundleIdentifier when `open` launches Kraki.app. The value
- * is useful only for the app process's initial Launch Services check-in. If it
- * remains in the environment, every child process inherits it; Pi's throwaway
- * Node catalog process then checks in as chat.kraki.cli and replaces/invalidates
- * the real daemon's runtime identity. The launcher subsequently sees a healthy
- * worker as identity-less, waits 30 seconds, and kills it.
+ * is private Launch Services bootstrap state and must not be forwarded as an
+ * application credential to every child process, so it is removed before the
+ * adapters start.
  *
- * Delete the private LS variable before importing adapters or spawning any
- * children. Publish the PID at the same earliest safe point so launchd startup
- * failures remain attributable even if a later module import throws. Readiness
- * is still published only by startWorker() after full initialization.
+ * More importantly, a bundle-external AppKit child can be attributed to the
+ * parent app through responsible-process ancestry even after that variable is
+ * removed. `lsappinfo(parentPid)` can then change from chat.kraki.cli to NULL
+ * while the original daemon remains healthy. Capture the daemon's correct
+ * PID-bound identity before any adapter child exists and persist it as the
+ * immutable startup proof; post-start live LS lookups are diagnostic only.
+ *
+ * Publish the PID at the same earliest safe point so launchd startup failures
+ * remain attributable even if a later module import throws. Readiness is still
+ * published only by startWorker() after full initialization.
  */
 export async function prepareDaemonWorkerBootstrap(
   env: NodeJS.ProcessEnv = process.env,

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -26,6 +26,9 @@ import {
   saveDaemonPid,
   loadDaemonPid,
   clearDaemonPid,
+  saveDaemonIdentity,
+  loadDaemonIdentity,
+  clearDaemonIdentity,
   loadDaemonReady,
   clearDaemonReady,
 } from './config.js';
@@ -125,10 +128,26 @@ export const INTERNAL_DAEMON_SMOKE_COMMAND = '__daemon-release-smoke';
  * failures remain attributable even if a later module import throws. Readiness
  * is still published only by startWorker() after full initialization.
  */
-export function prepareDaemonWorkerBootstrap(
+export async function prepareDaemonWorkerBootstrap(
   env: NodeJS.ProcessEnv = process.env,
   pid = process.pid,
-): void {
+  appBundle = getKrakiAppBundlePath(),
+  lookupIdentity: (pid: number) => string | null = getProcessBundleIdentity,
+  timeoutMs = 5000,
+): Promise<void> {
+  clearDaemonIdentity();
+  if (appBundle !== null) {
+    const deadline = Date.now() + timeoutMs;
+    do {
+      const bundleId = lookupIdentity(pid);
+      if (bundleId === KRAKI_BUNDLE_ID) {
+        saveDaemonIdentity({ pid, bundleId });
+        break;
+      }
+      if (Date.now() >= deadline) break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } while (true);
+  }
   delete env.__CFBundleIdentifier;
   clearDaemonReady();
   saveDaemonPid(pid);
@@ -363,6 +382,7 @@ export function isDaemonRunning(
     if (isLaunchdAgentLoaded(platform, uid)) return true;
     clearDaemonPid();
     clearDaemonReady();
+    clearDaemonIdentity();
     return false;
   }
   // `unknown` means the PID is alive but the OS refused command inspection.
@@ -386,6 +406,7 @@ export function getDaemonStatus(
     if (isLaunchdAgentLoaded(platform, uid)) return { running: true, pid: null };
     clearDaemonPid();
     clearDaemonReady();
+    clearDaemonIdentity();
     return { running: false, pid: null };
   }
   return { running: true, pid };
@@ -588,6 +609,7 @@ export async function startDaemonLaunchctl(
 
   const plistPath = getLaunchdPlistPath();
   clearDaemonReady();
+  clearDaemonIdentity();
   writeFileSync(plistPath, plist, { mode: 0o600 });
   chmodSync(plistPath, 0o600);
   unloadLaunchdAgent();
@@ -616,7 +638,10 @@ export async function startDaemonLaunchctl(
       if (!readinessPublished) continue;
 
       const workerReady = inspectDaemonProcess(pid) === 'daemon';
-      const launchServicesReady = appBundle === null || getProcessBundleIdentity(pid) === KRAKI_BUNDLE_ID;
+      const identityProof = loadDaemonIdentity();
+      const launchServicesReady = appBundle === null || (
+        identityProof?.pid === pid && identityProof.bundleId === KRAKI_BUNDLE_ID
+      );
       if (workerReady && launchServicesReady) return pid;
     }
   }
@@ -638,6 +663,7 @@ export async function startDaemonLaunchctl(
     cleanupLaunchdPlist();
     clearDaemonPid();
     clearDaemonReady();
+    clearDaemonIdentity();
     throw new DaemonStartupError(bootstrapLogPath);
   }
 
@@ -646,6 +672,7 @@ export async function startDaemonLaunchctl(
   if (!terminated) throw new DaemonStartupError(bootstrapLogPath);
   clearDaemonPid();
   clearDaemonReady();
+  clearDaemonIdentity();
   throw new DaemonStartupError(bootstrapLogPath);
 }
 
@@ -662,6 +689,7 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
     throw new Error('Refusing to start: the recorded daemon PID is alive but could not be verified. Remove the stale daemon.pid only after checking the process.');
   }
   clearDaemonReady();
+  clearDaemonIdentity();
 
   // On macOS SEA, use launchctl so launchd spawns the daemon in a clean
   // context that isn't blocked by CSM provenance tracking.
@@ -701,6 +729,7 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
     }
     clearDaemonPid();
     clearDaemonReady();
+    clearDaemonIdentity();
     throw err;
   }
 
@@ -730,7 +759,10 @@ export async function runDaemonReleaseSmoke(config: KrakiConfig): Promise<number
       const readyPid = loadDaemonReady();
       const status = getDaemonStatus();
       const workerIdentity = inspectDaemonProcess(pid);
-      const bundleIdentity = appBundle === null ? null : getProcessBundleIdentity(pid);
+      const identityProof = loadDaemonIdentity();
+      const bundleIdentity = appBundle === null ? null : (
+        identityProof?.pid === pid ? identityProof.bundleId : null
+      );
       const launchdLoaded = process.platform !== 'darwin' || isLaunchdAgentLoaded();
 
       if (
@@ -753,8 +785,8 @@ export async function runDaemonReleaseSmoke(config: KrakiConfig): Promise<number
       throw new Error(`Daemon release smoke could not stop PID ${pid}`);
     }
     stopped = true;
-    if (loadDaemonPid() !== null || loadDaemonReady() !== null) {
-      throw new Error('Daemon release smoke left stale PID/readiness state after stop');
+    if (loadDaemonPid() !== null || loadDaemonReady() !== null || loadDaemonIdentity() !== null) {
+      throw new Error('Daemon release smoke left stale PID/readiness/identity state after stop');
     }
     if (process.platform === 'darwin' && isLaunchdAgentLoaded()) {
       throw new Error('Daemon release smoke left its launchd job loaded after stop');
@@ -782,6 +814,7 @@ export function stopDaemon(
     if (hasUntrackedLaunchdDaemon(pid, platform, uid)) return false;
     if (platform === 'darwin') cleanupLaunchdPlist();
     clearDaemonReady();
+    clearDaemonIdentity();
     return false;
   }
 
@@ -812,6 +845,7 @@ export function stopDaemon(
     // holding that number.
     clearDaemonPid();
     clearDaemonReady();
+    clearDaemonIdentity();
     return true;
   }
 
@@ -825,6 +859,7 @@ export function stopDaemon(
     // Process already gone.
     clearDaemonPid();
     clearDaemonReady();
+    clearDaemonIdentity();
     return true;
   }
 
@@ -864,5 +899,6 @@ export function stopDaemon(
 
   clearDaemonPid();
   clearDaemonReady();
+  clearDaemonIdentity();
   return true;
 }

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -718,18 +718,47 @@ export async function runDaemonReleaseSmoke(config: KrakiConfig): Promise<number
   let stopped = false;
   try {
     pid = await startDaemon(config);
-    const readyPid = loadDaemonReady();
-    const status = getDaemonStatus();
-    if (readyPid !== pid || !status.running || status.pid !== pid) {
-      throw new Error(
-        `Daemon release smoke observed inconsistent readiness: started=${pid}, ready=${readyPid}, status=${JSON.stringify(status)}`,
-      );
+    const appBundle = getKrakiAppBundlePath();
+    const stabilityDeadline = Date.now() + 15_000;
+
+    // v0.31.10 reached readiness and connected to Relay, then lost its runtime
+    // Launch Services identity after adapter child processes started. A smoke
+    // that stops immediately at readiness cannot catch that class of failure.
+    // Hold across the post-ready window and continuously verify the complete
+    // authority tuple before declaring the binary releasable.
+    while (Date.now() < stabilityDeadline) {
+      const readyPid = loadDaemonReady();
+      const status = getDaemonStatus();
+      const workerIdentity = inspectDaemonProcess(pid);
+      const bundleIdentity = appBundle === null ? null : getProcessBundleIdentity(pid);
+      const launchdLoaded = process.platform !== 'darwin' || isLaunchdAgentLoaded();
+
+      if (
+        readyPid !== pid ||
+        !status.running ||
+        status.pid !== pid ||
+        workerIdentity !== 'daemon' ||
+        (appBundle !== null && bundleIdentity !== KRAKI_BUNDLE_ID) ||
+        !launchdLoaded
+      ) {
+        throw new Error(
+          'Daemon release smoke lost post-ready authority: ' +
+          JSON.stringify({ pid, readyPid, status, workerIdentity, bundleIdentity, launchdLoaded }),
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
     }
 
     if (!stopDaemon()) {
       throw new Error(`Daemon release smoke could not stop PID ${pid}`);
     }
     stopped = true;
+    if (loadDaemonPid() !== null || loadDaemonReady() !== null) {
+      throw new Error('Daemon release smoke left stale PID/readiness state after stop');
+    }
+    if (process.platform === 'darwin' && isLaunchdAgentLoaded()) {
+      throw new Error('Daemon release smoke left its launchd job loaded after stop');
+    }
     return pid;
   } finally {
     // If an assertion after successful startup throws, best-effort stop only the

--- a/packages/tentacle/src/daemon.ts
+++ b/packages/tentacle/src/daemon.ts
@@ -108,6 +108,31 @@ export function assertNoUntrackedLaunchdDaemon(
 }
 
 export const INTERNAL_DAEMON_WORKER_COMMAND = '__daemon-worker';
+export const INTERNAL_DAEMON_SMOKE_COMMAND = '__daemon-release-smoke';
+
+/**
+ * Prepare the LaunchServices-owned CLI process before daemon-worker imports.
+ *
+ * macOS injects __CFBundleIdentifier when `open` launches Kraki.app. The value
+ * is useful only for the app process's initial Launch Services check-in. If it
+ * remains in the environment, every child process inherits it; Pi's throwaway
+ * Node catalog process then checks in as chat.kraki.cli and replaces/invalidates
+ * the real daemon's runtime identity. The launcher subsequently sees a healthy
+ * worker as identity-less, waits 30 seconds, and kills it.
+ *
+ * Delete the private LS variable before importing adapters or spawning any
+ * children. Publish the PID at the same earliest safe point so launchd startup
+ * failures remain attributable even if a later module import throws. Readiness
+ * is still published only by startWorker() after full initialization.
+ */
+export function prepareDaemonWorkerBootstrap(
+  env: NodeJS.ProcessEnv = process.env,
+  pid = process.pid,
+): void {
+  delete env.__CFBundleIdentifier;
+  clearDaemonReady();
+  saveDaemonPid(pid);
+}
 
 export type DaemonProcessIdentity = 'daemon' | 'other' | 'gone' | 'unknown';
 
@@ -506,6 +531,11 @@ export async function startDaemonLaunchctl(
   const logLevel = getLogVerbosity(config) === 'verbose' ? 'debug' : 'info';
   const bootstrapLogPath = getDaemonBootstrapLogPath();
   mkdirSync(dirname(bootstrapLogPath), { recursive: true });
+  writeFileSync(
+    bootstrapLogPath,
+    `[${new Date().toISOString()}] launching daemon home=${getKrakiHome()}\n`,
+    'utf8',
+  );
 
   const plistDir = join(homedir(), 'Library', 'LaunchAgents');
   mkdirSync(plistDir, { recursive: true });
@@ -519,6 +549,11 @@ export async function startDaemonLaunchctl(
     ['LOG_LEVEL', logLevel],
     ['PATH', [...pathParts].filter(Boolean).join(':')],
     ['HOME', homedir()],
+    // The launchd label is scoped to KRAKI_HOME, so the worker must receive
+    // the exact same home. Without this, an isolated/dev job silently falls
+    // back to ~/.kraki and multiple jobs overwrite the production PID/ready
+    // files while connecting as the same device.
+    ['KRAKI_HOME', getKrakiHome()],
   ];
   if (process.env.KRAKI_RELAY_URL) envEntries.push(['KRAKI_RELAY_URL', process.env.KRAKI_RELAY_URL]);
 
@@ -532,7 +567,13 @@ export async function startDaemonLaunchctl(
     'GITHUB_TOKEN', 'GH_TOKEN',
   ];
   for (const key of forwardVars) {
-    if (process.env[key]) envEntries.push([key, process.env[key]!]);
+    const value = process.env[key];
+    if (!value) continue;
+    // Copilot CLI can inject a session-scoped gho_ token into its child
+    // environment. It is not valid for an independently launched daemon and
+    // must not be persisted in a launchd plist.
+    if ((key === 'GITHUB_TOKEN' || key === 'GH_TOKEN') && value.startsWith('gho_')) continue;
+    envEntries.push([key, value]);
   }
 
   const appBundle = getKrakiAppBundlePath();
@@ -666,6 +707,36 @@ export async function startDaemon(config: KrakiConfig, cliEntryPath?: string): P
   child.unref();
   saveDaemonPid(child.pid);
   return child.pid;
+}
+
+export async function runDaemonReleaseSmoke(config: KrakiConfig): Promise<number> {
+  if (process.env.KRAKI_RELEASE_SMOKE !== '1') {
+    throw new Error('The internal daemon release smoke command is disabled');
+  }
+
+  let pid: number | null = null;
+  let stopped = false;
+  try {
+    pid = await startDaemon(config);
+    const readyPid = loadDaemonReady();
+    const status = getDaemonStatus();
+    if (readyPid !== pid || !status.running || status.pid !== pid) {
+      throw new Error(
+        `Daemon release smoke observed inconsistent readiness: started=${pid}, ready=${readyPid}, status=${JSON.stringify(status)}`,
+      );
+    }
+
+    if (!stopDaemon()) {
+      throw new Error(`Daemon release smoke could not stop PID ${pid}`);
+    }
+    stopped = true;
+    return pid;
+  } finally {
+    // If an assertion after successful startup throws, best-effort stop only the
+    // PID recorded under this smoke's isolated KRAKI_HOME. stopDaemon() remains
+    // identity-gated and will not signal an unrelated process.
+    if (pid !== null && !stopped) stopDaemon();
+  }
 }
 
 export function stopDaemon(


### PR DESCRIPTION
## Incident

`v0.31.10` launched a healthy daemon through Launch Services, reached adapter readiness and connected to Relay, but the parent CLI still timed out at 30 seconds and terminated it. Repeated attempts could create several daemons using the same production home/device.

## Independently reproduced root cause

A minimal macOS AppKit PoC now runs in CI and reproduces the unstable identity semantics without any Kraki code:

1. an app launched by `open` initially has the expected bundle identity;
2. after it starts a bundle-external AppKit child, that child can be attributed to the parent app through responsible-process ancestry;
3. the child reports the parent bundle ID while `lsappinfo(parentPid)` changes to NULL;
4. this still happens after `__CFBundleIdentifier` is scrubbed, proving environment cleanup alone is insufficient.

`v0.31.10` incorrectly treated that mutable, post-start `lsappinfo(parentPid)` result as readiness authority. It therefore killed a healthy daemon after adapters/Pi child processes had started.

A second bug derived the launchd label from `KRAKI_HOME` but did not pass that home to the worker, allowing isolated/dev jobs to overwrite default `~/.kraki` PID/readiness state and connect as the production device.

## Fix

- capture the correct Launch Services identity before importing daemon adapters or spawning children
- persist a `0600` PID-bound `daemon.identity` startup proof
- require `PID + full worker marker + identity proof + daemon.ready` for launch success
- stop using mutable post-start `lsappinfo` as readiness authority
- scrub private Launch Services environment state as hygiene, but do not rely on it for correctness
- pass the exact absolute `KRAKI_HOME` used by the launchd label into the worker
- do not persist Copilot session-scoped `gho_` tokens in launchd
- clear PID/readiness/identity proof together on verified stop/failure
- truncate and stamp the bootstrap log for every launch attempt
- make doctor prefer a matching PID-bound proof over an unstable live lookup

## New gates

- minimal AppKit responsible-process identity instability PoC on macOS
- real ad-hoc signed `Kraki.app`: launchd → `open` → initial identity proof → ready
- 15-second post-ready stability hold checking PID, full marker, proof, readiness, and launchd supervision
- verified stop with no PID, ready, identity proof, or launchd job left behind
- release workflow repeats the full daemon smoke on every platform; macOS uses the built `.app` executable

## Validation

- Tentacle: 858/858
- Protocol/Crypto/Tentacle builds
- lint, diff check, workflow YAML parse, script syntax
- macOS minimal PoC and real `.app` smoke pass on GitHub hosted macOS

The installed local `0.31.8` process and its state were not modified by this implementation or validation.
