### PR TITLE
fix(web): lock the iOS document viewport

### DIFF
--- a/packages/arm/web/e2e/viewport-lock.spec.ts
+++ b/packages/arm/web/e2e/viewport-lock.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import { MockRelayServer } from './helpers/mock-ws-server';
+
+const SESSION_ID = 'session-viewport-lock';
+const DEVICE_ID = 'tentacle-viewport-lock';
+
+test('locks the document viewport while keeping chat independently scrollable', async ({ page }) => {
+  const server = await MockRelayServer.create();
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const connection = server.waitForConnection();
+    const navigation = page.goto(`/?relay=${encodeURIComponent(server.url)}`);
+    const ws = await connection;
+    const authMessage = server.waitForMessage(ws);
+    await navigation;
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty('--kraki-safe-area-top', '47px');
+    });
+
+    await authMessage;
+    server.sendAuthOk(ws, {
+      devices: [{
+        id: DEVICE_ID,
+        name: 'Viewport Tentacle',
+        role: 'tentacle',
+        kind: 'cli',
+        online: true,
+      }],
+      sessions: [{
+        id: SESSION_ID,
+        deviceId: DEVICE_ID,
+        deviceName: 'Viewport Tentacle',
+        agent: 'copilot',
+        state: 'active',
+        messageCount: 80,
+        preview: {
+          text: 'Viewport regression session',
+          type: 'agent',
+          timestamp: new Date().toISOString(),
+        },
+      }],
+    });
+
+    const card = page.locator('button').filter({ hasText: 'Viewport regression session' }).filter({ visible: true }).first();
+    await expect(card).toBeVisible({ timeout: 5_000 });
+    await card.click();
+
+    for (let i = 0; i < 80; i++) {
+      server.sendMessage(ws, {
+        type: i % 2 === 0 ? 'user_message' : 'agent_message',
+        sessionId: SESSION_ID,
+        seq: i + 1,
+        payload: { content: `Viewport line ${i}: ${'content '.repeat(12)}` },
+      });
+    }
+
+    const chat = page.locator('[data-chat-scroll]');
+    await expect(chat).toBeVisible();
+    await expect(page.getByText('Viewport line 79:', { exact: false })).toBeVisible();
+
+    const viewport = await page.evaluate(() => ({
+      innerHeight: window.innerHeight,
+      htmlClientHeight: document.documentElement.clientHeight,
+      htmlScrollHeight: document.documentElement.scrollHeight,
+      bodyClientHeight: document.body.clientHeight,
+      bodyScrollHeight: document.body.scrollHeight,
+      rootClientHeight: document.getElementById('root')!.clientHeight,
+      rootScrollHeight: document.getElementById('root')!.scrollHeight,
+      appClientHeight: document.querySelector<HTMLElement>('.app-viewport')!.clientHeight,
+      appScrollHeight: document.querySelector<HTMLElement>('.app-viewport')!.scrollHeight,
+      bodyPosition: getComputedStyle(document.body).position,
+      appPaddingTop: getComputedStyle(document.querySelector<HTMLElement>('.app-viewport')!).paddingTop,
+    }));
+
+    expect(viewport.bodyPosition).toBe('fixed');
+    expect(viewport.appPaddingTop).toBe('47px');
+    expect(viewport.htmlClientHeight).toBe(viewport.innerHeight);
+    expect(viewport.htmlScrollHeight).toBe(viewport.htmlClientHeight);
+    expect(viewport.bodyScrollHeight).toBe(viewport.bodyClientHeight);
+    expect(viewport.rootScrollHeight).toBe(viewport.rootClientHeight);
+    expect(viewport.appScrollHeight).toBe(viewport.appClientHeight);
+    expect(viewport.appClientHeight).toBe(viewport.innerHeight);
+
+    await page.evaluate(() => window.scrollTo(0, 500));
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+
+    const before = await chat.evaluate((el) => ({
+      top: el.scrollTop,
+      height: el.clientHeight,
+      scrollHeight: el.scrollHeight,
+    }));
+    expect(before.scrollHeight).toBeGreaterThan(before.height);
+
+    await chat.evaluate((el) => { el.scrollTop = 0; });
+    await chat.hover();
+    await page.mouse.wheel(0, 500);
+    await expect.poll(() => chat.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+
+    // Approximate the visual viewport shrinking when the iOS keyboard opens.
+    await page.setViewportSize({ width: 390, height: 500 });
+    const resized = await page.evaluate(() => ({
+      innerHeight: window.innerHeight,
+      htmlScrollHeight: document.documentElement.scrollHeight,
+      htmlClientHeight: document.documentElement.clientHeight,
+      appClientHeight: document.querySelector<HTMLElement>('.app-viewport')!.clientHeight,
+      rootScrollHeight: document.getElementById('root')!.scrollHeight,
+      rootClientHeight: document.getElementById('root')!.clientHeight,
+    }));
+    expect(resized.appClientHeight).toBe(resized.innerHeight);
+    expect(resized.htmlScrollHeight).toBe(resized.htmlClientHeight);
+    expect(resized.rootScrollHeight).toBe(resized.rootClientHeight);
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    await expect(page.locator('textarea')).toBeInViewport();
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/arm/web/src/App.tsx
+++ b/packages/arm/web/src/App.tsx
@@ -109,7 +109,7 @@ export function App() {
 
   if (status === 'awaiting_login') {
     return (
-      <div className="flex h-dvh overflow-hidden bg-surface-primary">
+      <div className="app-viewport flex overflow-hidden bg-surface-primary">
         <ErrorBanner />
         <main className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
           <ErrorBoundary>
@@ -121,7 +121,7 @@ export function App() {
   }
 
   return (
-    <div className="flex h-dvh overflow-hidden bg-surface-primary">
+    <div className="app-viewport flex overflow-hidden bg-surface-primary">
       <ErrorBanner />
       <aside className="hidden w-72 shrink-0 flex-col border-r border-border-primary md:flex lg:w-80" aria-hidden={showBlockingOverlay}>
         <Sidebar />

--- a/packages/arm/web/src/index.css
+++ b/packages/arm/web/src/index.css
@@ -63,17 +63,46 @@
   --color-text-muted: var(--color-slate-500);
 }
 
-/* Prevent iOS bounce scroll on the viewport */
-html, body {
-  overflow: hidden;
-  overscroll-behavior: none;
-  position: fixed;
+/* Keep the document itself fixed to the visual viewport. Only explicit app
+ * scrollers (chat, sidebar, dialogs) may scroll. Safe-area padding belongs on
+ * the single app viewport border box: putting it on both html/body made their
+ * boxes taller than the iOS viewport and exposed Safari chrome on outer bounce. */
+html {
+  --kraki-safe-area-top: env(safe-area-inset-top, 0px);
+  --kraki-safe-area-left: env(safe-area-inset-left, 0px);
+  --kraki-safe-area-right: env(safe-area-inset-right, 0px);
+}
+
+html,
+body,
+#root {
   width: 100%;
   height: 100%;
-  /* Safe area for PWA with viewport-fit=cover */
-  padding-top: env(safe-area-inset-top);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+html,
+body {
+  margin: 0;
+}
+
+body {
+  position: fixed;
+  inset: 0;
+}
+
+#root {
+  position: relative;
+}
+
+.app-viewport {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100dvh;
+  padding-top: var(--kraki-safe-area-top);
+  padding-left: var(--kraki-safe-area-left);
+  padding-right: var(--kraki-safe-area-right);
 }
 
 /* Scrollbar styling */


### PR DESCRIPTION
## Summary

- lock `html`, `body`, and `#root` to the visual viewport so the document cannot become a second scroll container
- apply iOS safe-area padding exactly once on `#root` instead of on both `html` and `body`
- size the app shell from the locked root rather than layering `100dvh` inside a padded document
- add a mobile regression proving the document stays fixed while only the chat scroller moves, including a simulated 47px iPhone safe area

## Root cause

`html` and `body` both had `height: 100%` and safe-area padding while the app shell also used `100dvh`. On iOS Safari that can make the document border box taller than the visual viewport, creating an outer scroll/bounce surface beneath the intended chat scroller. Pulling that outer surface exposed Safari UI/tab content below Kraki.

## Validation

- Web unit tests: `414/414`
- focused App tests: `6/6`
- mobile viewport E2E: Chromium `1/1`
- mobile viewport E2E: WebKit `1/1`
- workspace lint: pass
- production Web build: pass

Production and beta were not modified.
