### PR TITLE
fix(unread): make Tentacle cursors authoritative

### DIFF
--- a/packages/arm/web/src/hooks/useStore.test.ts
+++ b/packages/arm/web/src/hooks/useStore.test.ts
@@ -118,6 +118,26 @@ describe('useStore', () => {
       expect(sessions.get('sess-2')).toEqual(mockSession2);
     });
 
+    it('setSessions projects Tentacle cursors and removes stale session badges', () => {
+      useStore.setState({ unreadCount: new Map([['stale', 1]]) });
+      useStore.getState().setSessions([
+        { ...mockSession, lastSeq: 10, readSeq: 9 },
+        { ...mockSession2, lastSeq: 7, readSeq: 7 },
+      ]);
+
+      expect(useStore.getState().unreadCount.get('sess-1')).toBe(1);
+      expect(useStore.getState().unreadCount.has('sess-2')).toBe(false);
+      expect(useStore.getState().unreadCount.has('stale')).toBe(false);
+    });
+
+    it('upsertSession accepts a lower authoritative readSeq', () => {
+      useStore.getState().upsertSession({ ...mockSession, lastSeq: 10, readSeq: 10 });
+      useStore.getState().upsertSession({ ...mockSession, lastSeq: 10, readSeq: 9 });
+
+      expect(useStore.getState().sessions.get('sess-1')?.readSeq).toBe(9);
+      expect(useStore.getState().unreadCount.get('sess-1')).toBe(1);
+    });
+
     it('upsertSession adds a new session', () => {
       useStore.getState().upsertSession(mockSession);
       expect(useStore.getState().sessions.size).toBe(1);

--- a/packages/arm/web/src/hooks/useStore.ts
+++ b/packages/arm/web/src/hooks/useStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import type { Store, ChatMessage, ConnectionStatus, PendingInputMessage, SessionCard } from '../types/store';
-import type { SessionSummary, DeviceSummary } from '@kraki/protocol';
+import type { Store, ChatMessage, ConnectionStatus, PendingInputMessage, SessionCard, WebSessionSummary } from '../types/store';
+import type { DeviceSummary } from '@kraki/protocol';
 import { loadStoredDevice, getUrlParams } from '../lib/transport';
 
 // --- Custom Map/Set JSON serialization ---
@@ -45,7 +45,7 @@ const initialState = {
   reconnectAttempts: 0,
   nextReconnectDelayMs: null,
   user: null,
-  sessions: new Map<string, SessionSummary>(),
+  sessions: new Map<string, WebSessionSummary>(),
   devices: new Map<string, DeviceSummary>(),
   messages: new Map<string, ChatMessage[]>(),
   cards: new Map<string, SessionCard>(),
@@ -86,13 +86,33 @@ export const useStore = create<Store>()(persist((set) => ({
     }),
 
   setSessions: (sessions) =>
-    set({ sessions: new Map(sessions.map((s) => [s.id, s])) }),
+    set((state) => {
+      const incomingIds = new Set(sessions.map((session) => session.id));
+      const unreadCount = new Map(
+        [...state.unreadCount].filter(([sessionId]) => incomingIds.has(sessionId)),
+      );
+      for (const session of sessions) {
+        if (session.lastSeq !== undefined && session.readSeq !== undefined) {
+          if (session.readSeq < session.lastSeq) unreadCount.set(session.id, 1);
+          else unreadCount.delete(session.id);
+        }
+      }
+      return {
+        sessions: new Map(sessions.map((session) => [session.id, session])),
+        unreadCount,
+      };
+    }),
 
   upsertSession: (session) =>
     set((state) => {
-      const next = new Map(state.sessions);
-      next.set(session.id, session);
-      return { sessions: next };
+      const sessions = new Map(state.sessions);
+      sessions.set(session.id, session);
+      const unreadCount = new Map(state.unreadCount);
+      if (session.lastSeq !== undefined && session.readSeq !== undefined) {
+        if (session.readSeq < session.lastSeq) unreadCount.set(session.id, 1);
+        else unreadCount.delete(session.id);
+      }
+      return { sessions, unreadCount };
     }),
 
   removeSession: (sessionId) => {

--- a/packages/arm/web/src/lib/message-router.ts
+++ b/packages/arm/web/src/lib/message-router.ts
@@ -7,6 +7,7 @@ import { messageProvider } from './message-provider';
 import { ingestChunk } from './attachments';
 import type { SessionPreview } from '../types/store';
 import { traceEvent } from './trace';
+import { allowAutoRead, suppressAutoRead } from './read-visibility';
 
 const logger = createLogger('msg-router');
 
@@ -14,12 +15,6 @@ const PREVIEW_MAX = 80;
 function truncPreview(s: string): string {
   return s.length > PREVIEW_MAX ? s.slice(0, PREVIEW_MAX) + '…' : s;
 }
-
-/**
- * Message types that can trigger an unread badge.
- * Used by the live message handler and the reconnect IDB scan.
- */
-export const UNREAD_CANDIDATE_TYPES = new Set(['error', 'idle']);
 
 const RETIRED_LIVE_TYPES = new Set([
   'agent_narration',
@@ -35,20 +30,16 @@ const RETIRED_LIVE_TYPES = new Set([
   'answer',
 ]);
 
-/** Set session preview and optionally increment unread. */
-function updatePreview(sid: string, preview: SessionPreview, notify: boolean): void {
-  const store = getStore();
-  const shouldIncrement = notify && (!isViewingSession(sid) || !document.hasFocus());
-  store.setSessionPreview(sid, preview, shouldIncrement);
+/** Preview is display data only. The unread dot is projected from Tentacle's
+ * authoritative lastSeq/readSeq cursors in session_list/session_read. */
+function updatePreview(sid: string, preview: SessionPreview, _notify: boolean): void {
+  getStore().setSessionPreview(sid, preview, false);
 }
 
-/** Drive only the unread badge for a notify-worthy event. The preview text line
- *  is owned by the session_list digest (the tentacle is the single authority);
- *  some events still need to light up the unread dot without touching preview. */
-function notifyUnread(sid: string, notify: boolean): void {
-  if (!notify) return;
-  if (isViewingSession(sid) && document.hasFocus()) return;
-  getStore().incrementUnread(sid);
+function isActivelyReading(sessionId: string): boolean {
+  return isViewingSession(sessionId)
+    && document.visibilityState === 'visible'
+    && document.hasFocus();
 }
 
 export interface RouterContext {
@@ -175,6 +166,8 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
         model: msg.payload.model,
         state: 'active',
         messageCount: 0,
+        lastSeq: msg.payload.lastSeq ?? 0,
+        readSeq: msg.payload.lastSeq ?? 0,
       });
       // Clear pending state — session is now real
       store.removePendingSession(sid);
@@ -235,10 +228,8 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
         store.removePendingSession(sid);
       }
       store.appendMessage(sid, msg);
-      // Preview text is owned by the session_list digest; a transient error is
-      // not a turn boundary and must not displace the stable preview. Only the
-      // unread badge is driven here.
-      notifyUnread(sid, !replaying);
+      // A transient error does not own unread state. If the turn ultimately
+      // fails, the Tentacle's terminal boundary + session_list creates it.
       break;
 
     case 'turn_status': {
@@ -290,13 +281,11 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
       const idlePayload = (msg as IdleMessage).payload;
       const idleUsage = idlePayload?.usage;
       if (idleUsage) store.setSessionUsage(sid, idleUsage);
-      const idleReason = idlePayload?.reason;
-      // Preview is owned by the session_list digest (tentacle broadcasts on
-      // turn-close so the post-turn agent outcome advances authoritatively).
-      // Only drive the unread badge for completed (non-aborted) turns.
-      if (idleReason !== 'aborted') notifyUnread(sid, !replaying);
-      if (!replaying && isViewingSession(sid) && document.hasFocus()) {
-        import('./ws-client').then(({ wsClient }) => wsClient.markRead(sid)).catch(() => {});
+      // Preview and unread state are reconciled by the closing session_list
+      // digest. Synthetic create/fork/import idles therefore never manufacture
+      // a local badge.
+      if (!replaying && isActivelyReading(sid)) {
+        import('./ws-client').then(({ wsClient }) => wsClient.markRead(sid, msg.seq, true)).catch(() => {});
       }
       break;
     }
@@ -374,20 +363,17 @@ export function handleDataMessage(msg: InnerMessage, ctx: RouterContext): void {
 
     case 'session_read': {
       const readSeq = (msg as SessionReadMessage).payload?.seq;
-      if (typeof readSeq === 'number' && !isViewingSession(sid)) {
-        // Only clear unread up to the broadcast seq — keep unread for messages beyond it
-        const msgs = store.messages.get(sid);
-        if (msgs) {
-          const maxLocalSeq = msgs.reduce((max, m) => {
-            const s = 'seq' in m ? (m as { seq?: number }).seq ?? 0 : 0;
-            return s > max ? s : max;
-          }, 0);
-          if (readSeq >= maxLocalSeq) {
-            store.clearUnread(sid);
-          }
-        } else {
-          store.clearUnread(sid);
-        }
+      const session = getStore().sessions.get(sid);
+      if (session && typeof readSeq === 'number') {
+        if (readSeq < (session.readSeq ?? 0)) suppressAutoRead(sid);
+        else if (readSeq > (session.readSeq ?? 0)) allowAutoRead(sid);
+        getStore().upsertSession({
+          ...session,
+          lastSeq: Math.max(session.lastSeq ?? 0, readSeq),
+          // Tentacle is authoritative in both directions. A lower value is a
+          // legitimate mark_unread result and must not be swallowed by max().
+          readSeq: Math.max(0, readSeq),
+        });
       }
       break;
     }

--- a/packages/arm/web/src/lib/read-visibility.test.ts
+++ b/packages/arm/web/src/lib/read-visibility.test.ts
@@ -1,0 +1,16 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { allowAutoRead, isAutoReadSuppressed, suppressAutoRead } from './read-visibility';
+
+const SESSION_ID = 'session-manual-unread';
+
+afterEach(() => allowAutoRead(SESSION_ID));
+
+describe('read visibility guard', () => {
+  it('holds manual unread until the view explicitly allows auto-read again', () => {
+    expect(isAutoReadSuppressed(SESSION_ID)).toBe(false);
+    suppressAutoRead(SESSION_ID);
+    expect(isAutoReadSuppressed(SESSION_ID)).toBe(true);
+    allowAutoRead(SESSION_ID);
+    expect(isAutoReadSuppressed(SESSION_ID)).toBe(false);
+  });
+});

--- a/packages/arm/web/src/lib/read-visibility.ts
+++ b/packages/arm/web/src/lib/read-visibility.ts
@@ -1,0 +1,20 @@
+/**
+ * Ephemeral UI guard for a manual "mark unread" on the currently open Chat.
+ *
+ * Tentacle remains the durable authority. This set is deliberately not stored
+ * in Zustand/IndexedDB: it only prevents focus/visibility hooks in the current
+ * mounted view from immediately undoing the user's manual action.
+ */
+const suppressedAutoReadSessions = new Set<string>();
+
+export function suppressAutoRead(sessionId: string): void {
+  suppressedAutoReadSessions.add(sessionId);
+}
+
+export function allowAutoRead(sessionId: string): void {
+  suppressedAutoReadSessions.delete(sessionId);
+}
+
+export function isAutoReadSuppressed(sessionId: string): boolean {
+  return suppressedAutoReadSessions.has(sessionId);
+}

--- a/packages/arm/web/src/lib/ws-client.test.ts
+++ b/packages/arm/web/src/lib/ws-client.test.ts
@@ -3,6 +3,7 @@ import { decodeFrame } from '@coinfra/pulse';
 import { KrakiWSClient, wsClient } from '../lib/ws-client';
 import { useStore } from '../hooks/useStore';
 import { messageProvider } from './message-provider';
+import { allowAutoRead, isAutoReadSuppressed } from './read-visibility';
 
 /** Recover the inner producer message from a captured wire send. Reliable
  *  consumer messages now ride pulse: the arm emits a `unicast` envelope whose
@@ -99,6 +100,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  allowAutoRead('sess-1');
   globalThis.WebSocket = OriginalWebSocket;
   messageProvider.setSend((msg) => wsClient.sendEncrypted(msg));
   vi.restoreAllMocks();
@@ -317,6 +319,73 @@ describe('KrakiWSClient', () => {
       expect(useStore.getState().cards.get('sess-1')?.text).toBe('Reset');
     });
 
+    it('accepts authoritative read cursor rollbacks and later advances', async () => {
+      const client = new KrakiWSClient('ws://localhost:9999');
+      await connectAndAuth(client);
+      useStore.getState().upsertSession({
+        id: 'sess-1', deviceId: 'dev-1', deviceName: 'MacBook',
+        agent: 'pi', state: 'idle', messageCount: 10, lastSeq: 10, readSeq: 10,
+      });
+
+      receiveInner({
+        type: 'session_read', deviceId: 'dev-1', seq: 20, timestamp: '',
+        sessionId: 'sess-1', payload: { seq: 9 },
+      });
+      expect(useStore.getState().sessions.get('sess-1')?.readSeq).toBe(9);
+      expect(useStore.getState().unreadCount.get('sess-1')).toBe(1);
+      expect(isAutoReadSuppressed('sess-1')).toBe(true);
+
+      receiveInner({
+        type: 'session_read', deviceId: 'dev-1', seq: 21, timestamp: '',
+        sessionId: 'sess-1', payload: { seq: 10 },
+      });
+      expect(useStore.getState().sessions.get('sess-1')?.readSeq).toBe(10);
+      expect(useStore.getState().unreadCount.has('sess-1')).toBe(false);
+      expect(isAutoReadSuppressed('sess-1')).toBe(false);
+    });
+
+    it('uses the Tentacle processing order for read followed by unread', async () => {
+      const client = new KrakiWSClient('ws://localhost:9999');
+      await connectAndAuth(client);
+      useStore.getState().upsertSession({
+        id: 'sess-1', deviceId: 'dev-1', deviceName: 'MacBook',
+        agent: 'pi', state: 'idle', messageCount: 10, lastSeq: 10, readSeq: 9,
+      });
+
+      receiveInner({
+        type: 'session_read', deviceId: 'dev-1', seq: 30, timestamp: '',
+        sessionId: 'sess-1', payload: { seq: 10 },
+      });
+      receiveInner({
+        type: 'session_read', deviceId: 'dev-1', seq: 31, timestamp: '',
+        sessionId: 'sess-1', payload: { seq: 9 },
+      });
+
+      expect(useStore.getState().sessions.get('sess-1')?.readSeq).toBe(9);
+      expect(useStore.getState().unreadCount.get('sess-1')).toBe(1);
+    });
+
+    it('restores an offline manual-unread result from session_list', async () => {
+      const client = new KrakiWSClient('ws://localhost:9999');
+      await connectAndAuth(client);
+      useStore.getState().upsertSession({
+        id: 'sess-1', deviceId: 'dev-1', deviceName: 'MacBook',
+        agent: 'pi', state: 'idle', messageCount: 10, lastSeq: 10, readSeq: 10,
+      });
+
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-1', seq: 40, timestamp: '',
+        payload: { sessions: [{
+          id: 'sess-1', agent: 'pi', state: 'idle', mode: 'discuss',
+          lastSeq: 10, readSeq: 9, messageCount: 10, createdAt: '',
+        }] },
+      });
+
+      expect(useStore.getState().sessions.get('sess-1')?.readSeq).toBe(9);
+      expect(useStore.getState().unreadCount.get('sess-1')).toBe(1);
+      expect(isAutoReadSuppressed('sess-1')).toBe(true);
+    });
+
     it('transitions the session to idle on an idle message', async () => {
       const client = new KrakiWSClient('ws://localhost:9999');
       await connectAndAuth(client);
@@ -379,7 +448,8 @@ describe('KrakiWSClient', () => {
       expect(useStore.getState().unreadCount.get('sess-1')).toBeUndefined();
       expect(useStore.getState().messages.get('sess-1')?.length).toBe(2);
 
-      // New live message after batch should increment unread
+      // A live turn close updates Chat immediately but unread remains owned by
+      // the authoritative session_list digest that follows it.
       receiveInner({
         type: 'agent_message',
         deviceId: 'dev-1',
@@ -396,7 +466,15 @@ describe('KrakiWSClient', () => {
         sessionId: 'sess-1',
         payload: {},
       });
+      expect(useStore.getState().unreadCount.has('sess-1')).toBe(false);
 
+      receiveInner({
+        type: 'session_list', deviceId: 'dev-1', seq: 5, timestamp: '',
+        payload: { sessions: [{
+          id: 'sess-1', agent: 'copilot', state: 'idle', mode: 'execute',
+          lastSeq: 4, readSeq: 2, messageCount: 4, createdAt: '',
+        }] },
+      });
       expect(useStore.getState().unreadCount.get('sess-1')).toBe(1);
     });
 
@@ -584,6 +662,25 @@ describe('KrakiWSClient', () => {
       expect(sent.type).toBe('answer');
       expect(sent.payload.questionId).toBe('q-1');
       expect(sent.payload.answer).toBe('A');
+    });
+
+    it('manual unread suppresses automatic read until an explicit read', async () => {
+      const client = await setupClient();
+      useStore.getState().upsertSession({
+        id: 'sess-1', deviceId: 'dev-1', deviceName: 'MacBook',
+        agent: 'pi', state: 'idle', messageCount: 10, lastSeq: 10, readSeq: 10,
+      });
+
+      client.markUnread('sess-1');
+      expect((await waitForDecodedSend(lastWsInstance)).type).toBe('mark_unread');
+      lastWsInstance.sentMessages = [];
+
+      client.markRead('sess-1', undefined, true);
+      await Promise.resolve();
+      expect(lastWsInstance.sentMessages).toHaveLength(0);
+
+      client.markRead('sess-1');
+      expect((await waitForDecodedSend(lastWsInstance)).type).toBe('mark_read');
     });
 
     it('killSession sends correct message', async () => {

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -5,10 +5,11 @@ import { KrakiTransport, type MessageHandler } from './transport';
 import { EncryptionHandler } from './encryption';
 import { markSessionRead } from './replay';
 import { sendAuth, handleAuthChallenge, processAuthOk, processAuthError, applyPreferences } from './auth';
-import { handleDataMessage, UNREAD_CANDIDATE_TYPES } from './message-router';
+import { handleDataMessage } from './message-router';
 import { getStore, setStoreState } from './store-adapter';
 import { messageProvider } from './message-provider';
 import { CommandState } from './commands';
+import { allowAutoRead, isAutoReadSuppressed, suppressAutoRead } from './read-visibility';
 import * as commands from './commands';
 import { createLogger, setLogBroadcast } from './logger';
 import { ArmPulse } from './arm-pulse';
@@ -430,19 +431,20 @@ export class KrakiWSClient {
     return commands.importSession(localSessionId, targetDeviceId, (msg) => this.sendEncrypted(msg), this.cmdState, meta);
   }
 
-  markRead(sessionId: string, seq?: number): void {
-    markSessionRead(sessionId);
-    // Send to tentacle so it persists readSeq and broadcasts to other arms.
-    // When no explicit seq is supplied, fall back to the authoritative
-    // `lastSeq` carried on the session digest from session_list. The
-    // previous fallback walked `store.messages.get(sessionId)` and picked
-    // the last element's `seq`, which could be polluted by transient
-    // entries (envelope-level seq, replay residue, etc.) and produced
-    // wildly inflated values (~35 % of sessions on disk ended up with
-    // readSeq > lastSeq, one sample 57× overshoot).
-    const session = getStore().sessions.get(sessionId);
+  markRead(sessionId: string, seq?: number, automatic = false): void {
+    if (automatic && isAutoReadSuppressed(sessionId)) return;
+    if (!automatic) allowAutoRead(sessionId);
+    const store = getStore();
+    const session = store.sessions.get(sessionId);
     const resolvedSeq = seq ?? session?.lastSeq ?? 0;
-    if (resolvedSeq > 0) {
+    if (session && resolvedSeq > 0) {
+      const authoritativeHead = Math.max(session.lastSeq ?? 0, resolvedSeq);
+      store.upsertSession({
+        ...session,
+        lastSeq: authoritativeHead,
+        readSeq: Math.min(resolvedSeq, authoritativeHead),
+      });
+      markSessionRead(sessionId);
       this.sendEncrypted({
         type: 'mark_read',
         sessionId,
@@ -452,7 +454,16 @@ export class KrakiWSClient {
   }
 
   markUnread(sessionId: string): void {
-    getStore().incrementUnread(sessionId);
+    suppressAutoRead(sessionId);
+    const store = getStore();
+    const session = store.sessions.get(sessionId);
+    const lastSeq = session?.lastSeq ?? 0;
+    if (session && lastSeq > 0) {
+      store.upsertSession({
+        ...session,
+        readSeq: Math.min(session.readSeq ?? lastSeq, Math.max(0, lastSeq - 1)),
+      });
+    }
     this.sendEncrypted({
       type: 'mark_unread',
       sessionId,
@@ -498,7 +509,13 @@ export class KrakiWSClient {
     const pinnedFromTentacle = new Set<string>();
     for (const ts of tentacleSessions) {
       const currentStore = getStore();
+      const previousSession = currentStore.sessions.get(ts.id);
       const device = currentStore.devices.get(tentacleDeviceId);
+      if (previousSession && ts.readSeq < (previousSession.readSeq ?? 0)) {
+        suppressAutoRead(ts.id);
+      } else if (previousSession && ts.readSeq > (previousSession.readSeq ?? 0)) {
+        allowAutoRead(ts.id);
+      }
       store.upsertSession({
         id: ts.id,
         deviceId: tentacleDeviceId,
@@ -509,6 +526,8 @@ export class KrakiWSClient {
         autoTitle: ts.autoTitle,
         state: ts.state as SessionState,
         messageCount: ts.messageCount,
+        lastSeq: ts.lastSeq,
+        readSeq: ts.readSeq,
       });
 
       if (ts.mode) {
@@ -540,16 +559,8 @@ export class KrakiWSClient {
         pinnedFromTentacle.add(ts.id);
       }
 
-      // Reconstruct unread badge from readSeq vs lastSeq
-      // Only show badge if there are unread-worthy messages (not just transient state changes)
-      if (ts.lastSeq > (ts.readSeq ?? 0)) {
-        if (store.unreadCount.get(ts.id) === undefined) {
-          // Check IDB for unread-worthy messages between readSeq and lastSeq
-          this.checkUnreadFromDb(ts.id, ts.readSeq ?? 0);
-        }
-      } else {
-        store.clearUnread(ts.id);
-      }
+      // Tentacle's two cursors are the durable unread authority. Local history
+      // loading must never guess and overwrite this state.
 
       // Store tentacle info for later message loading
       messageProvider.setTentacleInfo(ts.id, ts.lastSeq, tentacleDeviceId);
@@ -692,46 +703,6 @@ export class KrakiWSClient {
   /** Clear all in-progress tracking (used on disconnect/close). */
   private clearReplayTracking(): void {
     messageProvider.clear();
-  }
-
-  /**
-   * Check IndexedDB for unread-worthy messages after readSeq.
-   * Only increments unread if there are messages that would produce visible chat bubbles.
-   */
-  private async checkUnreadFromDb(sessionId: string, readSeq: number): Promise<void> {
-    try {
-      const db = await import('./message-db');
-      const allMsgs = await db.getMessages(sessionId);
-      const afterRead = allMsgs.filter(m => {
-        const seq = 'seq' in m ? (m as { seq?: number }).seq : undefined;
-        return typeof seq === 'number' && seq > readSeq;
-      });
-
-      let hasUnreadContent = false;
-      for (let i = 0; i < afterRead.length; i++) {
-        const m = afterRead[i];
-        if (m.type === 'error' || m.type === 'permission' || m.type === 'question') {
-          hasUnreadContent = true;
-          break;
-        }
-        // idle is unread-worthy only if preceded by an agent_message (non-aborted turn)
-        if (m.type === 'idle') {
-          for (let j = i - 1; j >= 0; j--) {
-            const prev = afterRead[j];
-            if (prev.type === 'agent_message') { hasUnreadContent = true; break; }
-            if (prev.type === 'user_message' || prev.type === 'idle') break;
-          }
-          if (hasUnreadContent) break;
-        }
-      }
-
-      if (hasUnreadContent) {
-        getStore().incrementUnread(sessionId);
-      }
-    } catch {
-      // IDB unavailable — fall back to showing unread (better safe than silent)
-      getStore().incrementUnread(sessionId);
-    }
   }
 
   /**

--- a/packages/arm/web/src/pages/SessionPage.tsx
+++ b/packages/arm/web/src/pages/SessionPage.tsx
@@ -10,6 +10,7 @@ import { messageProvider } from '../lib/message-provider';
 import { HtmlArtifactPanel } from '../components/chat/HtmlArtifactPanel';
 import type { ContentRef } from '@kraki/protocol';
 import { setDesiredSessionSubscription } from '../lib/session-subscription-lifecycle';
+import { allowAutoRead, isAutoReadSuppressed } from '../lib/read-visibility';
 
 export function SessionPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -77,20 +78,30 @@ export function SessionPage() {
     messageProvider.ensureLoaded(sessionId);
   }, [sessionId]);
 
-  // Clear unread when viewing session + notify server
+  // Mark read only while this detail is genuinely visible and focused.
   useEffect(() => {
     if (!sessionId) return;
+    allowAutoRead(sessionId);
 
     const doMarkRead = () => {
-      if (document.hasFocus()) {
+      if (
+        !isAutoReadSuppressed(sessionId)
+        && document.visibilityState === 'visible'
+        && document.hasFocus()
+      ) {
         clearUnread(sessionId);
-        import('../lib/ws-client').then(({ wsClient }) => wsClient.markRead(sessionId));
+        import('../lib/ws-client').then(({ wsClient }) => wsClient.markRead(sessionId, undefined, true));
       }
     };
 
     doMarkRead();
     window.addEventListener('focus', doMarkRead);
-    return () => window.removeEventListener('focus', doMarkRead);
+    document.addEventListener('visibilitychange', doMarkRead);
+    return () => {
+      allowAutoRead(sessionId);
+      window.removeEventListener('focus', doMarkRead);
+      document.removeEventListener('visibilitychange', doMarkRead);
+    };
   }, [sessionId, clearUnread]);
 
   if (!session && isPending) {

--- a/packages/arm/web/src/types/store.ts
+++ b/packages/arm/web/src/types/store.ts
@@ -56,6 +56,12 @@ export interface SessionPreview {
   timestamp: string;
 }
 
+export interface WebSessionSummary extends SessionSummary {
+  /** Tentacle-owned Spine head/read cursors carried by session_list. */
+  lastSeq?: number;
+  readSeq?: number;
+}
+
 // --- Store ---
 
 export interface AppState {
@@ -69,7 +75,7 @@ export interface AppState {
   user: { id: string; login: string; provider: string; email?: string; preferences?: Record<string, unknown> } | null;
 
   // Data
-  sessions: Map<string, SessionSummary>;
+  sessions: Map<string, WebSessionSummary>;
   devices: Map<string, DeviceSummary>;
   messages: Map<string, ChatMessage[]>;
   cards: Map<string, SessionCard>;
@@ -135,8 +141,8 @@ export interface AppActions {
   setReconnectState: (attempts: number, nextDelayMs: number | null) => void;
 
   // Data
-  setSessions: (sessions: SessionSummary[]) => void;
-  upsertSession: (session: SessionSummary) => void;
+  setSessions: (sessions: WebSessionSummary[]) => void;
+  upsertSession: (session: WebSessionSummary) => void;
   removeSession: (sessionId: string) => void;
   setDevices: (devices: DeviceSummary[]) => void;
   upsertDevice: (device: DeviceSummary) => void;

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.14",
+  "version": "0.31.15",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -178,7 +178,7 @@ function createSessionManager(): Record<string, unknown> {
     setAutoTitle: vi.fn(),
     setMode: vi.fn(),
     deleteSession: vi.fn(),
-    markRead: vi.fn(),
+    markRead: vi.fn((_sessionId: string, seq: number) => seq),
     markUnread: vi.fn(() => 41),
     getSessionList: vi.fn(() => []),
     getPendingHumanAction: vi.fn(() => null),
@@ -625,7 +625,7 @@ describe('RelayClient set_session_model', () => {
       setMode: vi.fn(),
       markIdle: vi.fn(),
       markActive: vi.fn(),
-      markRead: vi.fn(),
+      markRead: vi.fn((_sessionId: string, seq: number) => seq),
       markUnread: vi.fn(() => 41),
       deleteSession: vi.fn(),
       removeLinkByKrakiId: vi.fn(),
@@ -1029,6 +1029,27 @@ describe('RelayClient set_session_model', () => {
     expect(readMsg).toBeDefined();
     expect(readMsg.payload.seq).toBe(42);
     expect(readMsg.sessionId).toBe('sess_1');
+  });
+
+  it('broadcasts the persisted session_read cursor, not the client input', () => {
+    const { sm } = buildConnectedClient();
+    const ws = sockets[0];
+    ws.sent.length = 0;
+    (sm.markRead as ReturnType<typeof vi.fn>).mockReturnValue(40);
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'mark_read',
+      sessionId: 'sess_1',
+      deviceId: 'dev_1',
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      payload: { seq: 999_999 },
+    })));
+
+    const sent = decodePulseSends(ws.sent);
+    const readMsg = sent.find(m => m.type === 'session_read');
+    expect(sm.markRead).toHaveBeenCalledWith('sess_1', 999_999);
+    expect(readMsg?.payload.seq).toBe(40);
   });
 
   it('rolls readSeq back and broadcasts session_read on mark_unread', () => {
@@ -2471,6 +2492,7 @@ describe('RelayClient pending-question digest', () => {
     expect(status.payload).toMatchObject({
       action: { type: 'user_abort' },
     });
+    expect(statusCall![3]).toBe(false);
     const cancelledQuestion = (sm.appendTrace as ReturnType<typeof vi.fn>).mock.calls
       .map((call) => JSON.parse(call[2]) as { type: string; payload: Record<string, unknown> })
       .find((entry) => entry.type === 'question' && entry.payload.id === 'q1' && entry.payload.cancelled === true);
@@ -2491,6 +2513,7 @@ describe('RelayClient pending-question digest', () => {
     const idleCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.find((call) => call[1] === 'idle');
     expect(idleCall).toBeDefined();
     expect(JSON.parse(idleCall![2]).payload).toEqual({ reason: 'aborted', turnArtifacts: [artifact] });
+    expect(idleCall![3]).toBe(false);
     expect(sm.readCurrentTurnArtifacts).toHaveBeenCalledWith('sess_1');
     expect(adapter.abortSession).toHaveBeenCalledWith('sess_1');
   });
@@ -2512,6 +2535,7 @@ describe('RelayClient pending-question digest', () => {
     expect(status.payload).toMatchObject({
       action: { type: 'failed', payload: { message: '524 status code (no body)', source: 'backend' } },
     });
+    expect(statusCall![3]).toBe(true);
     expect(status.payload.steps).toBe(2);
     const tracedError = (sm.appendTrace as ReturnType<typeof vi.fn>).mock.calls
       .map((call) => JSON.parse(call[2]) as { type: string; payload: Record<string, unknown> })
@@ -2524,6 +2548,7 @@ describe('RelayClient pending-question digest', () => {
     expect(interruptedTool).toBeDefined();
     const idleCall = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls.find((call) => call[1] === 'idle');
     expect(JSON.parse(idleCall![2]).payload).toEqual({ reason: 'failed', turnArtifacts: [artifact] });
+    expect(idleCall![3]).toBe(true);
   });
 
   it('dispatches push through @head when every consumer is offline', () => {

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -1140,12 +1140,41 @@ describe('SessionManager', () => {
       expect(meta.readSeq).toBe(2);
     });
 
-    it('still advances readSeq when seq is within range', () => {
+    it('keeps ordinary Spine entries read while the session is fully read', () => {
       const { sessionId } = sm.createSession('copilot');
       sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
       sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
       sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
-      sm.markRead(sessionId, 2);
+      const meta = sm.getMeta(sessionId)!;
+      expect(meta.lastSeq).toBe(3);
+      expect(meta.readSeq).toBe(3);
+    });
+
+    it('creates one unread gap only at an attention boundary', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ payload: {} }), true);
+      const meta = sm.getMeta(sessionId)!;
+      expect(meta.lastSeq).toBe(3);
+      expect(meta.readSeq).toBe(2);
+    });
+
+    it('does not let later ordinary entries clear an existing unread gap', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ payload: {} }), true);
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      const meta = sm.getMeta(sessionId)!;
+      expect(meta.lastSeq).toBe(3);
+      expect(meta.readSeq).toBe(1);
+    });
+
+    it('still advances readSeq when seq is within an unread range', () => {
+      const { sessionId } = sm.createSession('copilot');
+      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ payload: {} }), true);
       expect(sm.getMeta(sessionId)!.readSeq).toBe(2);
       sm.markRead(sessionId, 3);
       expect(sm.getMeta(sessionId)!.readSeq).toBe(3);
@@ -1174,11 +1203,11 @@ describe('SessionManager', () => {
       const { sessionId } = sm.createSession('copilot');
       sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
       sm.appendMessage(sessionId, 'agent_message', JSON.stringify({ payload: {} }));
-      sm.appendMessage(sessionId, 'user_message', JSON.stringify({ payload: {} }));
-      sm.markRead(sessionId, 1);
-      expect(sm.markUnread(sessionId)).toBe(1);
-      expect(sm.markUnread(sessionId)).toBe(1);
-      expect(sm.getMeta(sessionId)!.readSeq).toBe(1);
+      sm.appendMessage(sessionId, 'idle', JSON.stringify({ payload: {} }), true);
+      expect(sm.getMeta(sessionId)!.readSeq).toBe(2);
+      expect(sm.markUnread(sessionId)).toBe(2);
+      expect(sm.markUnread(sessionId)).toBe(2);
+      expect(sm.getMeta(sessionId)!.readSeq).toBe(2);
     });
   });
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -143,6 +143,13 @@ export class RelayClient {
     'session_ended',
     'idle',
   ]);
+  /** Persisted boundaries that preserve/create a lastSeq > readSeq gap. Idle is
+   *  contextual: only sendTurnIdle marks it, while create/fork/import idles do
+   *  not manufacture unread state. */
+  private static readonly UNREAD_BOUNDARY_TYPES = new Set([
+    'system_message',
+    'interrupted_turn',
+  ]);
   /** Tool/narration steps of the in-progress turn. No longer broadcast live —
    *  the tentacle folds them into the server-owned status card (see
    *  {@link CardManager}) and mirrors the raw step to `trace.jsonl` for the
@@ -277,7 +284,7 @@ export class RelayClient {
         ...payload,
         ...(turnArtifacts.length > 0 && { turnArtifacts }),
       },
-    });
+    }, payload.reason !== 'aborted');
   }
 
   private dispatchInput(sessionId: string, task: () => Promise<void>): Promise<void> {
@@ -629,7 +636,7 @@ export class RelayClient {
       type: 'turn_status',
       sessionId,
       payload: { draft: snapshot.draft, action, finishedAt, steps },
-    });
+    }, action.type === 'failed');
     this.clearOpenQuestions(sessionId);
     this.card.clear(sessionId);
   }
@@ -1230,14 +1237,17 @@ export class RelayClient {
           this.adapter.killSession(sessionId)
             .catch((err) => logger.error({ err, sessionId }, 'killSession on delete failed'));
           break;
-        case 'mark_read':
-          this.sessionManager.markRead(sessionId, msg.payload.seq);
-          this.send({
-            type: 'session_read',
-            sessionId,
-            payload: { seq: msg.payload.seq },
-          });
+        case 'mark_read': {
+          const readSeq = this.sessionManager.markRead(sessionId, msg.payload.seq);
+          if (readSeq !== null) {
+            this.send({
+              type: 'session_read',
+              sessionId,
+              payload: { seq: readSeq },
+            });
+          }
           break;
+        }
         case 'mark_unread': {
           const rolledBack = this.sessionManager.markUnread(sessionId);
           if (rolledBack !== null) {
@@ -1521,7 +1531,7 @@ export class RelayClient {
       });
 
       // Batch-write all backfilled messages (single write instead of N appends)
-      const lastSeq = this.sessionManager.appendMessagesBatch(krakiSessionId, backfilledMessages);
+      const lastSeq = this.sessionManager.appendMessagesBatch(krakiSessionId, backfilledMessages, true);
 
       // Write link table entry
       this.sessionManager.addLink({
@@ -2602,7 +2612,7 @@ export class RelayClient {
   // TODO: Make send() accept a discriminated union of ProducerMessage types
   // instead of Partial<ProducerMessage> so TypeScript enforces correct payload
   // shape per message type (e.g. user_message must have payload.content).
-  private send(msg: Partial<ProducerMessage>): void {
+  private send(msg: Partial<ProducerMessage>, createsUnread = false): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
 
     // Coalesce streaming card text deltas to amortize per-recipient RSA cost.
@@ -2680,7 +2690,12 @@ export class RelayClient {
       }
     }
     if (sessionId && RelayClient.PERSISTENT_TYPES.has(type)) {
-      enriched.seq = this.sessionManager.appendMessage(sessionId, type, JSON.stringify(enriched));
+      enriched.seq = this.sessionManager.appendMessage(
+        sessionId,
+        type,
+        JSON.stringify(enriched),
+        createsUnread || RelayClient.UNREAD_BOUNDARY_TYPES.has(type),
+      );
     } else if (sessionId && RelayClient.TRACE_TYPES.has(type)) {
       // Off-spine tool activity: mirror to trace.jsonl (keyed to the current
       // turn) and keep broadcasting transiently below. No per-session seq.

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -772,11 +772,13 @@ export class SessionManager {
    * Append a message to a session's log. Assigns the next per-session seq.
    * Returns the assigned seq number.
    */
-  appendMessage(sessionId: string, type: string, payload: string): number {
+  appendMessage(sessionId: string, type: string, payload: string, createsUnread = false): number {
     const meta = this.readMeta(sessionId);
     if (!meta) return 0;
 
-    const seq = (meta.lastSeq ?? 0) + 1;
+    const previousLastSeq = meta.lastSeq ?? 0;
+    const wasRead = (meta.readSeq ?? 0) >= previousLastSeq;
+    const seq = previousLastSeq + 1;
     const entry: LoggedMessage = { seq, type, payload, ts: new Date().toISOString() };
     const line = JSON.stringify(entry) + '\n';
     const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
@@ -802,6 +804,11 @@ export class SessionManager {
     }
 
     meta.lastSeq = seq;
+    // Preserve the existing two-cursor contract. Ordinary Spine bookkeeping
+    // must not create a badge when the session was fully read; a genuine
+    // attention boundary advances only lastSeq and intentionally leaves a gap.
+    // Once a gap exists, later ordinary entries must not clear it.
+    if (wasRead && !createsUnread) meta.readSeq = seq;
     meta.updatedAt = new Date().toISOString();
     this.writeMeta(sessionId, meta);
 
@@ -813,7 +820,11 @@ export class SessionManager {
    * Much faster than calling appendMessage() N times.
    * Returns the final seq number.
    */
-  appendMessagesBatch(sessionId: string, messages: Array<{ type: string; payload: string; ts?: string }>): number {
+  appendMessagesBatch(
+    sessionId: string,
+    messages: Array<{ type: string; payload: string; ts?: string }>,
+    markAppendedRead = false,
+  ): number {
     const meta = this.readMeta(sessionId);
     if (!meta || messages.length === 0) return meta?.lastSeq ?? 0;
 
@@ -848,6 +859,9 @@ export class SessionManager {
     }
 
     meta.lastSeq = seq;
+    // Imported/backfilled history is pre-existing content, not a new result.
+    // Its caller opts into marking the whole appended range read.
+    if (markAppendedRead) meta.readSeq = seq;
     meta.updatedAt = now;
     this.writeMeta(sessionId, meta);
 
@@ -1033,9 +1047,9 @@ export class SessionManager {
   /**
    * Update read state for a session (cross-device).
    */
-  markRead(sessionId: string, seq: number): void {
+  markRead(sessionId: string, seq: number): number | null {
     const meta = this.readMeta(sessionId);
-    if (!meta) return;
+    if (!meta) return null;
     // Clamp to lastSeq — readSeq must never exceed it. Pre-fix, arms
     // sometimes sent garbage seq values (web's stale `getLastSeq`
     // fallback), and a stuck readSeq > lastSeq broke unread badges
@@ -1046,6 +1060,7 @@ export class SessionManager {
       meta.updatedAt = new Date().toISOString();
       this.writeMeta(sessionId, meta);
     }
+    return meta.readSeq ?? 0;
   }
 
   /**


### PR DESCRIPTION
## Summary

- make Tentacle the sole durable Read/Unread authority using the existing `lastSeq` / `readSeq` protocol contract
- broadcast the cursor actually persisted by `mark_read`, including clamping and stale-input handling
- create unread gaps only at user-attention turn boundaries; keep create/fork/import/backfill and explicit user abort from manufacturing unread
- make Web project authoritative `session_list` / `session_read` cursors directly, including legitimate `mark_unread` rollback
- gate automatic Read on an actually visible, focused Chat
- keep manual Unread stable in the currently open Chat, including a rollback initiated by another Client, until an explicit Read or view re-entry
- remove IndexedDB/local-history inference from unread authority
- bump `@kraki/tentacle` to `0.31.15`

## Rules 6/7

- Manual Mark Unread is an authoritative rollback and is accepted in both live `session_read` and reconnect `session_list` paths.
- Tentacle serializes Read/Unread operations; Clients converge to the last operation processed by Tentacle.
- Web does not use monotonic `max(readSeq)` merging, so rollback is not swallowed.
- The currently open Web Chat uses only an ephemeral, non-persisted auto-read guard so a manual rollback is not immediately undone by focus/visibility hooks. Tentacle remains the durable authority.

## Compatibility / rollout

1. Merge this PR.
2. Publish Tentacle `0.31.15` (`v0.31.15`).
3. Confirm npm/GitHub Release success.
4. Deploy Web production from the merged commit.

The Web behavior relies on the corrected Tentacle cursor echo and attention-boundary semantics, so Tentacle should be available before production Web deployment.

## Scope

- Protocol source is unchanged; no `@kraki/protocol` release is required.
- Mac/iOS source is unchanged and excluded from this PR.

## Validation

- `pnpm lint` ✅
- `pnpm build` ✅
- Tentacle focused unread/read tests: 190/190 ✅
- Tentacle suite excluding pre-existing macOS config mock failure: 837/837 ✅
- Web focused unread/read tests: 146/146 ✅
- Web full suite: 34 files / 434 tests ✅
- `git diff --check` ✅

Local `pnpm validate` reaches the existing macOS-only `packages/tentacle/src/__tests__/config.test.ts` homedir mock isolation failure (`1 failed / 869 passed`). The same test fails in isolation before/independently of this change; no config files are modified here. CI runs on Ubuntu and remains the merge gate.
