### PR TITLE
fix(web): make attachment pulls self-healing

### DIFF
--- a/packages/arm/web/e2e/real-stack/attachment-pull-recovery.spec.ts
+++ b/packages/arm/web/e2e/real-stack/attachment-pull-recovery.spec.ts
@@ -1,0 +1,121 @@
+import { expect, request, test, type Page } from '@playwright/test';
+
+/**
+ * REAL-STACK attachment reliability regression.
+ *
+ * Covers the production network failure chain end-to-end:
+ *   1. the first paced request_attachment receives no response at all;
+ *   2. the chunk watchdog retries;
+ *   3. every returned chunk is reassembled and checksum/size verified;
+ *   4. the PNG decodes and a following attachment is not head-of-line blocked.
+ * Corrupt IndexedDB records are covered separately by attachments.test.ts.
+ */
+
+const CONTROL = process.env.REALSTACK_CONTROL_URL ?? 'http://localhost:4710';
+const RELAY = process.env.REALSTACK_RELAY_URL ?? 'ws://localhost:4700';
+const WEB_URL = process.env.REALSTACK_WEB_URL ?? 'http://localhost:3700';
+
+async function control(path: string, params: Record<string, string> = {}): Promise<Record<string, unknown>> {
+  const context = await request.newContext();
+  const query = new URLSearchParams(params).toString();
+  const response = await context.get(`${CONTROL}${path}${query ? `?${query}` : ''}`);
+  const body = await response.json();
+  await context.dispose();
+  if (!response.ok()) throw new Error(`control ${path} failed: ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function pairBrowser(page: Page): Promise<void> {
+  const { token, web } = await control('/token');
+  await page.goto(web as string);
+  await page.evaluate(() => localStorage.clear());
+  await page.goto(`${web}?relay=${encodeURIComponent(RELAY)}&token=${token}`);
+  await expect(page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText('Session ready. Ask me anything.', { exact: false }).first()).toBeVisible({ timeout: 20_000 });
+}
+
+test('one lost chunk self-heals without blocking the next image', async ({ browser }) => {
+  test.setTimeout(90_000);
+  const context = await browser.newContext();
+  let page = await context.newPage();
+  const pageErrors: string[] = [];
+  const capturePageErrors = (target: Page) => target.on('pageerror', (error) => pageErrors.push(error.message));
+  capturePageErrors(page);
+  await pairBrowser(page);
+
+  const sessionId = 'realstack-1';
+  await page.goto(`${WEB_URL}/session/${sessionId}`);
+  await expect(page.locator('[data-chat-scroll]')).toBeVisible({ timeout: 15_000 });
+  await control('/idle', { sid: sessionId });
+
+  // Open a real turn. Persisted turn artifacts attach to the turn's concluding
+  // agent bubble, so a bare show_image call without a user_message is not a
+  // valid production shape.
+  const prompt = `recover-this-image-${Date.now().toString(36)}`;
+  const input = page.getByPlaceholder('Send a message…');
+  await input.fill(prompt);
+  await input.press('Enter');
+  await expect.poll(async () => {
+    const received = await control('/received');
+    return (received.messages as Array<{ sid: string; text: string }>).some(
+      (message) => message.sid === sessionId && message.text === prompt,
+    );
+  }, { timeout: 15_000 }).toBe(true);
+
+  // Leave the detail view before the artifact exists so no image component can
+  // race ahead and populate a valid cache entry.
+  await page.goto(WEB_URL);
+  const firstReply = `RECOVERY-${Date.now().toString(36)}`;
+  const first = await control('/imageRef', { sid: sessionId, reply: firstReply });
+  const firstRef = {
+    id: first.id as string,
+    mimeType: first.mimeType as string,
+    size: first.size as number,
+  };
+  await expect(page.getByText(firstReply, { exact: false }).first()).toBeVisible({ timeout: 20_000 });
+  await page.waitForTimeout(500);
+
+  // The image has never mounted, so this is a cold cache. Swallow the first
+  // paced request and prove the watchdog retries without deadlocking the queue.
+  await control('/dropNextAttachmentRequest', { id: firstRef.id });
+  await page.goto(`${WEB_URL}/session/${sessionId}`);
+  await expect(page.locator('[data-chat-scroll]').getByText(firstReply, { exact: false }).first())
+    .toBeVisible({ timeout: 20_000 });
+  const recovered = page.locator('[data-chat-scroll] img[alt="gen.png"]').last();
+  await expect(recovered).toBeVisible({ timeout: 45_000 });
+  await expect.poll(() => recovered.evaluate((el) => (el as HTMLImageElement).naturalWidth), {
+    timeout: 45_000,
+    message: 'image did not recover after chunk timeout and retry',
+  }).toBeGreaterThan(0);
+
+  const reads = await control('/attachmentReads');
+  expect(reads.dropped).toBe(1);
+  expect((reads.reads as Array<{ id: string }>).filter((read) => read.id === firstRef.id))
+    .toHaveLength(first.chunkCount as number);
+
+  // A second image must still pass through the same global queue. This catches
+  // the original permanent head-of-line deadlock even if the first image happened
+  // to recover visually through another path.
+  const secondPrompt = `show-follow-up-${Date.now().toString(36)}`;
+  const secondInput = page.getByPlaceholder('Send a message…');
+  await secondInput.fill(secondPrompt);
+  await secondInput.press('Enter');
+  await expect.poll(async () => {
+    const received = await control('/received');
+    return (received.messages as Array<{ sid: string; text: string }>).some(
+      (message) => message.sid === sessionId && message.text === secondPrompt,
+    );
+  }, { timeout: 15_000 }).toBe(true);
+  const secondReply = `FOLLOW-UP-${Date.now().toString(36)}`;
+  await control('/imageRef', { sid: sessionId, reply: secondReply });
+  await expect(page.locator('[data-chat-scroll]').getByText(secondReply, { exact: false }).first())
+    .toBeVisible({ timeout: 20_000 });
+  const images = page.locator('[data-chat-scroll] img[alt="gen.png"]');
+  await expect(images).toHaveCount(2, { timeout: 30_000 });
+  await expect.poll(() => images.nth(1).evaluate((el) => (el as HTMLImageElement).naturalWidth), {
+    timeout: 30_000,
+  }).toBeGreaterThan(0);
+
+  expect(pageErrors).toEqual([]);
+  await context.close();
+});

--- a/packages/arm/web/src/components/chat/HtmlArtifactPanel.tsx
+++ b/packages/arm/web/src/components/chat/HtmlArtifactPanel.tsx
@@ -3,9 +3,9 @@ import type { ContentRef } from '@kraki/protocol';
 import { useAttachmentText } from '../../hooks/useAttachment';
 import { X, Maximize2, FileCode2, LoaderCircle, AlertTriangle } from 'lucide-react';
 
-const ATTACHMENT_PULL = (sessionId: string, id: string): void => {
+const ATTACHMENT_PULL = (sessionId: string, ref: ContentRef): void => {
   void import('../../lib/ws-client').then(({ wsClient }) => {
-    wsClient.requestAttachment(sessionId, id);
+    wsClient.requestAttachment(sessionId, ref);
   });
 };
 

--- a/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
+++ b/packages/arm/web/src/components/chat/LiveAgentBubble.tsx
@@ -18,9 +18,9 @@ import type { Attachment, ContentRef } from '@kraki/protocol';
 
 /** Lazy attachment pull for tool args/result refs rendered in the status
  *  section (mirrors MessageBubble's ATTACHMENT_PULL). */
-const ATTACHMENT_PULL = (sid: string, id: string): void => {
+const ATTACHMENT_PULL = (sid: string, ref: ContentRef): void => {
   void import('../../lib/ws-client').then(({ wsClient }) => {
-    wsClient.requestAttachment(sid, id);
+    wsClient.requestAttachment(sid, ref);
   });
 };
 

--- a/packages/arm/web/src/components/chat/MessageBubble.tsx
+++ b/packages/arm/web/src/components/chat/MessageBubble.tsx
@@ -19,9 +19,9 @@ const IMAGE_PLACEHOLDER = '[image]';
 /** Shared pull thunk for any ContentRef rendered inside a message bubble —
  *  args/result on tool calls, images, etc. We lazy-import ws-client to
  *  break the cycle (MessageBubble is re-exported through several layers). */
-const ATTACHMENT_PULL = (sid: string, id: string): void => {
+const ATTACHMENT_PULL = (sid: string, ref: ContentRef): void => {
   void import('../../lib/ws-client').then(({ wsClient }) => {
-    wsClient.requestAttachment(sid, id);
+    wsClient.requestAttachment(sid, ref);
   });
 };
 

--- a/packages/arm/web/src/components/chat/ToolActivity.tsx
+++ b/packages/arm/web/src/components/chat/ToolActivity.tsx
@@ -18,8 +18,8 @@ interface ToolActivityProps {
   /** Lazy ref to the full result body (complete events only). */
   resultRef?: ContentRef;
   sessionId: string;
-  /** Fired with a sessionId/id when the cache misses and we need to pull. */
-  requestPull: (sessionId: string, id: string) => void;
+  /** Fired with a sessionId/ref when the cache misses and we need to pull. */
+  requestPull: (sessionId: string, ref: ContentRef) => void;
   success?: boolean;
   termination?: 'cancelled' | 'interrupted';
   cancelled?: boolean;
@@ -115,7 +115,7 @@ function ToolArgsBody({
   toolName: string;
   argsRef: ContentRef;
   sessionId: string;
-  requestPull: (sessionId: string, id: string) => void;
+  requestPull: (sessionId: string, ref: ContentRef) => void;
   headline: string;
 }) {
   const { status, text, error } = useAttachmentText(argsRef, sessionId, requestPull, true);
@@ -208,7 +208,7 @@ function ToolResultBody({
 }: {
   resultRef: ContentRef;
   sessionId: string;
-  requestPull: (sessionId: string, id: string) => void;
+  requestPull: (sessionId: string, ref: ContentRef) => void;
 }) {
   const { status, text, error } = useAttachmentText(resultRef, sessionId, requestPull, true);
   return (

--- a/packages/arm/web/src/hooks/useAttachment.test.tsx
+++ b/packages/arm/web/src/hooks/useAttachment.test.tsx
@@ -1,0 +1,32 @@
+import 'fake-indexeddb/auto';
+import type { ContentRef } from '@kraki/protocol';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { __resetForTests } from '../lib/attachments';
+import { useAttachment } from './useAttachment';
+
+const REF: ContentRef = {
+  type: 'content_ref',
+  id: '00000000000000000000000000000000',
+  mimeType: 'image/png',
+  size: 8,
+};
+
+describe('useAttachment pull ownership', () => {
+  beforeEach(() => {
+    __resetForTests();
+  });
+
+  it('allows only one pull when duplicate mounts share the same IDB miss', async () => {
+    const requestPull = vi.fn();
+    const first = renderHook(() => useAttachment(REF, 'session-1', requestPull));
+    const second = renderHook(() => useAttachment(REF, 'session-1', requestPull));
+
+    await waitFor(() => expect(requestPull).toHaveBeenCalledTimes(1));
+    expect(requestPull).toHaveBeenCalledWith('session-1', REF);
+
+    first.unmount();
+    second.unmount();
+  });
+});

--- a/packages/arm/web/src/hooks/useAttachment.ts
+++ b/packages/arm/web/src/hooks/useAttachment.ts
@@ -40,22 +40,22 @@ interface UseAttachmentTextResult {
 }
 
 /** wsClient.requestAttachment thunk — kept loose to avoid an import cycle. */
-type RequestPull = (sessionId: string, id: string) => void;
+type RequestPull = (sessionId: string, ref: ContentRef) => void;
 
 /** Shared hydrate guard so concurrent mounts don't fan out duplicate IDB reads. */
 const hydratedIds = new Set<string>();
 const hydratingIds = new Map<string, Promise<boolean>>();
 
-function hydrateOnce(id: string): Promise<boolean> {
-  if (hydratedIds.has(id)) return Promise.resolve(true);
-  let p = hydratingIds.get(id);
+function hydrateOnce(ref: ContentRef): Promise<boolean> {
+  if (hydratedIds.has(ref.id)) return Promise.resolve(true);
+  let p = hydratingIds.get(ref.id);
   if (!p) {
-    p = hydrateFromIDB(id).then((hit) => {
-      if (hit) hydratedIds.add(id);
-      hydratingIds.delete(id);
+    p = hydrateFromIDB(ref).then((hit) => {
+      if (hit) hydratedIds.add(ref.id);
+      hydratingIds.delete(ref.id);
       return hit;
     });
-    hydratingIds.set(id, p);
+    hydratingIds.set(ref.id, p);
   }
   return p;
 }
@@ -81,11 +81,11 @@ function useAttachmentLifecycle(
       const existing = getState(ref.id);
       if (existing?.kind === 'ready') return;
       if (existing?.kind === 'awaiting-chunks' || existing?.kind === 'fetching') return;
-      const hit = await hydrateOnce(ref.id);
+      const hit = await hydrateOnce(ref);
       if (cancelled) return;
       if (hit) return;
-      markFetching(ref.id);
-      requestPull(sessionId, ref.id);
+      if (!markFetching(ref)) return;
+      requestPull(sessionId, ref);
     }
     void init();
     return () => {

--- a/packages/arm/web/src/lib/attachment-pull-queue.test.ts
+++ b/packages/arm/web/src/lib/attachment-pull-queue.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import type { ContentRef } from '@kraki/protocol';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AttachmentPullQueue } from './attachment-pull-queue';
 
+function ref(id: string, mimeType = 'application/octet-stream'): ContentRef {
+  return { type: 'content_ref', id, mimeType, size: 1 };
+}
+
 describe('AttachmentPullQueue', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   it('round-robins concurrent attachments one chunk at a time', () => {
     const sent: Array<{ sessionId: string; id: string; index: number }> = [];
     const queue = new AttachmentPullQueue((request) => {
@@ -10,8 +18,8 @@ describe('AttachmentPullQueue', () => {
       return true;
     });
 
-    queue.request('session-a', 'attachment-a');
-    queue.request('session-b', 'attachment-b');
+    queue.request('session-a', ref('attachment-a'));
+    queue.request('session-b', ref('attachment-b'));
     expect(sent).toEqual([
       { sessionId: 'session-a', id: 'attachment-a', index: 0 },
     ]);
@@ -26,15 +34,30 @@ describe('AttachmentPullQueue', () => {
     expect(sent.at(-1)).toEqual({ sessionId: 'session-b', id: 'attachment-b', index: 1 });
   });
 
+  it('prioritizes a newly queued image ahead of waiting text attachments', () => {
+    const sent: Array<{ sessionId: string; id: string; index: number }> = [];
+    const queue = new AttachmentPullQueue((request) => {
+      sent.push(request);
+      return true;
+    });
+
+    queue.request('session', ref('active-text', 'text/plain'));
+    queue.request('session', ref('waiting-text', 'application/json'));
+    queue.request('session', ref('image', 'image/png'));
+    queue.handleChunk({ sessionId: 'session', id: 'active-text', index: 0, total: 1, paced: true });
+
+    expect(sent.at(-1)).toEqual({ sessionId: 'session', id: 'image', index: 0 });
+  });
+
   it('releases the queue when an older tentacle returns an unpaced response', () => {
     const send = vi.fn(() => true);
     const queue = new AttachmentPullQueue(send);
 
-    queue.request('session-a', 'legacy');
-    queue.request('session-b', 'next');
+    queue.request('session-a', ref('legacy'));
+    queue.request('session-b', ref('next'));
     queue.handleChunk({ sessionId: 'session-a', id: 'legacy', index: 0, total: 3 });
 
-    expect(send).toHaveBeenNthCalledWith(2, { sessionId: 'session-b', id: 'next', index: 0 });
+    expect(send).toHaveBeenNthCalledWith(2, expect.objectContaining({ sessionId: 'session-b', id: 'next', index: 0 }));
   });
 
   it('retries the in-flight chunk after reconnect', () => {
@@ -46,7 +69,7 @@ describe('AttachmentPullQueue', () => {
       return true;
     });
 
-    queue.request('session-a', 'attachment-a');
+    queue.request('session-a', ref('attachment-a'));
     queue.disconnect();
     connected = false;
     queue.resume();
@@ -60,15 +83,58 @@ describe('AttachmentPullQueue', () => {
     ]);
   });
 
+  it('retries a timed-out chunk with a finite budget', () => {
+    const send = vi.fn(() => true);
+    const failure = vi.fn();
+    const queue = new AttachmentPullQueue(send, {
+      chunkTimeoutMs: 100,
+      maxRetries: 2,
+      onFailure: failure,
+    });
+
+    queue.request('session-a', ref('attachment-a'));
+    vi.advanceTimersByTime(100);
+    vi.advanceTimersByTime(100);
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(failure).not.toHaveBeenCalled();
+
+    queue.handleChunk({ sessionId: 'session-a', id: 'attachment-a', index: 0, total: 1, paced: true });
+    vi.advanceTimersByTime(100);
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails an exhausted chunk and continues with the next attachment', () => {
+    const send = vi.fn(() => true);
+    const failure = vi.fn();
+    const failedRef = ref('stuck-image', 'image/png');
+    const queue = new AttachmentPullQueue(send, {
+      chunkTimeoutMs: 100,
+      maxRetries: 1,
+      onFailure: failure,
+    });
+
+    queue.request('session-a', failedRef);
+    queue.request('session-b', ref('next'));
+    vi.advanceTimersByTime(200);
+
+    expect(failure).toHaveBeenCalledWith(
+      'session-a',
+      failedRef,
+      'Timed out receiving attachment chunk 1 after 2 attempts',
+    );
+    expect(send).toHaveBeenLastCalledWith(expect.objectContaining({ sessionId: 'session-b', id: 'next', index: 0 }));
+  });
+
   it('ignores duplicate and out-of-order chunks', () => {
     const send = vi.fn(() => true);
     const queue = new AttachmentPullQueue(send);
-    queue.request('session-a', 'attachment-a');
+    queue.request('session-a', ref('attachment-a'));
 
     queue.handleChunk({ sessionId: 'session-a', id: 'attachment-a', index: 1, total: 3, paced: true });
     expect(send).toHaveBeenCalledTimes(1);
 
     queue.handleChunk({ sessionId: 'session-a', id: 'attachment-a', index: 0, total: 3, paced: true });
-    expect(send).toHaveBeenNthCalledWith(2, { sessionId: 'session-a', id: 'attachment-a', index: 1 });
+    expect(send).toHaveBeenNthCalledWith(2, expect.objectContaining({ sessionId: 'session-a', id: 'attachment-a', index: 1 }));
   });
 });

--- a/packages/arm/web/src/lib/attachment-pull-queue.ts
+++ b/packages/arm/web/src/lib/attachment-pull-queue.ts
@@ -1,3 +1,5 @@
+import type { ContentRef } from '@kraki/protocol';
+
 export interface AttachmentChunkProgress {
   sessionId: string;
   id: string;
@@ -13,9 +15,25 @@ export interface AttachmentChunkRequest {
   index: number;
 }
 
-interface PullTask extends AttachmentChunkRequest {}
+interface PullTask extends AttachmentChunkRequest {
+  ref: ContentRef;
+  retries: number;
+  priority: 'high' | 'normal';
+}
 
 type SendChunkRequest = (request: AttachmentChunkRequest) => boolean;
+type PullFailure = (sessionId: string, ref: ContentRef, reason: string) => void;
+type PullRetry = (sessionId: string, ref: ContentRef, index: number, attempt: number) => void;
+
+interface AttachmentPullQueueOptions {
+  chunkTimeoutMs?: number;
+  maxRetries?: number;
+  onFailure?: PullFailure;
+  onRetry?: PullRetry;
+}
+
+const DEFAULT_CHUNK_TIMEOUT_MS = 8_000;
+const DEFAULT_MAX_RETRIES = 2;
 
 /**
  * Limits attachment traffic to one requested chunk at a time per Arm. Tasks
@@ -25,12 +43,35 @@ type SendChunkRequest = (request: AttachmentChunkRequest) => boolean;
 export class AttachmentPullQueue {
   private readonly queued: PullTask[] = [];
   private current: PullTask | null = null;
+  private timeout: ReturnType<typeof setTimeout> | null = null;
+  private readonly chunkTimeoutMs: number;
+  private readonly maxRetries: number;
+  private readonly onFailure?: PullFailure;
+  private readonly onRetry?: PullRetry;
 
-  constructor(private readonly send: SendChunkRequest) {}
+  constructor(
+    private readonly send: SendChunkRequest,
+    options: AttachmentPullQueueOptions = {},
+  ) {
+    this.chunkTimeoutMs = options.chunkTimeoutMs ?? DEFAULT_CHUNK_TIMEOUT_MS;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.onFailure = options.onFailure;
+    this.onRetry = options.onRetry;
+  }
 
-  request(sessionId: string, id: string): void {
-    if (this.has(sessionId, id)) return;
-    this.queued.push({ sessionId, id, index: 0 });
+  request(sessionId: string, ref: ContentRef): void {
+    if (this.has(sessionId, ref.id)) return;
+    const task: PullTask = {
+      sessionId,
+      id: ref.id,
+      ref,
+      index: 0,
+      retries: 0,
+      priority: ref.mimeType.startsWith('image/') ? 'high' : 'normal',
+    };
+    const firstNormal = this.queued.findIndex((queued) => queued.priority === 'normal');
+    if (task.priority === 'high' && firstNormal >= 0) this.queued.splice(firstNormal, 0, task);
+    else this.queued.push(task);
     this.pump();
   }
 
@@ -43,6 +84,7 @@ export class AttachmentPullQueue {
       || current.index !== chunk.index
     ) return;
 
+    this.clearChunkTimeout();
     this.current = null;
 
     // An older Tentacle ignores paced mode and sends the whole attachment.
@@ -55,13 +97,16 @@ export class AttachmentPullQueue {
 
     if (!chunk.error && chunk.index + 1 < chunk.total) {
       current.index = chunk.index + 1;
-      this.queued.push(current);
+      current.retries = 0;
+      this.enqueue(current);
     }
     this.pump();
   }
 
   disconnect(): void {
+    this.clearChunkTimeout();
     if (this.current) {
+      this.current.retries = 0;
       this.queued.unshift(this.current);
       this.current = null;
     }
@@ -76,13 +121,61 @@ export class AttachmentPullQueue {
     return this.queued.some((task) => task.sessionId === sessionId && task.id === id);
   }
 
+  private enqueue(task: PullTask): void {
+    if (task.priority === 'high') {
+      const firstNormal = this.queued.findIndex((queued) => queued.priority === 'normal');
+      if (firstNormal >= 0) {
+        this.queued.splice(firstNormal, 0, task);
+        return;
+      }
+    }
+    this.queued.push(task);
+  }
+
   private pump(): void {
     if (this.current || this.queued.length === 0) return;
     const next = this.queued.shift()!;
     this.current = next;
-    if (!this.send(next)) {
+    if (!this.sendRequest(next)) {
       this.current = null;
       this.queued.unshift(next);
+      return;
     }
+    this.armChunkTimeout(next);
+  }
+
+  private armChunkTimeout(task: PullTask): void {
+    this.clearChunkTimeout();
+    this.timeout = setTimeout(() => {
+      if (this.current !== task) return;
+      if (task.retries < this.maxRetries) {
+        if (this.sendRequest(task)) {
+          task.retries += 1;
+          this.onRetry?.(task.sessionId, task.ref, task.index, task.retries);
+          this.armChunkTimeout(task);
+          return;
+        }
+        this.current = null;
+        this.queued.unshift(task);
+        return;
+      }
+      this.current = null;
+      this.onFailure?.(
+        task.sessionId,
+        task.ref,
+        `Timed out receiving attachment chunk ${task.index + 1} after ${task.retries + 1} attempts`,
+      );
+      this.pump();
+    }, this.chunkTimeoutMs);
+  }
+
+  private sendRequest(task: PullTask): boolean {
+    return this.send({ sessionId: task.sessionId, id: task.id, index: task.index });
+  }
+
+  private clearChunkTimeout(): void {
+    if (!this.timeout) return;
+    clearTimeout(this.timeout);
+    this.timeout = null;
   }
 }

--- a/packages/arm/web/src/lib/attachments.test.ts
+++ b/packages/arm/web/src/lib/attachments.test.ts
@@ -1,34 +1,102 @@
 /**
- * Unit tests for the attachment state machine.
- *
- * Cover the four key paths:
- *   - live push: ref arrives → markAwaitingPush → chunks → ready
- *   - replay pull: ref arrives → markFetching → chunks → ready
- *   - error chunk: state transitions to error
- *   - safety timeout: ref arrives → no chunks → fallback fetch fires
+ * Unit tests for attachment assembly and cache integrity.
  */
 
+import { Blob as NodeBlob } from 'node:buffer';
+import 'fake-indexeddb/auto';
+import type { ContentRef } from '@kraki/protocol';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   __resetForTests,
   getState,
+  hydrateFromIDB,
   ingestChunk,
   markAwaitingPush,
   markFetching,
   subscribe,
 } from './attachments';
 
-// Tiny PNG bytes for assembly tests
-const PNG_HEX = '89504e470d0a1a0a';
-const PNG_BYTES = new Uint8Array(PNG_HEX.match(/.{2}/g)!.map((h) => parseInt(h, 16)));
-const PNG_B64 = btoa(String.fromCharCode(...PNG_BYTES));
+const DB_NAME = 'kraki-attachments';
+const STORE_NAME = 'attachments';
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function toBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function arrayBufferOf(bytes: Uint8Array): ArrayBuffer {
+  return Uint8Array.from(bytes).buffer;
+}
+
+async function contentId(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', arrayBufferOf(bytes));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('').slice(0, 32);
+}
+
+async function makeRef(bytes = PNG_BYTES, overrides: Partial<ContentRef> = {}): Promise<ContentRef> {
+  return {
+    type: 'content_ref',
+    id: await contentId(bytes),
+    mimeType: 'image/png',
+    size: bytes.length,
+    ...overrides,
+  };
+}
+
+async function putStoredAttachment(ref: ContentRef, bytes: Uint8Array, mimeType = ref.mimeType): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('lastAccessed', 'lastAccessed');
+      }
+    };
+    request.onerror = () => reject(new Error(`open attachment DB failed: ${request.error?.message ?? 'unknown'}`));
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const put = tx.objectStore(STORE_NAME).put({
+        id: ref.id,
+        mimeType,
+        size: bytes.length,
+        blob: new NodeBlob([Buffer.from(bytes)], { type: mimeType }) as unknown as Blob,
+        lastAccessed: Date.now(),
+      });
+      put.onerror = () => reject(new Error(`put attachment failed: ${put.error?.message ?? 'unknown'}`));
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onabort = () => reject(new Error(`attachment transaction aborted: ${tx.error?.message ?? 'unknown'}`));
+      tx.onerror = () => reject(new Error(`attachment transaction failed: ${tx.error?.message ?? 'unknown'}`));
+    };
+  });
+}
+
+async function getStoredAttachment(id: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const get = tx.objectStore(STORE_NAME).get(id);
+      get.onsuccess = () => {
+        db.close();
+        resolve(get.result);
+      };
+      get.onerror = () => reject(get.error);
+    };
+  });
+}
 
 describe('attachment state machine', () => {
-  let pulls: string[];
+  let pulls: ContentRef[];
 
   beforeEach(() => {
-    vi.useFakeTimers();
     pulls = [];
     __resetForTests();
   });
@@ -37,75 +105,140 @@ describe('attachment state machine', () => {
     vi.useRealTimers();
   });
 
-  it('markAwaitingPush sets awaiting state', () => {
-    markAwaitingPush('id1', (id) => pulls.push(id));
-    expect(getState('id1')?.kind).toBe('awaiting-chunks');
+  it('markAwaitingPush sets awaiting state', async () => {
+    const ref = await makeRef();
+    markAwaitingPush(ref, (requested) => pulls.push(requested));
+    expect(getState(ref.id)?.kind).toBe('awaiting-chunks');
   });
 
-  it('ingestChunk single chunk transitions to ready', async () => {
-    markAwaitingPush('id1', (id) => pulls.push(id));
-    await ingestChunk('id1', 0, 1, 'image/png', PNG_B64);
-    const s = getState('id1');
-    expect(s?.kind).toBe('ready');
-    if (s?.kind === 'ready') {
-      expect(s.mimeType).toBe('image/png');
-      expect(s.blob.size).toBe(PNG_BYTES.length);
+  it('ingestChunk single chunk transitions to ready after size and hash validation', async () => {
+    const ref = await makeRef();
+    markAwaitingPush(ref, (requested) => pulls.push(requested));
+    await ingestChunk(ref.id, 0, 1, ref.mimeType, toBase64(PNG_BYTES));
+    const state = getState(ref.id);
+    expect(state?.kind).toBe('ready');
+    if (state?.kind === 'ready') {
+      expect(state.mimeType).toBe('image/png');
+      expect(state.blob.size).toBe(PNG_BYTES.length);
     }
   });
 
-  it('ingestChunk reassembles multiple chunks regardless of order', async () => {
-    markAwaitingPush('id2', (id) => pulls.push(id));
-    // Two halves of the bytes, sent out of order
-    const first = PNG_B64.slice(0, 4);
-    const second = PNG_B64.slice(4);
-    await ingestChunk('id2', 1, 2, 'image/png', second);
-    expect(getState('id2')?.kind).toBe('awaiting-chunks');
-    await ingestChunk('id2', 0, 2, 'image/png', first);
-    expect(getState('id2')?.kind).toBe('ready');
+  it('reassembles multiple chunks regardless of arrival order', async () => {
+    const ref = await makeRef();
+    markAwaitingPush(ref, (requested) => pulls.push(requested));
+    await ingestChunk(ref.id, 1, 2, ref.mimeType, toBase64(PNG_BYTES.slice(4)));
+    expect(getState(ref.id)?.kind).toBe('awaiting-chunks');
+    await ingestChunk(ref.id, 0, 2, ref.mimeType, toBase64(PNG_BYTES.slice(0, 4)));
+    expect(getState(ref.id)?.kind).toBe('ready');
   });
 
-  it('ingestChunk with error transitions to error state', async () => {
-    markAwaitingPush('id3', (id) => pulls.push(id));
-    await ingestChunk('id3', 0, 0, '', '', 'not_found');
-    const s = getState('id3');
-    expect(s?.kind).toBe('error');
-    if (s?.kind === 'error') {
-      expect(s.reason).toBe('not_found');
-    }
+  it('rejects a completed transfer with the wrong byte size', async () => {
+    const ref = await makeRef(PNG_BYTES, { size: PNG_BYTES.length + 1 });
+    markFetching(ref);
+    const result = await ingestChunk(ref.id, 0, 1, ref.mimeType, toBase64(PNG_BYTES));
+    expect(result).toBe('terminal-error');
+    expect(getState(ref.id)).toEqual({
+      kind: 'error',
+      reason: `Attachment size mismatch: expected ${PNG_BYTES.length + 1}, got ${PNG_BYTES.length}`,
+    });
   });
 
-  it('safety timeout fires fallback pull when no chunks arrive', () => {
-    markAwaitingPush('id4', (id) => pulls.push(id));
+  it('rejects a completed transfer with a checksum mismatch', async () => {
+    const ref = await makeRef(PNG_BYTES, { id: '0'.repeat(32) });
+    markFetching(ref);
+    const result = await ingestChunk(ref.id, 0, 1, ref.mimeType, toBase64(PNG_BYTES));
+    expect(result).toBe('terminal-error');
+    expect(getState(ref.id)).toEqual({ kind: 'error', reason: 'Attachment checksum mismatch' });
+  });
+
+  it('rejects invalid indexes, changed totals and MIME mismatches', async () => {
+    const invalidIndexRef = await makeRef(PNG_BYTES, { id: '1'.repeat(32) });
+    markFetching(invalidIndexRef);
+    expect(await ingestChunk(invalidIndexRef.id, 2, 2, invalidIndexRef.mimeType, '')).toBe('terminal-error');
+
+    const changedTotalRef = await makeRef(PNG_BYTES, { id: '2'.repeat(32) });
+    markFetching(changedTotalRef);
+    expect(await ingestChunk(changedTotalRef.id, 0, 2, changedTotalRef.mimeType, toBase64(PNG_BYTES.slice(0, 4)))).toBe('accepted');
+    expect(await ingestChunk(changedTotalRef.id, 1, 3, changedTotalRef.mimeType, toBase64(PNG_BYTES.slice(4)))).toBe('terminal-error');
+
+    const mimeRef = await makeRef(PNG_BYTES, { id: '3'.repeat(32) });
+    markFetching(mimeRef);
+    expect(await ingestChunk(mimeRef.id, 0, 1, 'text/plain', toBase64(PNG_BYTES))).toBe('terminal-error');
+  });
+
+  it('ingestChunk with an explicit error transitions to error state', async () => {
+    const ref = await makeRef();
+    markAwaitingPush(ref, (requested) => pulls.push(requested));
+    await ingestChunk(ref.id, 0, 0, '', '', 'not_found');
+    expect(getState(ref.id)).toEqual({ kind: 'error', reason: 'not_found' });
+  });
+
+  it('safety timeout fires fallback pull when no chunks arrive', async () => {
+    vi.useFakeTimers();
+    const ref = await makeRef();
+    markAwaitingPush(ref, (requested) => pulls.push(requested));
     expect(pulls).toEqual([]);
     vi.advanceTimersByTime(10_001);
-    expect(pulls).toEqual(['id4']);
+    expect(pulls).toEqual([ref]);
   });
 
-  it('safety timeout does not fire if a chunk arrived first', async () => {
-    markAwaitingPush('id5', (id) => pulls.push(id));
-    await ingestChunk('id5', 0, 1, 'image/png', PNG_B64);
+  it('safety timeout does not fire if a valid chunk arrived first', async () => {
+    vi.useFakeTimers();
+    const ref = await makeRef();
+    markAwaitingPush(ref, (requested) => pulls.push(requested));
+    await ingestChunk(ref.id, 0, 2, ref.mimeType, toBase64(PNG_BYTES.slice(0, 4)));
     vi.advanceTimersByTime(15_000);
     expect(pulls).toEqual([]);
+    expect(getState(ref.id)?.kind).toBe('awaiting-chunks');
   });
 
-  it('markFetching is used by the pull path', () => {
-    markFetching('id6');
-    expect(getState('id6')?.kind).toBe('fetching');
+  it('markFetching grants pull ownership to only the first caller', async () => {
+    const ref = await makeRef();
+    expect(markFetching(ref)).toBe(true);
+    expect(markFetching(ref)).toBe(false);
+    expect(getState(ref.id)?.kind).toBe('fetching');
   });
 
-  it('chunks arriving during fetch state still complete', async () => {
-    markFetching('id7');
-    await ingestChunk('id7', 0, 1, 'image/png', PNG_B64);
-    expect(getState('id7')?.kind).toBe('ready');
+  it('does not downgrade a ready attachment on a late error or timeout failure', async () => {
+    const ref = await makeRef();
+    markFetching(ref);
+    await ingestChunk(ref.id, 0, 1, ref.mimeType, toBase64(PNG_BYTES));
+    expect(getState(ref.id)?.kind).toBe('ready');
+
+    expect(await ingestChunk(ref.id, 0, 0, '', '', 'not_found')).toBe('ignored');
+    const { failAttachment } = await import('./attachments');
+    failAttachment(ref, 'late timeout');
+    expect(getState(ref.id)?.kind).toBe('ready');
   });
 
   it('subscribers are notified on state changes', async () => {
+    const ref = await makeRef();
     const seen: string[] = [];
-    const unsub = subscribe('id8', () => seen.push(getState('id8')?.kind ?? '-'));
-    markAwaitingPush('id8', () => {});
-    await ingestChunk('id8', 0, 1, 'image/png', PNG_B64);
+    const unsubscribe = subscribe(ref.id, () => seen.push(getState(ref.id)?.kind ?? '-'));
+    markAwaitingPush(ref, () => {});
+    await ingestChunk(ref.id, 0, 1, ref.mimeType, toBase64(PNG_BYTES));
     expect(seen).toContain('awaiting-chunks');
     expect(seen).toContain('ready');
-    unsub();
+    unsubscribe();
+  });
+
+  it('hydrates a valid IDB record only after integrity validation', async () => {
+    const ref = await makeRef(PNG_BYTES, { id: await contentId(new Uint8Array([...PNG_BYTES, 1])) });
+    const bytes = new Uint8Array([...PNG_BYTES, 1]);
+    const validRef = { ...ref, size: bytes.length };
+    await putStoredAttachment(validRef, bytes);
+
+    expect(await hydrateFromIDB(validRef)).toBe(true);
+    expect(getState(validRef.id)?.kind).toBe('ready');
+  });
+
+  it('deletes a corrupt IDB record and reports a cache miss so the caller re-pulls', async () => {
+    const validBytes = new Uint8Array([...PNG_BYTES, 2]);
+    const ref = await makeRef(validBytes);
+    await putStoredAttachment(ref, PNG_BYTES);
+
+    expect(await hydrateFromIDB(ref)).toBe(false);
+    expect(getState(ref.id)).toBeUndefined();
+    expect(await getStoredAttachment(ref.id)).toBeUndefined();
   });
 });

--- a/packages/arm/web/src/lib/attachments.ts
+++ b/packages/arm/web/src/lib/attachments.ts
@@ -21,6 +21,7 @@
  * only in Blobs, so we don't leak URLs across hook unmounts.
  */
 
+import type { ContentRef } from '@kraki/protocol';
 import { openDB, type IDBPDatabase } from 'idb';
 
 import { createLogger } from './logger';
@@ -82,7 +83,10 @@ export type AttachmentState =
   | { kind: 'ready'; mimeType: string; blob: Blob }
   | { kind: 'error'; reason: string };
 
+export type AttachmentChunkIngestResult = 'accepted' | 'ignored' | 'terminal-error';
+
 const states = new Map<string, AttachmentState>();
+const expectedRefs = new Map<string, ContentRef>();
 const subscribers = new Map<string, Set<() => void>>();
 const PUSH_TIMEOUT_MS = 10_000;
 const pushTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
@@ -113,33 +117,34 @@ export function getState(id: string): AttachmentState | undefined {
 }
 
 /** Called by the message router for every ContentRef in a LIVE message. */
-export function markAwaitingPush(id: string, requestPull: (id: string) => void): void {
+export function markAwaitingPush(ref: ContentRef, requestPull: (ref: ContentRef) => void): void {
+  expectedRefs.set(ref.id, ref);
   // No-op if we already have it or are mid-fetch
-  const current = states.get(id);
+  const current = states.get(ref.id);
   if (current && (current.kind === 'ready' || current.kind === 'awaiting-chunks' || current.kind === 'fetching')) {
     return;
   }
-  states.set(id, {
+  states.set(ref.id, {
     kind: 'awaiting-chunks',
     received: new Map(),
     total: null,
     mimeType: null,
     startedAt: Date.now(),
   });
-  notify(id);
+  notify(ref.id);
   // Safety timeout — if no chunk arrives in PUSH_TIMEOUT_MS, fall back to
   // an explicit attachment_request. Cleared when first chunk arrives or
   // when assembly completes.
-  if (pushTimeouts.has(id)) {
-    clearTimeout(pushTimeouts.get(id)!);
+  if (pushTimeouts.has(ref.id)) {
+    clearTimeout(pushTimeouts.get(ref.id)!);
   }
   pushTimeouts.set(
-    id,
+    ref.id,
     setTimeout(() => {
-      const s = states.get(id);
+      const s = states.get(ref.id);
       if (s?.kind === 'awaiting-chunks' && s.received.size === 0) {
-        logger.warn('push timeout — falling back to fetch', { id });
-        requestPull(id);
+        logger.warn('push timeout — falling back to fetch', { id: ref.id });
+        requestPull(ref);
       }
     }, PUSH_TIMEOUT_MS),
   );
@@ -153,16 +158,29 @@ export async function ingestChunk(
   mimeType: string,
   data: string,
   error?: string,
-): Promise<boolean> {
+): Promise<AttachmentChunkIngestResult> {
+  const existing = states.get(id);
+  if (existing?.kind === 'ready' || existing?.kind === 'error') return 'ignored';
   if (error) {
-    states.set(id, { kind: 'error', reason: error });
-    clearPushTimeout(id);
-    notify(id);
-    return true;
+    setAttachmentError(id, error);
+    return 'terminal-error';
   }
 
-  let current = states.get(id);
-  if (current?.kind === 'ready') return false;
+  const ref = expectedRefs.get(id);
+  if (!ref) {
+    setAttachmentError(id, 'Attachment metadata unavailable');
+    return 'terminal-error';
+  }
+  if (!Number.isInteger(index) || !Number.isInteger(total) || total <= 0 || index < 0 || index >= total) {
+    setAttachmentError(id, 'Invalid attachment chunk index');
+    return 'terminal-error';
+  }
+  if (mimeType !== ref.mimeType) {
+    setAttachmentError(id, `Attachment MIME type mismatch: expected ${ref.mimeType}, got ${mimeType || 'empty'}`);
+    return 'terminal-error';
+  }
+
+  let current = existing;
   if (!current || (current.kind !== 'awaiting-chunks' && current.kind !== 'fetching')) {
     // No active assembly exists. Initialize one defensively for a stray chunk.
     current = {
@@ -185,29 +203,71 @@ export async function ingestChunk(
     states.set(id, current);
   }
 
-  if (current.received.has(index)) return false;
+  if (current.total !== null && current.total !== total) {
+    setAttachmentError(id, `Attachment chunk count changed from ${current.total} to ${total}`);
+    return 'terminal-error';
+  }
+  if (current.mimeType !== null && current.mimeType !== mimeType) {
+    setAttachmentError(id, 'Attachment MIME type changed during transfer');
+    return 'terminal-error';
+  }
+  if (current.received.has(index)) return 'accepted';
+  let decodedLength: number;
+  try {
+    decodedLength = base64Length(data);
+    if (decodedLength < 0) throw new Error('negative decoded length');
+  } catch {
+    setAttachmentError(id, 'Attachment chunk is not valid base64');
+    return 'terminal-error';
+  }
+  let receivedBytes = decodedLength;
+  for (const chunk of current.received.values()) receivedBytes += base64Length(chunk);
+  if (receivedBytes > ref.size) {
+    setAttachmentError(id, `Attachment exceeds declared size ${ref.size}`);
+    return 'terminal-error';
+  }
   current.received.set(index, data);
   current.total = total;
   current.mimeType = mimeType;
   if (current.received.size === total) {
-    // Complete — assemble Blob
-    const sorted = Array.from(current.received.entries()).sort((a, b) => a[0] - b[0]);
-    const buf = new Uint8Array(sorted.reduce((acc, [, b64]) => acc + base64Length(b64), 0));
-    let offset = 0;
-    for (const [, b64] of sorted) {
-      const bytes = base64ToBytes(b64);
-      buf.set(bytes, offset);
-      offset += bytes.length;
+    // Complete — require every expected index, then assemble and verify the
+    // content-addressed ref before exposing or persisting the blob.
+    const chunks: string[] = [];
+    for (let i = 0; i < total; i++) {
+      const chunk = current.received.get(i);
+      if (chunk === undefined) {
+        setAttachmentError(id, `Attachment is missing chunk ${i}`);
+        return 'terminal-error';
+      }
+      chunks.push(chunk);
     }
-    const blob = new Blob([buf], { type: mimeType });
-    states.set(id, { kind: 'ready', mimeType, blob });
-    clearPushTimeout(id);
-    await persistToIDB({ id, mimeType, size: blob.size, blob, lastAccessed: Date.now() });
-    notify(id);
+    try {
+      const buf = new Uint8Array(chunks.reduce((acc, b64) => acc + base64Length(b64), 0));
+      let offset = 0;
+      for (const b64 of chunks) {
+        const bytes = base64ToBytes(b64);
+        buf.set(bytes, offset);
+        offset += bytes.length;
+      }
+      const blob = new Blob([buf], { type: mimeType });
+      const validationError = await validateBlob(ref, mimeType, blob);
+      if (validationError) {
+        void deleteFromIDB(id);
+        setAttachmentError(id, validationError);
+        return 'terminal-error';
+      }
+      states.set(id, { kind: 'ready', mimeType, blob });
+      clearPushTimeout(id);
+      void persistToIDB({ id, mimeType, size: blob.size, blob, lastAccessed: Date.now() });
+      notify(id);
+    } catch (err) {
+      setAttachmentError(id, `Attachment decode failed: ${(err as Error).message}`);
+      return 'terminal-error';
+    }
   } else {
     notify(id);
   }
-  return true;
+  return 'accepted';
 }
 
 function clearPushTimeout(id: string): void {
@@ -218,27 +278,95 @@ function clearPushTimeout(id: string): void {
   }
 }
 
-/** Called by useAttachment to mark a pull in progress. */
-export function markFetching(id: string): void {
-  const current = states.get(id);
-  if (current?.kind === 'ready' || current?.kind === 'awaiting-chunks') return;
-  states.set(id, { kind: 'fetching' });
+function setAttachmentError(id: string, reason: string): void {
+  states.set(id, { kind: 'error', reason });
+  clearPushTimeout(id);
+  logger.warn('attachment rejected', { id, reason });
   notify(id);
 }
 
-/** Try to hydrate state from IDB. Returns true if hit. */
-export async function hydrateFromIDB(id: string): Promise<boolean> {
+export function failAttachment(ref: ContentRef, reason: string): void {
+  expectedRefs.set(ref.id, ref);
+  if (states.get(ref.id)?.kind === 'ready') return;
+  setAttachmentError(ref.id, reason);
+}
+
+async function validateBlob(ref: ContentRef, mimeType: string, blob: Blob): Promise<string | null> {
+  if (!/^[0-9a-f]{32}$/i.test(ref.id)) {
+    return 'Attachment id is not a valid content hash';
+  }
+  if (mimeType !== ref.mimeType) {
+    return `Attachment MIME type mismatch: expected ${ref.mimeType}, got ${mimeType || 'empty'}`;
+  }
+  if (blob.size !== ref.size) {
+    return `Attachment size mismatch: expected ${ref.size}, got ${blob.size}`;
+  }
+  const bytes = await blobToArrayBuffer(blob);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+  if (!hex.startsWith(ref.id.toLowerCase())) {
+    return 'Attachment checksum mismatch';
+  }
+  return null;
+}
+
+function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  const modernBlob = blob as Blob & { arrayBuffer?: () => Promise<ArrayBuffer> };
+  if (typeof modernBlob.arrayBuffer === 'function') return modernBlob.arrayBuffer();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read attachment blob'));
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) resolve(reader.result);
+      else reject(new Error('Attachment blob did not produce bytes'));
+    };
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+/** Called by useAttachment to acquire ownership of a pull. */
+export function markFetching(ref: ContentRef): boolean {
+  expectedRefs.set(ref.id, ref);
+  const current = states.get(ref.id);
+  if (current?.kind === 'ready' || current?.kind === 'awaiting-chunks' || current?.kind === 'fetching') {
+    return false;
+  }
+  states.set(ref.id, { kind: 'fetching' });
+  notify(ref.id);
+  return true;
+}
+
+/** Try to hydrate state from IDB. Returns true if a verified record exists. */
+export async function hydrateFromIDB(ref: ContentRef): Promise<boolean> {
+  expectedRefs.set(ref.id, ref);
   try {
     const db = await getDB();
-    const got = (await db.get(STORE_NAME, id)) as StoredAttachment | undefined;
+    const got = (await db.get(STORE_NAME, ref.id)) as StoredAttachment | undefined;
     if (!got) return false;
-    states.set(id, { kind: 'ready', mimeType: got.mimeType, blob: got.blob });
+    const validationError = await validateBlob(ref, got.mimeType, got.blob);
+    if (validationError) {
+      await db.delete(STORE_NAME, ref.id);
+      logger.warn('discarded invalid attachment cache entry', { id: ref.id, reason: validationError });
+      return false;
+    }
+    states.set(ref.id, { kind: 'ready', mimeType: got.mimeType, blob: got.blob });
     // Update lastAccessed in the background; ignore errors
-    void db.put(STORE_NAME, { ...got, lastAccessed: Date.now() });
-    notify(id);
+    void db.put(STORE_NAME, { ...got, size: got.blob.size, lastAccessed: Date.now() });
+    notify(ref.id);
     return true;
-  } catch {
+  } catch (err) {
+    await deleteFromIDB(ref.id);
+    logger.warn('failed to hydrate attachment from IDB', { id: ref.id, error: (err as Error).message });
     return false;
+  }
+}
+
+async function deleteFromIDB(id: string): Promise<void> {
+  try {
+    const db = await getDB();
+    await db.delete(STORE_NAME, id);
+  } catch {
+    // Best effort. A failed delete must not make corrupt bytes visible.
   }
 }
 
@@ -297,7 +425,12 @@ async function evictIfOverCap(aggressive = false): Promise<void> {
 // ── base64 helpers ─────────────────────────────────────────────────────
 
 function base64Length(b64: string): number {
-  // Approximate decoded length without decoding
+  if (
+    b64.length % 4 !== 0
+    || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(b64)
+  ) {
+    throw new Error('invalid base64');
+  }
   let pad = 0;
   if (b64.endsWith('==')) pad = 2;
   else if (b64.endsWith('=')) pad = 1;
@@ -320,6 +453,7 @@ function base64ToBytes(b64: string): Uint8Array {
 /** Reset state. Tests only. */
 export function __resetForTests(): void {
   states.clear();
+  expectedRefs.clear();
   subscribers.clear();
   for (const t of pushTimeouts.values()) clearTimeout(t);
   pushTimeouts.clear();

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -96,16 +96,16 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
   // but we route it before the session-existence check because the chunk's
   // session may not be in our store yet during early load.
   if (msg.type === 'attachment_data') {
-    const payload = (msg as { payload: { id: string; index: number; total: number; mimeType: string; data: string; paced?: true; error?: string } }).payload;
-    void ingestChunk(payload.id, payload.index, payload.total, payload.mimeType, payload.data, payload.error).then((accepted) => {
-      if (!accepted) return;
+    const attachmentMsg = msg as { sessionId: string; payload: { id: string; index: number; total: number; mimeType: string; data: string; paced?: true; error?: string } };
+    const payload = attachmentMsg.payload;
+    void ingestChunk(payload.id, payload.index, payload.total, payload.mimeType, payload.data, payload.error).then((result) => {
       ctx.onAttachmentChunk?.({
-        sessionId: msg.sessionId,
+        sessionId: attachmentMsg.sessionId,
         id: payload.id,
         index: payload.index,
         total: payload.total,
         paced: payload.paced,
-        error: payload.error,
+        error: payload.error ?? (result === 'terminal-error' ? 'invalid_attachment' : undefined),
       });
     });
     return;

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -1,4 +1,4 @@
-import type { InnerMessage, SessionListMessage, SessionSubscriptionSetMessage, AuthOkMessage, AuthInfoResponse, ServerErrorMessage, AuthChallengeMessage, DeviceJoinedMessage, DeviceLeftMessage, RelayEnvelope, Message, SessionState } from '@kraki/protocol';
+import type { ContentRef, InnerMessage, SessionListMessage, SessionSubscriptionSetMessage, AuthOkMessage, AuthInfoResponse, ServerErrorMessage, AuthChallengeMessage, DeviceJoinedMessage, DeviceLeftMessage, RelayEnvelope, Message, SessionState } from '@kraki/protocol';
 import { HEAD_PULSE_TARGET } from '@kraki/protocol';
 import { createAppKeyStore } from './e2e';
 import { KrakiTransport, type MessageHandler } from './transport';
@@ -14,6 +14,7 @@ import { createLogger, setLogBroadcast } from './logger';
 import { ArmPulse } from './arm-pulse';
 import { traceEvent } from './trace';
 import { SessionSubscriptionController } from './session-subscription';
+import { failAttachment } from './attachments';
 import { AttachmentPullQueue } from './attachment-pull-queue';
 
 const logger = createLogger('ws-client');
@@ -37,6 +38,11 @@ export class KrakiWSClient {
       payload: { id, sessionId, mode: 'paced', index },
     });
     return true;
+  }, {
+    onRetry: (sessionId, ref, index, attempt) => {
+      logger.warn('attachment chunk timed out — retrying', { sessionId, id: ref.id, index, attempt });
+    },
+    onFailure: (_sessionId, ref, reason) => failAttachment(ref, reason),
   });
 
   get url(): string { return this.transport.url; }
@@ -306,8 +312,8 @@ export class KrakiWSClient {
    *   - sessionId inside payload too, so the tentacle's AttachmentStore knows
    *     which session dir to read from.
    */
-  requestAttachment(sessionId: string, attachmentId: string) {
-    this.attachmentPulls.request(sessionId, attachmentId);
+  requestAttachment(sessionId: string, ref: ContentRef) {
+    this.attachmentPulls.request(sessionId, ref);
   }
 
   approve(permissionId: string, sessionId: string) {

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -268,6 +268,23 @@ async function main(): Promise<void> {
   /** Records every paced attachment read so the concurrency spec can prove the
    *  browser pulls one 256 KiB chunk at a time (not the whole blob at once). */
   const attachmentReads: Array<{ ts: number; id: string }> = [];
+  let dropNextAttachmentRequestId: string | null = null;
+  let droppedAttachmentRequests = 0;
+  const installAttachmentDropHook = (client: RelayClient): void => {
+    const internal = client as unknown as {
+      handleRequestAttachment: (msg: Record<string, unknown>) => Promise<void>;
+    };
+    const originalHandleRequest = internal.handleRequestAttachment.bind(client);
+    internal.handleRequestAttachment = async (msg: Record<string, unknown>) => {
+      const payload = msg.payload as { id?: string } | undefined;
+      if (payload?.id === dropNextAttachmentRequestId) {
+        dropNextAttachmentRequestId = null;
+        droppedAttachmentRequests += 1;
+        return;
+      }
+      await originalHandleRequest(msg);
+    };
+  };
   const origRead = attachmentStore.read.bind(attachmentStore);
   attachmentStore.read = (sid: string, id: string) => {
     const r = origRead(sid, id);
@@ -278,6 +295,7 @@ async function main(): Promise<void> {
     relayUrl: RELAY_URL,
     device: { name: 'RealStack Tentacle', role: 'tentacle', kind: 'desktop' },
   }, keyManager, attachmentStore);
+  installAttachmentDropHook(relay);
   await new Promise<void>((resolve, reject) => {
     relay!.onAuthenticated = () => resolve();
     relay!.onFatalError = (m: string) => reject(new Error(`tentacle auth failed: ${m}`));
@@ -461,6 +479,7 @@ async function main(): Promise<void> {
             relayUrl: RELAY_URL,
             device: { name: 'RealStack Tentacle', role: 'tentacle', kind: 'desktop' },
           }, keyManager, attachmentStore);
+          installAttachmentDropHook(relay);
           await new Promise<void>((resolve, reject) => {
             relay!.onAuthenticated = () => resolve();
             relay!.onFatalError = (m: string) => reject(new Error(`tentacle restart auth failed: ${m}`));
@@ -537,7 +556,13 @@ async function main(): Promise<void> {
           adapter.idle(sid);
           return json(200, { ok: true, marker, sizeKb, chunkCount: Math.ceil((body.length) / (256 * 1024)) });
         }
-        case '/attachmentReads': return json(200, { reads: attachmentReads });
+        case '/attachmentReads': return json(200, { reads: attachmentReads, dropped: droppedAttachmentRequests });
+        case '/dropNextAttachmentRequest': {
+          dropNextAttachmentRequestId = q.get('id');
+          droppedAttachmentRequests = 0;
+          attachmentReads.length = 0;
+          return json(200, { ok: true, id: dropNextAttachmentRequestId });
+        }
         // ── build one real turn with hundreds of trace entries. The browser's
         //    lazy request_turn_trace gets a large turn_trace_batch over bulk
         //    stream 1 while the test injects a concurrent live echo. ──
@@ -596,7 +621,7 @@ async function main(): Promise<void> {
           adapter.toolComplete(sid, 'show_image', '', tcid, [ref]);
           adapter.msg(sid, q.get('reply') ?? 'Here is the generated image.');
           adapter.idle(sid);
-          return json(200, { ok: true, id: ref.id, sizeKb: Math.round(png.length / 1024), chunkCount: Math.ceil(png.length / (256 * 1024)) });
+          return json(200, { ok: true, id: ref.id, size: png.length, mimeType: ref.mimeType, sizeKb: Math.round(png.length / 1024), chunkCount: Math.ceil(png.length / (256 * 1024)) });
         }
         case '/shutdown': json(200, { ok: true }); cleanup(); process.exit(0); return;
         default: return json(404, { error: 'unknown control endpoint' });


### PR DESCRIPTION
## Summary

Make Web attachment pulls self-healing under dropped Pulse responses, reconnects, corrupt browser cache entries, and large TRACE turns.

- add an 8s paced-chunk watchdog with two finite retries and guaranteed queue release
- prioritize visible image refs ahead of queued tool args/result text refs
- carry complete `ContentRef` metadata through the pull path
- verify chunk structure, MIME, declared size, and SHA-256-derived ContentRef id before exposing or persisting a Blob
- validate IndexedDB hits, delete corrupt records, and re-pull automatically
- make fetch ownership atomic across duplicate React mounts
- ignore late failures after an attachment is already ready
- add structured retry diagnostics

No wire-protocol change. The real-stack fault injection is test-only.

## Production failure addressed

A missing paced `attachment_data` response previously left the single global attachment queue occupied forever. In a turn with many tool args/results, visible images could remain loading indefinitely. Separately, an invalid Blob could be hydrated from IndexedDB and exposed as ready without validating its declared ContentRef.

## Validation

- `env -u KRAKI_HOME pnpm validate`
  - Biome: 147 files
  - Crypto: 36/36
  - Head: 253/253
  - Tentacle: 864/864
  - integration: 44/44
  - Web: 423/423
- Protocol, Crypto, Tentacle, and Web production builds
- Chromium real-stack: swallowed first paced request → watchdog retry → decoded PNG → following image not blocked
- WebKit real-stack: same recovery chain
- existing multi-chunk image real-stack regression
- existing attachment concurrency/live-message regression
- `git diff --check`

## Deployment boundary

Merge deploys the Web bundle to the isolated beta target through the existing workflow. Production Web deployment remains manual and is not part of this PR.
