### PR TITLE
fix(mac): adapt streaming voice text to appearance

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1474,7 +1474,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1484,7 +1484,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1550,7 +1550,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1560,7 +1560,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
@@ -549,17 +549,11 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             "A short live transcript that updates while voice input is recording.",
             String(repeating: "This longer transcript verifies an eight-line scroller-free viewport and bottom anchoring without recursive AppKit layout. ", count: 14),
         ]
-        func transcriptText(_ voice: String) -> AttributedString {
-            var text = AttributedString(VoiceDraftMerger.merge(existing: existingDraft, final: voice))
-            text.font = .system(size: 15)
-            text.foregroundColor = NSColor.labelColor
-            return text
+        func transcriptPieces(_ voice: String) -> [MacComposerVoiceTranscriptView.Piece] {
+            [(VoiceDraftMerger.merge(existing: existingDraft, final: voice), 1)]
         }
-        func voiceOnlyText(_ voice: String) -> AttributedString {
-            var text = AttributedString(voice)
-            text.font = .system(size: 15)
-            text.foregroundColor = NSColor.labelColor
-            return text
+        func voiceOnlyPieces(_ voice: String) -> [MacComposerVoiceTranscriptView.Piece] {
+            [(voice, 1)]
         }
         func descendants(of view: NSView) -> [NSView] {
             view.subviews.flatMap { [$0] + descendants(of: $0) }
@@ -567,7 +561,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         let host = NSHostingView(
             rootView: AnyView(
                 MacComposerVoiceTranscript(
-                    text: transcriptText(samples[0]),
+                    pieces: transcriptPieces(samples[0]),
                     revision: "0"
                 )
                 .frame(width: 560)
@@ -586,7 +580,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         for round in 0..<200 {
             let index = round % samples.count
             host.rootView = AnyView(
-                MacComposerVoiceTranscript(text: transcriptText(samples[index]), revision: "\(round)")
+                MacComposerVoiceTranscript(pieces: transcriptPieces(samples[index]), revision: "\(round)")
                     .frame(width: 560)
             )
             host.layoutSubtreeIfNeeded()
@@ -616,7 +610,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         for count in 1...chineseStream.count {
             let streamed = String(chineseStream.prefix(count))
             host.rootView = AnyView(
-                MacComposerVoiceTranscript(text: voiceOnlyText(streamed), revision: "cjk-\(count)")
+                MacComposerVoiceTranscript(pieces: voiceOnlyPieces(streamed), revision: "cjk-\(count)")
                     .frame(width: 560)
             )
             host.layoutSubtreeIfNeeded()
@@ -648,19 +642,40 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         let renderedFont = rendered?.length ?? 0 > 0
             ? rendered?.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
             : nil
-        let renderedColor = rendered?.length ?? 0 > 0
-            ? rendered?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
-            : nil
-        let labelColorMatch = renderedColor?.usingColorSpace(.deviceRGB)
-            == NSColor.labelColor.usingColorSpace(.deviceRGB)
+        let appearancePieces: [MacComposerVoiceTranscriptView.Piece] = [
+            ("Streaming voice transcript", 1),
+            (" lookahead", 0.30),
+        ]
+        let lightText = MacComposerVoiceTranscriptView.debugAttributedText(
+            pieces: appearancePieces,
+            appearance: NSAppearance(named: .aqua)!
+        )
+        let darkText = MacComposerVoiceTranscriptView.debugAttributedText(
+            pieces: appearancePieces,
+            appearance: NSAppearance(named: .darkAqua)!
+        )
+        let lightColor = lightText.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        let darkColor = darkText.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        let lightBrightness = lightColor?.usingColorSpace(.deviceRGB)?.brightnessComponent ?? 1
+        let darkBrightness = darkColor?.usingColorSpace(.deviceRGB)?.brightnessComponent ?? 0
+        let adaptiveColor = lightBrightness < 0.25 && darkBrightness > 0.75
+        let lookaheadAlpha = darkText.attribute(
+            .foregroundColor,
+            at: max(0, darkText.length - 1),
+            effectiveRange: nil
+        ) as? NSColor
+        let lookaheadOpacityOK = abs((lookaheadAlpha?.alphaComponent ?? 0) - 0.30) < 0.01
         NSLog(
-            "[voice-transcript-regression] rounds=200 ms=%.3f pureCoreText=%d scrollViews=%d prefixOK=%d font=%.1f labelColor=%d height=%.1f",
+            "[voice-transcript-regression] rounds=200 ms=%.3f pureCoreText=%d scrollViews=%d prefixOK=%d font=%.1f adaptiveColor=%d lookaheadOpacity=%d lightBrightness=%.3f darkBrightness=%.3f height=%.1f",
             elapsed,
             transcriptView == nil ? 0 : 1,
             scrollViewCount,
             prefixPreserved ? 1 : 0,
             renderedFont?.pointSize ?? 0,
-            labelColorMatch ? 1 : 0,
+            adaptiveColor ? 1 : 0,
+            lookaheadOpacityOK ? 1 : 0,
+            lightBrightness,
+            darkBrightness,
             transcriptView?.bounds.height ?? 0
         )
         NSLog(

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
@@ -1077,11 +1077,9 @@ private struct MacComposerVoiceSurface: View {
     let draftPrefix: String
     let onFinish: () -> Void
 
-    private static let textFont = NSFont.systemFont(ofSize: 15)
-
     var body: some View {
         HStack(spacing: 12) {
-            MacComposerVoiceTranscript(text: displayedText, revision: revision)
+            MacComposerVoiceTranscript(pieces: displayedPieces, revision: revision)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Button(action: onFinish) {
@@ -1104,8 +1102,8 @@ private struct MacComposerVoiceSurface: View {
         "\(draftPrefix)-\(controller.state)-\(controller.rawText)-\(controller.correctionText)-\(controller.correctionSourceOffset)"
     }
 
-    private var displayedText: AttributedString {
-        VoiceComposerPresentation.attributedTranscript(
+    private var displayedPieces: [(text: String, opacity: Double)] {
+        VoiceComposerPresentation.transcriptPieces(
             prefix: draftPrefix,
             state: controller.state,
             rawText: controller.rawText,
@@ -1117,23 +1115,18 @@ private struct MacComposerVoiceSurface: View {
 }
 
 final class MacComposerVoiceTranscriptView: NSView {
+    typealias Piece = (text: String, opacity: Double)
+
+    private var pieces: [Piece] = []
     private var value = NSAttributedString(string: "")
     private var framesetter: CTFramesetter?
 
     override var isFlipped: Bool { true }
     override var isOpaque: Bool { false }
 
-    func update(text: AttributedString, width: CGFloat) -> CGFloat {
-        let normalized = NSMutableAttributedString(attributedString: NSAttributedString(text))
-        if normalized.length > 0 {
-            normalized.addAttribute(
-                .font,
-                value: NSFont.systemFont(ofSize: 15),
-                range: NSRange(location: 0, length: normalized.length)
-            )
-        }
-        value = normalized.copy() as? NSAttributedString ?? normalized
-        framesetter = CTFramesetterCreateWithAttributedString(value)
+    func update(pieces: [Piece], width: CGFloat) -> CGFloat {
+        self.pieces = pieces
+        rebuildAttributedText()
         setAccessibilityElement(true)
         setAccessibilityRole(.staticText)
         setAccessibilityLabel("Voice transcript")
@@ -1143,16 +1136,44 @@ final class MacComposerVoiceTranscriptView: NSView {
         return height
     }
 
-    static func measure(_ text: AttributedString, width: CGFloat) -> CGFloat {
-        let normalized = NSMutableAttributedString(attributedString: NSAttributedString(text))
-        if normalized.length > 0 {
-            normalized.addAttribute(
-                .font,
-                value: NSFont.systemFont(ofSize: 15),
-                range: NSRange(location: 0, length: normalized.length)
-            )
+    static func measure(_ pieces: [Piece], width: CGFloat) -> CGFloat {
+        measure(attributedText(pieces: pieces, color: .labelColor), width: width)
+    }
+
+    private static func attributedText(pieces: [Piece], color: NSColor) -> NSAttributedString {
+        let output = NSMutableAttributedString()
+        for piece in pieces where !piece.text.isEmpty {
+            output.append(NSAttributedString(
+                string: piece.text,
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: 15),
+                    .foregroundColor: color.withAlphaComponent(max(0, min(1, piece.opacity))),
+                ]
+            ))
         }
-        return measure(normalized, width: width)
+        return output
+    }
+
+    private static func resolvedLabelColor(for appearance: NSAppearance) -> NSColor {
+        var resolved = NSColor.labelColor
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor.labelColor.usingColorSpace(.deviceRGB) ?? NSColor.labelColor
+        }
+        return resolved
+    }
+
+    private func rebuildAttributedText() {
+        value = Self.attributedText(
+            pieces: pieces,
+            color: Self.resolvedLabelColor(for: effectiveAppearance)
+        )
+        framesetter = CTFramesetterCreateWithAttributedString(value)
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        rebuildAttributedText()
+        needsDisplay = true
     }
 
     private static func measure(_ text: NSAttributedString, width: CGFloat) -> CGFloat {
@@ -1184,7 +1205,9 @@ final class MacComposerVoiceTranscriptView: NSView {
             path,
             nil
         )
-        CTFrameDraw(frame, context)
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            CTFrameDraw(frame, context)
+        }
         context.restoreGState()
     }
 
@@ -1223,11 +1246,14 @@ final class MacComposerVoiceTranscriptView: NSView {
     func debugVisibleRange(width: CGFloat, height: CGFloat) -> CFRange {
         visibleSuffixRange(width: width, height: height)
     }
+    static func debugAttributedText(pieces: [Piece], appearance: NSAppearance) -> NSAttributedString {
+        attributedText(pieces: pieces, color: resolvedLabelColor(for: appearance))
+    }
     #endif
 }
 
 struct MacComposerVoiceTranscript: NSViewRepresentable {
-    let text: AttributedString
+    let pieces: [MacComposerVoiceTranscriptView.Piece]
     let revision: String
 
     final class Coordinator {
@@ -1250,7 +1276,7 @@ struct MacComposerVoiceTranscript: NSViewRepresentable {
                 || abs(context.coordinator.width - width) > 0.5 else { return }
         context.coordinator.revision = revision
         context.coordinator.width = width
-        transcriptView.update(text: text, width: width)
+        transcriptView.update(pieces: pieces, width: width)
     }
 
     func sizeThatFits(
@@ -1260,7 +1286,7 @@ struct MacComposerVoiceTranscript: NSViewRepresentable {
     ) -> CGSize? {
         guard let proposedWidth = proposal.width, proposedWidth > 1 else { return nil }
         let width = proposedWidth
-        let contentHeight = MacComposerVoiceTranscriptView.measure(text, width: width)
+        let contentHeight = MacComposerVoiceTranscriptView.measure(pieces, width: width)
         let lineHeight = ceil(NSLayoutManager().defaultLineHeight(for: .systemFont(ofSize: 15)))
         return CGSize(width: width, height: min(contentHeight, lineHeight * 8))
     }

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -171,8 +171,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.1"
-        CURRENT_PROJECT_VERSION: 3
+        MARKETING_VERSION: "0.2.2"
+        CURRENT_PROJECT_VERSION: 4
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- render macOS streaming voice transcript pieces with AppKit semantic label colors
- rebuild the CoreText transcript when the effective appearance changes
- preserve correction and lookahead opacity while switching correctly between light and dark themes
- prepare Mac GUI `0.2.2 (4)`

## Validation
- macOS Debug build passed
- universal arm64 + x86_64 Release dry build passed
- voice transcript regression passed with light brightness `0.000`, dark brightness `1.000`, adaptive color and lookahead opacity checks
- 39-step CJK streaming regression passed without collapse
- Composer paste/IME regression passed
- `git diff --check` passed