### PR TITLE
chore(release): v0.31.11

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.10",
+  "version": "0.31.11",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump `@kraki/tentacle` from `0.31.10` to `0.31.11`
- includes PR #206, which fixes the macOS Launch Services readiness false-negative and KRAKI_HOME cross-instance pollution

## Release gates already on main

- Validate
- Linux x64 real SEA background lifecycle
- Windows x64 real SEA background lifecycle
- macOS arm64 real signed-app Launch Services lifecycle
- independent AppKit PoC proving post-child live bundle identity is not stable readiness authority

The release workflow repeats full daemon lifecycle smoke tests for Linux, Windows, macOS x64 and macOS arm64 before npm publication.
