### PR TITLE
fix(mac): preserve composer and session transient state

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1474,7 +1474,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1484,7 +1484,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.3;
+				MARKETING_VERSION = 0.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1550,7 +1550,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1560,7 +1560,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.3;
+				MARKETING_VERSION = 0.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
@@ -70,7 +70,10 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         #if DEBUG
-        if ProcessInfo.processInfo.environment["KRAKI_HTML_ARTIFACT_BENCH"] == "1" {
+        if ProcessInfo.processInfo.environment["KRAKI_RELEASE_POLISH_BENCH"] == "1" {
+            NSApp.setActivationPolicy(.prohibited)
+            DispatchQueue.main.async { [weak self] in self?.runReleasePolishRegression() }
+        } else if ProcessInfo.processInfo.environment["KRAKI_HTML_ARTIFACT_BENCH"] == "1" {
             NSApp.setActivationPolicy(.prohibited)
             DispatchQueue.main.async { [weak self] in self?.runHTMLArtifactRegression() }
         } else if ProcessInfo.processInfo.environment["KRAKI_IMAGE_PREVIEW_BENCH"] == "1" {
@@ -188,6 +191,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             ensureMainWindowLaidOutOffscreen()
         } else {
             let automatedWindowMode = nativeAutomation || [
+                "KRAKI_RELEASE_POLISH_BENCH",
                 "KRAKI_HTML_ARTIFACT_BENCH",
                 "KRAKI_IMAGE_PREVIEW_BENCH",
                 "KRAKI_CORETEXT_SCROLL_BENCH",
@@ -224,6 +228,104 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     #if DEBUG
+    private func runReleasePolishRegression() {
+        MacComposerPasteFocusRegression.run { composerResult in
+            let placeholderHidden = composerResult["placeholderHiddenForNativeText"] as? Bool == true
+            let placeholderRestored = composerResult["placeholderRestoredAfterClear"] as? Bool == true
+
+            let artifact = ContentRef(
+                type: "content_ref",
+                id: "release-polish-html",
+                mimeType: "text/html",
+                size: 1_024,
+                caption: "Release polish report",
+                name: "release-polish.html",
+                width: nil,
+                height: nil
+            )
+            var artifactCache = MacHTMLArtifactSessionCache()
+            artifactCache.open(sessionId: "session-a", ref: artifact)
+            artifactCache.toggleExpanded(for: "session-a")
+            let otherSessionStayedClosed = artifactCache.presentation(for: "session-b") == nil
+            let restoredArtifact = artifactCache.presentation(for: "session-a")
+            let artifactRestored = restoredArtifact?.selection.ref.id == artifact.id
+            let artifactModeRestored = restoredArtifact?.expanded == true
+
+            var liveCardCached = false
+            var liveCardReplaced = false
+            var durableConclusionCleared = false
+            var storeError: String?
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("kraki-release-polish-\(UUID().uuidString)", isDirectory: true)
+            do {
+                let database = try MessageDatabase(
+                    databaseURL: root.appendingPathComponent("messages.sqlite")
+                )
+                let store = MessageStore(db: database)
+                let sessionID = "cached-live-card"
+                let user = ChatMessage(
+                    type: "user_message",
+                    seq: 1,
+                    sessionId: sessionID,
+                    deviceId: nil,
+                    timestamp: nil,
+                    payload: ["content": AnyCodable("go")]
+                )
+                let final = ChatMessage(
+                    type: "agent_message",
+                    seq: 2,
+                    sessionId: sessionID,
+                    deviceId: nil,
+                    timestamp: nil,
+                    payload: ["content": AnyCodable("done")]
+                )
+
+                store.beginCardTurn(sessionID)
+                store.applyCardMessage(sessionID, "cached first frame", reset: true)
+                store.restoreCardTurnGate(sessionID, from: [user])
+                liveCardCached = store.cards[sessionID]?.text == "cached first frame"
+
+                store.replaceCardFromSubscription(
+                    sessionID,
+                    draft: "authoritative live frame",
+                    action: nil,
+                    state: .active
+                )
+                liveCardReplaced = store.cards[sessionID]?.text == "authoritative live frame"
+
+                store.restoreCardTurnGate(sessionID, from: [user, final])
+                durableConclusionCleared = store.cards[sessionID] == nil
+            } catch {
+                storeError = error.localizedDescription
+            }
+            try? FileManager.default.removeItem(at: root)
+
+            let passed = placeholderHidden
+                && placeholderRestored
+                && otherSessionStayedClosed
+                && artifactRestored
+                && artifactModeRestored
+                && liveCardCached
+                && liveCardReplaced
+                && durableConclusionCleared
+                && storeError == nil
+            NSLog(
+                "[release-polish-regression] placeholderHidden=%d placeholderRestored=%d artifactIsolated=%d artifactRestored=%d artifactMode=%d liveCached=%d liveReplaced=%d conclusionCleared=%d storeError=%@ passed=%d",
+                placeholderHidden ? 1 : 0,
+                placeholderRestored ? 1 : 0,
+                otherSessionStayedClosed ? 1 : 0,
+                artifactRestored ? 1 : 0,
+                artifactModeRestored ? 1 : 0,
+                liveCardCached ? 1 : 0,
+                liveCardReplaced ? 1 : 0,
+                durableConclusionCleared ? 1 : 0,
+                storeError ?? "none",
+                passed ? 1 : 0
+            )
+            NSApp.terminate(nil)
+        }
+    }
+
     private func runImagePreviewRegression() {
         func makeImage(
             size: NSSize,
@@ -714,12 +816,14 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         )
         MacComposerPasteFocusRegression.run { result in
             NSLog(
-                "[composer-paste-focus-regression] passed=%d teardown=%d replacement=%d binding=%d firstResponder=%d imeDraft=%d imeRequested=%d imeFocus=%d externalCleared=%d",
+                "[composer-paste-focus-regression] passed=%d teardown=%d replacement=%d binding=%d firstResponder=%d placeholderHidden=%d placeholderRestored=%d imeDraft=%d imeRequested=%d imeFocus=%d externalCleared=%d",
                 result["passed"] as? Bool == true ? 1 : 0,
                 result["teardownPreserved"] as? Bool == true ? 1 : 0,
                 result["replacementPreserved"] as? Bool == true ? 1 : 0,
                 result["pasteRestoredBinding"] as? Bool == true ? 1 : 0,
                 result["replacementBecameFirstResponder"] as? Bool == true ? 1 : 0,
+                result["placeholderHiddenForNativeText"] as? Bool == true ? 1 : 0,
+                result["placeholderRestoredAfterClear"] as? Bool == true ? 1 : 0,
                 result["imeDraftCommitted"] as? Bool == true ? 1 : 0,
                 result["imeRequestedFocus"] as? Bool == true ? 1 : 0,
                 result["imeRetainedFirstResponder"] as? Bool == true ? 1 : 0,

--- a/packages/arm/ios/Kraki/App/Mac/MainWindowView.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MainWindowView.swift
@@ -217,6 +217,36 @@ private struct MacReadVisibilityObserver: NSViewRepresentable {
     }
 }
 
+struct MacHTMLArtifactSessionPresentation: Equatable {
+    let selection: MacSelectedHTMLArtifact
+    var expanded: Bool
+}
+
+struct MacHTMLArtifactSessionCache: Equatable {
+    private var presentations: [String: MacHTMLArtifactSessionPresentation] = [:]
+
+    func presentation(for sessionId: String) -> MacHTMLArtifactSessionPresentation? {
+        presentations[sessionId]
+    }
+
+    mutating func open(sessionId: String, ref: ContentRef) {
+        presentations[sessionId] = MacHTMLArtifactSessionPresentation(
+            selection: MacSelectedHTMLArtifact(sessionId: sessionId, ref: ref),
+            expanded: false
+        )
+    }
+
+    mutating func toggleExpanded(for sessionId: String) {
+        guard var presentation = presentations[sessionId] else { return }
+        presentation.expanded.toggle()
+        presentations[sessionId] = presentation
+    }
+
+    mutating func close(sessionId: String) {
+        presentations.removeValue(forKey: sessionId)
+    }
+}
+
 struct MainWindowView: View {
     private struct ChatPresentation {
         let sessionId: String
@@ -249,8 +279,7 @@ struct MainWindowView: View {
     @State private var sidebarSearchText = ""
     @State private var chatPresentation: ChatPresentation?
     @State private var selectedImagePreview: MacImagePreviewSelection?
-    @State private var selectedHTMLArtifact: MacSelectedHTMLArtifact?
-    @State private var htmlArtifactExpanded = false
+    @State private var htmlArtifactSessions = MacHTMLArtifactSessionCache()
 
     private let sidebarWidth: CGFloat = 280
     private let inspectorWidth: CGFloat = 320
@@ -378,8 +407,9 @@ struct MainWindowView: View {
                 guard let sessionId = note.userInfo?["sessionId"] as? String else { return }
                 selectedSessionId = sessionId
             case "closeHTMLArtifact":
-                selectedHTMLArtifact = nil
-                htmlArtifactExpanded = false
+                if let selectedSessionId {
+                    htmlArtifactSessions.close(sessionId: selectedSessionId)
+                }
             default:
                 break
             }
@@ -396,6 +426,7 @@ struct MainWindowView: View {
             Button("Delete Session", role: .destructive) {
                 if let id = pendingDeleteSessionId {
                     appState.commandSender?.deleteSession(sessionId: id)
+                    htmlArtifactSessions.close(sessionId: id)
                     if selectedSessionId == id { selectedSessionId = nil }
                 }
                 pendingDeleteSessionId = nil
@@ -407,8 +438,6 @@ struct MainWindowView: View {
                 appState.endViewingSession(oldValue)
             }
             selectedImagePreview = nil
-            selectedHTMLArtifact = nil
-            htmlArtifactExpanded = false
             if let newValue {
                 prepareSelectedSession(newValue)
             } else {
@@ -505,7 +534,9 @@ struct MainWindowView: View {
             chatPresentation = nil
             return
         }
-        appState.messageStore.clearCard(id)
+        // Keep the previous per-Session live card mounted while the local
+        // history gate is restored. A persisted conclusion clears it; otherwise
+        // the subscription ACK atomically replaces this cached first frame.
         // One presentation owner, one reanchor, one model snapshot. The Chat
         // view consumes this prepared transaction and never opens the Session a
         // second time with stale @State from the previous selection.
@@ -552,7 +583,11 @@ struct MainWindowView: View {
         } else if let presentation = chatPresentation {
             GeometryReader { geometry in
                 let compactArtifactPresentation = geometry.size.width < 780
-                let showArtifactFullWidth = htmlArtifactExpanded || compactArtifactPresentation
+                let artifactPresentation = htmlArtifactSessions.presentation(
+                    for: presentation.sessionId
+                )
+                let showArtifactFullWidth = (artifactPresentation?.expanded ?? false)
+                    || compactArtifactPresentation
                 ZStack(alignment: .trailing) {
                     HStack(spacing: 0) {
                         MacChatView(
@@ -563,11 +598,10 @@ struct MainWindowView: View {
                                 selectedImagePreview = selection
                             },
                             onOpenHTMLArtifact: { ref in
-                                selectedHTMLArtifact = MacSelectedHTMLArtifact(
+                                htmlArtifactSessions.open(
                                     sessionId: presentation.sessionId,
                                     ref: ref
                                 )
-                                htmlArtifactExpanded = false
                             }
                         )
                         // The breadcrumb and Chat live in separate SwiftUI
@@ -578,12 +612,12 @@ struct MainWindowView: View {
                         .id(presentation.generation)
                         .frame(minWidth: 0, maxWidth: .infinity, maxHeight: .infinity)
 
-                        if let selectedHTMLArtifact, !showArtifactFullWidth {
+                        if let artifactPresentation, !showArtifactFullWidth {
                             Rectangle()
                                 .fill(Color.borderPrimary.opacity(0.7))
                                 .frame(width: 1)
                             htmlArtifactPanel(
-                                selectedHTMLArtifact,
+                                artifactPresentation.selection,
                                 width: min(680, max(380, geometry.size.width * 0.46)),
                                 expanded: false,
                                 canToggleExpanded: true
@@ -591,9 +625,9 @@ struct MainWindowView: View {
                         }
                     }
 
-                    if let selectedHTMLArtifact, showArtifactFullWidth {
+                    if let artifactPresentation, showArtifactFullWidth {
                         htmlArtifactPanel(
-                            selectedHTMLArtifact,
+                            artifactPresentation.selection,
                             width: geometry.size.width,
                             expanded: true,
                             canToggleExpanded: !compactArtifactPresentation
@@ -629,11 +663,10 @@ struct MainWindowView: View {
             canToggleExpanded: canToggleExpanded,
             onToggleExpanded: {
                 guard canToggleExpanded else { return }
-                htmlArtifactExpanded.toggle()
+                htmlArtifactSessions.toggleExpanded(for: selection.sessionId)
             },
             onClose: {
-                selectedHTMLArtifact = nil
-                htmlArtifactExpanded = false
+                htmlArtifactSessions.close(sessionId: selection.sessionId)
             }
         )
         .frame(width: width)

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
@@ -11,6 +11,12 @@ private enum MacComposerIntent: Equatable {
     case denyPermission
 }
 
+enum MacComposerPlaceholderPolicy {
+    static func isVisible(committedText: String, nativeEditorHasText: Bool) -> Bool {
+        committedText.isEmpty && !nativeEditorHasText
+    }
+}
+
 /// macOS counterpart of the production iOS `MessageInputView`.
 ///
 /// The view intentionally keeps the same hierarchy and constants: a floating
@@ -34,6 +40,7 @@ struct MacChatComposer: View {
     @State private var voiceDraftPrefix = ""
     @State private var composerFocusRequest = 0
     @State private var isFocused = false
+    @State private var nativeEditorHasText = false
 
     // Mode swipe state — mirrors iOS MessageInputView.
     @State private var rawDragX: CGFloat = 0
@@ -334,7 +341,10 @@ struct MacChatComposer: View {
                 .font(.system(size: 15))
                 .foregroundStyle(.tertiary)
                 .padding(.leading, 18)
-                .opacity(text.isEmpty ? 1 : 0)
+                .opacity(MacComposerPlaceholderPolicy.isVisible(
+                    committedText: text,
+                    nativeEditorHasText: nativeEditorHasText
+                ) ? 1 : 0)
                 .allowsHitTesting(false)
             MacComposerScrollableTextInput(
                 text: Binding(
@@ -345,6 +355,7 @@ struct MacChatComposer: View {
                     get: { isFocused },
                     set: { isFocused = $0 }
                 ),
+                nativeEditorHasText: $nativeEditorHasText,
                 enabled: !voiceOwnsComposer,
                 focusRequest: composerFocusRequest,
                 onRequestFocus: requestComposerFocus,
@@ -857,6 +868,7 @@ private final class MacComposerTextView: NSTextView {
 private struct MacComposerScrollableTextInput: NSViewRepresentable {
     @Binding var text: String
     @Binding var focused: Bool
+    @Binding var nativeEditorHasText: Bool
     let enabled: Bool
     let focusRequest: Int
     let onRequestFocus: () -> Void
@@ -878,9 +890,33 @@ private struct MacComposerScrollableTextInput: NSViewRepresentable {
             self.parent = parent
         }
 
+        func reportVisualTextPresence(
+            of textView: MacComposerTextView,
+            deferred: Bool = false
+        ) {
+            let apply = { [weak self, weak textView] in
+                guard let self,
+                      let textView,
+                      self.textView === textView else { return }
+                let hasText = !textView.string.isEmpty
+                if self.parent.nativeEditorHasText != hasText {
+                    self.parent.nativeEditorHasText = hasText
+                }
+            }
+            if deferred {
+                DispatchQueue.main.async(execute: apply)
+            } else {
+                apply()
+            }
+        }
+
         func textDidChange(_ notification: Notification) {
-            guard !isApplying,
-                  let textView = notification.object as? MacComposerTextView else { return }
+            guard let textView = notification.object as? MacComposerTextView else { return }
+            // Marked IME text intentionally does not round-trip through the
+            // persisted draft, but it is still visible native text and must
+            // hide the SwiftUI placeholder immediately.
+            reportVisualTextPresence(of: textView)
+            guard !isApplying else { return }
             textView.scrollRangeToVisible(textView.selectedRange())
             // Do not round-trip marked IME text through SwiftUI. Replacing the
             // backing string while a Chinese/Japanese composition is active
@@ -1005,6 +1041,7 @@ private struct MacComposerScrollableTextInput: NSViewRepresentable {
         scrollView.documentView = textView
         context.coordinator.scrollView = scrollView
         context.coordinator.textView = textView
+        context.coordinator.reportVisualTextPresence(of: textView, deferred: true)
         return scrollView
     }
 
@@ -1024,6 +1061,7 @@ private struct MacComposerScrollableTextInput: NSViewRepresentable {
             textView.setSelectedRange(NSRange(location: min(selection.location, textView.string.utf16.count), length: 0))
             context.coordinator.isApplying = false
         }
+        context.coordinator.reportVisualTextPresence(of: textView, deferred: true)
         let layoutText = textView.hasMarkedText() ? textView.string : text
         let measuredHeight = Self.measuredHeight(layoutText, width: max(1, scrollView.contentSize.width))
         textView.frame = NSRect(
@@ -1523,6 +1561,7 @@ private struct MacModeChangeToast: View {
 private final class MacComposerFocusRegressionState {
     var text = ""
     var focused = true
+    var nativeEditorHasText = false
     var focusRequest = 0
 }
 
@@ -1537,6 +1576,10 @@ enum MacComposerPasteFocusRegression {
         let input = MacComposerScrollableTextInput(
             text: Binding(get: { state.text }, set: { state.text = $0 }),
             focused: Binding(get: { state.focused }, set: { state.focused = $0 }),
+            nativeEditorHasText: Binding(
+                get: { state.nativeEditorHasText },
+                set: { state.nativeEditorHasText = $0 }
+            ),
             enabled: true,
             focusRequest: state.focusRequest,
             onRequestFocus: {
@@ -1599,6 +1642,34 @@ enum MacComposerPasteFocusRegression {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
                     let replacementBecameFirstResponder = window.firstResponder === replacement
 
+                    // Simulate visible native IME text before it commits. The
+                    // persisted draft remains empty, but the placeholder must
+                    // already be hidden because the NSTextView is not empty.
+                    state.text = ""
+                    coordinator.isApplying = true
+                    replacement.string = "zhong"
+                    coordinator.textDidChange(
+                        Notification(name: NSText.didChangeNotification, object: replacement)
+                    )
+                    coordinator.isApplying = false
+                    let placeholderHiddenForNativeText = state.nativeEditorHasText
+                        && !MacComposerPlaceholderPolicy.isVisible(
+                            committedText: state.text,
+                            nativeEditorHasText: state.nativeEditorHasText
+                        )
+
+                    replacement.string = ""
+                    coordinator.isApplying = true
+                    coordinator.textDidChange(
+                        Notification(name: NSText.didChangeNotification, object: replacement)
+                    )
+                    coordinator.isApplying = false
+                    let placeholderRestoredAfterClear = !state.nativeEditorHasText
+                        && MacComposerPlaceholderPolicy.isVisible(
+                            committedText: state.text,
+                            nativeEditorHasText: state.nativeEditorHasText
+                        )
+
                     // Simulate an IME composition committing Chinese text. The
                     // committed draft must publish while retaining the live
                     // native text view as first responder.
@@ -1626,6 +1697,8 @@ enum MacComposerPasteFocusRegression {
                                 && replacementPreserved
                                 && pasteRestoredBinding
                                 && replacementBecameFirstResponder
+                                && placeholderHiddenForNativeText
+                                && placeholderRestoredAfterClear
                                 && imeDraftCommitted
                                 && imeRequestedFocus
                                 && imeRetainedFirstResponder
@@ -1637,6 +1710,8 @@ enum MacComposerPasteFocusRegression {
                                 "replacementPreserved": replacementPreserved,
                                 "pasteRestoredBinding": pasteRestoredBinding,
                                 "replacementBecameFirstResponder": replacementBecameFirstResponder,
+                                "placeholderHiddenForNativeText": placeholderHiddenForNativeText,
+                                "placeholderRestoredAfterClear": placeholderRestoredAfterClear,
                                 "imeDraftCommitted": imeDraftCommitted,
                                 "imeRequestedFocus": imeRequestedFocus,
                                 "imeRetainedFirstResponder": imeRetainedFirstResponder,

--- a/packages/arm/ios/KrakiTests/MessageStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/MessageStoreTests.swift
@@ -179,13 +179,31 @@ final class MessageStoreTests: XCTestCase {
         let final = ChatMessage(type: "agent_message", seq: 2, sessionId: sid, deviceId: nil,
                                 timestamp: nil, payload: ["content": AnyCodable("done")])
 
+        store.beginCardTurn(sid)
+        store.applyCardMessage(sid, "previous authoritative card", reset: true)
         store.restoreCardTurnGate(sid, from: [user, final])
+        XCTAssertNil(store.cards[sid], "a durable conclusion clears a stale retained card on entry")
         store.applyCardMessage(sid, "stale snapshot", reset: true)
         XCTAssertNil(store.cards[sid])
 
         store.restoreCardTurnGate(sid, from: [user])
         store.applyCardMessage(sid, "live snapshot", reset: true)
         XCTAssertEqual(store.cards[sid]?.text, "live snapshot")
+    }
+
+    func testRestoreCardGateKeepsLiveCardUntilSubscriptionReplacement() {
+        let sid = "retained-live-card"
+        let user = ChatMessage(type: "user_message", seq: 1, sessionId: sid, deviceId: nil,
+                               timestamp: nil, payload: ["content": AnyCodable("go")])
+        store.beginCardTurn(sid)
+        store.applyCardMessage(sid, "locally authoritative", reset: true)
+
+        store.restoreCardTurnGate(sid, from: [user])
+        XCTAssertEqual(store.cards[sid]?.text, "locally authoritative")
+
+        store.replaceCardFromSubscription(
+            sid, draft: "subscription authority", action: nil, state: .active)
+        XCTAssertEqual(store.cards[sid]?.text, "subscription authority")
     }
 
     // MARK: - Trace (per-turn steps, in-memory)

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -171,8 +171,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.3"
-        CURRENT_PROJECT_VERSION: 5
+        MARKETING_VERSION: "0.2.4"
+        CURRENT_PROJECT_VERSION: 6
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- hide the Composer placeholder as soon as native/IME text becomes visible
- retain each Session’s open HTML Report and split/expanded presentation across Session switches
- render the cached per-Session streaming Card immediately, then atomically replace it from the subscription ACK
- prepare KrakiMac 0.2.4 (build 6)

## Local validation
- KrakiMac Debug build passed
- KrakiMac Release build passed
- release-polish regression: `passed=1`
- HTML Artifact regression: `allOK=1`
- Composer paste/focus/IME regression: `passed=1`
- signed Dev app installed and strict codesign verification passed

## Safety
- HTML Report state remains Session-owned and nonpersistent
- persisted conclusions still clear stale cached Cards
- production `/Applications/Kraki.app` and Tentacle were not modified