### PR TITLE
fix(web): detect tail gaps masked by fractional cache rows

### DIFF
--- a/packages/arm/web/src/lib/message-db.test.ts
+++ b/packages/arm/web/src/lib/message-db.test.ts
@@ -116,5 +116,7 @@ describe('message-db transient filtering on read (defense-in-depth)', () => {
 
     const msgs = await db.getMessagesInRange('sess-read-range-1', 10, 12);
     expect(msgs.map((m) => (m as { seq?: number }).seq)).toEqual([10, 12]);
+    expect(await db.getLastSeq('sess-read-range-1', 11)).toBe(10);
+    expect(await db.getLastSeq('sess-read-range-1')).toBe(12);
   });
 });

--- a/packages/arm/web/src/lib/message-db.test.ts
+++ b/packages/arm/web/src/lib/message-db.test.ts
@@ -53,11 +53,15 @@ describe('message-db transient filtering on write', () => {
     await db.putMessages('sess-pms-1', [
       { type: 'user_message', seq: 1, payload: { content: 'a' } } as Msg,
       { type: 'agent_narration', seq: 1.5, payload: { content: 'thinking' } } as Msg,
+      // A synthetic row with a durable-looking type must still be rejected by
+      // its fractional seq; type filtering alone is not sufficient.
+      { type: 'agent_message', seq: 1.75, payload: { content: 'synthetic' } } as Msg,
       { type: 'agent_message', seq: 2, payload: { content: 'reply' } } as Msg,
       { type: 'tool_complete', seq: 2.5, payload: {} } as Msg,
     ]);
     const msgs = await db.getMessages('sess-pms-1');
     expect(msgs.map((m) => m.type)).toEqual(['user_message', 'agent_message']);
+    expect(msgs.map((m) => (m as { seq?: number }).seq)).toEqual([1, 2]);
   });
 
   it('updateSessionMessages (whole-array rewrite) drops transient rows', async () => {
@@ -85,19 +89,32 @@ describe('message-db transient filtering on read (defense-in-depth)', () => {
     // distinct session id so they're independent.
   });
 
-  it('getMessages drops transient rows even if they reach IDB via another path', async () => {
+  it('getMessagesInRange drops fractional rows even with a durable-looking type', async () => {
     const db = await freshModule();
-    // The write filters make transient rows unreacheable via the module, so
-    // verify the read filter directly: put a real row, then confirm the type
-    // predicate rejects transient types. (This guards against someone removing
-    // the read .filter() while believing the write filter is enough.)
-    await db.putMessages('sess-read-1', [
-      { type: 'user_message', seq: 1, payload: { content: 'keep' } } as Msg,
-      { type: 'idle', seq: 2, payload: {} } as Msg,
+    await db.putMessages('sess-read-range-1', [
+      { type: 'user_message', seq: 10, payload: { content: 'keep' } } as Msg,
+      { type: 'idle', seq: 12, payload: {} } as Msg,
     ]);
-    const msgs = await db.getMessages('sess-read-1');
-    expect(msgs.map((m) => m.type)).toEqual(['user_message', 'idle']);
-    // Every returned row has an integer seq (no leaked fractional trace).
-    expect(msgs.every((m) => Number.isInteger((m as { seq?: number }).seq))).toBe(true);
+
+    // Bypass module write guards to simulate an old client that leaked a TRACE
+    // projection row whose type looks durable enough to pass a type-only filter.
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME);
+      request.onsuccess = () => {
+        const raw = request.result;
+        const tx = raw.transaction(STORE_NAME, 'readwrite');
+        tx.objectStore(STORE_NAME).put({
+          sessionId: 'sess-read-range-1',
+          seq: 10.5,
+          data: { type: 'agent_message', seq: 10.5, payload: { content: 'synthetic trace row' } },
+        });
+        tx.oncomplete = () => { raw.close(); resolve(); };
+        tx.onerror = () => { raw.close(); reject(tx.error); };
+      };
+      request.onerror = () => reject(request.error);
+    });
+
+    const msgs = await db.getMessagesInRange('sess-read-range-1', 10, 12);
+    expect(msgs.map((m) => (m as { seq?: number }).seq)).toEqual([10, 12]);
   });
 });

--- a/packages/arm/web/src/lib/message-db.ts
+++ b/packages/arm/web/src/lib/message-db.ts
@@ -237,8 +237,13 @@ export async function getAllMessages(): Promise<Map<string, ChatMessage[]>> {
 export async function getLastSeq(sessionId: string, maxSeq?: number): Promise<number> {
   const db = await getDB();
   const range = IDBKeyRange.bound([sessionId, 0], [sessionId, maxSeq ?? Number.MAX_SAFE_INTEGER]);
-  const cursor = await db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).openCursor(range, 'prev');
-  return (cursor?.value as StoredMessage | undefined)?.seq ?? 0;
+  let cursor = await db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).openCursor(range, 'prev');
+  while (cursor) {
+    const row = cursor.value as StoredMessage;
+    if (isSpineCacheRow(row)) return row.seq;
+    cursor = await cursor.continue();
+  }
+  return 0;
 }
 
 /**

--- a/packages/arm/web/src/lib/message-db.ts
+++ b/packages/arm/web/src/lib/message-db.ts
@@ -39,6 +39,16 @@ function isTransientMessage(message: ChatMessage): boolean {
   return TRANSIENT_TYPES.has(message.type);
 }
 
+function messageSeq(message: ChatMessage): number {
+  return 'seq' in message ? (message as { seq?: number }).seq ?? 0 : 0;
+}
+
+/** Only integer-seq durable rows belong to the persistent spine cache. */
+function isSpineCacheRow(row: StoredMessage): boolean {
+  const dataSeq = messageSeq(row.data);
+  return Number.isInteger(row.seq) && dataSeq === row.seq && !isTransientMessage(row.data);
+}
+
 interface StoredMessage {
   sessionId: string;
   seq: number;
@@ -164,10 +174,10 @@ export async function putMessages(sessionId: string, messages: ChatMessage[]): P
   const tx = db.transaction(STORE_NAME, 'readwrite');
   const store = tx.objectStore(STORE_NAME);
   for (const msg of messages) {
-    // Never persist transient trace/pending rows — they carry fractional seqs
-    // and would resurrect as duplicate bubbles on the next load.
-    if (isTransientMessage(msg)) continue;
-    const seq = 'seq' in msg ? (msg as { seq?: number }).seq ?? 0 : 0;
+    // Never persist transient trace/pending rows or any synthetic fractional
+    // seq, even if a future trace type is missing from TRANSIENT_TYPES.
+    const seq = messageSeq(msg);
+    if (isTransientMessage(msg) || !Number.isInteger(seq)) continue;
     await store.put({ sessionId, seq, data: msg } satisfies StoredMessage);
   }
   await tx.done;
@@ -178,9 +188,9 @@ export async function putMessages(sessionId: string, messages: ChatMessage[]): P
  * already gates on isTransient, but this is the authoritative guard).
  */
 export async function putMessage(sessionId: string, message: ChatMessage): Promise<void> {
-  if (isTransientMessage(message)) return;
+  const seq = messageSeq(message);
+  if (isTransientMessage(message) || !Number.isInteger(seq)) return;
   const db = await getDB();
-  const seq = 'seq' in message ? (message as { seq?: number }).seq ?? 0 : 0;
   await db.put(STORE_NAME, { sessionId, seq, data: message } satisfies StoredMessage);
 }
 
@@ -192,9 +202,9 @@ export async function getMessages(sessionId: string): Promise<ChatMessage[]> {
   const index = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).index('sessionId');
   const records = await index.getAll(sessionId) as StoredMessage[];
   records.sort((a, b) => a.seq - b.seq);
-  // Defense-in-depth: drop any transient row that slipped through (older
-  // builds, or a future type). Trace is pulled on demand via request_turn_trace.
-  return records.map(r => r.data).filter((m) => !isTransientMessage(m));
+  // Defense-in-depth: old builds may have leaked both known transient types
+  // and synthetic fractional rows whose type is no longer recognized.
+  return records.filter(isSpineCacheRow).map(r => r.data);
 }
 
 /**
@@ -205,8 +215,8 @@ export async function getAllMessages(): Promise<Map<string, ChatMessage[]>> {
   const records = await db.getAll(STORE_NAME) as StoredMessage[];
   const grouped = new Map<string, ChatMessage[]>();
   for (const r of records) {
-    // Defense-in-depth: skip transient rows (trace/pending) — see getMessages.
-    if (isTransientMessage(r.data)) continue;
+    // Defense-in-depth: only integer-seq durable spine rows hydrate the cache.
+    if (!isSpineCacheRow(r)) continue;
     if (!grouped.has(r.sessionId)) grouped.set(r.sessionId, []);
     grouped.get(r.sessionId)!.push(r.data);
   }
@@ -239,7 +249,7 @@ export async function getMessagesInRange(sessionId: string, fromSeq: number, toS
   const range = IDBKeyRange.bound([sessionId, fromSeq], [sessionId, toSeq]);
   const records = await db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).getAll(range) as StoredMessage[];
   records.sort((a, b) => a.seq - b.seq);
-  return records.map(r => r.data).filter((m) => !isTransientMessage(m));
+  return records.filter(isSpineCacheRow).map(r => r.data);
 }
 
 /**
@@ -276,8 +286,8 @@ export async function updateSessionMessages(sessionId: string, messages: ChatMes
   // Write updated messages (transient types are filtered out so a whole-array
   // rewrite cannot persist trace/pending rows that only live in memory).
   for (const msg of messages) {
-    if (isTransientMessage(msg)) continue;
-    const seq = 'seq' in msg ? (msg as { seq?: number }).seq ?? 0 : 0;
+    const seq = messageSeq(msg);
+    if (isTransientMessage(msg) || !Number.isInteger(seq)) continue;
     await store.put({ sessionId, seq, data: msg } satisfies StoredMessage);
   }
   await tx.done;

--- a/packages/arm/web/src/lib/message-provider.test.tsx
+++ b/packages/arm/web/src/lib/message-provider.test.tsx
@@ -269,6 +269,57 @@ describe('message-provider: range-fetch protocol', () => {
     });
   });
 
+  it('repairs a real tail gap even when fractional cache rows inflate the row count', async () => {
+    setupSession();
+    messageProvider.setTentacleInfo('s1', 334, 'd1');
+    const sent: Record<string, unknown>[] = [];
+    messageProvider.setSend((m) => sent.push(m));
+
+    // Reproduce the monitor profile exactly: the requested 285–334 window has
+    // 46 durable integer rows, is missing 317/318/332/333, and contains eight
+    // old fractional rows. A count-only coverage check sees 54 >= 50 and
+    // falsely declares the cache complete.
+    const missing = new Set([317, 318, 332, 333]);
+    const cached = Array.from({ length: 50 }, (_, index) => 285 + index)
+      .filter((seq) => !missing.has(seq))
+      .map((seq) => ({
+        type: seq === 334 ? 'user_message' : 'agent_message',
+        sessionId: 's1', deviceId: 'd1', seq, timestamp: '',
+        payload: { content: `message ${seq}` },
+      }));
+    cached.push(...Array.from({ length: 8 }, (_, index) => ({
+      // Durable-looking type proves the provider also rejects by seq shape,
+      // rather than relying only on the transient type allowlist.
+      type: 'agent_message', sessionId: 's1', deviceId: 'd1',
+      seq: 285.96 + index * 0.005, timestamp: '', payload: { content: 'old trace row' },
+    })));
+    expect(cached).toHaveLength(54);
+    getMessagesInRange.mockResolvedValue(cached);
+
+    const pending = messageProvider.fetchRange('s1', 285, 334, { initial: true, foreground: true });
+    await vi.waitFor(() => {
+      expect(sent.find((message) => message.type === 'request_session_messages_range')).toBeDefined();
+    });
+
+    const request = sent.find((message) => message.type === 'request_session_messages_range')!;
+    expect(request.payload).toMatchObject({
+      sessionId: 's1', fromSeq: 317, toSeq: 334, targetDeviceId: 'd1',
+    });
+
+    messageProvider.handleRangeBatch('s1', [
+      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 317, timestamp: '', payload: { content: 'older recovered reply' } },
+      { type: 'idle', sessionId: 's1', deviceId: 'd1', seq: 318, timestamp: '', payload: {} },
+      { type: 'agent_message', sessionId: 's1', deviceId: 'd1', seq: 332, timestamp: '', payload: { content: 'latest recovered reply' } },
+      { type: 'idle', sessionId: 's1', deviceId: 'd1', seq: 333, timestamp: '', payload: {} },
+      { type: 'user_message', sessionId: 's1', deviceId: 'd1', seq: 334, timestamp: '', payload: { content: 'next turn' } },
+    ], 317, 334, false);
+    await pending;
+
+    const delivered = useStore.getState().messages.get('s1') ?? [];
+    expect(delivered.some((message) => 'seq' in message && message.seq === 332)).toBe(true);
+    expect(delivered.every((message) => !('seq' in message) || Number.isInteger(message.seq))).toBe(true);
+  });
+
   it('does not let an older timeout cancel a newer tail request', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/arm/web/src/lib/message-provider.ts
+++ b/packages/arm/web/src/lib/message-provider.ts
@@ -34,7 +34,8 @@ const NON_SPINE_CACHE_TYPES = new Set([
 ]);
 
 function isSpineCacheMessage(message: ChatMessage): boolean {
-  return !NON_SPINE_CACHE_TYPES.has(message.type);
+  const seq = 'seq' in message ? (message as { seq?: number }).seq : undefined;
+  return typeof seq === 'number' && Number.isInteger(seq) && !NON_SPINE_CACHE_TYPES.has(message.type);
 }
 
 interface PendingRequest {
@@ -180,29 +181,29 @@ class MessageProvider {
         // IDB unavailable
       }
 
-      // Step 2: Check if IDB covers the full range
+      // Step 2: Check whether every integer seq in the requested window exists.
+      // Row count is not sufficient: older builds leaked fractional TRACE rows
+      // into IDB, and those extras can numerically mask missing durable rows.
       const expectedCount = toSeq - clampedFrom + 1;
-      if (idbMessages.length >= expectedCount) {
-        // IDB has everything — put in store and done
+      const idbSeqs = new Set(idbMessages.flatMap(m => {
+        const seq = 'seq' in m ? (m as { seq?: number }).seq : undefined;
+        return typeof seq === 'number' && Number.isInteger(seq) && seq >= clampedFrom && seq <= toSeq
+          ? [seq]
+          : [];
+      }));
+      if (idbSeqs.size === expectedCount) {
+        // IDB has every durable seq — put in store and done.
         this.deliverMessages(sessionId, idbMessages, options?.initial);
         return;
       }
 
-      // Step 3: IDB has partial or no data — request from tentacle
-      // Find the highest seq IDB has to request only the missing portion
-      const idbSeqs = new Set(idbMessages.map(m => {
-        const seq = 'seq' in m ? (m as { seq?: number }).seq : undefined;
-        return typeof seq === 'number' ? seq : 0;
-      }));
+      // Step 3: IDB has a gap — request from the first missing seq onward.
+      // Tentacle range requests are contiguous, so the response also refreshes
+      // any cached rows after the gap and restores a coherent tail window.
       let afterSeq = clampedFrom - 1;
-      if (idbMessages.length > 0) {
-        // Find the highest contiguous seq from IDB to minimize tentacle request
-        let highestIdb = clampedFrom - 1;
-        for (let s = clampedFrom; s <= toSeq; s++) {
-          if (idbSeqs.has(s)) highestIdb = s;
-          else break;
-        }
-        afterSeq = highestIdb;
+      for (let s = clampedFrom; s <= toSeq; s++) {
+        if (idbSeqs.has(s)) afterSeq = s;
+        else break;
       }
 
       const tentacleMessages = await this.requestFromTentacle(sessionId, afterSeq, toSeq - afterSeq);


### PR DESCRIPTION
## Summary

Fix reconnect tail reconciliation when old fractional TRACE rows in IndexedDB numerically mask missing durable spine messages.

The active-session reconciliation added in #210 was running, but `MessageProvider.fetchRange()` treated the cache as complete using only `idbMessages.length >= expectedCount`. A real production profile had a 50-seq tail window with:

- 46 durable integer rows
- missing durable seqs `317`, `318`, `332`, `333`
- 8 leaked fractional TRACE rows (`285.96` … `285.995`)

The 54 returned rows therefore falsely satisfied a 50-row count check, so no `request_session_messages_range` was sent.

## Changes

- Reject non-integer synthetic seqs on all IndexedDB write paths.
- Reject non-integer or key/data-seq-mismatched rows on IndexedDB read paths.
- Validate tail coverage by the complete set of expected integer seqs rather than total row count.
- Request a contiguous range beginning at the first missing durable seq.
- Add a regression reproducing the production profile shape exactly.

## Validation

- Web unit tests: `414/414` passed.
- Focused IDB/provider tests: `19/19` passed.
- Focused reconnect/cache tests: `84/84` passed.
- Workspace lint: passed.
- Production Web build: passed (existing chunk warnings only).
- Checked every local durable `messages.jsonl`: no integer spine seq gaps, confirming the continuity invariant used by the coverage check.

### Real Chromium / encrypted live-stack proof

Using a clone of the authenticated production monitor profile (the original profile and production bundle were left intact):

1. Deleted durable seq `332/333` from the clone while retaining the 8 fractional rows.
2. Loaded the patched bundle on the same origin with the real encrypted Relay/Tentacle path.
3. Received authoritative `session_list lastSeq=349`.
4. Observed an actual `request_session_messages_range` for `332–349`.
5. Received `session_messages_range_batch` containing `332–349`.
6. Verified seq `332/333` returned to IndexedDB and the missing assistant reply rendered in the UI.

Result: `ok: true`.

## Safety

- No Head, Relay, Tentacle, daemon, or protocol changes.
- Production static bundle was not deployed or modified.
- The production monitor was restored after validation.
- Kraki daemon PID remained unchanged throughout.
