### PR TITLE
fix(mac): resolve CLI auth after Sparkle relaunch

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1474,7 +1474,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1484,7 +1484,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.2;
+				MARKETING_VERSION = 0.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1550,7 +1550,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1560,7 +1560,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.2;
+				MARKETING_VERSION = 0.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
@@ -78,6 +78,13 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         } else if ProcessInfo.processInfo.environment["KRAKI_VOICE_TRANSCRIPT_BENCH"] == "1" {
             NSApp.setActivationPolicy(.prohibited)
             DispatchQueue.main.async { [weak self] in self?.runVoiceTranscriptRegression() }
+        } else if ProcessInfo.processInfo.environment["KRAKI_MAC_CLI_AUTH_BENCH"] == "1" {
+            NSApp.setActivationPolicy(.prohibited)
+            Task { @MainActor in
+                let found = await AuthManager.loadCLICredentials() != nil
+                KLog.diag("Mac CLI credential regression found=\(found ? 1 : 0)")
+                NSApp.terminate(nil)
+            }
         }
         if ProcessInfo.processInfo.environment["KRAKI_NATIVE_AUTOMATION"] == "1" {
             // A native automation host is a background rendering/control
@@ -169,6 +176,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
                 "KRAKI_CODE_HIGHLIGHT_BENCH",
                 "KRAKI_CODE_HIGHLIGHT_UPGRADE_BENCH",
                 "KRAKI_VOICE_TRANSCRIPT_BENCH",
+                "KRAKI_MAC_CLI_AUTH_BENCH",
                 "KRAKI_RENDER_BUBBLE_TEST",
                 "KRAKI_RENDER_CHAT_TEST",
                 "KRAKI_RENDER_COMPOSER_TEST",

--- a/packages/arm/ios/Kraki/Core/Networking/AuthManager.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/AuthManager.swift
@@ -133,42 +133,76 @@ final class AuthManager {
         guard let configData = try? Data(contentsOf: URL(fileURLWithPath: krakiHome + "/config.json")),
               let config = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
               let relay = config["relay"] as? String,
-              relay.hasPrefix("ws") else { return nil }
+              relay.hasPrefix("ws") else {
+            KLog.diag("Mac CLI login unavailable: ~/.kraki/config.json has no relay")
+            return nil
+        }
 
         // 1. gh CLI token — the daemon's primary path (used whenever `gh` is
         //    authenticated, which is the common case on a dev machine).
         if let ghToken = await runGhAuthToken(), !ghToken.isEmpty {
+            KLog.diag("Mac CLI login resolved a GitHub token")
             return (relay, ghToken)
         }
         // 2. Saved device-flow token (~/.kraki/github-token).
         if let raw = try? String(contentsOfFile: krakiHome + "/github-token", encoding: .utf8) {
             let saved = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !saved.isEmpty { return (relay, saved) }
+            if !saved.isEmpty {
+                KLog.diag("Mac CLI login resolved a saved device-flow token")
+                return (relay, saved)
+            }
         }
+        KLog.diag("Mac CLI login unavailable: no GitHub credential was found")
         return nil
     }
 
-    /// Run `gh auth token` via a login shell and return its trimmed output,
-    /// or nil if gh is unavailable / not authenticated. Login shell so a
-    /// GUI-launched app still resolves gh from the user's normal PATH.
+    /// Resolve `gh` without assuming a GUI process inherited the user's shell
+    /// PATH. Sparkle and LaunchServices relaunch apps with a minimal system
+    /// environment, while MacPorts and Homebrew install `gh` outside it.
     private static func runGhAuthToken() async -> String? {
-        await Task.detached(priority: .userInitiated) {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/bin/sh")
-            process.arguments = ["-lc", "gh auth token"]
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = FileHandle.nullDevice
-            do {
-                try process.run()
-                process.waitUntilExit()
-                guard process.terminationStatus == 0 else { return nil }
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                return String(data: data, encoding: .utf8)?
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-            } catch {
-                return nil
+        let environment = ProcessInfo.processInfo.environment
+        let home = NSHomeDirectory()
+        var candidates = environment["PATH"]?
+            .split(separator: ":")
+            .map { String($0) + "/gh" } ?? []
+        candidates.append(contentsOf: [
+            "/opt/local/bin/gh",
+            "/opt/homebrew/bin/gh",
+            "/usr/local/bin/gh",
+            "/usr/bin/gh",
+            home + "/.local/bin/gh",
+        ])
+        var seen: Set<String> = []
+        let executables = candidates.filter {
+            seen.insert($0).inserted && FileManager.default.isExecutableFile(atPath: $0)
+        }
+
+        return await Task.detached(priority: .userInitiated) {
+            for executable in executables {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: executable)
+                process.arguments = ["auth", "token"]
+                process.standardInput = FileHandle.nullDevice
+                let pipe = Pipe()
+                process.standardOutput = pipe
+                process.standardError = FileHandle.nullDevice
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    guard process.terminationStatus == 0 else { continue }
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    let token = String(data: data, encoding: .utf8)?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    if let token, !token.isEmpty {
+                        KLog.diag("Mac CLI login executed gh from \(executable)")
+                        return token
+                    }
+                } catch {
+                    continue
+                }
             }
+            KLog.diag("Mac CLI login could not execute gh (candidates=\(executables.count))")
+            return nil
         }.value
     }
     #endif

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -171,8 +171,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.2"
-        CURRENT_PROJECT_VERSION: 4
+        MARKETING_VERSION: "0.2.3"
+        CURRENT_PROJECT_VERSION: 5
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- resolve `gh` from explicit MacPorts, Homebrew, `/usr/local`, and user-local paths
- avoid relying on the minimal PATH inherited by Sparkle/LaunchServices relaunches
- add Release-safe, token-free auth diagnostics
- prepare Mac GUI `0.2.3 (5)`

## Root cause
After Sparkle relaunched `0.2.2`, the GUI inherited only `/usr/bin:/bin:/usr/sbin:/sbin`. This machine's `gh` is installed at `/opt/local/bin/gh`, so the existing shell-based `gh auth token` lookup returned command-not-found. The GUI had no persisted challenge key/device identity available and therefore never opened an authenticated WebSocket.

## Validation
- Debug build passed
- universal arm64 + x86_64 Release dry build passed
- in-app CLI auth regression passed under the same minimal LaunchServices PATH
- isolated Dev GUI authenticated successfully against the production relay under that minimal PATH
- workflow YAML, plist validation, and `git diff --check` passed
