### PR TITLE
test(crypto): check full PEM markers

### DIFF
--- a/packages/crypto/src/__tests__/crypto.test.ts
+++ b/packages/crypto/src/__tests__/crypto.test.ts
@@ -228,9 +228,10 @@ describe('@kraki/crypto', () => {
     it('exported key should be compact (no PEM headers)', () => {
       const kp = generateKeyPair();
       const exported = exportPublicKey(kp.publicKey);
-      expect(exported).not.toContain('BEGIN');
-      expect(exported).not.toContain('END');
+      expect(exported).not.toContain('-----BEGIN PUBLIC KEY-----');
+      expect(exported).not.toContain('-----END PUBLIC KEY-----');
       expect(exported).not.toContain('\n');
+      expect(Buffer.from(exported, 'base64').toString('base64')).toBe(exported);
     });
 
     it('should handle empty key string', () => {


### PR DESCRIPTION
## Summary

Fix a flaky crypto assertion that rejected any random Base64 key containing the ordinary substring `END`. A compact DER Base64 payload may legally contain those three characters.

The test now rejects only the full PEM header/footer, verifies there is no newline, and confirms canonical Base64 round-trip.

## Validation

- crypto suite passed 5 consecutive runs (180 tests)
- `git diff --check`

This failure appeared in main CI run 30804649479 after #222; all three daemon launch jobs passed.