### PR TITLE
fix(web): restore live subscription after tentacle reconnect

### DIFF
--- a/docs/session-subscription-protocol-proposal.zh-CN.md
+++ b/docs/session-subscription-protocol-proposal.zh-CN.md
@@ -530,7 +530,7 @@ currentSessionByArm[arm] = B
 device_left -> currentSessionByArm.delete(deviceId)
 ```
 
-Tentacle restart 后 map 为空。Arm 在 reconnect/session page assure 中重新发送当前 desired session。
+Tentacle restart 或同 device ID 的 socket replacement 后 map 为空。即使 Arm 自己的 WebSocket 没断，Head 也会提供连接 epoch 信号：普通断线为 `device_left`，无离线窗口的原子替换为新的 `device_joined`。Arm 收到任一信号后必须撤销该 Tentacle 的旧 confirmed/in-flight authority 并删除旧 barrier；随后由新连接的 `session_list` barrier 重新发送当前 desired session。
 
 ---
 

--- a/packages/arm/web/e2e/real-stack/session-subscription.spec.ts
+++ b/packages/arm/web/e2e/real-stack/session-subscription.spec.ts
@@ -128,6 +128,26 @@ test.describe.serial('real-stack session subscription + opaque multicast', () =>
     await expect(arm1.page.getByText(after, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
   });
 
+  test('tentacle reconnect reasserts the mounted session subscription', async () => {
+    await openSession(arm1.page, sessionC);
+    await expectSubscribed(arm1.deviceId, sessionC);
+
+    const before = `before-tentacle-reconnect-${Date.now().toString(36)}`;
+    await control('/active', { sid: sessionC });
+    await control('/delta', { sid: sessionC, text: before });
+    await expect(arm1.page.getByText(before, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+
+    await control('/tentacle/disconnect');
+    await arm1.page.waitForTimeout(800);
+    await control('/tentacle/connect');
+    await expect(arm1.page.getByText('RealStack Tentacle').first()).toBeVisible({ timeout: 15_000 });
+    await expectSubscribed(arm1.deviceId, sessionC);
+
+    const after = `after-tentacle-reconnect-${Date.now().toString(36)}`;
+    await control('/delta', { sid: sessionC, text: after });
+    await expect(arm1.page.getByText(after, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+  });
+
   test('leaving the session page confirms null subscription', async () => {
     await arm1.page.goto(WEB_URL);
     await expectSubscribed(arm1.deviceId, null);

--- a/packages/arm/web/e2e/real-stack/session-subscription.spec.ts
+++ b/packages/arm/web/e2e/real-stack/session-subscription.spec.ts
@@ -148,6 +148,18 @@ test.describe.serial('real-stack session subscription + opaque multicast', () =>
     await expect(arm1.page.getByText(after, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
   });
 
+  test('same-device socket replacement reasserts without a device_left event', async () => {
+    await openSession(arm1.page, sessionC);
+    await expectSubscribed(arm1.deviceId, sessionC);
+
+    await control('/tentacle/replace');
+    await expectSubscribed(arm1.deviceId, sessionC);
+
+    const after = `after-tentacle-replace-${Date.now().toString(36)}`;
+    await control('/delta', { sid: sessionC, text: after });
+    await expect(arm1.page.getByText(after, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+  });
+
   test('leaving the session page confirms null subscription', async () => {
     await arm1.page.goto(WEB_URL);
     await expectSubscribed(arm1.deviceId, null);

--- a/packages/arm/web/src/lib/session-subscription.test.ts
+++ b/packages/arm/web/src/lib/session-subscription.test.ts
@@ -98,12 +98,25 @@ describe('SessionSubscriptionController', () => {
     controller.onSessionList('T1'); controller.setDesired('A'); await Promise.resolve(); controller.onAck(ack('T1', 'A'));
     expect(controller.acceptsLive('A')).toBe(true);
 
-    controller.onTentacleDisconnected('T1');
+    controller.onTentacleAuthorityReset('T1');
     expect(controller.acceptsLive('A')).toBe(false);
     controller.onSessionList('T1');
     await Promise.resolve();
 
     expect(sends).toEqual([['T1', 'A'], ['T1', 'A']]);
+  });
+
+  it('continues a cross-tentacle handoff when the old tentacle disconnects before its null ACK', async () => {
+    const { controller, sends } = setup({ A: 'T1', B: 'T2' });
+    controller.onSessionList('T1'); controller.onSessionList('T2');
+    controller.setDesired('A'); await Promise.resolve(); controller.onAck(ack('T1', 'A'));
+
+    controller.setDesired('B'); await Promise.resolve();
+    expect(sends.at(-1)).toEqual(['T1', null]);
+    controller.onTentacleAuthorityReset('T1');
+    await Promise.resolve();
+
+    expect(sends.at(-1)).toEqual(['T2', 'B']);
   });
 
   it('retains desired across a full Arm reconnect but requires a new barrier and ACK', async () => {

--- a/packages/arm/web/src/lib/session-subscription.test.ts
+++ b/packages/arm/web/src/lib/session-subscription.test.ts
@@ -93,7 +93,20 @@ describe('SessionSubscriptionController', () => {
     expect(controller.liveReady).toBe(true);
   });
 
-  it('retains desired across reconnect but requires a new barrier and ACK', async () => {
+  it('reassures after the tentacle reconnects while the Arm stays connected', async () => {
+    const { controller, sends } = setup();
+    controller.onSessionList('T1'); controller.setDesired('A'); await Promise.resolve(); controller.onAck(ack('T1', 'A'));
+    expect(controller.acceptsLive('A')).toBe(true);
+
+    controller.onTentacleDisconnected('T1');
+    expect(controller.acceptsLive('A')).toBe(false);
+    controller.onSessionList('T1');
+    await Promise.resolve();
+
+    expect(sends).toEqual([['T1', 'A'], ['T1', 'A']]);
+  });
+
+  it('retains desired across a full Arm reconnect but requires a new barrier and ACK', async () => {
     const { controller, sends, disconnect } = setup();
     controller.onSessionList('T1'); controller.setDesired('A'); await Promise.resolve(); controller.onAck(ack('T1', 'A'));
     disconnect();

--- a/packages/arm/web/src/lib/session-subscription.ts
+++ b/packages/arm/web/src/lib/session-subscription.ts
@@ -59,12 +59,11 @@ export class SessionSubscriptionController {
     this.blockedDesired = null;
   }
 
-  /** A tentacle link went away while the Arm itself stayed connected.
-   *  Its in-memory subscription authority is connection-scoped and is rebuilt
-   *  as null on reconnect, so any old local confirmation must be revoked. The
-   *  next post-auth session_list re-establishes the barrier and drives a fresh
-   *  set_session_subscription request. */
-  onTentacleDisconnected(tentacleId: string): void {
+  /** A tentacle connection epoch ended or was replaced while the Arm stayed
+   *  connected. Tentacle rebuilds its in-memory subscription authority as null
+   *  after every auth, so revoke any old local confirmation. The next post-auth
+   *  session_list re-establishes the barrier and drives a fresh request. */
+  onTentacleAuthorityReset(tentacleId: string): void {
     this.barriers.delete(tentacleId);
     if (this.confirmedTentacleId === tentacleId) {
       this.confirmedSessionId = null;
@@ -74,6 +73,7 @@ export class SessionSubscriptionController {
     if (this.desiredSessionId && this.host.resolveTentacle(this.desiredSessionId) === tentacleId) {
       this.blockedDesired = null;
     }
+    this.drive();
   }
 
   /** Current post-auth session_list from this tentacle is the inbound barrier. */

--- a/packages/arm/web/src/lib/session-subscription.ts
+++ b/packages/arm/web/src/lib/session-subscription.ts
@@ -59,6 +59,23 @@ export class SessionSubscriptionController {
     this.blockedDesired = null;
   }
 
+  /** A tentacle link went away while the Arm itself stayed connected.
+   *  Its in-memory subscription authority is connection-scoped and is rebuilt
+   *  as null on reconnect, so any old local confirmation must be revoked. The
+   *  next post-auth session_list re-establishes the barrier and drives a fresh
+   *  set_session_subscription request. */
+  onTentacleDisconnected(tentacleId: string): void {
+    this.barriers.delete(tentacleId);
+    if (this.confirmedTentacleId === tentacleId) {
+      this.confirmedSessionId = null;
+      this.confirmedTentacleId = null;
+    }
+    if (this.inFlight?.tentacleId === tentacleId) this.inFlight = null;
+    if (this.desiredSessionId && this.host.resolveTentacle(this.desiredSessionId) === tentacleId) {
+      this.blockedDesired = null;
+    }
+  }
+
   /** Current post-auth session_list from this tentacle is the inbound barrier. */
   onSessionList(tentacleId: string): void {
     this.barriers.add(tentacleId);

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -848,6 +848,7 @@ export class KrakiWSClient {
       case 'device_left': {
         const left = msg as DeviceLeftMessage;
         if (left.deviceId) {
+          this.subscription.onTentacleDisconnected(left.deviceId);
           getStore().clearDeviceAgents(left.deviceId);
           getStore().setDeviceOnline(left.deviceId, false);
         }

--- a/packages/arm/web/src/lib/ws-client.ts
+++ b/packages/arm/web/src/lib/ws-client.ts
@@ -840,6 +840,12 @@ export class KrakiWSClient {
       case 'device_joined': {
         const joined = msg as DeviceJoinedMessage;
         if (joined.device) {
+          // Head emits device_joined for every authenticated connection epoch,
+          // including same-device socket replacement where no device_left is
+          // broadcast. Tentacle rebuilds currentSessionByArm during that auth.
+          if (joined.device.role === 'tentacle') {
+            this.subscription.onTentacleAuthorityReset(joined.device.id);
+          }
           getStore().upsertDevice(joined.device);
         }
         break;
@@ -848,7 +854,7 @@ export class KrakiWSClient {
       case 'device_left': {
         const left = msg as DeviceLeftMessage;
         if (left.deviceId) {
-          this.subscription.onTentacleDisconnected(left.deviceId);
+          this.subscription.onTentacleAuthorityReset(left.deviceId);
           getStore().clearDeviceAgents(left.deviceId);
           getStore().setDeviceOnline(left.deviceId, false);
         }

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.15",
+  "version": "0.31.16",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/scripts/pulse-realstack-server.ts
+++ b/scripts/pulse-realstack-server.ts
@@ -464,6 +464,27 @@ async function main(): Promise<void> {
         // ── tentacle link control ──
         case '/tentacle/disconnect': relay!.disconnect(); return json(200, { ok: true });
         case '/tentacle/connect': relay!.connect(); return json(200, { ok: true });
+        case '/tentacle/replace': {
+          // Authenticate a new socket with the SAME device id before the old
+          // socket closes. Head replaces the old connection without emitting
+          // device_left, so device_joined is the only Arm-visible epoch signal.
+          const previous = relay!;
+          const deviceId = previous.getAuthInfo()?.deviceId;
+          if (!deviceId) throw new Error('tentacle has no authenticated device id');
+          (previous as unknown as { intentionalDisconnect: boolean }).intentionalDisconnect = true;
+          const replacement = new RelayClient(adapter as unknown as AgentAdapter, sm, {
+            relayUrl: RELAY_URL,
+            device: { deviceId, name: 'RealStack Tentacle', role: 'tentacle', kind: 'desktop' },
+          }, keyManager, attachmentStore);
+          installAttachmentDropHook(replacement);
+          await new Promise<void>((resolve, reject) => {
+            replacement.onAuthenticated = () => resolve();
+            replacement.onFatalError = (m: string) => reject(new Error(`tentacle replacement auth failed: ${m}`));
+            replacement.connect();
+          });
+          relay = replacement;
+          return json(200, { ok: true, deviceId });
+        }
         case '/tentacle/restart': {
           // Faithful process-restart simulation: destroy the RelayClient and
           // rebuild it against the SAME SessionManager (disk state persists),


### PR DESCRIPTION
## Summary

- revoke stale live-subscription authority when a Tentacle connection ends or is replaced
- recognize both ordinary `device_left` and same-device replacement `device_joined` epoch signals
- wait for the new connection’s `session_list` barrier, then reissue the current subscription
- keep cross-Tentacle handoff progressing if the old Tentacle disappears before its null ACK
- add unit, disconnect/reconnect, and no-`device_left` socket-replacement regressions

## Root cause

Tentacle authentication rebuilds its connection-scoped `currentSessionByArm` map with every online Arm set to `null`. When only the Tentacle connection changed, the browser WebSocket stayed connected and retained its old `confirmedSessionId`. The new `session_list` therefore did not trigger another `set_session_subscription`, leaving the two sides split: the browser believed live was ready while the Tentacle filtered every later `agent_message_delta` and `card_action`. Persistent `agent_message` events still arrived, producing the apparent jump from no progress to a final answer.

The original state machine modeled Arm reconnect and page refresh, but not the independent Tentacle connection epoch. Head may expose that epoch in two ways:

- ordinary disconnect/reconnect: `device_left`, then `device_joined`
- fast same-device socket replacement: only a new `device_joined`; Head deliberately suppresses `device_left` for the replaced socket

A real-stack packet-drop experiment also confirmed that losing one subscription ACK frame is not sufficient to cause the persistent state: Pulse retransmits that frame and live delivery recovers.

## Review follow-ups

Review found and fixed two gaps in the first patch revision:

- clearing an old Tentacle’s in-flight null subscription now calls the state-machine driver, preventing a T1 to T2 handoff from stalling
- `device_joined` also invalidates stale Tentacle authority, covering same-device connection replacement without `device_left`

## Validation

- `pnpm exec vitest run src/lib/session-subscription.test.ts src/lib/ws-client.test.ts` (72 passed)
- `pnpm --filter @kraki/arm-web build`
- `playwright test -c packages/arm/web/playwright.realstack.config.ts packages/arm/web/e2e/real-stack/session-subscription.spec.ts` (11 passed)
- `git diff --check`

The real-stack tests run a real Chromium Arm, Head, Tentacle RelayClient, Pulse transport, WebSocket, and E2E encryption. They cover both a visible Tentacle disconnect/reconnect and same-device socket replacement where Head emits no `device_left`.
