### PR TITLE
chore(release): v0.31.13

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.12",
+  "version": "0.31.13",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release `@kraki/tentacle@0.31.13` from the main commit containing the Web attachment pull reliability fix.

The source fix is Web-only; the Tentacle patch version is bumped because `v*` is the repository's release authority for signed cross-platform assets, GitHub Release, and npm publication.

## Included fix

- finite paced chunk timeout/retry with queue release
- visible image priority over queued tool args/result refs
- ContentRef size/MIME/SHA-256 verification
- corrupt IndexedDB eviction and automatic re-pull
- duplicate-mount fetch ownership
- Chromium and WebKit real-stack lost-response recovery

## Validation

- source PR #217 merged after all four CI jobs passed
- main CI run `30745753393` passed
- isolated beta deploy run `30745845936` passed; production skipped
- Protocol, Crypto, and Tentacle release builds passed locally
- tag/package gate simulated for `v0.31.13`
- `git diff --check`
