### PR TITLE
fix(web): keep prompt TRACE off the conversation spine

### DIFF
--- a/packages/arm/web/package.json
+++ b/packages/arm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/arm-web",
-  "version": "0.16.0",
+  "version": "0.16.2",
   "description": "Kraki web receiver — view and control your agents from any browser",
   "type": "module",
   "scripts": {

--- a/packages/arm/web/src/components/chat/ChatView.test.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.test.tsx
@@ -401,6 +401,33 @@ describe('ChatView', () => {
     expect(screen.getByPlaceholderText('Send a message…')).toBeInTheDocument();
   });
 
+  it('does not render question request and resolution TRACE as duplicate spine bubbles', () => {
+    const question = '为了按真实缓冲期计算，请问你目前可用于出国、学费、租房和生活的存款大约在哪个区间？';
+    useStore.getState().setSessions([
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 3 },
+    ]);
+    useStore.setState({
+      messages: new Map([['s1', [
+        { type: 'user_message', deviceId: 'd1', seq: 106, timestamp: '2026-07-31T07:33:50Z', sessionId: 's1', payload: { content: 'continue' } } as ChatMessage,
+        { type: 'question', deviceId: 'd1', seq: 106.25, timestamp: '2026-07-31T07:34:07Z', sessionId: 's1', payload: {
+          id: 'q1', question, choices: ['人民币30万元以上'],
+        } } as ChatMessage,
+        { type: 'question', deviceId: 'd1', seq: 106.5, timestamp: '2026-07-31T07:35:04Z', sessionId: 's1', payload: {
+          id: 'q1', question, answer: '人民币30万元以上',
+        } } as ChatMessage,
+        { type: 'agent_message', deviceId: 'd1', seq: 107, timestamp: '2026-07-31T07:35:30Z', sessionId: 's1', payload: { content: '继续分析结果' } } as ChatMessage,
+        { type: 'idle', deviceId: 'd1', seq: 108, timestamp: '2026-07-31T07:35:31Z', sessionId: 's1', payload: {} } as ChatMessage,
+      ]]]),
+    });
+
+    renderChatView('s1');
+
+    expect(screen.queryByText(question)).not.toBeInTheDocument();
+    expect(screen.queryByText('人民币30万元以上')).not.toBeInTheDocument();
+    expect(screen.getByText('continue')).toBeInTheDocument();
+    expect(screen.getByText('继续分析结果')).toBeInTheDocument();
+  });
+
   it('shows message input for active session', () => {
     useStore.getState().setSessions([
       { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'copilot', messageCount: 0 },

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import type { Store, ChatMessage, ConnectionStatus, PendingInputMessage, SessionCard } from '../types/store';
 import type { SessionSummary, DeviceSummary } from '@kraki/protocol';
 import { loadStoredDevice, getUrlParams } from '../lib/transport';
+import { isDurableSpineMessage } from '../lib/message-axis';
 
 // --- Custom Map/Set JSON serialization ---
 
@@ -150,22 +151,10 @@ export const useStore = create<Store>()(persist((set) => ({
     }),
 
   appendMessage: (sessionId, message) => {
-    // pending_input is optimistic, transient UI — never persist it.
-    // tool_start/tool_complete/agent_narration are the TRACE axis: they stream
-    // live for the in-progress turn but are pulled lazily from the tentacle's
-    // trace.jsonl (see setTurnSteps / messageProvider.requestTurnTrace) rather
-    // than living on the spine — so they are kept in memory for live rendering
-    // but NEVER written to IndexedDB. The compound IDB key is [sessionId, seq]
-    // and ALL pending_input messages have seq=0, so writing them would collide-
-    // and-overwrite each other on rapid send. After resolve, the resulting
-    // user_message has a real seq and goes through updateSessionMessages.
-    const isTransient = message.type === 'pending_input'
-      || message.type === 'tool_start'
-      || message.type === 'tool_complete'
-      || message.type === 'agent_narration'
-      || message.type === 'active'
-      || message.type === 'compacting';
-    if (!isTransient) {
+    // IndexedDB is exclusively the durable conversation spine. Everything else
+    // (optimistic pending input, live card, TRACE, and control messages) stays
+    // in memory and fails closed unless deliberately added to message-axis.
+    if (isDurableSpineMessage(message)) {
       // Write to IndexedDB (async, fire-and-forget — idempotent by [sessionId, seq])
       import('../lib/message-db').then(db => db.putMessage(sessionId, message)).catch((e) => { console.error('[Kraki:idb]', e); });
     }

--- a/packages/arm/web/src/lib/message-axis.ts
+++ b/packages/arm/web/src/lib/message-axis.ts
@@ -1,0 +1,24 @@
+import type { ChatMessage } from '../types/store';
+
+/** Durable per-session conversation-spine types.
+ *
+ * This mirrors Tentacle's fail-closed PERSISTENT_TYPES allowlist. Any new wire
+ * type defaults to live/TRACE/control-plane state until it is deliberately
+ * added to both authorities. Keeping this list shared across Web projection,
+ * range-cache coverage, and IndexedDB prevents a transient record from being
+ * mistaken for a durable chat bubble. */
+export const DURABLE_SPINE_TYPES = new Set([
+  'session_created',
+  'agent_message',
+  'user_message',
+  'error',
+  'system_message',
+  'interrupted_turn',
+  'turn_status',
+  'session_ended',
+  'idle',
+]);
+
+export function isDurableSpineMessage(message: ChatMessage): boolean {
+  return DURABLE_SPINE_TYPES.has(message.type);
+}

--- a/packages/arm/web/src/lib/message-db.test.ts
+++ b/packages/arm/web/src/lib/message-db.test.ts
@@ -25,6 +25,20 @@ const STORE_NAME = 'messages';
 
 type Msg = { type: string; seq?: number; payload?: Record<string, unknown>; [k: string]: unknown };
 
+async function rawPut(sessionId: string, seq: number, data: Msg): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const database = request.result;
+      const tx = database.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).put({ sessionId, seq, data });
+      tx.oncomplete = () => { database.close(); resolve(); };
+      tx.onerror = () => { database.close(); reject(tx.error); };
+    };
+  });
+}
+
 async function freshModule() {
   // Clear the module cache + localStorage sweep flag so each test starts clean.
   localStorage.removeItem('kraki-idb-transient-swept');
@@ -39,9 +53,11 @@ describe('message-db transient filtering on write', () => {
     // the module holds an open connection under fake-indexeddb).
   });
 
-  it('putMessage skips transient types', async () => {
+  it('putMessage skips transient and unknown non-spine types', async () => {
     const db = await freshModule();
     await db.putMessage('sess-pm-1', { type: 'tool_start', seq: 2.5, payload: {} } as Msg);
+    await db.putMessage('sess-pm-1', { type: 'question', seq: 2.6, payload: { id: 'q1', question: 'Q?' } } as Msg);
+    await db.putMessage('sess-pm-1', { type: 'future_control_message', seq: 2.7, payload: {} } as Msg);
     await db.putMessage('sess-pm-1', { type: 'user_message', seq: 1, payload: { content: 'hi' } } as Msg);
     const msgs = await db.getMessages('sess-pm-1');
     expect(msgs).toHaveLength(1);
@@ -83,6 +99,15 @@ describe('message-db transient filtering on read (defense-in-depth)', () => {
     // Note: we don't deleteDB here (it hangs under fake-indexeddb when the
     // module holds an open connection). Instead each test seeds + reads in a
     // distinct session id so they're independent.
+  });
+
+  it('ignores an unknown highest-seq row already present in IndexedDB', async () => {
+    const db = await freshModule();
+    await db.putMessage('sess-read-last-1', { type: 'user_message', seq: 1, payload: { content: 'keep' } } as Msg);
+    await rawPut('sess-read-last-1', 2, { type: 'future_control_message', seq: 2, payload: {} });
+
+    expect(await db.getLastSeq('sess-read-last-1')).toBe(1);
+    expect((await db.getMessages('sess-read-last-1')).map((m) => m.type)).toEqual(['user_message']);
   });
 
   it('getMessages drops transient rows even if they reach IDB via another path', async () => {

--- a/packages/arm/web/src/lib/message-db.ts
+++ b/packages/arm/web/src/lib/message-db.ts
@@ -7,36 +7,18 @@
 
 import { openDB, type IDBPDatabase } from 'idb';
 import type { ChatMessage } from '../types/store';
+import { isDurableSpineMessage } from './message-axis';
 
 const DB_NAME = 'kraki-messages';
 const DB_VERSION = 5;
 const STORE_NAME = 'messages';
 
-/** Message types that are TRANSIENT — they stream live for the in-progress turn
- *  (or are optimistic UI) and are pulled lazily from the tentacle's trace.jsonl.
- *  They must NEVER be persisted to IndexedDB: they carry fractional seqs
- *  (assigned by setTurnSteps) and a future load would resurrect them as
- *  duplicate/spurious bubbles. This is the authoritative filter shared by all
- *  write paths; read paths also filter as defense-in-depth. */
-const TRANSIENT_TYPES = new Set([
-  'pending_input',
-  'tool_start',
-  'tool_complete',
-  'agent_narration',
-  'active',
-  'compacting',
-  // question/permission/answer are turn-internal mechanics surfaced via the
-  // live card + TRACE, never durable spine bubbles.
-  'question',
-  'permission',
-  'answer',
-  'question_resolved',
-  'permission_resolved',
-]);
-
-/** True for a message that must never be written to / read from IndexedDB. */
-function isTransientMessage(message: ChatMessage): boolean {
-  return TRANSIENT_TYPES.has(message.type);
+/** IndexedDB is a durable-spine cache, not a generic message log. New wire
+ *  types fail closed: only the shared durable allowlist may be written/read.
+ *  This keeps TRACE, live-card, optimistic, and control-plane records from
+ *  resurrecting as duplicate/spurious bubbles after reload. */
+function isPersistableMessage(message: ChatMessage): boolean {
+  return isDurableSpineMessage(message);
 }
 
 interface StoredMessage {
@@ -130,12 +112,11 @@ function sweepTransientRows(): Promise<{ before: number; deleted: number }> {
         if (!cursor) return;
         before++;
         const row = cursor.value as unknown as StoredMessage;
-        const dataType = row?.data?.type as string | undefined;
         const seq = row?.seq;
-        const isTransient =
-          (dataType && TRANSIENT_TYPES.has(dataType)) ||
+        const shouldDelete =
+          !row?.data || !isPersistableMessage(row.data) ||
           (typeof seq === 'number' && !Number.isInteger(seq));
-        if (isTransient) {
+        if (shouldDelete) {
           deleted++;
           cursor.delete();
         }
@@ -164,21 +145,19 @@ export async function putMessages(sessionId: string, messages: ChatMessage[]): P
   const tx = db.transaction(STORE_NAME, 'readwrite');
   const store = tx.objectStore(STORE_NAME);
   for (const msg of messages) {
-    // Never persist transient trace/pending rows — they carry fractional seqs
-    // and would resurrect as duplicate bubbles on the next load.
-    if (isTransientMessage(msg)) continue;
+    // Only durable spine records belong in this cache. Fractional TRACE rows
+    // and all non-spine types are rejected by the shared allowlist.
+    if (!isPersistableMessage(msg)) continue;
     const seq = 'seq' in msg ? (msg as { seq?: number }).seq ?? 0 : 0;
     await store.put({ sessionId, seq, data: msg } satisfies StoredMessage);
   }
   await tx.done;
 }
 
-/**
- * Store a single message. Filters out transient types (the caller in useStore
- * already gates on isTransient, but this is the authoritative guard).
- */
+/** Store one durable spine record. Both the caller and this cache use the
+ *  shared allowlist; this guard remains authoritative defense-in-depth. */
 export async function putMessage(sessionId: string, message: ChatMessage): Promise<void> {
-  if (isTransientMessage(message)) return;
+  if (!isPersistableMessage(message)) return;
   const db = await getDB();
   const seq = 'seq' in message ? (message as { seq?: number }).seq ?? 0 : 0;
   await db.put(STORE_NAME, { sessionId, seq, data: message } satisfies StoredMessage);
@@ -192,9 +171,9 @@ export async function getMessages(sessionId: string): Promise<ChatMessage[]> {
   const index = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).index('sessionId');
   const records = await index.getAll(sessionId) as StoredMessage[];
   records.sort((a, b) => a.seq - b.seq);
-  // Defense-in-depth: drop any transient row that slipped through (older
-  // builds, or a future type). Trace is pulled on demand via request_turn_trace.
-  return records.map(r => r.data).filter((m) => !isTransientMessage(m));
+  // Defense-in-depth: expose only durable spine rows, even if an older or
+  // malformed client inserted some other type.
+  return records.map(r => r.data).filter(isPersistableMessage);
 }
 
 /**
@@ -205,8 +184,8 @@ export async function getAllMessages(): Promise<Map<string, ChatMessage[]>> {
   const records = await db.getAll(STORE_NAME) as StoredMessage[];
   const grouped = new Map<string, ChatMessage[]>();
   for (const r of records) {
-    // Defense-in-depth: skip transient rows (trace/pending) — see getMessages.
-    if (isTransientMessage(r.data)) continue;
+    // Defense-in-depth: IndexedDB exposes only durable spine rows.
+    if (!isPersistableMessage(r.data)) continue;
     if (!grouped.has(r.sessionId)) grouped.set(r.sessionId, []);
     grouped.get(r.sessionId)!.push(r.data);
   }
@@ -227,8 +206,13 @@ export async function getAllMessages(): Promise<Map<string, ChatMessage[]>> {
 export async function getLastSeq(sessionId: string, maxSeq?: number): Promise<number> {
   const db = await getDB();
   const range = IDBKeyRange.bound([sessionId, 0], [sessionId, maxSeq ?? Number.MAX_SAFE_INTEGER]);
-  const cursor = await db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).openCursor(range, 'prev');
-  return (cursor?.value as StoredMessage | undefined)?.seq ?? 0;
+  let cursor = await db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).openCursor(range, 'prev');
+  while (cursor) {
+    const row = cursor.value as StoredMessage;
+    if (isPersistableMessage(row.data) && Number.isInteger(row.seq)) return row.seq;
+    cursor = await cursor.continue();
+  }
+  return 0;
 }
 
 /**
@@ -239,7 +223,7 @@ export async function getMessagesInRange(sessionId: string, fromSeq: number, toS
   const range = IDBKeyRange.bound([sessionId, fromSeq], [sessionId, toSeq]);
   const records = await db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).getAll(range) as StoredMessage[];
   records.sort((a, b) => a.seq - b.seq);
-  return records.map(r => r.data).filter((m) => !isTransientMessage(m));
+  return records.map(r => r.data).filter(isPersistableMessage);
 }
 
 /**
@@ -273,10 +257,10 @@ export async function updateSessionMessages(sessionId: string, messages: ChatMes
     cursor = await cursor.continue();
   }
 
-  // Write updated messages (transient types are filtered out so a whole-array
-  // rewrite cannot persist trace/pending rows that only live in memory).
+  // Write updated durable messages. The shared allowlist prevents a whole-array
+  // rewrite from persisting TRACE/live/control rows that only belong in memory.
   for (const msg of messages) {
-    if (isTransientMessage(msg)) continue;
+    if (!isPersistableMessage(msg)) continue;
     const seq = 'seq' in msg ? (msg as { seq?: number }).seq ?? 0 : 0;
     await store.put({ sessionId, seq, data: msg } satisfies StoredMessage);
   }

--- a/packages/arm/web/src/lib/message-provider.test.tsx
+++ b/packages/arm/web/src/lib/message-provider.test.tsx
@@ -191,7 +191,7 @@ describe('message-provider: range-fetch protocol', () => {
     });
   });
 
-  it('repairs a cached tail where a legacy transient row hides the reply seq', async () => {
+  it('repairs a cached tail where an unknown non-spine row hides the reply seq', async () => {
     setupSession();
     messageProvider.setTentacleInfo('s1', 496, 'd1');
     const sent: Record<string, unknown>[] = [];
@@ -200,7 +200,7 @@ describe('message-provider: range-fetch protocol', () => {
     const cached = Array.from({ length: 50 }, (_, index) => {
       const seq = 447 + index;
       if (seq === 495) {
-        return { type: 'active', sessionId: 's1', deviceId: 'd1', seq, timestamp: '', payload: {} };
+        return { type: 'future_control_message', sessionId: 's1', deviceId: 'd1', seq, timestamp: '', payload: {} };
       }
       return {
         type: seq === 496 ? 'idle' : 'agent_message',

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -8,33 +8,18 @@
 
 import { getStore } from './store-adapter';
 import { createLogger } from './logger';
+import { isDurableSpineMessage } from './message-axis';
 import type { ChatMessage } from '../types/store';
 
 const logger = createLogger('msg-provider');
 
 const BATCH_TIMEOUT_MS = 10_000;
 
-// Rows written by older web clients before runtime/TRACE state was separated
-// from the persistent conversation spine. They must never count toward cache
-// range coverage, or a stale `active` row can hide a missing agent reply at the
+// Only durable spine rows count toward range coverage. TRACE/control records
+// from an old or malformed cache must not hide a missing durable row at the
 // same session seq.
-const NON_SPINE_CACHE_TYPES = new Set([
-  'pending_input',
-  'active',
-  'compacting',
-  'agent_message_delta',
-  'card_action',
-  'agent_narration',
-  'tool_start',
-  'tool_complete',
-  'permission',
-  'question',
-  'permission_resolved',
-  'question_resolved',
-]);
-
 function isSpineCacheMessage(message: ChatMessage): boolean {
-  return !NON_SPINE_CACHE_TYPES.has(message.type);
+  return isDurableSpineMessage(message);
 }
 
 interface PendingRequest {

--- a/packages/arm/web/src/lib/turn-projection.test.ts
+++ b/packages/arm/web/src/lib/turn-projection.test.ts
@@ -106,6 +106,47 @@ describe('projectSpineMessages', () => {
     expect((projected[0].payload as { attachments?: unknown[] }).attachments).toEqual([artifact]);
   });
 
+  it('keeps TRACE and prompt lifecycle records out of the top-level spine', () => {
+    const projected = projectSpineMessages([
+      { type: 'user_message', deviceId: 'd1', seq: 106, timestamp: '2026-07-31T07:33:50Z', sessionId: 's1', payload: { content: 'continue' } } as ChatMessage,
+      { type: 'agent_narration', deviceId: 'd1', seq: 106.1, timestamp: '2026-07-31T07:34:00Z', sessionId: 's1', payload: { content: 'checking' } } as ChatMessage,
+      { type: 'question', deviceId: 'd1', seq: 106.2, timestamp: '2026-07-31T07:34:07Z', sessionId: 's1', payload: {
+        id: 'q1',
+        question: 'How much is available?',
+        choices: ['30+'],
+      } } as ChatMessage,
+      { type: 'question', deviceId: 'd1', seq: 106.3, timestamp: '2026-07-31T07:35:04Z', sessionId: 's1', payload: {
+        id: 'q1',
+        question: 'How much is available?',
+        answer: '30+',
+      } } as ChatMessage,
+      { type: 'permission', deviceId: 'd1', seq: 106.4, timestamp: '2026-07-31T07:35:05Z', sessionId: 's1', payload: {
+        id: 'p1', toolName: 'bash', description: 'Run command', args: {},
+      } } as ChatMessage,
+      { type: 'answer', deviceId: 'd1', seq: 106.5, timestamp: '2026-07-31T07:35:06Z', sessionId: 's1', payload: {
+        questionId: 'q1', answer: '30+',
+      } } as ChatMessage,
+      { type: 'tool_complete', deviceId: 'd1', seq: 106.6, timestamp: '2026-07-31T07:35:07Z', sessionId: 's1', payload: {
+        toolName: 'bash', headline: '$ true', toolCallId: 't1', success: true,
+      } } as ChatMessage,
+      { type: 'session_title_updated', deviceId: 'd1', seq: 106.7, timestamp: '2026-07-31T07:35:08Z', sessionId: 's1', payload: {
+        title: 'control-plane update',
+      } } as ChatMessage,
+      { type: 'agent_message', deviceId: 'd1', seq: 107, timestamp: '2026-07-31T07:36:00Z', sessionId: 's1', payload: { content: 'done' } } as ChatMessage,
+      { type: 'idle', deviceId: 'd1', seq: 108, timestamp: '2026-07-31T07:36:01Z', sessionId: 's1', payload: {} } as ChatMessage,
+    ]);
+
+    expect(projected.map((message) => message.type)).toEqual(['user_message', 'agent_message', 'idle']);
+  });
+
+  it('keeps the optimistic pending input visible until the durable echo arrives', () => {
+    const projected = projectSpineMessages([
+      { type: 'pending_input', id: 'c1', clientId: 'c1', sessionId: 's1', text: 'hello', timestamp: '2026-07-31T07:34:00Z' },
+    ] as ChatMessage[]);
+
+    expect(projected.map((message) => message.type)).toEqual(['pending_input']);
+  });
+
   it('projects idle artifacts onto a no-reply system outcome', () => {
     const report = { type: 'content_ref' as const, id: 'report', mimeType: 'text/html', size: 4 };
     const projected = projectSpineMessages([

--- a/packages/arm/web/src/lib/turn-projection.ts
+++ b/packages/arm/web/src/lib/turn-projection.ts
@@ -1,8 +1,14 @@
 import type { Attachment, ContentRef } from '@kraki/protocol';
 import type { ChatMessage } from '../types/store';
+import { isDurableSpineMessage } from './message-axis';
 
-/** TRACE / transient activity types — never top-level chat bubbles. */
-const TRACE_TYPES = new Set(['tool_start', 'tool_complete', 'agent_narration', 'active']);
+/** Only durable conversation-spine records become settled top-level bubbles.
+ *  Keep the optimistic pending_input placeholder visible until its durable
+ *  user_message echo arrives; all other live/TRACE/control records stay on
+ *  their own axes. */
+function isVisibleSpineMessage(message: ChatMessage): boolean {
+  return message.type === 'pending_input' || isDurableSpineMessage(message);
+}
 
 function attachmentKey(attachment: Attachment): string {
   return attachment.type === 'content_ref'
@@ -106,7 +112,7 @@ export function projectSpineMessages(messages: ChatMessage[]): ChatMessage[] {
   };
 
   for (const msg of messages) {
-    if (TRACE_TYPES.has(msg.type)) continue;
+    if (!isVisibleSpineMessage(msg)) continue;
     segment.push(msg);
     if (msg.type === 'idle') flush();
   }


### PR DESCRIPTION
## Root cause

A pulled turn TRACE contains both the opening `question` record and the same-id resolved `question` record with `answer`. `setTurnSteps` correctly injected both into the in-memory turn region for the Steps UI, but `projectSpineMessages` only excluded tool/narration types. The two prompt lifecycle records therefore crossed the axis boundary and rendered as two top-level question bubbles.

The durable `messages.jsonl` was clean: neither question was persisted to the Tentacle spine. This is a Web projection/cache-boundary bug, not duplicate spine persistence.

## Fix

- introduce one fail-closed Web durable-spine allowlist matching Tentacle `PERSISTENT_TYPES`
- use it for top-level chat projection, store→IDB writes, all IDB reads/writes/sweeps, range-cache coverage, and highest cached seq
- keep only optimistic `pending_input` as the intentional non-durable top-level placeholder
- unknown future wire types default to non-spine
- add regression coverage for the exact same-id question request → answer TRACE sequence from the reported screenshot
- correct private Web package metadata from the accidental `0.16.0` rollback to `0.16.2`

## Validation

- Web full suite: 415/415
- focused boundary/IDB/provider/store/ChatView: 101/101
- Protocol build
- Crypto build
- Web production build
- git diff --check
