### PR TITLE
fix(tentacle): scan complete JSONL rows for previews

### DIFF
--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -698,6 +698,69 @@ describe('SessionManager', () => {
       expect(entry!.preview!.text).toBe('Fix the migration');
     });
 
+    it('finds a preview before errors when its inline-image row exceeds one scan chunk', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message',
+        sessionId,
+        payload: {
+          content: 'Investigate the stalled API',
+          attachments: [{ type: 'image', mimeType: 'image/png', data: 'a'.repeat(400_000) }],
+        },
+      }));
+      for (let i = 0; i < 8; i++) {
+        sm.appendMessage(sessionId, 'error', JSON.stringify({
+          type: 'error', sessionId, payload: { message: '502 status code (no body)' },
+        }));
+      }
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview).toMatchObject({
+        type: 'user',
+        text: 'Investigate the stalled API',
+      });
+    });
+
+    it('reconstructs a multi-chunk Unicode row when the file has no final newline', () => {
+      const { sessionId } = sm.createSession('copilot');
+      const content = `${'界'.repeat(50_000)} final answer`;
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({
+        type: 'agent_message', sessionId, payload: { content },
+      }));
+
+      const logPath = join(dir, sessionId, 'messages.jsonl');
+      const log = readFileSync(logPath);
+      expect(log.at(-1)).toBe(0x0a);
+      writeFileSync(logPath, log.subarray(0, -1));
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview!.type).toBe('agent');
+      expect(entry!.preview!.text.startsWith('界')).toBe(true);
+      expect(entry!.preview!.text).not.toContain('�');
+    });
+
+    it('skips a malformed row spanning multiple chunks and finds the earlier preview', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'Keep this preview' },
+      }));
+      appendFileSync(join(dir, sessionId, 'messages.jsonl'), `${'{'.repeat(100_000)}\n`);
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview).toMatchObject({ type: 'user', text: 'Keep this preview' });
+    });
+
+    it('bounds a corrupt oversized row and continues scanning before it', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({
+        type: 'agent_message', sessionId, payload: { content: 'Earlier valid answer' },
+      }));
+      appendFileSync(join(dir, sessionId, 'messages.jsonl'), 'x'.repeat(16 * 1024 * 1024 + 1));
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview).toMatchObject({ type: 'agent', text: 'Earlier valid answer' });
+    });
+
     it('preview stays at the user_message during a multi-tool turn', () => {
       const { sessionId } = sm.createSession('copilot');
       sm.appendMessage(sessionId, 'user_message', JSON.stringify({

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -13,6 +13,10 @@ import { getConfigDir } from './config.js';
 import type { CardActionState, ContentRef } from '@kraki/protocol';
 
 const PREVIEW_MAX = 80;
+const PREVIEW_SCAN_CHUNK_BYTES = 32 * 1024;
+// Valid inline-image rows currently reach roughly 1.2 MB. Bound reconstruction
+// well above that so a corrupt newline-free log cannot grow memory without limit.
+const PREVIEW_SCAN_MAX_LINE_BYTES = 16 * 1024 * 1024;
 
 /** Replace lone UTF-16 surrogates before serializing text for strict JSON consumers. */
 function toWellFormedText(text: string): string {
@@ -1126,42 +1130,21 @@ export class SessionManager {
    * and are layered on top separately by `enrichSessionList` (the attention
    * override), so they must never come from this file scan.
    *
-   * Scans the whole 32KB tail (not just the last 20 lines): the spine is now
+   * Scans complete JSONL rows backwards in bounded chunks: the spine is now
    * sparse (`tool_start`/`tool_complete` live in `trace.jsonl`), but older
-   * sessions still carry them and a 20-line window could be entirely
-   * non-anchor entries.
+   * sessions still carry them, and an inline-image row can be much larger than
+   * one read chunk.
    */
   private getSessionPreview(sessionId: string): import('@kraki/protocol').SessionPreviewDigest | undefined {
     const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
     if (!existsSync(logPath)) return undefined;
 
-    // Read the tail of the file (last 32KB is plenty for the last few messages)
-    const TAIL_BYTES = 32 * 1024;
-    let tail: string;
-    try {
-      const fd = openSync(logPath, 'r');
+    const previewFromLine = (line: string): import('@kraki/protocol').SessionPreviewDigest | undefined => {
       try {
-        const { size } = fstatSync(fd);
-        const readStart = Math.max(0, size - TAIL_BYTES);
-        const buf = Buffer.alloc(Math.min(size, TAIL_BYTES));
-        readSync(fd, buf, 0, buf.length, readStart);
-        tail = buf.toString('utf8');
-      } finally {
-        closeSync(fd);
-      }
-    } catch {
-      return undefined;
-    }
-
-    // Turn-boundary scan (most recent first). Returns the first anchor found.
-    const lines = tail.split('\n');
-    for (let i = lines.length - 1; i >= 0; i--) {
-      if (!lines[i]) continue;
-      try {
-        const entry = JSON.parse(lines[i]) as LoggedMessage;
+        const entry = JSON.parse(line) as LoggedMessage;
         const inner = JSON.parse(entry.payload) as { type?: string; payload?: Record<string, unknown> };
         const payload = inner.payload;
-        if (!payload) continue;
+        if (!payload) return undefined;
 
         switch (inner.type) {
           case 'agent_message': {
@@ -1209,10 +1192,80 @@ export class SessionManager {
           // compacting are intentionally NOT turn boundaries — skip them.
         }
       } catch {
-        // Skip malformed lines
+        // Skip malformed lines.
       }
+      return undefined;
+    };
+
+    try {
+      const fd = openSync(logPath, 'r');
+      try {
+        let position = fstatSync(fd).size;
+        let suffixParts: Buffer[] = [];
+        let suffixBytes = 0;
+        let discardOversizedLine = false;
+
+        const inspectLine = (prefix: Buffer): import('@kraki/protocol').SessionPreviewDigest | undefined => {
+          if (discardOversizedLine) {
+            discardOversizedLine = false;
+            suffixParts = [];
+            suffixBytes = 0;
+            return undefined;
+          }
+
+          const lineBytes = prefix.length + suffixBytes;
+          if (lineBytes === 0) return undefined;
+          if (lineBytes > PREVIEW_SCAN_MAX_LINE_BYTES) {
+            suffixParts = [];
+            suffixBytes = 0;
+            return undefined;
+          }
+
+          const line = suffixParts.length === 0
+            ? prefix
+            : Buffer.concat([prefix, ...suffixParts.reverse()], lineBytes);
+          suffixParts = [];
+          suffixBytes = 0;
+          return previewFromLine(line.toString('utf8'));
+        };
+
+        while (position > 0) {
+          const requested = Math.min(PREVIEW_SCAN_CHUNK_BYTES, position);
+          position -= requested;
+          const buf = Buffer.allocUnsafe(requested);
+          const bytesRead = readSync(fd, buf, 0, requested, position);
+          if (bytesRead <= 0) break;
+          const chunk = bytesRead === requested ? buf : buf.subarray(0, bytesRead);
+
+          let end = chunk.length;
+          while (end > 0) {
+            const newline = chunk.lastIndexOf(0x0a, end - 1);
+            if (newline < 0) break;
+            const preview = inspectLine(chunk.subarray(newline + 1, end));
+            if (preview) return preview;
+            end = newline;
+          }
+
+          if (end > 0 && !discardOversizedLine) {
+            const part = chunk.subarray(0, end);
+            if (suffixBytes + part.length > PREVIEW_SCAN_MAX_LINE_BYTES) {
+              discardOversizedLine = true;
+              suffixParts = [];
+              suffixBytes = 0;
+            } else {
+              suffixParts.push(part);
+              suffixBytes += part.length;
+            }
+          }
+        }
+
+        return inspectLine(Buffer.alloc(0));
+      } finally {
+        closeSync(fd);
+      }
+    } catch {
+      return undefined;
     }
-    return undefined;
   }
 
   // ── Turn-aligned pagination ──────────────────────────


### PR DESCRIPTION
## Summary

- scan `messages.jsonl` backwards by complete JSONL rows instead of parsing a fixed 32 KB tail
- recover sidebar previews when an inline-image row spans multiple chunks
- bound malformed single-line reconstruction at 16 MB
- keep the fix isolated to Tentacle; no Web preview or sorting policy changes

## Why

A fixed byte tail can begin in the middle of a large JSONL row. If the rows after it are transient errors, `getSessionPreview()` returns no preview and an active session can appear to disappear from the sidebar.

Current local session data still contains 185 rows larger than 32 KB, including inline-image user messages up to roughly 1.18 MB, so this is not only a legacy theoretical case.

## Validation

- `session-manager.test.ts`: 96/96
- Tentacle full suite: 862/862
- Protocol build: passed
- Crypto build: passed
- Tentacle build: passed
- `git diff --check`: passed
- real incident-data copy truncated through seq 293 recovered the seq 285 user preview

## Scope deliberately excluded

- no missing-idle Web projection change
- no active preview retention fallback
- no active-first sidebar sorting
