### PR TITLE
fix(tentacle): bound preview log scanning

### DIFF
--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -761,6 +761,51 @@ describe('SessionManager', () => {
       expect(entry!.preview).toMatchObject({ type: 'agent', text: 'Earlier valid answer' });
     });
 
+    it('bounds the number of complete non-preview rows inspected', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({
+        type: 'user_message', sessionId, payload: { content: 'Too far back' },
+      }));
+      for (let i = 0; i < 4096; i++) {
+        sm.appendMessage(sessionId, 'error', JSON.stringify({
+          type: 'error', sessionId, payload: { message: 'retryable error' },
+        }));
+      }
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview).toBeUndefined();
+    });
+
+    it('does not parse a partial row at the total scan-budget boundary', () => {
+      const { sessionId } = sm.createSession('copilot');
+      const fakeBoundaryEntry = JSON.stringify({
+        seq: 1,
+        type: 'user_message',
+        ts: '2026-01-01T00:00:00.000Z',
+        payload: JSON.stringify({
+          type: 'user_message',
+          sessionId,
+          payload: { content: 'Must not escape the scan budget' },
+        }),
+      });
+      const boundarySuffix = Buffer.from(`${fakeBoundaryEntry}\n`);
+      const scanBudget = 32 * 1024 * 1024;
+      const tail = Buffer.concat([
+        boundarySuffix,
+        Buffer.alloc(scanBudget - boundarySuffix.length, 0x0a),
+      ]);
+
+      // The JSON-looking suffix belongs to one malformed row whose prefix is
+      // outside the scan window, so it must not be treated as a complete row.
+      writeFileSync(
+        join(dir, sessionId, 'messages.jsonl'),
+        Buffer.concat([Buffer.from('outside-window-prefix'), tail]),
+      );
+
+      const entry = sm.getSessionList().find(s => s.id === sessionId);
+      expect(entry!.preview).toBeUndefined();
+    });
+
     it('preview stays at the user_message during a multi-tool turn', () => {
       const { sessionId } = sm.createSession('copilot');
       sm.appendMessage(sessionId, 'user_message', JSON.stringify({

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -17,6 +17,18 @@ const PREVIEW_SCAN_CHUNK_BYTES = 32 * 1024;
 // Valid inline-image rows currently reach roughly 1.2 MB. Bound reconstruction
 // well above that so a corrupt newline-free log cannot grow memory without limit.
 const PREVIEW_SCAN_MAX_LINE_BYTES = 16 * 1024 * 1024;
+// Keep session-list generation bounded even if a log has no preview boundary.
+// This is large enough for the oversized rows seen in real session data while
+// avoiding an unbounded synchronous scan of a multi-hundred-megabyte log.
+const PREVIEW_SCAN_MAX_BYTES = 32 * 1024 * 1024;
+const PREVIEW_SCAN_MAX_LINES = 4096;
+const PREVIEW_BOUNDARY_TYPES = new Set([
+  'agent_message',
+  'user_message',
+  'interrupted_turn',
+  'turn_status',
+  'system_message',
+]);
 
 /** Replace lone UTF-16 surrogates before serializing text for strict JSON consumers. */
 function toWellFormedText(text: string): string {
@@ -1142,6 +1154,7 @@ export class SessionManager {
     const previewFromLine = (line: string): import('@kraki/protocol').SessionPreviewDigest | undefined => {
       try {
         const entry = JSON.parse(line) as LoggedMessage;
+        if (!PREVIEW_BOUNDARY_TYPES.has(entry.type)) return undefined;
         const inner = JSON.parse(entry.payload) as { type?: string; payload?: Record<string, unknown> };
         const payload = inner.payload;
         if (!payload) return undefined;
@@ -1201,9 +1214,12 @@ export class SessionManager {
       const fd = openSync(logPath, 'r');
       try {
         let position = fstatSync(fd).size;
+        const scanStart = Math.max(0, position - PREVIEW_SCAN_MAX_BYTES);
         let suffixParts: Buffer[] = [];
         let suffixBytes = 0;
         let discardOversizedLine = false;
+        let inspectedLines = 0;
+        let lineLimitReached = false;
 
         const inspectLine = (prefix: Buffer): import('@kraki/protocol').SessionPreviewDigest | undefined => {
           if (discardOversizedLine) {
@@ -1215,6 +1231,11 @@ export class SessionManager {
 
           const lineBytes = prefix.length + suffixBytes;
           if (lineBytes === 0) return undefined;
+          if (inspectedLines >= PREVIEW_SCAN_MAX_LINES) {
+            lineLimitReached = true;
+            return undefined;
+          }
+          inspectedLines++;
           if (lineBytes > PREVIEW_SCAN_MAX_LINE_BYTES) {
             suffixParts = [];
             suffixBytes = 0;
@@ -1229,8 +1250,8 @@ export class SessionManager {
           return previewFromLine(line.toString('utf8'));
         };
 
-        while (position > 0) {
-          const requested = Math.min(PREVIEW_SCAN_CHUNK_BYTES, position);
+        while (position > scanStart) {
+          const requested = Math.min(PREVIEW_SCAN_CHUNK_BYTES, position - scanStart);
           position -= requested;
           const buf = Buffer.allocUnsafe(requested);
           const bytesRead = readSync(fd, buf, 0, requested, position);
@@ -1243,6 +1264,7 @@ export class SessionManager {
             if (newline < 0) break;
             const preview = inspectLine(chunk.subarray(newline + 1, end));
             if (preview) return preview;
+            if (lineLimitReached) return undefined;
             end = newline;
           }
 
@@ -1259,7 +1281,10 @@ export class SessionManager {
           }
         }
 
-        return inspectLine(Buffer.alloc(0));
+        // Only the start of the file is a known line boundary. If the scan hit
+        // its byte budget, the remaining suffix may be the tail of a line that
+        // began before the window and must not be parsed as a complete record.
+        return scanStart === 0 ? inspectLine(Buffer.alloc(0)) : undefined;
       } finally {
         closeSync(fd);
       }


### PR DESCRIPTION
## Summary

- cap preview reconstruction at 32 MiB and 4096 complete JSONL rows per session
- do not parse a partial record when the byte budget begins in the middle of a row
- skip inner payload parsing for durable outer types that cannot produce a preview

## Review finding

The complete-line scanner from #214 correctly fixes previews hidden behind oversized inline-image rows, but its initial form could synchronously scan an entire log when no preview boundary existed. This hardening keeps both per-line reconstruction and total scanning bounded before release.

## Validation

- Tentacle full suite: 864/864
- session-manager focused suite: 98/98
- Protocol, Crypto, Tentacle builds: passed
- real 169-session store: 169 previews, about 24 ms in a warm local run
- isolated 259 MiB no-preview log, scanner only: 4.29 MiB read, 4096 JSON parses, about 7.5 ms, about 5.25 MiB RSS delta
- 16 MiB corrupt line still recovers the earlier valid preview
- `git diff --check`: passed

## Scope

Tentacle scanner only. No Web projection, active-preview retention, or sidebar sorting changes.
