### PR TITLE
chore(release): v0.31.14

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.13",
+  "version": "0.31.14",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release the non-blocking background compaction lifecycle from #222.

## Versions

- `@kraki/tentacle`: `0.31.13` → `0.31.14`
- `@kraki/protocol`: `0.21.0` → `0.21.1`
- Head, Crypto, and Web package versions unchanged

The protocol patch bump publishes the new public `SessionRuntimeStatusDigest` type; the wire change remains backward compatible.

## What ships

- conversation `active/idle` state is independent from compaction maintenance
- threshold/manual maintenance keeps an idle composer available
- new input is queued through Pi's native `streamingBehavior: "followUp"`
- overflow/unknown compaction remains blocking
- Web/iOS recover runtime maintenance from session-list digests
- new and legacy `state: compacting` clients/tentacles remain compatible

## Release gate

- source PR #222 merged; its four PR CI jobs passed
- post-merge main daemon jobs passed
- post-merge Validate exposed unrelated flaky crypto test #223
- #223 fixes the invalid random-Base64 `END` substring assertion and passed all four CI jobs before merge
- release worktree `env -u KRAKI_HOME pnpm validate` passed
- Web `427/427`, Tentacle `866/866`
- package builds passed
- packed Tentacle `0.31.14` resolves `@kraki/protocol` to `0.21.1`
- both npm versions are currently available
- `git diff --check`

## Post-merge

Tag `v0.31.14` after main CI passes. The tag triggers signed/notarized cross-platform assets, GitHub Release, npm provenance publication, and checksums.

No production Web deployment or local daemon upgrade is included.
