### PR TITLE
fix(voice): settle quota from actual audio usage

### DIFF
--- a/packages/head/.env.example
+++ b/packages/head/.env.example
@@ -16,6 +16,15 @@
 # API key for apikey auth mode
 # API_KEY=
 
+# Voice input (optional; all four must be configured together)
+# VOICE_LEASE_ENABLED=1
+# VOICE_BROKER_URL=wss://stt.example.com/voice
+# VOICE_LEASE_TTL_SEC=600
+# VOICE_LEASE_QUOTA_SEC=300
+# VOICE_DAILY_QUOTA_SEC=7200
+# Shared only with the regional voice broker. Generate with: openssl rand -hex 32
+# VOICE_SETTLEMENT_KEY=
+
 # Server settings
 # PORT=4000
 # DB_PATH=kraki-head.db

--- a/packages/head/src/__tests__/voice-lease.test.ts
+++ b/packages/head/src/__tests__/voice-lease.test.ts
@@ -5,11 +5,13 @@
 
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, statSync } from 'fs';
+import Database from 'better-sqlite3';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { verifyChallenge, canonicalJson } from '@kraki/crypto';
 import { Storage } from '../storage.js';
 import { LeaseIssuer, _LEASE_KEY_FILENAMES } from '../lease-issuer.js';
+import { handleVoiceSettlement } from '../voice-settlement.js';
 import { createTestEnv, connectDevice, type TestEnv, type MockDevice } from './integration-helpers.js';
 
 function mkTmpLeaseDir(): string {
@@ -91,6 +93,52 @@ describe('Storage voice_leases', () => {
   });
   afterEach(() => storage.close());
 
+  it('migrates v8 leases conservatively and prevents legacy replay', () => {
+    const dir = mkTmpLeaseDir();
+    const dbPath = join(dir, 'legacy.db');
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE voice_leases (
+        jti TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        device_id TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        quota_seconds INTEGER NOT NULL,
+        issued_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        revoked_at TEXT
+      );
+      INSERT INTO voice_leases (
+        jti, user_id, device_id, resource, quota_seconds, issued_at, expires_at
+      ) VALUES (
+        'legacy-lease', 'u1', 'd1', 'voice/doubao', 300,
+        '2026-06-15T10:00:00.000Z', '2026-06-15T10:05:00.000Z'
+      );
+      PRAGMA user_version = 8;
+    `);
+    legacy.close();
+
+    const migrated = new Storage(dbPath);
+    try {
+      expect(migrated.rawDb.pragma('user_version', { simple: true })).toBe(10);
+      expect(migrated.getVoiceLease('legacy-lease')).toMatchObject({
+        activationId: 'legacy:legacy-lease',
+        activatedAt: '2026-06-15T10:00:00.000Z',
+        usedSeconds: null,
+      });
+      expect(migrated.sumVoiceLeaseQuotaIssuedToday(
+        'u1', Math.floor(new Date('2026-06-15T23:00:00Z').getTime() / 1000)
+      )).toBe(300);
+      expect(migrated.activateVoiceLease({
+        jti: 'legacy-lease', activationId: 'activation-replay',
+        activatedAtUnixSec: Math.floor(new Date('2026-06-15T10:01:00Z').getTime() / 1000),
+      })).toEqual({ status: 'conflict' });
+    } finally {
+      migrated.close();
+      rm(dir);
+    }
+  });
+
   it('records and reads back a single lease', () => {
     storage.upsertUser('u1', 'alice');
     storage.recordVoiceLease({
@@ -118,6 +166,104 @@ describe('Storage voice_leases', () => {
     })).toThrow();
   });
 
+  it('releases expired unsettled reservations but retains settled usage', () => {
+    storage.upsertUser('u1', 'a');
+    const issued = Math.floor(new Date('2026-06-15T10:00:00Z').getTime() / 1000);
+    storage.recordVoiceLease({
+      jti: 'unused-expired', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: issued, expiresAtUnixSec: issued + 60,
+    });
+    storage.recordVoiceLease({
+      jti: 'used-expired', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: issued + 1, expiresAtUnixSec: issued + 61,
+    });
+    storage.recordVoiceLease({
+      jti: 'active-unsettled', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: issued + 2, expiresAtUnixSec: issued + 62,
+    });
+    storage.activateVoiceLease({
+      jti: 'active-unsettled', activationId: 'activation-pending', activatedAtUnixSec: issued + 3,
+    });
+    storage.activateVoiceLease({ jti: 'used-expired', activationId: 'activation-used', activatedAtUnixSec: issued + 2 });
+    storage.settleVoiceLease({ jti: 'used-expired', activationId: 'activation-used', audioSeconds: 4.1, settledAtUnixSec: issued + 10 });
+
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', issued + 100)).toBe(605);
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', issued + 500)).toBe(305);
+  });
+
+  it('rejects activation after expiry and preserves one-time activation', () => {
+    storage.upsertUser('u1', 'a');
+    const now = Math.floor(new Date('2026-06-15T10:00:00Z').getTime() / 1000);
+    storage.recordVoiceLease({
+      jti: 'expired', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: now - 120, expiresAtUnixSec: now - 60,
+    });
+    expect(storage.activateVoiceLease({
+      jti: 'expired', activationId: 'activation-expired', activatedAtUnixSec: now,
+    })).toEqual({ status: 'expired' });
+
+    storage.recordVoiceLease({
+      jti: 'single-use', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: now, expiresAtUnixSec: now + 60,
+    });
+    expect(storage.activateVoiceLease({
+      jti: 'single-use', activationId: 'activation-first', activatedAtUnixSec: now + 1,
+    })).toEqual({ status: 'activated' });
+    expect(storage.activateVoiceLease({
+      jti: 'single-use', activationId: 'activation-first', activatedAtUnixSec: now + 2,
+    })).toEqual({ status: 'unchanged' });
+    expect(storage.activateVoiceLease({
+      jti: 'single-use', activationId: 'activation-replay', activatedAtUnixSec: now + 2,
+    })).toEqual({ status: 'conflict' });
+
+    const beforeMidnight = Math.floor(new Date('2026-06-15T23:59:30Z').getTime() / 1000);
+    const afterMidnight = Math.floor(new Date('2026-06-16T00:00:10Z').getTime() / 1000);
+    storage.recordVoiceLease({
+      jti: 'previous-day', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: beforeMidnight, expiresAtUnixSec: afterMidnight + 300,
+    });
+    expect(storage.activateVoiceLease({
+      jti: 'previous-day', activationId: 'activation-next-day', activatedAtUnixSec: afterMidnight,
+    })).toEqual({ status: 'wrong_day' });
+  });
+
+  it('settles reservations to actual audio seconds and preserves idempotency', () => {
+    storage.upsertUser('u1', 'a');
+    const now = Math.floor(new Date('2026-06-15T10:00:00Z').getTime() / 1000);
+    storage.recordVoiceLease({
+      jti: 'actual', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: now, expiresAtUnixSec: now + 3600,
+    });
+    storage.recordVoiceLease({
+      jti: 'reserved', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: now + 1, expiresAtUnixSec: now + 3601,
+    });
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', now)).toBe(600);
+
+    storage.activateVoiceLease({ jti: 'actual', activationId: 'activation-actual', activatedAtUnixSec: now + 2 });
+    expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 5.01, settledAtUnixSec: now + 10 }))
+      .toEqual({ status: 'settled', usedSeconds: 6 });
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', now)).toBe(306);
+    expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 5.01, settledAtUnixSec: now + 20 }))
+      .toEqual({ status: 'unchanged', usedSeconds: 6 });
+    expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 7, settledAtUnixSec: now + 20 }).status)
+      .toBe('conflict');
+  });
+
+  it('clamps settled usage to the signed lease quota', () => {
+    storage.upsertUser('u1', 'a');
+    const now = Math.floor(Date.now() / 1000);
+    storage.recordVoiceLease({
+      jti: 'clamp', userId: 'u1', deviceId: 'd', resource: 'voice/doubao',
+      quotaSeconds: 300, issuedAtUnixSec: now, expiresAtUnixSec: now + 3600,
+    });
+    storage.activateVoiceLease({ jti: 'clamp', activationId: 'activation-clamp' });
+    expect(storage.settleVoiceLease({ jti: 'clamp', activationId: 'activation-clamp', audioSeconds: 999 }))
+      .toEqual({ status: 'settled', usedSeconds: 300 });
+    expect(storage.settleVoiceLease({ jti: 'missing', activationId: 'activation-missing', audioSeconds: 1 }))
+      .toEqual({ status: 'not_found' });
+  });
+
   it('sums daily quota correctly across multiple leases', () => {
     storage.upsertUser('u1', 'a');
     const day0 = Math.floor(new Date('2026-06-15T10:00:00Z').getTime() / 1000);
@@ -139,6 +285,83 @@ describe('Storage voice_leases', () => {
     expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', day0)).toBe(1500);
     expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', day1)).toBe(2000);
     expect(storage.sumVoiceLeaseQuotaIssuedToday('u_other', day0)).toBe(0);
+  });
+});
+
+describe('Voice settlement endpoint contract', () => {
+  let storage: Storage;
+  beforeEach(() => {
+    storage = new Storage(':memory:');
+    storage.upsertUser('u1', 'alice');
+    const now = Math.floor(Date.now() / 1000);
+    storage.recordVoiceLease({
+      jti: 'lease-12345678', userId: 'u1', deviceId: 'd1',
+      resource: 'voice/doubao', quotaSeconds: 300,
+      issuedAtUnixSec: now - 5, expiresAtUnixSec: now + 3600,
+    });
+  });
+  afterEach(() => storage.close());
+
+  it('authenticates, activates once and idempotently settles actual usage', () => {
+    const activation = JSON.stringify({
+      action: 'activate', jti: 'lease-12345678', activationId: 'activation-12345678',
+    });
+    const body = JSON.stringify({
+      action: 'settle', jti: 'lease-12345678', activationId: 'activation-12345678',
+      audioSeconds: 5.2, reason: 'done',
+    });
+    expect(handleVoiceSettlement(storage, 'secret', { authorization: 'Bearer wrong', body }).status).toBe(401);
+    expect(handleVoiceSettlement(storage, 'secret', { authorization: 'Bearer secret', body: '{' }).status).toBe(400);
+    expect(handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret',
+      body: JSON.stringify({
+        action: 'settle', jti: 'missing-123456', activationId: 'activation-missing', audioSeconds: 1,
+      }),
+    }).status).toBe(404);
+
+    expect(handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret', body: activation,
+    })).toEqual({
+      status: 200,
+      body: { ok: true, activationStatus: 'activated' },
+    });
+    expect(handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret', body: activation,
+    }).body.activationStatus).toBe('unchanged');
+    expect(handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret',
+      body: JSON.stringify({
+        action: 'activate', jti: 'lease-12345678', activationId: 'different-activation',
+      }),
+    }).status).toBe(409);
+
+    storage.recordVoiceLease({
+      jti: 'expired-12345678', userId: 'u1', deviceId: 'd1',
+      resource: 'voice/doubao', quotaSeconds: 300,
+      issuedAtUnixSec: 1_700_000_000, expiresAtUnixSec: 1_700_000_100,
+    });
+    const expired = handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret',
+      body: JSON.stringify({
+        action: 'activate', jti: 'expired-12345678', activationId: 'activation-expired',
+      }),
+    });
+    expect(expired).toEqual({ status: 409, body: { error: 'lease_expired' } });
+
+    const first = handleVoiceSettlement(storage, 'secret', { authorization: 'Bearer secret', body });
+    expect(first).toEqual({
+      status: 200,
+      body: { ok: true, usedSeconds: 6, settlementStatus: 'settled' },
+    });
+    const retry = handleVoiceSettlement(storage, 'secret', { authorization: 'Bearer secret', body });
+    expect(retry.body.settlementStatus).toBe('unchanged');
+    const conflict = handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret',
+      body: JSON.stringify({
+        action: 'settle', jti: 'lease-12345678', activationId: 'activation-12345678', audioSeconds: 8,
+      }),
+    });
+    expect(conflict.status).toBe(409);
   });
 });
 

--- a/packages/head/src/cli.ts
+++ b/packages/head/src/cli.ts
@@ -37,6 +37,7 @@ import { GitHubAuthProvider, OpenAuthProvider, ApiKeyAuthProvider, ThrottledAuth
 import type { AuthProvider } from './auth.js';
 import { LeaseIssuer, defaultVoiceLeaseDir } from './lease-issuer.js';
 import { validateVoiceConfig } from './voice-config.js';
+import { handleVoiceSettlement } from './voice-settlement.js';
 import { Logger, setGlobalLogger } from './logger.js';
 import { PushManager, ApnsProvider, WebPushProvider } from './push/index.js';
 import type { PushProvider as IPushProvider } from './push/index.js';
@@ -94,10 +95,14 @@ if (args.includes('--help') || args.includes('-h')) {
     VOICE_LEASE_ENABLED            Set to "1" to enable lease issuance (default: off).
     VOICE_LEASE_DIR                Directory for the lease signing keypair
                                    (default: $HOME/.kraki-head).
-    VOICE_LEASE_TTL_SEC            Per-lease TTL in seconds (default: 86400 = 24h).
-    VOICE_LEASE_QUOTA_SEC          Per-lease audio quota in seconds (default: 7200 = 2h).
-    VOICE_DAILY_QUOTA_SEC          Per-user-per-day cap on issued lease quota
+    VOICE_LEASE_TTL_SEC            Authorization-start window in seconds
+                                   (default: 600 = 10 min).
+    VOICE_LEASE_QUOTA_SEC          Per-recording audio budget in seconds
+                                   (default: 300 = 5 min).
+    VOICE_DAILY_QUOTA_SEC          Per-user-per-day cap on reserved/settled seconds
                                    (default: 7200 = 2h).
+    VOICE_SETTLEMENT_KEY           Shared secret for broker usage settlement.
+                                   Required when voice leases are enabled.
     VOICE_BROKER_URL               Public WSS URL of this region's voice broker
                                    (e.g. wss://cn.stt.kraki.chat/voice).
                                    Advertised in auth_ok so clients render the
@@ -450,9 +455,10 @@ if (IS_CONNECTED_MODE) {
 
 // --- Voice lease issuance (optional) ---
 const VOICE_LEASE_DIR = process.env.VOICE_LEASE_DIR || defaultVoiceLeaseDir();
-const VOICE_LEASE_TTL_SEC = Math.max(60, parseInt(process.env.VOICE_LEASE_TTL_SEC || '86400', 10) || 86400);
-const VOICE_LEASE_QUOTA_SEC = Math.max(1, parseInt(process.env.VOICE_LEASE_QUOTA_SEC || '7200', 10) || 7200);
+const VOICE_LEASE_TTL_SEC = Math.max(60, parseInt(process.env.VOICE_LEASE_TTL_SEC || '600', 10) || 600);
+const VOICE_LEASE_QUOTA_SEC = Math.max(1, parseInt(process.env.VOICE_LEASE_QUOTA_SEC || '300', 10) || 300);
 const VOICE_DAILY_QUOTA_SEC = Math.max(VOICE_LEASE_QUOTA_SEC, parseInt(process.env.VOICE_DAILY_QUOTA_SEC || '7200', 10) || 7200);
+const VOICE_SETTLEMENT_KEY = process.env.VOICE_SETTLEMENT_KEY?.trim() || '';
 
 let voiceConfig;
 try {
@@ -466,6 +472,11 @@ try {
 }
 const VOICE_LEASE_ENABLED = voiceConfig.enabled;
 const VOICE_BROKER_URL = voiceConfig.brokerUrl;
+
+if (VOICE_LEASE_ENABLED && !VOICE_SETTLEMENT_KEY) {
+  console.error('[fatal] VOICE_LEASE_ENABLED=1 requires VOICE_SETTLEMENT_KEY for actual-usage settlement');
+  process.exit(1);
+}
 
 let voiceLeaseIssuer: LeaseIssuer | undefined;
 if (VOICE_LEASE_ENABLED) {
@@ -509,6 +520,56 @@ const httpServer = createServer(async (req, res) => {
       res.end(JSON.stringify({ error: 'internal_error' }));
       return;
     }
+  }
+
+  if (url.pathname === '/internal/voice/settle') {
+    if (!VOICE_LEASE_ENABLED || !VOICE_SETTLEMENT_KEY) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not_found' }));
+      return;
+    }
+    const authHeader = req.headers.authorization ?? '';
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    if (!token || !safeEqual(token, VOICE_SETTLEMENT_KEY)) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unauthorized' }));
+      return;
+    }
+    if (req.method !== 'POST') {
+      res.writeHead(405, { Allow: 'POST', 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'method_not_allowed' }));
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let tooLarge = false;
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total <= 16 * 1024) chunks.push(chunk);
+      else tooLarge = true;
+    });
+    req.on('end', () => {
+      if (tooLarge) {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'payload_too_large' }));
+        return;
+      }
+      const result = handleVoiceSettlement(storage!, VOICE_SETTLEMENT_KEY, {
+        authorization: req.headers.authorization,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      if (result.status === 200) {
+        logger.info('Voice lease accounting updated', {
+          action: result.body.activationStatus ? 'activate' : 'settle',
+          usedSeconds: result.body.usedSeconds,
+          status: result.body.activationStatus ?? result.body.settlementStatus,
+        });
+      }
+      res.writeHead(result.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result.body));
+    });
+    return;
   }
 
   if (url.pathname === '/admin/stats') {

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -72,11 +72,11 @@ export interface HeadServerOptions {
   region?: string;
   /** Voice-broker lease signer. If absent, request_voice_lease is rejected with 'not_entitled'. */
   leaseIssuer?: LeaseIssuer;
-  /** Per-lease TTL in seconds. Default 86400 (24h). */
+  /** Authorization-start window in seconds. Default 600 (10m). */
   voiceLeaseTtlSec?: number;
-  /** Quota seconds embedded in each lease. Default 7200 (2h). */
+  /** Per-recording audio budget in seconds. Default 300 (5m). */
   voiceLeaseQuotaSec?: number;
-  /** Per-user-per-day cap on total issued lease quota. Default 7200 (2h). */
+  /** Per-user-per-day cap on reserved/settled seconds. Default 7200 (2h). */
   voiceDailyQuotaSec?: number;
   /**
    * Public WSS URL of the voice broker for this region (e.g.
@@ -94,8 +94,8 @@ export interface HeadServerOptions {
   voiceBrokerUrl?: string;
 }
 
-const DEFAULT_VOICE_LEASE_TTL_SEC = 86_400;
-const DEFAULT_VOICE_LEASE_QUOTA_SEC = 7_200;
+const DEFAULT_VOICE_LEASE_TTL_SEC = 600;
+const DEFAULT_VOICE_LEASE_QUOTA_SEC = 300;
 const DEFAULT_VOICE_DAILY_QUOTA_SEC = 7_200;
 const VALID_VOICE_RESOURCES = new Set<VoiceResource>(['voice/doubao']);
 
@@ -657,15 +657,15 @@ export class HeadServer {
     const dailyCap = this.options.voiceDailyQuotaSec ?? DEFAULT_VOICE_DAILY_QUOTA_SEC;
     const nowSec = Math.floor(Date.now() / 1000);
 
-    const issuedToday = this.storage.sumVoiceLeaseQuotaIssuedToday(userId, nowSec);
-    if (issuedToday + quotaPerLease > dailyCap) {
+    const accountedToday = this.storage.sumVoiceLeaseQuotaIssuedToday(userId, nowSec);
+    if (accountedToday + quotaPerLease > dailyCap) {
       logger.info('Voice lease denied: daily quota exhausted', {
-        userId, deviceId, issuedToday, quotaPerLease, dailyCap,
+        userId, deviceId, accountedToday, quotaPerLease, dailyCap,
       });
       this.sendControlToDevice(deviceId, {
         type: 'voice_lease_denied',
         reason: 'quota_exhausted',
-        detail: `Daily quota reached (${issuedToday}/${dailyCap}s)`,
+        detail: `Daily quota reached (${accountedToday}/${dailyCap}s)`,
       });
       return;
     }

--- a/packages/head/src/storage.ts
+++ b/packages/head/src/storage.ts
@@ -96,7 +96,7 @@ export interface StoredRegion {
   lastSeenAt?: string;
 }
 
-const SCHEMA_VERSION = 8;
+const SCHEMA_VERSION = 10;
 
 export class Storage {
   private db: Database.Database;
@@ -256,9 +256,9 @@ export class Storage {
     }
 
     if (currentVersion < 8) {
-      // Voice-broker leases — audit trail + daily-quota source of truth.
-      // Rows are never deleted; cumulative seconds per (user, day) come from
-      // `SUM(quota_seconds) WHERE user_id=? AND DATE(issued_at)=DATE('now')`.
+      // Voice-broker leases — audit trail + daily reservation source of truth.
+      // New leases reserve `quota_seconds`; later migrations add one-time
+      // activation and trusted actual-audio settlement.
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS voice_leases (
           jti            TEXT PRIMARY KEY,
@@ -272,6 +272,49 @@ export class Storage {
         );
         CREATE INDEX IF NOT EXISTS idx_voice_leases_user_day
           ON voice_leases(user_id, issued_at);
+      `);
+    }
+
+    if (currentVersion < 9) {
+      // Voice usage settlement. A newly issued lease reserves its full quota;
+      // once the broker reports trusted audio usage, daily accounting uses the
+      // settled seconds instead. Unsettled rows remain conservatively reserved.
+      const columns = new Set(
+        (this.db.prepare('PRAGMA table_info(voice_leases)').all() as Array<{ name: string }>)
+          .map((column) => column.name)
+      );
+      if (!columns.has('used_seconds')) {
+        this.db.exec('ALTER TABLE voice_leases ADD COLUMN used_seconds INTEGER');
+      }
+      if (!columns.has('settled_at')) {
+        this.db.exec('ALTER TABLE voice_leases ADD COLUMN settled_at TEXT');
+      }
+      if (!columns.has('settlement_reason')) {
+        this.db.exec('ALTER TABLE voice_leases ADD COLUMN settlement_reason TEXT');
+      }
+    }
+
+    if (currentVersion < 10) {
+      // One-time lease activation distinguishes an unused expired reservation
+      // from a real session whose final settlement may be delayed or lost.
+      const columns = new Set(
+        (this.db.prepare('PRAGMA table_info(voice_leases)').all() as Array<{ name: string }>)
+          .map((column) => column.name)
+      );
+      if (!columns.has('activation_id')) {
+        this.db.exec('ALTER TABLE voice_leases ADD COLUMN activation_id TEXT');
+      }
+      if (!columns.has('activated_at')) {
+        this.db.exec('ALTER TABLE voice_leases ADD COLUMN activated_at TEXT');
+      }
+      // Rows created before activation accounting existed have unknown usage.
+      // Preserve their historical full reservation and make them non-replayable
+      // instead of incorrectly treating them as unused after an upgrade.
+      this.db.exec(`
+        UPDATE voice_leases
+        SET activation_id = 'legacy:' || jti,
+            activated_at = issued_at
+        WHERE activation_id IS NULL AND activated_at IS NULL
       `);
     }
 
@@ -650,19 +693,137 @@ export class Storage {
   }
 
   /**
-   * Sum of `quota_seconds` for leases issued to this user on the same UTC day
-   * as `nowUnixSec`. Used by head to enforce per-user-per-day caps.
-   * Revoked leases still count — that's intentional: revocation doesn't
-   * refund quota in MVP.
+   * Daily reserved/consumed voice seconds for a user. Unsettled leases reserve
+   * their full signed quota so concurrent sessions cannot bypass the cap.
+   * Settled leases count only trusted broker-reported audio seconds.
    */
   sumVoiceLeaseQuotaIssuedToday(userId: string, nowUnixSec: number): number {
     const day = new Date(nowUnixSec * 1000).toISOString().slice(0, 10);
     const row = this.db.prepare(`
-      SELECT COALESCE(SUM(quota_seconds), 0) AS total
+      SELECT COALESCE(SUM(
+        CASE
+          WHEN settled_at IS NOT NULL THEN COALESCE(used_seconds, quota_seconds)
+          WHEN activated_at IS NOT NULL THEN quota_seconds
+          WHEN unixepoch(expires_at) + 60 > ? THEN quota_seconds
+          ELSE 0
+        END
+      ), 0) AS total
       FROM voice_leases
       WHERE user_id = ? AND substr(issued_at, 1, 10) = ?
-    `).get(userId, day) as { total: number };
+    `).get(nowUnixSec, userId, day) as { total: number };
     return Number(row.total) || 0;
+  }
+
+  /**
+   * Activate a signed lease exactly once before the broker accepts audio.
+   * Retries carrying the same activation id are idempotent; a different id is
+   * a replay attempt and conflicts.
+   */
+  activateVoiceLease(input: {
+    jti: string;
+    activationId: string;
+    activatedAtUnixSec?: number;
+  }): { status: 'activated' | 'unchanged' | 'conflict' | 'expired' | 'wrong_day' | 'revoked' | 'not_found' } {
+    const nowUnixSec = input.activatedAtUnixSec ?? Math.floor(Date.now() / 1000);
+    const activationDay = new Date(nowUnixSec * 1000).toISOString().slice(0, 10);
+    const lease = this.db.prepare(`
+      SELECT activation_id, activated_at, issued_at,
+             unixepoch(expires_at) AS expires_at_unix, revoked_at
+      FROM voice_leases WHERE jti = ?
+    `).get(input.jti) as {
+      activation_id: string | null;
+      activated_at: string | null;
+      issued_at: string;
+      expires_at_unix: number;
+      revoked_at: string | null;
+    } | undefined;
+    if (!lease) return { status: 'not_found' };
+    if (lease.revoked_at !== null) return { status: 'revoked' };
+    if (lease.activated_at !== null) {
+      return { status: lease.activation_id === input.activationId ? 'unchanged' : 'conflict' };
+    }
+    if (lease.expires_at_unix <= nowUnixSec) return { status: 'expired' };
+    if (lease.issued_at.slice(0, 10) !== activationDay) return { status: 'wrong_day' };
+    const activatedAt = new Date(nowUnixSec * 1000).toISOString();
+    const result = this.db.prepare(`
+      UPDATE voice_leases SET activation_id = ?, activated_at = ?
+      WHERE jti = ? AND activated_at IS NULL AND revoked_at IS NULL
+        AND unixepoch(expires_at) > ? AND substr(issued_at, 1, 10) = ?
+    `).run(input.activationId, activatedAt, input.jti, nowUnixSec, activationDay);
+    if (result.changes === 1) return { status: 'activated' };
+    const current = this.db.prepare(`
+      SELECT activation_id, activated_at, issued_at,
+             unixepoch(expires_at) AS expires_at_unix, revoked_at
+      FROM voice_leases WHERE jti = ?
+    `).get(input.jti) as {
+      activation_id: string | null;
+      activated_at: string | null;
+      issued_at: string;
+      expires_at_unix: number;
+      revoked_at: string | null;
+    } | undefined;
+    if (!current) return { status: 'not_found' };
+    if (current.revoked_at !== null) return { status: 'revoked' };
+    if (current.activated_at !== null) {
+      return { status: current.activation_id === input.activationId ? 'unchanged' : 'conflict' };
+    }
+    if (current.expires_at_unix <= nowUnixSec) return { status: 'expired' };
+    if (current.issued_at.slice(0, 10) !== activationDay) return { status: 'wrong_day' };
+    return { status: 'conflict' };
+  }
+
+  /**
+   * Idempotently settle one lease to actual broker-observed audio seconds.
+   * First write wins; retries with the same value are accepted, while a
+   * conflicting replay is rejected instead of silently changing accounting.
+   */
+  settleVoiceLease(input: {
+    jti: string;
+    activationId: string;
+    audioSeconds: number;
+    reason?: string;
+    settledAtUnixSec?: number;
+  }): { status: 'settled' | 'unchanged' | 'conflict' | 'not_found' | 'not_activated'; usedSeconds?: number } {
+    const lease = this.db.prepare(`
+      SELECT quota_seconds, used_seconds, settled_at, activation_id, activated_at
+      FROM voice_leases WHERE jti = ?
+    `).get(input.jti) as {
+      quota_seconds: number;
+      used_seconds: number | null;
+      settled_at: string | null;
+      activation_id: string | null;
+      activated_at: string | null;
+    } | undefined;
+    if (!lease) return { status: 'not_found' };
+    if (lease.activated_at === null) return { status: 'not_activated' };
+    if (lease.activation_id !== input.activationId) return { status: 'conflict' };
+
+    const usedSeconds = Math.min(
+      lease.quota_seconds,
+      Math.max(0, Math.ceil(input.audioSeconds))
+    );
+    if (lease.settled_at !== null) {
+      return lease.used_seconds === usedSeconds
+        ? { status: 'unchanged', usedSeconds }
+        : { status: 'conflict', usedSeconds: lease.used_seconds ?? undefined };
+    }
+
+    const settledAt = new Date(
+      (input.settledAtUnixSec ?? Math.floor(Date.now() / 1000)) * 1000
+    ).toISOString();
+    const result = this.db.prepare(`
+      UPDATE voice_leases
+      SET used_seconds = ?, settled_at = ?, settlement_reason = ?
+      WHERE jti = ? AND settled_at IS NULL
+    `).run(usedSeconds, settledAt, input.reason?.slice(0, 64) ?? null, input.jti);
+    if (result.changes === 1) return { status: 'settled', usedSeconds };
+
+    const current = this.db.prepare(`
+      SELECT used_seconds FROM voice_leases WHERE jti = ?
+    `).get(input.jti) as { used_seconds: number | null } | undefined;
+    return current?.used_seconds === usedSeconds
+      ? { status: 'unchanged', usedSeconds }
+      : { status: 'conflict', usedSeconds: current?.used_seconds ?? undefined };
   }
 
   /** Fetch a single lease by jti (audit / debug). Returns undefined if unknown. */
@@ -675,13 +836,22 @@ export class Storage {
     issuedAt: string;
     expiresAt: string;
     revokedAt: string | null;
+    usedSeconds: number | null;
+    settledAt: string | null;
+    settlementReason: string | null;
+    activationId: string | null;
+    activatedAt: string | null;
   } | undefined {
     const row = this.db.prepare(`
-      SELECT jti, user_id, device_id, resource, quota_seconds, issued_at, expires_at, revoked_at
+      SELECT jti, user_id, device_id, resource, quota_seconds, issued_at,
+             expires_at, revoked_at, used_seconds, settled_at, settlement_reason,
+             activation_id, activated_at
       FROM voice_leases WHERE jti = ?
     `).get(jti) as {
       jti: string; user_id: string; device_id: string; resource: string;
       quota_seconds: number; issued_at: string; expires_at: string; revoked_at: string | null;
+      used_seconds: number | null; settled_at: string | null; settlement_reason: string | null;
+      activation_id: string | null; activated_at: string | null;
     } | undefined;
     if (!row) return undefined;
     return {
@@ -693,6 +863,11 @@ export class Storage {
       issuedAt: row.issued_at,
       expiresAt: row.expires_at,
       revokedAt: row.revoked_at,
+      usedSeconds: row.used_seconds,
+      settledAt: row.settled_at,
+      settlementReason: row.settlement_reason,
+      activationId: row.activation_id,
+      activatedAt: row.activated_at,
     };
   }
 

--- a/packages/head/src/voice-settlement.ts
+++ b/packages/head/src/voice-settlement.ts
@@ -1,0 +1,82 @@
+import { safeEqual } from './auth.js';
+import type { Storage } from './storage.js';
+
+export interface VoiceSettlementRequest {
+  authorization?: string;
+  body: string;
+}
+
+export interface VoiceSettlementResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+export function handleVoiceSettlement(
+  storage: Storage,
+  settlementKey: string,
+  request: VoiceSettlementRequest,
+): VoiceSettlementResponse {
+  const token = request.authorization?.startsWith('Bearer ')
+    ? request.authorization.slice(7)
+    : '';
+  if (!token || !settlementKey || !safeEqual(token, settlementKey)) {
+    return { status: 401, body: { error: 'unauthorized' } };
+  }
+
+  let input: {
+    action?: unknown;
+    jti?: unknown;
+    activationId?: unknown;
+    audioSeconds?: unknown;
+    reason?: unknown;
+  };
+  try {
+    input = JSON.parse(request.body) as typeof input;
+  } catch {
+    return { status: 400, body: { error: 'invalid_json' } };
+  }
+  if ((input.action !== 'activate' && input.action !== 'settle')
+      || typeof input.jti !== 'string' || input.jti.length < 8 || input.jti.length > 128
+      || typeof input.activationId !== 'string'
+      || input.activationId.length < 8 || input.activationId.length > 128) {
+    return { status: 400, body: { error: 'invalid_request' } };
+  }
+
+  if (input.action === 'activate') {
+    const result = storage.activateVoiceLease({
+      jti: input.jti,
+      activationId: input.activationId,
+    });
+    if (result.status === 'not_found') return { status: 404, body: { error: 'not_found' } };
+    if (result.status === 'expired') return { status: 409, body: { error: 'lease_expired' } };
+    if (result.status === 'wrong_day') return { status: 409, body: { error: 'lease_wrong_day' } };
+    if (result.status === 'revoked') return { status: 409, body: { error: 'lease_revoked' } };
+    if (result.status === 'conflict') return { status: 409, body: { error: 'activation_conflict' } };
+    return { status: 200, body: { ok: true, activationStatus: result.status } };
+  }
+
+  if (typeof input.audioSeconds !== 'number' || !Number.isFinite(input.audioSeconds)
+      || input.audioSeconds < 0) {
+    return { status: 400, body: { error: 'invalid_request' } };
+  }
+
+  const result = storage.settleVoiceLease({
+    jti: input.jti,
+    activationId: input.activationId,
+    audioSeconds: input.audioSeconds,
+    reason: typeof input.reason === 'string' ? input.reason : undefined,
+  });
+  if (result.status === 'not_found') {
+    return { status: 404, body: { error: 'not_found' } };
+  }
+  if (result.status === 'not_activated') {
+    return { status: 409, body: { error: 'not_activated' } };
+  }
+  if (result.status === 'conflict') {
+    return { status: 409, body: { error: 'settlement_conflict' } };
+  }
+  return {
+    status: 200,
+    body: { ok: true, usedSeconds: result.usedSeconds, settlementStatus: result.status },
+  };
+}

--- a/packages/voice-broker/.env.example
+++ b/packages/voice-broker/.env.example
@@ -30,6 +30,8 @@ DOUBAO_RESOURCE_ID=volc.bigasr.sauc.duration
 # KRAKI_VOICE_SETTLEMENT_URL=http://127.0.0.1:4000/internal/voice/settle
 # Must equal Head's VOICE_SETTLEMENT_KEY. Generate with: openssl rand -hex 32
 # KRAKI_VOICE_SETTLEMENT_KEY=
+# Per-attempt Head request timeout in milliseconds (default: 2000).
+# KRAKI_VOICE_SETTLEMENT_TIMEOUT_MS=2000
 # Legacy server-only migration key; never ship in Kraki arm builds.
 # VOICE_API_KEY=
 

--- a/packages/voice-broker/.env.example
+++ b/packages/voice-broker/.env.example
@@ -24,6 +24,15 @@ DOUBAO_RESOURCE_ID=volc.bigasr.sauc.duration
 # Port the mock Doubao server listens on when DOUBAO_MOCK=1.
 # MOCK_DOUBAO_PORT=7801
 
+# ── Kraki production lease + actual-usage settlement ──
+# KRAKI_VOICE_LEASE_PUBLIC_KEY_PATH=/var/lib/kraki/voice-lease/voice-lease.pub.pem
+# Internal Head endpoint, normally loopback because broker is a sidecar.
+# KRAKI_VOICE_SETTLEMENT_URL=http://127.0.0.1:4000/internal/voice/settle
+# Must equal Head's VOICE_SETTLEMENT_KEY. Generate with: openssl rand -hex 32
+# KRAKI_VOICE_SETTLEMENT_KEY=
+# Legacy server-only migration key; never ship in Kraki arm builds.
+# VOICE_API_KEY=
+
 # ── Broker server ──
 # Port the broker's WSS server listens on (arm clients connect here).
 # BROKER_PORT=7800

--- a/packages/voice-broker/README.md
+++ b/packages/voice-broker/README.md
@@ -1,12 +1,15 @@
 # @kraki/voice-broker
 
-> **Status:** MVP scaffold + full local mock pipeline. Real Doubao credentials not yet
-> wired in (waiting on Volcengine console). See `kraki-voice-broker-handover.md`
-> in `~/Documents/` for the design background.
+Kraki's product-owned voice authorization and deployment layer. It provides:
 
-The voice-broker is a sidecar process to the Kraki `head`. It holds the
-Doubao/Volcengine streaming-ASR secret, accepts audio over WSS from `arm`
-clients, and streams transcripts back. The phone never sees the key.
+- the original standalone Doubao broker and local mock pipeline under `src/`;
+- signed Kraki voice-lease verification;
+- the production adapter under `deploy/` that plugs Kraki leases into the
+  provider-agnostic `@coinfra/voice` gateway while retaining its streaming
+  correction and authoritative-final protocol.
+
+The Mac/iOS client never receives provider credentials or the legacy gateway
+API key.
 
 ```
 arm  ─audio→  voice-broker  ─audio→  Doubao
@@ -15,15 +18,13 @@ arm  ←text─   voice-broker  ←text─   Doubao
 
 This package currently delivers:
 
-- ✅ Doubao binary wire protocol (frame builders + parser) — pure, unit-tested
-- ✅ `DoubaoClient` — WS wrapper with `connect → start → sendAudio → finish`
-- ✅ Mock Doubao server — speaks the same binary protocol, lets us test
-  end-to-end without real credentials
-- ✅ Broker WSS server — bridges arm clients to Doubao (no auth in this phase)
-- ✅ Phase-0 probe CLI — stream a local WAV/PCM file, print transcripts
-- ✅ Browser mic test page — captures mic → 16 kHz PCM → broker → transcripts
-- ⏸ Lease auth / Apple IAP / multi-region sidecar — explicitly deferred
-  (handover §5, phases 4-6)
+- ✅ Doubao binary wire protocol, client, mock server and standalone broker
+- ✅ Offline RSA verification of Head-issued, user/device/resource-bound leases
+- ✅ Per-session audio limits from signed `quota_seconds`
+- ✅ Production Coinfra adapter with correction deltas and authoritative final
+- ✅ Migration-safe legacy API-key compatibility for non-Kraki clients; a frame
+  carrying a bad lease is never allowed to downgrade to the legacy key path
+- ✅ File probe and browser microphone test page
 
 ---
 
@@ -63,7 +64,53 @@ ffmpeg -i in.m4a -ac 1 -ar 16000 -sample_fmt s16 fixtures/your-clip.wav
 
 ---
 
-## Going live (when credentials arrive)
+## Production Coinfra adapter
+
+`deploy/coinfra-lease-serve.mjs` is the Kraki-owned entrypoint used with a
+built `@coinfra/voice` distribution. Configure:
+
+```text
+KRAKI_VOICE_LEASE_PUBLIC_KEY_PATH=/path/to/voice-lease.pub.pem
+KRAKI_VOICE_SETTLEMENT_URL=http://127.0.0.1:4000/internal/voice/settle
+KRAKI_VOICE_SETTLEMENT_KEY=<same secret as Head VOICE_SETTLEMENT_KEY>
+VOICE_API_KEY=<legacy server-only migration key>
+```
+
+Start frames containing `lease` are verified exclusively as Kraki leases:
+signature, algorithm, issuer, user, device, resource, time window, and quota
+must all match. Frames without `lease` may use the legacy key while older
+VoiceType clients migrate. Never ship `VOICE_API_KEY` in Kraki arm builds.
+
+The gateway first activates each `jti` with a random `activationId`; Head accepts
+that pair exactly once, preventing lease replay. It then reports trusted
+`audioSeconds` exactly once per Kraki session with the same pair. Head reserves
+the full lease budget while an activated session is unsettled, then atomically
+replaces that reservation with rounded-up actual audio seconds. An expired
+never-activated lease releases its reservation; an activated lease whose final
+report is lost remains conservatively reserved. Settlement retries are
+idempotent and conflicting replays are rejected. Legacy-key VoiceType sessions
+have no `jti` and are not reported.
+
+Validate the deployment adapter with:
+
+```bash
+pnpm --filter @kraki/voice-broker test:deploy
+```
+
+---
+
+## Coordinated release requirement
+
+Head settlement and the Broker activation adapter are one rollout unit. Do not
+release only one side while the public voice endpoint remains available: an old
+Broker does not activate sessions, and a new Broker cannot settle against an old
+Head. For production rollout, first stop accepting new voice connections, then
+upgrade both components and configure the matching settlement secret. Start
+Head, start the Broker, verify one activation/settlement probe, and only then
+restore the public voice route. Database backup and schema-v10 verification are
+required before reopening traffic.
+
+## Going live
 
 1. Create a Doubao app at <https://console.volcengine.com/speech> →
    流式语音识别大模型. Note the App Key, Access Key, and Resource ID.

--- a/packages/voice-broker/README.md
+++ b/packages/voice-broker/README.md
@@ -73,6 +73,7 @@ built `@coinfra/voice` distribution. Configure:
 KRAKI_VOICE_LEASE_PUBLIC_KEY_PATH=/path/to/voice-lease.pub.pem
 KRAKI_VOICE_SETTLEMENT_URL=http://127.0.0.1:4000/internal/voice/settle
 KRAKI_VOICE_SETTLEMENT_KEY=<same secret as Head VOICE_SETTLEMENT_KEY>
+KRAKI_VOICE_SETTLEMENT_TIMEOUT_MS=2000
 VOICE_API_KEY=<legacy server-only migration key>
 ```
 
@@ -88,8 +89,10 @@ the full lease budget while an activated session is unsettled, then atomically
 replaces that reservation with rounded-up actual audio seconds. An expired
 never-activated lease releases its reservation; an activated lease whose final
 report is lost remains conservatively reserved. Settlement retries are
-idempotent and conflicting replays are rejected. Legacy-key VoiceType sessions
-have no `jti` and are not reported.
+idempotent and conflicting replays are rejected. Each Head request has a
+bounded timeout (2 seconds by default) plus bounded retries, so activation
+fails closed and graceful shutdown cannot hang forever when Head is unhealthy.
+Legacy-key VoiceType sessions have no `jti` and are not reported.
 
 Validate the deployment adapter with:
 

--- a/packages/voice-broker/deploy/coinfra-lease-serve.mjs
+++ b/packages/voice-broker/deploy/coinfra-lease-serve.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Kraki product adapter for the provider-agnostic @coinfra/voice gateway.
+ *
+ * The shared voice wheel owns ASR/correction/streaming. This adapter owns only
+ * Kraki's signed lease verification and deployment configuration. Legacy
+ * static-key authorization remains available only for non-Kraki clients during
+ * migration; Kraki lease frames never downgrade to that path.
+ */
+import { readFileSync } from 'node:fs';
+import { createKrakiOrLegacyAuthorizer, createKrakiSettlementClient } from './kraki-lease-authorizer.mjs';
+import {
+  createDoubaoAsrProvider,
+  createLogger,
+  createOpenAiCorrector,
+  levelFromEnv,
+  passthroughCorrector,
+  startGateway,
+} from './coinfra/index.mjs';
+
+const log = createLogger('serve', levelFromEnv(process.env.LOG_LEVEL));
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`missing required environment variable: ${name}`);
+  return value;
+}
+
+function envInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) throw new Error(`${name} must be a number`);
+  return value;
+}
+
+async function main() {
+  const publicKey = readFileSync(required('KRAKI_VOICE_LEASE_PUBLIC_KEY_PATH'), 'utf8');
+  const settlementUrl = required('KRAKI_VOICE_SETTLEMENT_URL');
+  const settlementKey = required('KRAKI_VOICE_SETTLEMENT_KEY');
+  const correctionEnabled = process.env.CORRECTION_ENABLED !== '0';
+  const asr = createDoubaoAsrProvider({
+    endpoint: required('DOUBAO_ENDPOINT'),
+    accessKey: required('DOUBAO_ACCESS_KEY'),
+    resourceId: process.env.DOUBAO_RESOURCE_ID?.trim() || 'volc.seedasr.sauc.duration',
+    model: 'seedasr',
+    appKey: process.env.DOUBAO_APP_KEY?.trim() || undefined,
+  });
+  const corrector = correctionEnabled
+    ? createOpenAiCorrector({
+        baseUrl: process.env.CORRECTOR_BASE_URL?.trim() || 'https://api.deepseek.com/v1',
+        apiKey: required('CORRECTOR_API_KEY'),
+        model: process.env.CORRECTOR_MODEL?.trim() || 'deepseek-chat',
+        timeoutMs: envInt('CORRECTOR_TIMEOUT_MS', 15_000),
+        maxTokens: envInt('CORRECTOR_MAX_TOKENS', 512),
+        disableThinking: /^(1|true|yes|on)$/i.test(process.env.CORRECTOR_DISABLE_THINKING?.trim() ?? ''),
+        log: (message, fields) => log.debug(`corrector ${message}`, fields),
+      })
+    : passthroughCorrector;
+
+  const settlement = createKrakiSettlementClient(settlementUrl, settlementKey);
+  const gateway = await startGateway({
+    host: process.env.VOICE_HOST?.trim() || '127.0.0.1',
+    port: envInt('VOICE_PORT', 7800),
+    path: process.env.VOICE_PATH?.trim() || '/voice',
+    asr,
+    corrector,
+    correctOn: correctionEnabled ? 'final' : 'never',
+    authorize: createKrakiOrLegacyAuthorizer(
+      publicKey,
+      required('VOICE_API_KEY'),
+      { activate: settlement.activate },
+    ),
+    onUsage: settlement.onUsage,
+  });
+  log.info('Kraki lease gateway ready', {
+    url: gateway.url,
+    correction: correctionEnabled,
+    authorization: 'kraki-signed-lease+legacy-api-key',
+    settlement: 'actual-audio-seconds',
+  });
+
+  let closing = false;
+  const shutdown = async (signal) => {
+    if (closing) return;
+    closing = true;
+    log.info('shutting down', { signal });
+    try { await gateway.close(); } catch (error) {
+      log.warn('shutdown error', { error: error.message });
+    }
+    process.exit(0);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    log.error('fatal', { error: error.message });
+    process.exit(1);
+  });
+}

--- a/packages/voice-broker/deploy/coinfra-lease-serve.mjs
+++ b/packages/voice-broker/deploy/coinfra-lease-serve.mjs
@@ -58,7 +58,9 @@ async function main() {
       })
     : passthroughCorrector;
 
-  const settlement = createKrakiSettlementClient(settlementUrl, settlementKey);
+  const settlement = createKrakiSettlementClient(settlementUrl, settlementKey, {
+    timeoutMs: envInt('KRAKI_VOICE_SETTLEMENT_TIMEOUT_MS', 2_000),
+  });
   const gateway = await startGateway({
     host: process.env.VOICE_HOST?.trim() || '127.0.0.1',
     port: envInt('VOICE_PORT', 7800),

--- a/packages/voice-broker/deploy/kraki-lease-authorizer.mjs
+++ b/packages/voice-broker/deploy/kraki-lease-authorizer.mjs
@@ -1,0 +1,146 @@
+import { createVerify, randomUUID, timingSafeEqual } from 'node:crypto';
+
+const RESOURCE = 'voice/doubao';
+
+export function canonicalLeasePayload(payload) {
+  const sorted = {};
+  for (const key of Object.keys(payload).sort()) sorted[key] = payload[key];
+  return JSON.stringify(sorted);
+}
+
+function validLeaseShape(value) {
+  if (!value || typeof value !== 'object') return false;
+  const lease = value;
+  const payload = lease.payload;
+  return lease.alg === 'RSA-SHA256' &&
+    typeof lease.signature === 'string' && lease.signature.length > 0 &&
+    payload && typeof payload === 'object' &&
+    payload.ver === 1 && payload.iss === 'kraki-head' &&
+    typeof payload.sub === 'string' && payload.sub.length > 0 &&
+    typeof payload.did === 'string' && payload.did.length > 0 &&
+    Number.isInteger(payload.iat) && Number.isInteger(payload.exp) &&
+    Number.isFinite(payload.quota_seconds) && payload.quota_seconds > 0 &&
+    payload.resource === RESOURCE &&
+    typeof payload.jti === 'string' && payload.jti.length > 0;
+}
+
+export function createKrakiLeaseAuthorizer(publicKeyPem, options = {}) {
+  if (!publicKeyPem?.trim()) throw new Error('Kraki lease public key must not be empty');
+  const now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  const clockSkewSec = options.clockSkewSec ?? 30;
+  const activate = options.activate;
+  return ({ start }) => {
+    const lease = start?.lease;
+    if (!validLeaseShape(lease)) {
+      return { ok: false, reason: 'malformed_lease', detail: 'missing or malformed Kraki lease' };
+    }
+    if (typeof start.deviceId !== 'string' || start.deviceId !== lease.payload.did) {
+      return { ok: false, reason: 'wrong_device', detail: 'lease does not match device' };
+    }
+    if (typeof start.uid !== 'string' || start.uid !== lease.payload.sub) {
+      return { ok: false, reason: 'wrong_user', detail: 'lease does not match user' };
+    }
+    const current = now();
+    if (lease.payload.iat > current + clockSkewSec) {
+      return { ok: false, reason: 'not_yet_valid', detail: 'lease is not active yet' };
+    }
+    if (lease.payload.exp <= current) {
+      return { ok: false, reason: 'expired', detail: 'lease expired' };
+    }
+    try {
+      const verifier = createVerify('SHA256');
+      verifier.update(canonicalLeasePayload(lease.payload));
+      if (!verifier.verify(publicKeyPem, lease.signature, 'base64')) {
+        return { ok: false, reason: 'bad_signature', detail: 'lease signature invalid' };
+      }
+    } catch {
+      return { ok: false, reason: 'bad_signature', detail: 'lease signature invalid' };
+    }
+    const activationId = randomUUID();
+    const success = () => ({
+      ok: true,
+      quotaSeconds: lease.payload.quota_seconds,
+      usageContext: { jti: lease.payload.jti, activationId },
+    });
+    if (activate) {
+      return Promise.resolve(activate({ jti: lease.payload.jti, activationId }))
+        .then((activated) => activated.ok
+          ? success()
+          : { ok: false, reason: activated.reason ?? 'activation_failed', detail: activated.detail });
+    }
+    return success();
+  };
+}
+
+export function createKrakiSettlementClient(settleUrl, settlementKey, options = {}) {
+  if (!settleUrl?.trim()) throw new Error('Kraki settlement URL must not be empty');
+  if (!settlementKey?.trim()) throw new Error('Kraki settlement key must not be empty');
+  const request = options.fetch ?? globalThis.fetch;
+  const wait = options.wait ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const post = async (payload) => {
+    let lastError;
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      try {
+        const response = await request(settleUrl, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${settlementKey}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+        if (response.ok) return { ok: true };
+        lastError = new Error(`settlement returned ${response.status}`);
+        if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+          return { ok: false, reason: 'settlement_rejected', detail: lastError.message };
+        }
+      } catch (error) {
+        lastError = error;
+      }
+      await wait(100 * 2 ** attempt);
+    }
+    throw lastError ?? new Error('voice settlement failed');
+  };
+  return {
+    activate: ({ jti, activationId }) => post({ action: 'activate', jti, activationId }),
+    async onUsage(input) {
+      const jti = input?.authorization?.usageContext?.jti;
+      const activationId = input?.authorization?.usageContext?.activationId;
+      if (typeof jti !== 'string' || jti.length === 0
+          || typeof activationId !== 'string' || activationId.length === 0) return;
+      const result = await post({
+        action: 'settle',
+        jti,
+        activationId,
+        audioSeconds: input.audioSeconds,
+        reason: input.reason,
+      });
+      if (!result.ok) throw new Error(result.detail ?? result.reason ?? 'voice settlement failed');
+    },
+  };
+}
+
+export function createKrakiUsageReporter(settleUrl, settlementKey, options = {}) {
+  return createKrakiSettlementClient(settleUrl, settlementKey, options).onUsage;
+}
+
+function safeEqualSecret(actual, expected) {
+  if (typeof actual !== 'string' || !expected) return false;
+  const left = Buffer.from(actual);
+  const right = Buffer.from(expected);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/**
+ * Migration authorizer: Kraki lease frames never fall back to the legacy key;
+ * frames without a lease may still serve existing VoiceType clients.
+ */
+export function createKrakiOrLegacyAuthorizer(publicKeyPem, legacyApiKey, options = {}) {
+  const authorizeLease = createKrakiLeaseAuthorizer(publicKeyPem, options);
+  return (input) => {
+    if (input?.start?.lease !== undefined) return authorizeLease(input);
+    return safeEqualSecret(input?.start?.apiKey, legacyApiKey)
+      ? { ok: true }
+      : { ok: false, reason: 'missing_authorization', detail: 'missing Kraki lease or legacy API key' };
+  };
+}

--- a/packages/voice-broker/deploy/kraki-lease-authorizer.mjs
+++ b/packages/voice-broker/deploy/kraki-lease-authorizer.mjs
@@ -77,6 +77,10 @@ export function createKrakiSettlementClient(settleUrl, settlementKey, options = 
   if (!settlementKey?.trim()) throw new Error('Kraki settlement key must not be empty');
   const request = options.fetch ?? globalThis.fetch;
   const wait = options.wait ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('Kraki settlement timeout must be a positive number');
+  }
   const post = async (payload) => {
     let lastError;
     for (let attempt = 0; attempt < 4; attempt += 1) {
@@ -88,6 +92,7 @@ export function createKrakiSettlementClient(settleUrl, settlementKey, options = 
             'content-type': 'application/json',
           },
           body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(timeoutMs),
         });
         if (response.ok) return { ok: true };
         lastError = new Error(`settlement returned ${response.status}`);

--- a/packages/voice-broker/deploy/kraki-lease-authorizer.test.mjs
+++ b/packages/voice-broker/deploy/kraki-lease-authorizer.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { generateKeyPairSync, createSign } from 'node:crypto';
+import test from 'node:test';
+import {
+  canonicalLeasePayload,
+  createKrakiLeaseAuthorizer,
+  createKrakiOrLegacyAuthorizer,
+  createKrakiSettlementClient,
+  createKrakiUsageReporter,
+} from './kraki-lease-authorizer.mjs';
+
+const NOW = 1_800_000_000;
+const keys = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+function signedLease(overrides = {}) {
+  const payload = {
+    ver: 1,
+    iss: 'kraki-head',
+    sub: 'user-1',
+    did: 'device-1',
+    iat: NOW - 5,
+    exp: NOW + 300,
+    quota_seconds: 300,
+    resource: 'voice/doubao',
+    jti: 'lease-1',
+    ...overrides,
+  };
+  const signer = createSign('SHA256');
+  signer.update(canonicalLeasePayload(payload));
+  return {
+    payload,
+    signature: signer.sign(keys.privateKey, 'base64'),
+    alg: 'RSA-SHA256',
+  };
+}
+
+function authorize(lease = signedLease(), start = {}) {
+  return createKrakiLeaseAuthorizer(keys.publicKey, { now: () => NOW })({
+    start: {
+      type: 'start',
+      uid: 'user-1',
+      deviceId: 'device-1',
+      lease,
+      ...start,
+    },
+  });
+}
+
+test('accepts a Head-compatible signed lease and returns its audio quota', () => {
+  const result = authorize();
+  assert.equal(result.ok, true);
+  assert.equal(result.quotaSeconds, 300);
+  assert.equal(result.usageContext.jti, 'lease-1');
+  assert.equal(typeof result.usageContext.activationId, 'string');
+  assert.ok(result.usageContext.activationId.length > 8);
+});
+
+test('rejects a lease whose signed payload was tampered', () => {
+  const lease = signedLease();
+  lease.payload.quota_seconds = 7200;
+  assert.equal(authorize(lease).reason, 'bad_signature');
+});
+
+test('rejects wrong user, device, resource and time window', () => {
+  assert.equal(authorize(signedLease(), { uid: 'other' }).reason, 'wrong_user');
+  assert.equal(authorize(signedLease(), { deviceId: 'other' }).reason, 'wrong_device');
+  assert.equal(authorize(signedLease({ resource: 'voice/other' })).reason, 'malformed_lease');
+  assert.equal(authorize(signedLease({ exp: NOW })).reason, 'expired');
+  assert.equal(authorize(signedLease({ iat: NOW + 31 })).reason, 'not_yet_valid');
+});
+
+test('migration authorizer preserves legacy clients without allowing lease downgrade', () => {
+  const mixed = createKrakiOrLegacyAuthorizer(keys.publicKey, 'legacy-secret', { now: () => NOW });
+  assert.deepEqual(mixed({ start: { type: 'start', apiKey: 'legacy-secret' } }), { ok: true });
+  assert.equal(mixed({ start: { type: 'start', apiKey: 'wrong' } }).reason, 'missing_authorization');
+  const badLease = signedLease();
+  badLease.payload.quota_seconds = 7200;
+  assert.equal(mixed({
+    start: {
+      type: 'start', uid: 'user-1', deviceId: 'device-1',
+      apiKey: 'legacy-secret', lease: badLease,
+    },
+  }).reason, 'bad_signature');
+});
+
+test('production activation precedes acceptance and settlement binds the activation id', async () => {
+  const requests = [];
+  const client = createKrakiSettlementClient('https://head/internal/voice/settle', 'secret', {
+    wait: async () => {},
+    fetch: async (url, init) => {
+      requests.push({ url, init, body: JSON.parse(init.body) });
+      return { ok: true, status: 200 };
+    },
+  });
+  const authorizer = createKrakiLeaseAuthorizer(keys.publicKey, {
+    now: () => NOW,
+    activate: client.activate,
+  });
+  const verdict = await authorizer({
+    start: { type: 'start', uid: 'user-1', deviceId: 'device-1', lease: signedLease() },
+  });
+  assert.equal(verdict.ok, true);
+  assert.equal(requests[0].body.action, 'activate');
+  assert.equal(requests[0].body.jti, 'lease-1');
+  assert.equal(requests[0].body.activationId, verdict.usageContext.activationId);
+
+  await client.onUsage({ authorization: verdict, audioSeconds: 5.25, reason: 'asr closed' });
+  assert.equal(requests[1].body.action, 'settle');
+  assert.equal(requests[1].body.activationId, verdict.usageContext.activationId);
+  assert.equal(requests[1].body.audioSeconds, 5.25);
+});
+
+test('usage reporter settles Kraki leases with retries and skips legacy sessions', async () => {
+  const requests = [];
+  let attempts = 0;
+  const reporter = createKrakiUsageReporter('https://head/internal/voice/settle', 'secret', {
+    wait: async () => {},
+    fetch: async (url, init) => {
+      attempts += 1;
+      requests.push({ url, init });
+      return { ok: attempts > 1, status: attempts > 1 ? 200 : 503 };
+    },
+  });
+  await reporter({
+    authorization: { usageContext: { jti: 'lease-1', activationId: 'activation-1' } },
+    audioSeconds: 5.25,
+    reason: 'asr closed',
+  });
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].url, 'https://head/internal/voice/settle');
+  assert.equal(requests[0].init.headers.authorization, 'Bearer secret');
+  assert.deepEqual(JSON.parse(requests[0].init.body), {
+    action: 'settle', jti: 'lease-1', activationId: 'activation-1',
+    audioSeconds: 5.25, reason: 'asr closed',
+  });
+
+  await reporter({ authorization: { ok: true }, audioSeconds: 10, reason: 'legacy' });
+  assert.equal(requests.length, 2);
+});
+
+test('usage reporter rejects permanent settlement failures', async () => {
+  let attempts = 0;
+  const reporter = createKrakiUsageReporter('https://head/internal/voice/settle', 'secret', {
+    wait: async () => {},
+    fetch: async () => { attempts += 1; return { ok: false, status: 401 }; },
+  });
+  await assert.rejects(() => reporter({
+    authorization: { usageContext: { jti: 'lease-1', activationId: 'activation-1' } },
+    audioSeconds: 1,
+    reason: 'done',
+  }), /401/);
+  assert.equal(attempts, 1);
+});
+
+test('rejects missing, zero-quota and unknown-algorithm leases', () => {
+  const authorizer = createKrakiLeaseAuthorizer(keys.publicKey, { now: () => NOW });
+  assert.equal(authorizer({ start: { type: 'start', uid: 'user-1', deviceId: 'device-1' } }).reason, 'malformed_lease');
+  assert.equal(authorize(signedLease({ quota_seconds: 0 })).reason, 'malformed_lease');
+  const lease = signedLease();
+  lease.alg = 'none';
+  assert.equal(authorize(lease).reason, 'malformed_lease');
+});

--- a/packages/voice-broker/deploy/kraki-lease-authorizer.test.mjs
+++ b/packages/voice-broker/deploy/kraki-lease-authorizer.test.mjs
@@ -133,6 +133,7 @@ test('usage reporter settles Kraki leases with retries and skips legacy sessions
   assert.equal(requests.length, 2);
   assert.equal(requests[0].url, 'https://head/internal/voice/settle');
   assert.equal(requests[0].init.headers.authorization, 'Bearer secret');
+  assert.ok(requests[0].init.signal instanceof AbortSignal);
   assert.deepEqual(JSON.parse(requests[0].init.body), {
     action: 'settle', jti: 'lease-1', activationId: 'activation-1',
     audioSeconds: 5.25, reason: 'asr closed',
@@ -140,6 +141,15 @@ test('usage reporter settles Kraki leases with retries and skips legacy sessions
 
   await reporter({ authorization: { ok: true }, audioSeconds: 10, reason: 'legacy' });
   assert.equal(requests.length, 2);
+});
+
+test('settlement client rejects an invalid request timeout', () => {
+  assert.throws(
+    () => createKrakiSettlementClient('https://head/internal/voice/settle', 'secret', {
+      timeoutMs: 0,
+    }),
+    /positive number/,
+  );
 });
 
 test('usage reporter rejects permanent settlement failures', async () => {

--- a/packages/voice-broker/package.json
+++ b/packages/voice-broker/package.json
@@ -24,6 +24,7 @@
     "serve": "tsx src/cli.ts serve",
     "web": "tsx src/cli.ts web",
     "test": "vitest run",
+    "test:deploy": "node --test deploy/kraki-lease-authorizer.test.mjs && node --check deploy/coinfra-lease-serve.mjs",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
## Summary

Fix voice quota accounting so a short recording no longer permanently consumes the full per-gesture lease budget.

- reserve each newly issued lease conservatively
- activate each `jti` exactly once before the Broker accepts audio
- settle the reservation to rounded-up actual PCM seconds after the session closes
- retain the full reservation if an activated session cannot be settled
- release only expired leases that were never activated
- reject lease replay, conflicting settlement, expired activation, and cross-UTC-day activation
- migrate `voice_leases` from schema v8 to v10 without rewriting or releasing historical usage
- reduce the default lease start window to 10 minutes and per-recording budget to 300 seconds
- add a Bearer-protected loopback settlement endpoint and deployment adapter tests

## Root cause

Head currently enforces the daily cap with `SUM(voice_leases.quota_seconds)`. Every microphone gesture issues a 300-second lease, so even a few seconds of audio permanently count as 300 seconds. The Broker already knows actual PCM usage, but Kraki did not close the accounting loop.

Read-only production analysis found 24 sessions with 400.107 seconds of actual PCM. Per-session rounding would account for 411 seconds, while the existing model accounted for 7200 seconds.

## Accounting model

- issued, unexpired, never-activated lease: full reservation
- expired, never-activated lease: released
- activated, unsettled lease: full reservation, even after expiry
- settled lease: `ceil(actualAudioSeconds)`, clamped to signed quota
- pre-v10 lease: conservatively migrated as legacy-activated and non-replayable

The daily boundary remains UTC. A never-activated lease cannot cross UTC midnight and then stack with the next day's quota.

## Security and failure behavior

- settlement endpoint uses a dedicated constant-time-compared Bearer secret
- Broker verifies issuer, signature, algorithm, user, device, resource, time window, and quota
- activation ID is random and one-time per `jti`
- retries with the same activation/usage are idempotent
- conflicting replay is rejected
- settlement failure never refunds an activated session
- a malformed Kraki lease never falls back to the legacy static-key path
- request bodies are capped at 16 KiB
- logs contain identifiers/status/seconds only, never audio or transcript text

## Dependency

Depends on corelli18512/coinfra#10 for the generic `@coinfra/voice` `onUsage` callback. Merge/release that dependency before releasing this change.

## Coordinated release gate

**Do not deploy this PR automatically.** Head and Voice Broker must be rolled out as one controlled change:

1. stop accepting new public voice connections
2. back up the relay database
3. upgrade Head and Broker together and configure the same settlement secret
4. start Head, then Broker
5. verify activation + settlement and schema v10
6. restore the public voice route

Releasing only one side while voice traffic remains open is unsupported.

## Validation

- `pnpm --filter @kraki/head test` — 259 tests passed
- `pnpm --filter @kraki/head build`
- `pnpm --filter @kraki/voice-broker test` — 40 tests passed
- `pnpm --filter @kraki/voice-broker typecheck`
- `pnpm --filter @kraki/voice-broker test:deploy` — 8 tests passed
- `pnpm lint`
- `git diff --check`
- read-only production DB copy migrated v8 → v10 successfully
  - 25 historical rows retained
  - 25 marked legacy-activated
  - 0 rows left replayable with empty activation state

## Deployment

No production configuration, database, process, or service was modified. No deployment or restart is included in this PR.
