### PR TITLE
chore(release): v0.31.12

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.11",
+  "version": "0.31.12",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bump `@kraki/tentacle` to `0.31.12`.

## Included fixes

- scan complete JSONL rows when deriving sidebar previews, including rows larger than the old fixed 32 KB tail
- support multi-chunk UTF-8, missing final newline, and malformed/oversized rows
- bound preview scanning to 16 MiB per reconstructed line, 32 MiB total, and 4096 complete rows
- avoid parsing inner payloads for durable message types that cannot form a preview

## Validation

- Tentacle: 864/864
- Protocol, Crypto, Tentacle builds: passed
- PR #214 and #215 CI: Validate + macOS/Linux/Windows daemon lifecycle passed
- main CI `30732981995`: all four jobs passed
- real 169-session store recovered all 169 previews
- isolated 259 MiB no-preview scanner path: 4.29 MiB read, 4096 rows, ~7.5 ms, bounded memory

No Web behavior changes are included.
