### PR TITLE
chore(release): head v0.17.2

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump `@kraki/head` from `0.17.1` to `0.17.2`
- prepare the reviewed schema-v10 voice activation and actual-usage settlement fix for package release

## Scope

This is a Head-only package release. It does not bump Tentacle, Mac/iOS, or the private Voice Broker package, and it does not deploy or restart production services.

## Release

After merge and green CI, tag the merge commit as `head-v0.17.2` so the existing Head-only release path publishes `@kraki/head@0.17.2`.