### PR TITLE
fix: keep background compaction non-blocking

### DIFF
--- a/packages/arm/ios/Kraki/App/AppState.swift
+++ b/packages/arm/ios/Kraki/App/AppState.swift
@@ -565,11 +565,17 @@ extension AppState: SessionSubscriptionHost {
             )
         }
 
-        switch digest.state {
-        case .compacting:
-            messageStore.setCompacting(sessionId, reason: nil)
-        case .idle, .active:
-            messageStore.clearRuntimeStatus(sessionId)
+        switch digest.runtimeStatus?.status {
+        case "compacting":
+            let reason = digest.runtimeStatus?.reason.flatMap(CompactionReason.init(rawValue:))
+            messageStore.setCompacting(sessionId, reason: reason)
+        default:
+            if digest.state == .compacting {
+                // Older tentacles encoded maintenance directly in state.
+                messageStore.setCompacting(sessionId, reason: nil)
+            } else {
+                messageStore.clearRuntimeStatus(sessionId)
+            }
         }
 
         let cardJSON = snapshot["card"] as? [String: Any] ?? [:]

--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -49,6 +49,12 @@ extension SessionDigest {
             return SessionPreview(text: text, type: type, timestamp: timestamp)
         }()
 
+        let runtimeStatus: SessionRuntimeStatusDigest? = {
+            guard let dict = json["runtimeStatus"] as? [String: Any],
+                  let status = dict["status"] as? String else { return nil }
+            return SessionRuntimeStatusDigest(status: status, reason: dict["reason"] as? String)
+        }()
+
         self.init(
             id: id,
             agent: json["agent"] as? String ?? "",
@@ -56,6 +62,7 @@ extension SessionDigest {
             title: json["title"] as? String,
             autoTitle: json["autoTitle"] as? String,
             state: SessionState(rawValue: json["state"] as? String ?? "idle") ?? .idle,
+            runtimeStatus: runtimeStatus,
             mode: SessionMode(rawValue: json["mode"] as? String ?? "discuss") ?? .discuss,
             lastSeq: json["lastSeq"] as? Int ?? 0,
             readSeq: json["readSeq"] as? Int ?? 0,
@@ -551,9 +558,8 @@ final class MessageRouter {
             // explicitly filters out `active` from rendering anyway, so
             // persisting it had zero UI value.
 
-        case "compact":
-            // Transient compaction runtime status (peer of active/idle).
-            // Never touches the card action slot, TRACE, or spine.
+        case "compact", "compacting":
+            // Transient compaction maintenance, orthogonal to active/idle.
             let phase = payload?["phase"] as? String
             if phase == "start" {
                 let reason = (payload?["reason"] as? String).flatMap(CompactionReason.init(rawValue:))

--- a/packages/arm/ios/Kraki/Core/Protocol/ProtocolTypes.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/ProtocolTypes.swift
@@ -207,6 +207,11 @@ struct SessionUsage: Codable, Equatable, Sendable {
     var contextTokens: Int?
 }
 
+struct SessionRuntimeStatusDigest: Codable, Equatable, Sendable {
+    let status: String
+    var reason: String? = nil
+}
+
 /// Compact session metadata sent in session_list for sync.
 struct SessionDigest: Codable, Identifiable, Sendable {
     let id: String
@@ -215,6 +220,7 @@ struct SessionDigest: Codable, Identifiable, Sendable {
     var title: String? = nil
     var autoTitle: String? = nil
     var state: SessionState
+    var runtimeStatus: SessionRuntimeStatusDigest? = nil
     var mode: SessionMode
     var lastSeq: Int
     var readSeq: Int

--- a/packages/arm/ios/Kraki/Features/Chat/ChatView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatView.swift
@@ -246,6 +246,7 @@ struct ChatView: View {
                     pendingPermission: viewModel?.permissions.first,
                     pendingQuestion: viewModel?.questions.first,
                     isCompacting: viewModel?.isCompacting == true,
+                    compactionReason: viewModel?.compactionReason,
                     hasLiveCard: viewModel?.card != nil,
                     onHeightChange: { newHeight in
                         if abs(newHeight - bottomInputHeight) > 0.5 {

--- a/packages/arm/ios/Kraki/Features/Chat/ChatViewModel.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatViewModel.swift
@@ -87,6 +87,11 @@ final class ChatViewModel {
         return false
     }
 
+    var compactionReason: CompactionReason? {
+        if case .compacting(let reason) = runtimeStatus { return reason }
+        return nil
+    }
+
     /// Pulled TRACE steps for a concluded bubble (for the "Steps" popup).
     func steps(forBubbleSeq seq: Int) -> [ChatMessage] {
         appState?.messageStore.turnSteps(sessionId, bubbleSeq: seq) ?? []

--- a/packages/arm/ios/Kraki/Features/Chat/MessageInputView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/MessageInputView.swift
@@ -45,6 +45,7 @@ struct MessageInputView: View {
     var pendingPermission: PendingPermission? = nil
     var pendingQuestion: PendingQuestion? = nil
     var isCompacting: Bool = false
+    var compactionReason: CompactionReason? = nil
     var hasLiveCard: Bool = false
     var onHeightChange: (CGFloat) -> Void = { _ in }
 
@@ -176,8 +177,11 @@ struct MessageInputView: View {
     private var sessionActive: Bool {
         session?.state == .active || session?.state == .compacting
     }
+    private var maintenanceBlocksInput: Bool {
+        isCompacting && compactionReason != .threshold && compactionReason != .manual
+    }
     private var text: String { sessionStore.drafts[sessionId] ?? "" }
-    private var isBusy: Bool { sessionActive || isCompacting || awaitingActive }
+    private var isBusy: Bool { sessionActive || maintenanceBlocksInput || awaitingActive }
     private var isIdle: Bool { !isBusy }
     private var isStructuredResponse: Bool { pendingPermission != nil || pendingQuestion != nil }
     private var submissionIntent: MessageComposerIntent {
@@ -192,7 +196,7 @@ struct MessageInputView: View {
     private var canSend: Bool {
         isStructuredResponse ? hasText : (hasText || hasImage)
     }
-    private var canShowAbort: Bool { sessionActive || isCompacting || hasLiveCard }
+    private var canShowAbort: Bool { sessionActive || maintenanceBlocksInput || hasLiveCard }
 
     /// True when we can actually deliver a message right now —
     /// tentacle is online AND the relay channel is up. Drives the

--- a/packages/arm/web/src/components/chat/ChatView.test.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.test.tsx
@@ -67,13 +67,15 @@ describe('ChatView', () => {
 
   it('renders compacting as page runtime state without creating a live bubble', () => {
     useStore.getState().setSessions([
-      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'compacting', messageCount: 0 },
+      { id: 's1', deviceId: 'd1', deviceName: 'Mac', agent: 'pi', state: 'idle', messageCount: 0 },
     ]);
+    useStore.getState().setRuntimeStatus('s1', { status: 'compacting', reason: 'threshold' });
     useStore.getState().setDevices([{ id: 'd1', name: 'Mac', role: 'tentacle', online: true }]);
     const { container } = renderChatView('s1');
     expect(screen.getByRole('status')).toHaveTextContent('Compacting context…');
     expect(container.querySelector('[data-session-runtime-status="compacting"]')).toBeInTheDocument();
     expect(container.querySelector('[data-live-bubble]')).toBeNull();
+    expect(screen.getByPlaceholderText('Send a message…')).toBeInTheDocument();
   });
 
   it('renders inline permission card', () => {

--- a/packages/arm/web/src/components/chat/ChatView.tsx
+++ b/packages/arm/web/src/components/chat/ChatView.tsx
@@ -40,7 +40,7 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
   const isDeviceOnline = useStore(
     useCallback((s) => deviceId ? s.devices.get(deviceId)?.online ?? false : false, [deviceId]),
   );
-  const isConnected = useStore((s) => s.status === 'connected');
+  const runtimeStatus = useStore((s) => s.runtimeStatuses.get(sessionId));
 
   // ── SPINE ─────────────────────────────────────────────
   // Persistent, replayed bubbles rendered directly in seq order. Excludes the
@@ -95,7 +95,7 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
   // Compacting is page/session chrome, not a card owner. It must not make an
   // empty card eligible or create a live bubble by itself. Existing real card
   // content/actions may continue rendering independently while compacting.
-  const cardEligible = status === 'working' || status === 'pending' || status === 'compacting';
+  const cardEligible = status === 'working' || status === 'pending';
   const showLive = cardEligible && !!card && (draft.length > 0 || actionLive);
 
   // First seq for prepend tracking (passed to scroll controller)
@@ -215,7 +215,7 @@ export const ChatView = memo(function ChatView({ onOpenArtifact }: { onOpenArtif
         )}
       </div>
 
-      {session.state === 'compacting' && (
+      {runtimeStatus?.status === 'compacting' && (
         <div
           className="border-t border-border-primary bg-surface-secondary/70 px-3 py-2 sm:px-6"
           data-session-runtime-status="compacting"

--- a/packages/arm/web/src/components/chat/MessageInput.tsx
+++ b/packages/arm/web/src/components/chat/MessageInput.tsx
@@ -23,7 +23,11 @@ export function MessageInput({ sessionId }: { sessionId: string }) {
   const setDraft = useStore((s) => s.setDraft);
   const sessionMode = useStore((s) => s.sessionModes.get(sessionId) ?? 'discuss') as typeof MODES[number];
   const session = useStore((s) => s.sessions.get(sessionId));
-  const sessionActive = session?.state === 'active' || session?.state === 'compacting';
+  const runtimeStatus = useStore((s) => s.runtimeStatuses.get(sessionId));
+  const maintenanceBlocksInput = runtimeStatus?.status === 'compacting'
+    && runtimeStatus.reason !== 'threshold'
+    && runtimeStatus.reason !== 'manual';
+  const sessionActive = session?.state === 'active' || session?.state === 'compacting' || maintenanceBlocksInput;
   const [awaitingActive, setAwaitingActive] = useState(false);
   const isIdle = !sessionActive && !awaitingActive;
 

--- a/packages/arm/web/src/components/sessions/SessionCard.tsx
+++ b/packages/arm/web/src/components/sessions/SessionCard.tsx
@@ -40,7 +40,10 @@ export function SessionCard({ session, pinned, openSwipeId, setOpenSwipeId }: Se
     : undefined;
   const isDeviceOnline = device?.online ?? false;
   const livePending = useStore((s) => countPendingQuestions(session.id, s.cards));
-  const status = getSessionStatus(session, livePending, sessionPreview?.type);
+  const runtimeStatus = useStore((s) => s.runtimeStatuses.get(session.id));
+  const status = runtimeStatus?.status === 'compacting'
+    ? 'compacting'
+    : getSessionStatus(session, livePending, sessionPreview?.type);
   const machineName = session.deviceName || device?.name;
 
   // Context menu (desktop right-click only, not mobile long-press)

--- a/packages/arm/web/src/lib/message-router.narration.test.ts
+++ b/packages/arm/web/src/lib/message-router.narration.test.ts
@@ -91,7 +91,7 @@ describe('handleDataMessage card messages', () => {
     expect(useStore.getState().cards.get('s1')?.action?.type).toBe('question');
   });
 
-  it('routes compacting start/end through session state without touching the card or IndexedDB', async () => {
+  it('keeps compaction on the runtime axis without changing conversation state or IndexedDB', async () => {
     seedSession('runtime-s1');
     useStore.getState().setCardAction('runtime-s1', {
       type: 'question',
@@ -104,7 +104,8 @@ describe('handleDataMessage card messages', () => {
       payload: { phase: 'start', reason: 'threshold' },
     } as unknown as InnerMessage, { cmdState: new CommandState() });
 
-    expect(useStore.getState().sessions.get('runtime-s1')?.state).toBe('compacting');
+    expect(useStore.getState().sessions.get('runtime-s1')?.state).toBe('active');
+    expect(useStore.getState().runtimeStatuses.get('runtime-s1')).toEqual({ status: 'compacting', reason: 'threshold' });
     expect(useStore.getState().cards.get('runtime-s1')?.action?.type).toBe('question');
 
     handleDataMessage({
@@ -113,13 +114,14 @@ describe('handleDataMessage card messages', () => {
       payload: { phase: 'end', nextState: 'idle' },
     } as unknown as InnerMessage, { cmdState: new CommandState() });
 
-    expect(useStore.getState().sessions.get('runtime-s1')?.state).toBe('idle');
+    expect(useStore.getState().sessions.get('runtime-s1')?.state).toBe('active');
+    expect(useStore.getState().runtimeStatuses.has('runtime-s1')).toBe(false);
     expect(useStore.getState().cards.get('runtime-s1')?.action?.type).toBe('question');
     await new Promise((r) => setTimeout(r, 5));
     expect(putMessage).not.toHaveBeenCalled();
   });
 
-  it('does not let real card or active updates end new-protocol compacting state', () => {
+  it('does not let card or active updates clear independent compaction maintenance', () => {
     seedSession('mixed-s1');
     handleDataMessage({
       type: 'compacting', deviceId: 'dev-tentacle', seq: 12,
@@ -136,7 +138,8 @@ describe('handleDataMessage card messages', () => {
       timestamp: new Date().toISOString(), sessionId: 'mixed-s1', payload: {},
     } as unknown as InnerMessage, { cmdState: new CommandState() });
 
-    expect(useStore.getState().sessions.get('mixed-s1')?.state).toBe('compacting');
+    expect(useStore.getState().sessions.get('mixed-s1')?.state).toBe('active');
+    expect(useStore.getState().runtimeStatuses.get('mixed-s1')?.status).toBe('compacting');
     expect(useStore.getState().cards.get('mixed-s1')?.action?.type).toBe('tool_start');
   });
 

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -315,15 +315,13 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
 
     case 'compacting': {
       const compactingMsg = msg as CompactingMessage;
-      const session = store.sessions.get(sid);
-      if (session) {
-        // `compacting` is a peer of active/idle on the session-state axis. On
-        // `phase: 'start'` the session enters compacting; `end.nextState` is the
-        // authoritative state to restore. Never persists, never creates a bubble.
-        const next: SessionState = compactingMsg.payload.phase === 'start'
-          ? 'compacting'
-          : compactingMsg.payload.nextState;
-        store.upsertSession({ ...session, state: next });
+      if (compactingMsg.payload.phase === 'start') {
+        store.setRuntimeStatus(sid, {
+          status: 'compacting',
+          reason: compactingMsg.payload.reason,
+        });
+      } else {
+        store.setRuntimeStatus(sid, null);
       }
       break;
     }

--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -1279,6 +1279,29 @@ describe('KrakiWSClient', () => {
       expect(preview!.type).toBe('agent');
     });
 
+    it('restores runtime maintenance from new and legacy session digests', async () => {
+      const client = new KrakiWSClient('ws://localhost:9999');
+      await connectAndAuth(client);
+
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-t1', seq: 1, timestamp: new Date().toISOString(),
+        payload: { sessions: [
+          {
+            id: 'sess-new', agent: 'pi', state: 'idle', mode: 'execute',
+            lastSeq: 5, readSeq: 5, messageCount: 5, createdAt: new Date().toISOString(),
+            runtimeStatus: { status: 'compacting', reason: 'threshold' },
+          },
+          {
+            id: 'sess-legacy', agent: 'pi', state: 'compacting', mode: 'execute',
+            lastSeq: 4, readSeq: 4, messageCount: 4, createdAt: new Date().toISOString(),
+          },
+        ] },
+      });
+
+      expect(useStore.getState().runtimeStatuses.get('sess-new')).toEqual({ status: 'compacting', reason: 'threshold' });
+      expect(useStore.getState().runtimeStatuses.get('sess-legacy')).toEqual({ status: 'compacting' });
+    });
+
     it('applies an open-question digest preview to the store session preview', async () => {
       const client = new KrakiWSClient('ws://localhost:9999');
       await connectAndAuth(client);

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -554,14 +554,21 @@ export class KrakiWSClient {
       // Store tentacle info for later message loading
       messageProvider.setTentacleInfo(ts.id, ts.lastSeq, tentacleDeviceId);
 
-      // Session metadata is authoritative for coarse liveness; the dedicated
-      // runtime snapshot resolves the finer transient state. Re-request on
-      // every active session_list so an offline compaction end can clear stale
-      // local state. Idle/ended proves compaction is no longer running.
-      if (ts.state === 'active') {
-        messageProvider.requestCard(ts.id, true);
+      const runtimeStatus = tsRecord.runtimeStatus as { status?: string; reason?: 'manual' | 'threshold' | 'overflow' } | undefined;
+      if (runtimeStatus?.status === 'compacting') {
+        store.setRuntimeStatus(ts.id, { status: 'compacting', reason: runtimeStatus.reason });
+      } else if (ts.state === 'compacting') {
+        // Backward compatibility: older tentacles encoded maintenance directly
+        // in session.state and did not send runtimeStatus in the digest.
+        store.setRuntimeStatus(ts.id, { status: 'compacting' });
       } else {
         store.setRuntimeStatus(ts.id, null);
+      }
+
+      // Session metadata is authoritative for conversational liveness. Runtime
+      // maintenance is orthogonal and must not make an idle composer busy.
+      if (ts.state === 'active') {
+        messageProvider.requestCard(ts.id, true);
       }
     }
 

--- a/packages/arm/web/src/pages/SessionPage.tsx
+++ b/packages/arm/web/src/pages/SessionPage.tsx
@@ -44,7 +44,10 @@ export function SessionPage() {
   const isPending = useStore((s) => sessionId ? s.pendingSessions.has(sessionId) : false);
   const livePending = useStore((s) => sessionId ? countPendingQuestions(sessionId, s.cards) : 0);
   const sessionPreviewType = useStore((s) => sessionId ? s.sessionPreviews.get(sessionId)?.type : undefined);
-  const sessionStatus = session ? getSessionStatus(session, livePending, sessionPreviewType) : 'idle';
+  const runtimeStatus = useStore((s) => sessionId ? s.runtimeStatuses.get(sessionId) : undefined);
+  const sessionStatus = runtimeStatus?.status === 'compacting'
+    ? 'compacting'
+    : session ? getSessionStatus(session, livePending, sessionPreviewType) : 'idle';
 
   // Navigate home when session is deleted (removed from store while viewing)
   // but not if it's a pending session (optimistic open before session_created)

--- a/packages/arm/web/src/pages/pages.test.tsx
+++ b/packages/arm/web/src/pages/pages.test.tsx
@@ -395,6 +395,37 @@ describe('MessageInput', () => {
     expect(screen.getByLabelText('Send message')).toBeDisabled();
   });
 
+  it.each(['threshold', 'manual'] as const)('keeps idle composer non-blocking during %s maintenance', async (reason) => {
+    const user = userEvent.setup();
+    useStore.getState().upsertSession({ id: 'sess-1', deviceId: 'd1', deviceName: 'Test', agent: 'pi', state: 'idle', messageCount: 0 });
+    useStore.getState().setRuntimeStatus('sess-1', { status: 'compacting', reason });
+    render(
+      <MemoryRouter>
+        <MessageInput sessionId="sess-1" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText('Stop')).not.toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('Send a message…'), 'new turn{Enter}');
+    expect(wsClient.sendInput).toHaveBeenCalledWith('sess-1', 'new turn', undefined);
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument();
+  });
+
+  it('keeps overflow compaction blocking as the current run', async () => {
+    const user = userEvent.setup();
+    useStore.getState().upsertSession({ id: 'sess-1', deviceId: 'd1', deviceName: 'Test', agent: 'pi', state: 'idle', messageCount: 0 });
+    useStore.getState().setRuntimeStatus('sess-1', { status: 'compacting', reason: 'overflow' });
+    render(
+      <MemoryRouter>
+        <MessageInput sessionId="sess-1" />
+      </MemoryRouter>,
+    );
+
+    await user.type(screen.getByPlaceholderText('Send a message…'), 'recovery guidance{Enter}');
+    expect(wsClient.sendInput).toHaveBeenCalledWith('sess-1', 'recovery guidance', undefined, 'steer');
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument();
+  });
+
   it('keeps send and stop as separate controls while the session is active', async () => {
     const user = userEvent.setup();
     useStore.getState().upsertSession({ id: 'sess-1', deviceId: 'd1', deviceName: 'Test', agent: 'copilot', state: 'active', messageCount: 0 });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -436,16 +436,14 @@ export interface CardAction extends BaseEnvelope {
 }
 
 /**
- * The agent runtime is compacting its context. This is a peer of
- * {@link ActiveMessage} / {@link IdleMessage} on the session-state axis: it is
- * transient (never persisted to the spine or trace, never replayed) and may
- * occur before streaming starts (prompt preflight) or after output completes
- * (finalize / auto-retry continuation), so it is NOT a subset of `active`.
+ * The agent runtime is compacting its context. This is transient maintenance,
+ * orthogonal to the active/idle conversational state: a completed turn may be
+ * idle and accept a fresh user message while threshold compaction continues.
+ * Overflow recovery can still coincide with an active turn.
  *
- * `phase: 'start'` enters the compacting state; `phase: 'end'` carries the
- * authoritative state to restore. The session's current compacting state is
- * also reflected in {@link SessionState} (carried by the session-list digest)
- * so reconnects recover it authoritatively.
+ * Never persisted to spine/TRACE. `phase: 'end'.nextState` remains for wire
+ * compatibility with older clients; new clients use it only as a fallback and
+ * keep compaction in their independent runtime-status store.
  */
 export interface CompactingMessage extends BaseEnvelope {
   type: 'compacting';

--- a/packages/protocol/src/sessions.ts
+++ b/packages/protocol/src/sessions.ts
@@ -43,6 +43,11 @@ export interface SessionPreviewDigest {
   timestamp: string;
 }
 
+export interface SessionRuntimeStatusDigest {
+  status: 'compacting';
+  reason?: 'manual' | 'threshold' | 'overflow';
+}
+
 /** Compact session metadata sent in session_list for sync. */
 export interface SessionDigest {
   id: string;
@@ -51,6 +56,8 @@ export interface SessionDigest {
   title?: string;
   autoTitle?: string;
   state: SessionState;
+  /** Orthogonal runtime maintenance. Does not make an idle conversation busy. */
+  runtimeStatus?: SessionRuntimeStatusDigest;
   mode: SessionMode;
   lastSeq: number;
   readSeq: number;

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -321,6 +321,22 @@ describe('pi prompt recovery', () => {
     expect(session.lastNarration).toBe('working');
   });
 
+  it('queues a fresh turn through Pi followUp during background compaction', async () => {
+    const { adapter, proc, session } = makeAdapter();
+    session.narrationSegments = 2;
+    session.lastNarration = 'old turn';
+
+    await adapter.sendMessage('s1', 'new turn', undefined, { delivery: 'follow_up' });
+
+    expect(proc.request).toHaveBeenCalledWith('prompt', {
+      message: 'new turn',
+      streamingBehavior: 'followUp',
+    }, { timeoutMs: null });
+    expect(proc.request).not.toHaveBeenCalledWith('abort');
+    expect(session.narrationSegments).toBe(0);
+    expect(session.lastNarration).toBe('');
+  });
+
   it('treats isStreaming as accepted while retaining the late ACK cleanup', async () => {
     const { adapter, proc } = makeAdapter({ ackGraceMs: 1, intervalMs: 1 });
     const onError = vi.fn();
@@ -382,7 +398,7 @@ describe('pi prompt recovery', () => {
     expect(onIdle).toHaveBeenCalledTimes(1);
   });
 
-  it('maps native compaction events once and never forwards summary content', () => {
+  it('maps native compaction events once and never forwards summary content', async () => {
     const { adapter, emit } = makeAdapter();
     const onCompaction = vi.fn();
     adapter.onCompaction = onCompaction;
@@ -393,6 +409,7 @@ describe('pi prompt recovery', () => {
       type: 'compaction_end', reason: 'threshold', aborted: false, willRetry: true,
       result: { summary: 'private conversation summary' },
     });
+    await Promise.resolve();
 
     expect(onCompaction).toHaveBeenCalledTimes(2);
     expect(onCompaction).toHaveBeenNthCalledWith(1, 's1', { phase: 'start', reason: 'threshold' });

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2087,13 +2087,15 @@ describe('RelayClient pending-question digest', () => {
     return { adapter, sm, client, ws, askQ, askP, answerQ, digest, preview };
   }
 
-  it('restores compacting from session_list state without replaying runtime events', () => {
+  it('restores compaction as runtime maintenance without overriding session state', () => {
     const { adapter, ws, digest } = buildClient();
     (adapter.onCompaction as (sid: string, e: Record<string, unknown>) => void)('sess_1', {
       phase: 'start', reason: 'threshold',
     });
 
-    expect(digest()?.state).toBe('compacting');
+    const current = digest();
+    expect(current?.state).toBe('active');
+    expect(current?.runtimeStatus).toEqual({ status: 'compacting', reason: 'threshold' });
     expect(decodePulseSends(ws.sent).some((message) => message.type === 'compacting')).toBe(false);
   });
 
@@ -2169,6 +2171,26 @@ describe('RelayClient pending-question digest', () => {
     expect(preview()?.type).toBe('permission');
     (adapter.onIdle as (sid: string) => void)('sess_1');
     expect(preview()?.type).not.toBe('permission');
+  });
+
+  it('queues a fresh normal turn behind idle threshold maintenance without blocking input', async () => {
+    const { adapter, ws, sm } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 'sess_1', state: 'idle' });
+    (adapter.onCompaction as (sid: string, e: Record<string, unknown>) => void)('sess_1', {
+      phase: 'start', reason: 'threshold',
+    });
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 599,
+      timestamp: new Date().toISOString(), payload: { text: 'new work during maintenance' },
+    })));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    expect(adapter.sendMessage).toHaveBeenCalledWith(
+      'sess_1', 'new work during maintenance', undefined, { delivery: 'follow_up' },
+    );
+    expect(smMock.markActive).toHaveBeenCalledWith('sess_1');
   });
 
   it('serializes distinct composer prompts until the preceding turn idles', async () => {

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -123,8 +123,10 @@ export interface QuestionAnswer {
 }
 
 export interface SendMessageOptions {
-  /** Normal prompt starts a turn; steer interjects into the active turn. */
-  delivery?: 'prompt' | 'steer';
+  /** Normal prompt starts a turn; steer interjects into the active turn;
+   *  follow_up queues a new turn behind runtime maintenance such as threshold
+   *  compaction without aborting that maintenance. */
+  delivery?: 'prompt' | 'steer' | 'follow_up';
 }
 
 export type QuestionResponseResult = 'accepted' | 'not_found' | 'session_gone';

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -842,6 +842,20 @@ export class PiAdapter extends AgentAdapter {
     return value === 'manual' || value === 'threshold' || value === 'overflow' ? value : undefined;
   }
 
+  private resetTurnTracking(s: PiSession): void {
+    s.narrationSegments = 0;
+    s.toolSinceLastNarration = false;
+    s.lastNarration = '';
+    s.lastStopReason = undefined;
+    s.pendingNarration = '';
+    s.aborting = false;
+    s.finalizing = false;
+    s.finalizeResolved = false;
+    s.finalizeNarration = '';
+    s.finalizeStreamId = undefined;
+    s.finalizeStreamLen = 0;
+  }
+
   /** Wait for the ORIGINAL prompt's preflight ACK without ever resending it.
    *  After the normal 30s grace, bounded get_state probes distinguish healthy
    *  compaction/streaming from a dead RPC channel or a genuinely idle stall. */
@@ -1416,19 +1430,19 @@ export class PiAdapter extends AgentAdapter {
       return;
     }
 
+    if (options?.delivery === 'follow_up') {
+      // The previous conversational turn is already idle while Pi's native
+      // threshold/manual maintenance is still inside the same agent lifecycle.
+      // Queue this canonical new turn with Pi's official follow-up behavior: it
+      // ACKs immediately, survives compaction, and starts after maintenance.
+      this.resetTurnTracking(s);
+      await s.proc.request('prompt', { ...promptPayload, streamingBehavior: 'followUp' }, { timeoutMs: null });
+      return;
+    }
+
     // A normal prompt opens a fresh logical turn: reset the finalize/skip
     // tracking so the skip-finalize rule and finalize round apply per user prompt.
-    s.narrationSegments = 0;
-    s.toolSinceLastNarration = false;
-    s.lastNarration = '';
-    s.lastStopReason = undefined;
-    s.pendingNarration = '';
-    s.aborting = false;
-    s.finalizing = false;
-    s.finalizeResolved = false;
-    s.finalizeNarration = '';
-    s.finalizeStreamId = undefined;
-    s.finalizeStreamLen = 0;
+    this.resetTurnTracking(s);
     // Submit exactly once. Pi only ACKs after prompt preflight, which may spend
     // minutes compacting even though the frame was delivered successfully. The
     // state-aware watchdog preserves the original request and never translates a

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -247,9 +247,9 @@ export class RelayClient {
     }
     this.resolveTurnIdle(sessionId);
     this.sessionManager.markIdle(sessionId);
-    // Idle ends the turn: any in-flight compaction is over. Clear before idle
-    // so clients never show compacting once idle lands.
-    this.clearCompacting(sessionId);
+    // Compaction is an orthogonal maintenance axis. A successful turn may be
+    // idle while threshold/manual compaction continues; its own end event clears
+    // the runtime indicator. Overflow recovery never reaches this idle path.
     const usage = this.adapter.getSessionUsage(sessionId) ?? undefined;
     if (usage) this.sessionManager.setUsage(sessionId, usage);
     this.sendTurnIdle(sessionId, { usage, ...(terminalError && { reason: 'failed' as const }) });
@@ -313,28 +313,24 @@ export class RelayClient {
    *  `agent_message_delta` text deltas). */
   private card = new CardManager((msg) => this.send(msg as Partial<ProducerMessage>));
 
-  /** Sessions whose agent runtime is currently compacting context. This is the
-   *  single in-memory source of truth for the compacting session-state (a peer
-   *  of active/idle). It is NEVER written to meta.json - a tentacle restart
-   *  means the compacting process is gone, so no stale disk state survives.
-   *  {@link getSessionList} overlays it onto the digest `state`. */
-  private compactingSessions = new Set<string>();
+  /** Sessions whose agent runtime is currently compacting context. The reason
+   *  determines whether new user work may queue behind it: threshold/manual
+   *  compaction is maintenance; overflow compaction remains part of recovery. */
+  private compactingSessions = new Map<string, 'manual' | 'threshold' | 'overflow' | undefined>();
 
-  /** Enter/leave the compacting session-state. Broadcasts a transient
-   *  `compacting` message (peer of active/idle) so clients update the runtime
-   *  indicator without it ever touching the card action slot, TRACE, or spine. */
+  /** Enter/leave transient compaction maintenance. This no longer overwrites
+   *  the conversational session state: a completed turn may stay `idle` while
+   *  threshold compaction runs, keeping the composer available. */
   private setCompacting(sessionId: string, active: boolean, reason?: 'manual' | 'threshold' | 'overflow'): void {
     if (active) {
       if (!this.compactingSessions.has(sessionId)) {
-        this.compactingSessions.add(sessionId);
+        this.compactingSessions.set(sessionId, reason);
         this.send({ type: 'compacting', sessionId, payload: { phase: 'start', ...(reason && { reason }) } });
       }
-    } else {
-      if (this.compactingSessions.delete(sessionId)) {
-        const metaState = this.sessionManager.getMeta(sessionId)?.state;
-        const nextState = metaState === 'active' ? 'active' : 'idle';
-        this.send({ type: 'compacting', sessionId, payload: { phase: 'end', nextState } });
-      }
+    } else if (this.compactingSessions.delete(sessionId)) {
+      const metaState = this.sessionManager.getMeta(sessionId)?.state;
+      const nextState = metaState === 'active' ? 'active' : 'idle';
+      this.send({ type: 'compacting', sessionId, payload: { phase: 'end', nextState } });
     }
   }
 
@@ -1098,10 +1094,17 @@ export class RelayClient {
             try {
               await this.dispatchInput(sessionId, async () => {
                 await this.ensureSessionResumed(sessionId);
+                const compactionReason = this.compactingSessions.get(sessionId);
+                const queueBehindMaintenance = this.sessionManager.getMeta(sessionId)?.state === 'idle'
+                  && (compactionReason === 'threshold' || compactionReason === 'manual');
                 this.send({ type: 'active', sessionId, payload: {} });
-                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId });
+                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId, queueBehindMaintenance });
                 this.sessionManager.markActive(sessionId);
-                await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
+                if (queueBehindMaintenance) {
+                  await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'follow_up' });
+                } else {
+                  await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
+                }
                 traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-DONE', sessionId, clientId });
               });
               await idle;
@@ -2105,23 +2108,26 @@ export class RelayClient {
 
   /** Override each digest's `preview` with the live open question (if any) so a
    *  reloading arm can render the "pending" status - the question no longer
-   *  persists to the spine, so the file-based preview can't surface it. Sessions
-   *  without an open question keep their file-derived preview untouched.
+   *  persists to the spine, so the file-based preview can't surface it.
    *
-   *  Also overlays the in-memory compacting state onto `state`: a session whose
-   *  agent runtime is currently compacting reports `state: 'compacting'`
-   *  (a peer of active/idle) regardless of the disk meta, so a reconnecting
-   *  arm recovers the runtime indicator from the session list alone. */
+   *  Compaction is intentionally NOT overlaid onto `state`: conversation state
+   *  stays active/idle while the transient `compacting` envelope owns the
+   *  orthogonal maintenance indicator. */
   private enrichSessionList<
     T extends { id: string; state: import('@kraki/protocol').SessionState; preview?: import('@kraki/protocol').SessionPreviewDigest },
   >(sessions: T[]): T[] {
     return sessions.map((s) => {
-      const compacting = this.compactingSessions.has(s.id);
+      const compactingReason = this.compactingSessions.get(s.id);
       const attention = this.latestOpenAttention(s.id);
-      if (!compacting && attention === undefined) return s;
+      if (compactingReason === undefined && !this.compactingSessions.has(s.id) && attention === undefined) return s;
       return {
         ...s,
-        ...(compacting && { state: 'compacting' as const }),
+        ...(this.compactingSessions.has(s.id) && {
+          runtimeStatus: {
+            status: 'compacting' as const,
+            ...(compactingReason && { reason: compactingReason }),
+          },
+        }),
         ...(attention !== undefined && {
           preview: {
             type: attention.type,


### PR DESCRIPTION
## Summary

- split conversational liveness (`active` / `idle`) from transient compaction maintenance
- keep threshold/manual compaction visible without disabling an idle composer
- queue a fresh user turn through Pi's native `streamingBehavior: "followUp"` while maintenance finishes
- keep overflow/unknown compaction blocking, and retain compatibility with older tentacles that encode compaction in `session.state`
- restore the independent runtime status through session-list digests on Web and iOS

## Lifecycle

```text
conversation: active -> idle -> active (new queued turn)
maintenance:  none   -> compacting -> none
```

When a completed Pi turn enters threshold/manual compaction:

1. the existing turn settles normally and becomes durable/idle
2. compaction remains an independent runtime indicator
3. a new canonical `user_message` opens a new Run
4. Tentacle submits it with `delivery: follow_up`
5. Pi queues it natively and starts it after compaction

Overflow compaction remains part of the in-flight recovery path and continues to block/steer the current Run.

## Compatibility

- new clients accept both iOS runtime envelope names: `compact` and `compacting`
- Web/iOS restore new `runtimeStatus` digests
- Web/iOS still treat legacy `state: compacting` digests as blocking compaction
- `CompactingMessage.payload.nextState` remains on the wire for older clients

## Validation

- `env -u KRAKI_HOME pnpm validate`
- Tentacle: `866/866` tests
- Web: `427/427` tests
- Web production build
- protocol, crypto, and Tentacle builds
- iOS Simulator build:
  - `xcodebuild -project Kraki.xcodeproj -scheme Kraki -sdk iphonesimulator -configuration Debug ... build`
  - `BUILD SUCCEEDED`
- `git diff --check`

`swift test` alone cannot resolve the project-provided `Pulse` module in this repository; the supported Xcode project build resolves it and passes.

No daemon, production checkout, deployment, or live session was changed.
