### PR TITLE
feat(mac): add Sparkle auto-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -514,7 +514,16 @@ jobs:
           # the stapled ticket is part of the signed distribution artifact.
           tar -czf "$RUNNER_TEMP/kraki-mac-gui-universal.app.tar.gz" \
             -C "$RUNNER_TEMP/stage" Kraki.app
-          ls -lh "$RUNNER_TEMP/kraki-mac-gui-universal.app.tar.gz"
+          # Sparkle updates use a zip containing the notarized app bundle.
+          ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/Kraki.app.zip"
+          ls -lh "$RUNNER_TEMP/kraki-mac-gui-universal.app.tar.gz" "$RUNNER_TEMP/Kraki.app.zip"
+
+      - name: Upload Sparkle update archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-kraki-mac-sparkle-update
+          path: ${{ runner.temp }}/Kraki.app.zip
+          if-no-files-found: error
 
       - name: Verify packaged app
         run: |
@@ -610,6 +619,87 @@ jobs:
             --title "${{ needs.prepare.outputs.release_tag }}" \
             --generate-notes \
             release-assets/*
+
+  # ─── Publish Sparkle appcast ───────────────────────────
+
+  publish-mac-appcast:
+    name: Publish macOS Sparkle Appcast
+    needs:
+      - prepare
+      - publish
+    if: |
+      needs.prepare.result == 'success' &&
+      needs.publish.result == 'success' &&
+      startsWith(needs.prepare.outputs.release_tag, 'mac-v')
+    runs-on: macos-26
+    timeout-minutes: 15
+    concurrency:
+      group: mac-updates-appcast
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out appcast branch
+        uses: actions/checkout@v6
+        with:
+          ref: mac-updates
+          fetch-depth: 1
+
+      - name: Generate and publish signed appcast
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          test -n "$SPARKLE_ED25519_PRIVATE_KEY"
+
+          WORK_DIR="$RUNNER_TEMP/sparkle-appcast"
+          mkdir -p "$WORK_DIR/archives" "$WORK_DIR/sparkle"
+          cp appcast.xml "$WORK_DIR/archives/appcast.xml"
+
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'Kraki.app.zip' \
+            --dir "$WORK_DIR/archives"
+          test -f "$WORK_DIR/archives/Kraki.app.zip"
+
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json body --jq .body > "$WORK_DIR/archives/Kraki.app.md"
+
+          gh release download 2.9.5 --repo sparkle-project/Sparkle \
+            --pattern 'Sparkle-for-Swift-Package-Manager.zip' \
+            --dir "$RUNNER_TEMP"
+          unzip -q "$RUNNER_TEMP/Sparkle-for-Swift-Package-Manager.zip" -d "$WORK_DIR/sparkle"
+          GENERATE_APPCAST="$WORK_DIR/sparkle/bin/generate_appcast"
+
+          "$GENERATE_APPCAST" \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/" \
+            --full-release-notes-url "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}" \
+            --embed-release-notes \
+            --link "https://kraki.chat" \
+            --maximum-versions 3 \
+            "$WORK_DIR/archives" <<< "$SPARKLE_ED25519_PRIVATE_KEY"
+
+          test -f "$WORK_DIR/archives/appcast.xml"
+          grep -q 'sparkle:edSignature=' "$WORK_DIR/archives/appcast.xml"
+          grep -q 'Kraki.app.zip' "$WORK_DIR/archives/appcast.xml"
+          VERIFY_DIR="$RUNNER_TEMP/sparkle-update-verify"
+          mkdir -p "$VERIFY_DIR"
+          unzip -q "$WORK_DIR/archives/Kraki.app.zip" -d "$VERIFY_DIR"
+          UPDATE_BUILD_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' \
+            "$VERIFY_DIR/Kraki.app/Contents/Info.plist")
+          test -n "$UPDATE_BUILD_VERSION"
+          grep -q "sparkle:version>${UPDATE_BUILD_VERSION}<" "$WORK_DIR/archives/appcast.xml"
+          cp "$WORK_DIR/archives/appcast.xml" appcast.xml
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add appcast.xml
+          git diff --cached --quiet && exit 0
+          git commit -m "chore(mac): publish appcast for ${RELEASE_TAG}"
+          git push origin mac-updates
 
   # ─── Publish npm packages ──────────────────────────────
 

--- a/docs/mac-auto-updates.md
+++ b/docs/mac-auto-updates.md
@@ -1,0 +1,34 @@
+# macOS Auto Updates
+
+Kraki's signed production macOS GUI uses Sparkle 2 for in-app updates.
+
+## Bootstrap
+
+`0.2.0` predates Sparkle, so it cannot update itself. The first release containing this updater is `0.2.1` and must be installed once through the existing GitHub Release download. Every later `mac-v*` release can then be installed from inside the app.
+
+## User behavior
+
+- Production builds check the stable appcast after launch and then on Sparkle's 24-hour schedule.
+- `Kraki > Check for Updates...` starts an explicit check and shows Sparkle's standard update UI.
+- Updates are downloaded only after the user chooses to install them. The app is then relaunched by Sparkle.
+- Debug and `Kraki Dev.app` builds do not start Sparkle and cannot consume the production feed.
+
+The current feed is:
+
+`https://raw.githubusercontent.com/corelli18512/kraki/mac-updates/appcast.xml`
+
+The `mac-updates` branch contains only the generated appcast. Release archives remain GitHub Release assets.
+
+## Release flow
+
+A `mac-v*` tag runs the normal signed universal Mac archive pipeline. The archive is Developer ID signed, notarized, stapled, and uploaded as both the existing `.tar.gz` distribution asset and a `Kraki.app.zip` Sparkle update asset.
+
+After the GitHub Release is created, a macOS release job downloads `Kraki.app.zip`, runs Sparkle's `generate_appcast`, signs the feed with the Ed25519 key, and pushes the updated `appcast.xml` to `mac-updates`.
+
+The public Sparkle key is embedded in the production `Info.plist` as `SUPublicEDKey`. The matching private key is stored only in the GitHub Actions secret `SPARKLE_ED25519_PRIVATE_KEY`. It must never be committed, printed in logs, or placed in a release asset.
+
+## Safety boundaries
+
+Sparkle verifies the Ed25519 update signature before installation. Apple Developer ID signing, notarization, and Gatekeeper validation remain required for every archive. The GUI updater does not update the separate Tentacle daemon; daemon compatibility and upgrade sequencing remain a separate release concern.
+
+The appcast publisher is serialized with the `mac-updates-appcast` workflow concurrency group so two Mac tags cannot overwrite the feed concurrently.

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		26409CB796F338EFEF4A5DD1 /* PulseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45FF5DF9F0159EB23B50D72 /* PulseManager.swift */; };
 		26EB8AA427A1FAD44EA48D39 /* MacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE814884FDD9A0A46CCCCB69 /* MacApp.swift */; };
 		2A26932045F45889AB8373D9 /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA32D66EC88B6BEDF4675518 /* Commands.swift */; };
+		2B734C69AB104A3752E06468 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = CFD03BF89A6EEE14EFB497BF /* Sparkle */; };
 		2C0D85737E6D0F881D7CF1D0 /* ThemePlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBACFBCC6FD0563946CD080A /* ThemePlatform.swift */; };
 		2C1831EFAF427D90721F787F /* ToolChipHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F163484AD442AE1D67F4E8A7 /* ToolChipHeader.swift */; };
 		2CF1B0661EEF7C51B63C4A35 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33641605B16E960C6A553E38 /* ChatView.swift */; };
@@ -168,6 +169,7 @@
 		AED2EEE52613B3E5D0C8A542 /* MacAutomationDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5906FEF75EAE0DB111F19BD /* MacAutomationDriver.swift */; };
 		AF7953ABEEC72701AE83C546 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447FC84D6CEC57ADB1D93CA5 /* AppDelegate.swift */; };
 		B152A5034175B728B186EE0C /* TurnSpineProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52AA4B3D7FFBB698F94CE9 /* TurnSpineProjection.swift */; };
+		B28AD9034476281891032293 /* MacUpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6C23118C2C309C39C2A515 /* MacUpdateController.swift */; };
 		B2B5C216D8E6ECDE5FEDB42B /* MacAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6813B385E0446BBC371C8AD3 /* MacAppDelegate.swift */; };
 		B320E431D3B0720779F6C57B /* AgentAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427C7B2406F858D980E5DFBB /* AgentAvatar.swift */; };
 		B481E371DBAC6C56C5F80E1E /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805046685AE086D68B890D4 /* MainTabView.swift */; };
@@ -183,6 +185,7 @@
 		BD1B72D8C802E5E5C45BE8CD /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 61D4D890D63054395E2C6FEB /* GRDB */; };
 		BDBC81A8682AC662CD78C2F1 /* MainWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5469FDA14AA91327B6DF4400 /* MainWindowView.swift */; };
 		C00B760A90E96341077B088A /* BubbleCatalogTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF1D3D6CED61870261C4724 /* BubbleCatalogTestView.swift */; };
+		C0AD5E96F22955DB2473E341 /* MacUpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6C23118C2C309C39C2A515 /* MacUpdateController.swift */; };
 		C0C4528A1D3D1773A0BA9870 /* MessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6472A002F2CB9C07380792 /* MessagesTests.swift */; };
 		C359E909D1763DA606DD8A6E /* ToolActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AC5E0472D90CCB91CC0778 /* ToolActivityView.swift */; };
 		C3DD6301585CDBA8DB9E1FA4 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF2FADB7D9A46A1299A30E2 /* KeychainManager.swift */; };
@@ -385,6 +388,7 @@
 		CA4B2EA2532F558EBA4F7D16 /* MacChatBubbleContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacChatBubbleContent.swift; sourceTree = "<group>"; };
 		CB922ECF579C3FD8B1C99006 /* KrakiTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = KrakiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC62AF0A675E25283C546919 /* SessionCardPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCardPresentation.swift; sourceTree = "<group>"; };
+		CD6C23118C2C309C39C2A515 /* MacUpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacUpdateController.swift; sourceTree = "<group>"; };
 		D219A1249EBFCAA247533E07 /* TentacleCLIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TentacleCLIManager.swift; sourceTree = "<group>"; };
 		D4764BEF479FF106EBE37D34 /* BubbleActionSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleActionSlot.swift; sourceTree = "<group>"; };
 		D5B791C3F6BA99245733A941 /* PairingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingView.swift; sourceTree = "<group>"; };
@@ -422,6 +426,7 @@
 				028B61458E76278B13E26B2F /* Pulse in Frameworks */,
 				00D9A1D724388C88656314A9 /* Highlightr in Frameworks */,
 				EF182DDCEE43C64585164D92 /* VoiceInputCore in Frameworks */,
+				2B734C69AB104A3752E06468 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -460,6 +465,7 @@
 				B66C3EAC80F5625784F50037 /* MacChatPerfTestView.swift */,
 				63302839C21EFDE37CC56C13 /* MacMockData.swift */,
 				C024AE6690757FB0A6916CEE /* MacNotifications.swift */,
+				CD6C23118C2C309C39C2A515 /* MacUpdateController.swift */,
 				5469FDA14AA91327B6DF4400 /* MainWindowView.swift */,
 				735BA6282777D61A4335E5F5 /* MenuBarExtraView.swift */,
 				F499644AEF4467B28CDD1A6A /* PreferencesWindow.swift */,
@@ -876,6 +882,7 @@
 				7FF5AA6801C008E56910369C /* Pulse */,
 				58A77F08B0D342014F734926 /* Highlightr */,
 				C18741B12304BDBDCC5AF55E /* VoiceInputCore */,
+				CFD03BF89A6EEE14EFB497BF /* Sparkle */,
 			);
 			productName = KrakiMac;
 			productReference = 36547BB6B68E22C1BEB7D1CD /* KrakiMac.app */;
@@ -959,6 +966,7 @@
 			packageReferences = (
 				67485AEC5E20A50F92197C43 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
 				C1BACD62B59892C792C08AB1 /* XCRemoteSwiftPackageReference "Highlightr" */,
+				DADBF5538A6575068485F6DC /* XCRemoteSwiftPackageReference "Sparkle" */,
 				3F224EC43C74D3ECE997EFD2 /* XCLocalSwiftPackageReference "Vendor/Pulse" */,
 				A64FCAB32F5BA20F2CEE80BC /* XCLocalSwiftPackageReference "Vendor/VoiceInputCore" */,
 			);
@@ -1082,6 +1090,7 @@
 				5C84A7024B48EF2DE6194D83 /* MacNotifications.swift in Sources */,
 				E578C3D28FE88D4B38B71B55 /* MacStepsView.swift in Sources */,
 				058F05193E5F187FE59EA1F9 /* MacToolActivityRow.swift in Sources */,
+				B28AD9034476281891032293 /* MacUpdateController.swift in Sources */,
 				B481E371DBAC6C56C5F80E1E /* MainTabView.swift in Sources */,
 				BDBC81A8682AC662CD78C2F1 /* MainWindowView.swift in Sources */,
 				4E27FE6760FD0B131488F0FF /* MenuBarExtraView.swift in Sources */,
@@ -1190,6 +1199,7 @@
 				2CF36A2578842439CD9CA78A /* MacNotifications.swift in Sources */,
 				40A33A5867D20686790F9258 /* MacStepsView.swift in Sources */,
 				5294ABB3C1CF9D77CD60F131 /* MacToolActivityRow.swift in Sources */,
+				C0AD5E96F22955DB2473E341 /* MacUpdateController.swift in Sources */,
 				1BA230F7EC3DA0D4AF911D14 /* MainWindowView.swift in Sources */,
 				000021788275B9A715E2E204 /* MenuBarExtraView.swift in Sources */,
 				D760ADD6B42A59302671894C /* MessageBodyParser.swift in Sources */,
@@ -1464,20 +1474,17 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = KrakiMac.Debug.Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Kraki (Dev)";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_LSUIElement = NO;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2026 Kraki";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Kraki uses the microphone to transcribe voice input into the current Session draft.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1543,20 +1550,17 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = KrakiMac.Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Kraki;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_LSUIElement = NO;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2026 Kraki";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Kraki uses the microphone to transcribe voice input into the current Session draft.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;
@@ -1642,6 +1646,14 @@
 				version = 2.3.0;
 			};
 		};
+		DADBF5538A6575068485F6DC /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle.git";
+			requirement = {
+				kind = exactVersion;
+				version = 2.9.5;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1675,6 +1687,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 67485AEC5E20A50F92197C43 /* XCRemoteSwiftPackageReference "GRDB.swift" */;
 			productName = GRDB;
+		};
+		CFD03BF89A6EEE14EFB497BF /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DADBF5538A6575068485F6DC /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 		D489C81EB3DBE25897423901 /* Highlightr */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/packages/arm/ios/Kraki.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/arm/ios/Kraki.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,6 +16,15 @@
         "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
         "version" : "2.3.0"
       }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle.git",
+      "state" : {
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
+      }
     }
   ],
   "version" : 2

--- a/packages/arm/ios/Kraki/App/Mac/Commands.swift
+++ b/packages/arm/ios/Kraki/App/Mac/Commands.swift
@@ -192,6 +192,14 @@ struct MacCommands: Commands {
             }
         }
 
+        // App menu — Sparkle owns the standard update dialog and installation
+        // lifecycle; this command only routes the user's explicit request.
+        CommandGroup(after: .appInfo) {
+            Button("Check for Updates…") {
+                NotificationCenter.default.post(name: .macCheckForUpdates, object: nil)
+            }
+        }
+
         // Help menu — replace the default (search field + nothing useful)
         // with Feedback + Rate, mirroring the iOS Settings screen.
         CommandGroup(replacing: .help) {
@@ -236,6 +244,7 @@ extension Notification.Name {
     static let macNavigateSession  = Notification.Name("mac.navigateSession")
     static let macDeleteSession   = Notification.Name("mac.deleteSession")
     static let macRequestReview   = Notification.Name("mac.requestReview")
+    static let macCheckForUpdates  = Notification.Name("mac.checkForUpdates")
 }
 
 #endif

--- a/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
@@ -47,6 +47,14 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     @AppStorage("mac.keepRunningInMenuBar")
     private var keepRunningInMenuBar: Bool = true
 
+    private(set) var updateController: MacUpdateController?
+    private var updateNotificationObserver: NSObjectProtocol?
+
+    override init() {
+        updateController = nil
+        super.init()
+    }
+
     func applicationWillFinishLaunching(_ notification: Notification) {
         #if DEBUG
         if ProcessInfo.processInfo.environment["KRAKI_HTML_ARTIFACT_BENCH"] == "1" {
@@ -94,6 +102,12 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        if Bundle.main.bundleIdentifier == MacUpdateController.productionBundleIdentifier {
+            updateController = MacUpdateController.makeIfProduction()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 8) { [weak self] in
+                self?.updateController?.start()
+            }
+        }
         #if DEBUG
         let nativeAutomation = ProcessInfo.processInfo.environment["KRAKI_NATIVE_AUTOMATION"] == "1"
         if !nativeAutomation {
@@ -110,6 +124,16 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         // again whenever the app reactivates.
         removeUnwantedMenus()
         DispatchQueue.main.async { [weak self] in self?.removeUnwantedMenus() }
+
+        updateNotificationObserver = NotificationCenter.default.addObserver(
+            forName: .macCheckForUpdates,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateController?.checkForUpdates()
+            }
+        }
 
         #if DEBUG
         if nativeAutomation {
@@ -1890,6 +1914,12 @@ struct MacChatView: View {
             if let item = mainMenu.items.first(where: { $0.submenu?.title == title }) {
                 mainMenu.removeItem(item)
             }
+        }
+    }
+
+    deinit {
+        if let updateNotificationObserver {
+            NotificationCenter.default.removeObserver(updateNotificationObserver)
         }
     }
 

--- a/packages/arm/ios/Kraki/App/Mac/MacUpdateController.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacUpdateController.swift
@@ -1,0 +1,58 @@
+/// MacUpdateController — Sparkle 2 lifecycle for the signed production GUI.
+///
+/// Debug/Dev builds intentionally do not start an updater. The bundle identity
+/// check also prevents a copied Dev build from ever consuming the production
+/// appcast or replacing the production app.
+
+#if os(macOS)
+import AppKit
+import Sparkle
+
+@MainActor
+final class MacUpdateController: NSObject, SPUUpdaterDelegate {
+    static let productionBundleIdentifier = "chat.kraki.mac"
+    static let productionFeedURL = "https://raw.githubusercontent.com/corelli18512/kraki/mac-updates/appcast.xml"
+
+    private(set) lazy var controller: SPUStandardUpdaterController = {
+        SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: self,
+            userDriverDelegate: nil
+        )
+    }()
+
+    static func makeIfProduction() -> MacUpdateController? {
+        guard Bundle.main.bundleIdentifier == productionBundleIdentifier else {
+            return nil
+        }
+        return MacUpdateController()
+    }
+
+    override init() {
+        super.init()
+
+        // Sparkle keeps these values in UserDefaults. Set the initial policy
+        // through Info.plist and only use this object for lifecycle/actions.
+    }
+
+    func start() {
+        controller.startUpdater()
+    }
+
+    func checkForUpdates() {
+        controller.checkForUpdates(nil)
+    }
+
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        Self.productionFeedURL
+    }
+
+    func updaterShouldPromptForPermissionToCheck(forUpdates updater: SPUUpdater) -> Bool {
+        false
+    }
+
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        []
+    }
+}
+#endif

--- a/packages/arm/ios/KrakiMac.Debug.Info.plist
+++ b/packages/arm/ios/KrakiMac.Debug.Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>Kraki (Dev)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconName</key>

--- a/packages/arm/ios/KrakiMac.Debug.Info.plist
+++ b/packages/arm/ios/KrakiMac.Debug.Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>$(ASSETCATALOG_COMPILER_APPICON_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSUIElement</key>
+	<false/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Kraki uses the microphone to transcribe voice input into the current Session draft.</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>(c) 2026 Kraki</string>
+</dict>
+</plist>

--- a/packages/arm/ios/KrakiMac.Info.plist
+++ b/packages/arm/ios/KrakiMac.Info.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>$(ASSETCATALOG_COMPILER_APPICON_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>INFOPLIST_KEY_LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSUIElement</key>
+	<false/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Kraki uses the microphone to transcribe voice input into the current Session draft.</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>(c) 2026 Kraki</string>
+	<key>SUAllowsAutomaticUpdates</key>
+	<true/>
+	<key>SURequireSignedFeed</key>
+	<true/>
+	<key>SUVerifyUpdateBeforeExtraction</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<false/>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/corelli18512/kraki/mac-updates/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>A4kuMcvwBiRpyam3qYJpXd5rncSLIk1Aflgyl7vD1jQ=</string>
+	<key>SUScheduledCheckInterval</key>
+	<real>86400</real>
+</dict>
+</plist>

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -19,6 +19,9 @@ packages:
     path: ./Vendor/Pulse
   VoiceInputCore:
     path: ./Vendor/VoiceInputCore
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle.git
+    exactVersion: 2.9.5
 
 settings:
   base:
@@ -139,6 +142,9 @@ targets:
       - path: Kraki/App/AppState.swift
       # Mac-only app shell, scenes, commands.
       - path: Kraki/App/Mac
+        excludes:
+          - MacUpdateController.swift
+      - path: Kraki/App/Mac/MacUpdateController.swift
       # Mac-only feature surfaces (sidebar, welcome, tentacle, preferences,
       # chat placeholder, pairing). Their iOS analogues stay iOS-only — the
       # macOS chat surface will be rewritten against the pure-spine model.
@@ -165,14 +171,9 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.0"
-        CURRENT_PROJECT_VERSION: 2
-        GENERATE_INFOPLIST_FILE: true
-        INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.developer-tools
-        INFOPLIST_KEY_CFBundleDisplayName: Kraki
-        INFOPLIST_KEY_NSMicrophoneUsageDescription: "Kraki uses the microphone to transcribe voice input into the current Session draft."
-        INFOPLIST_KEY_NSHumanReadableCopyright: "© 2026 Kraki"
-        INFOPLIST_KEY_LSUIElement: "NO"
+        MARKETING_VERSION: "0.2.1"
+        CURRENT_PROJECT_VERSION: 3
+        GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 3A83X5JZ3S
@@ -187,11 +188,13 @@ targets:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac.dev
           PRODUCT_NAME: "Kraki Dev"
+          INFOPLIST_FILE: KrakiMac.Debug.Info.plist
           INFOPLIST_KEY_CFBundleDisplayName: "Kraki (Dev)"
           ASSETCATALOG_COMPILER_APPICON_NAME: DevAppIcon
         Release:
           PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
           PRODUCT_NAME: Kraki
+          INFOPLIST_FILE: KrakiMac.Info.plist
           INFOPLIST_KEY_CFBundleDisplayName: Kraki
           ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
     dependencies:
@@ -199,3 +202,4 @@ targets:
       - package: Pulse
       - package: Highlightr
       - package: VoiceInputCore
+      - package: Sparkle


### PR DESCRIPTION
## Summary
- integrate Sparkle 2.9.5 into the production `KrakiMac` target
- add signed production appcast configuration with Ed25519 verification
- add delayed startup checks and `Kraki > Check for Updates...`
- keep `Kraki Dev.app` isolated from the production update feed
- publish a notarized `Kraki.app.zip` and signed appcast from the Mac release workflow
- document the bootstrap requirement: `0.2.0` needs one manual install of `0.2.1`

## Security
- Developer ID signing, notarization, stapling, and Gatekeeper checks remain required
- Sparkle requires a signed appcast and verifies updates before extraction
- the private Ed25519 key is stored only as `SPARKLE_ED25519_PRIVATE_KEY` in GitHub Actions
- the `mac-updates` branch contains only the generated appcast

## Validation
- macOS Debug build passed with Sparkle resolved at 2.9.5
- macOS universal Release build passed (`x86_64 arm64`)
- final Release plist contains `SUFeedURL`, `SUPublicEDKey`, `SURequireSignedFeed`, and `SUVerifyUpdateBeforeExtraction`
- Debug plist contains no production Sparkle feed or signing keys
- local signed appcast generation produced `sparkle:edSignature`
- `git diff --check` passed