### PR TITLE
ci(ios): add simulator CI and TestFlight delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,69 @@ jobs:
       - name: Run validation
         run: pnpm validate
 
+  test-ios:
+    name: Test iOS (Kraki)
+    runs-on: macos-26
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/arm/ios/.build
+            ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
+          key: ios-ci-spm-${{ hashFiles('packages/arm/ios/Kraki.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ios-ci-spm-
+
+      - name: Select iOS Simulator
+        id: simulator
+        run: |
+          set -euo pipefail
+          DEVICE_ID="$(xcrun simctl list devices available -j | python3 -c '
+          import json, sys
+          data = json.load(sys.stdin)
+          preferred = ("iPhone 17 Pro", "iPhone 16 Pro", "iPhone 16")
+          devices = [d for runtime in data["devices"].values() for d in runtime if d.get("isAvailable")]
+          for name in preferred:
+              for device in devices:
+                  if device.get("name") == name:
+                      print(device["udid"])
+                      raise SystemExit(0)
+          raise SystemExit("No supported iPhone Simulator is available")
+          ')"
+          echo "id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
+          echo "Using Simulator $DEVICE_ID"
+
+      - name: Build and test iOS
+        run: |
+          set -euo pipefail
+          cd packages/arm/ios
+          xcodebuild \
+            -project Kraki.xcodeproj \
+            -scheme Kraki \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,id=${{ steps.simulator.outputs.id }}' \
+            -derivedDataPath build/DerivedData-iOS \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            test
+
+      - name: Upload iOS test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-test-results
+          path: packages/arm/ios/build/DerivedData-iOS/Logs/Test/*.xcresult
+          if-no-files-found: ignore
+          retention-days: 7
+
   build-mac-gui:
     name: Build macOS GUI (KrakiMac)
     runs-on: macos-26

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,172 @@
+name: iOS TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Marketing version to upload (for example 0.1.1)
+        required: true
+        type: string
+  push:
+    tags:
+      - "ios-v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-testflight
+  cancel-in-progress: false
+
+jobs:
+  upload-testflight:
+    name: Archive and upload iOS to TestFlight
+    runs-on: macos-26
+    timeout-minutes: 60
+    environment: ios-release
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/ios-v* ]]; then
+            VERSION="${GITHUB_REF_NAME#ios-v}"
+          else
+            VERSION="$INPUT_VERSION"
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid iOS marketing version: $VERSION" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "build=$GITHUB_RUN_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/arm/ios/.build
+            ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
+          key: ios-release-spm-${{ hashFiles('packages/arm/ios/Kraki.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ios-release-spm-
+
+      - name: Install App Store Connect API key
+        env:
+          API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_BASE64 }}
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+        run: |
+          set -euo pipefail
+          test -n "$API_KEY_BASE64"
+          test -n "$API_KEY_ID"
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          echo "$API_KEY_BASE64" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8"
+
+      - name: Import Apple Distribution certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$CERTIFICATE_BASE64"
+          KEYCHAIN_PATH="$RUNNER_TEMP/ios-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+          echo "$CERTIFICATE_BASE64" | base64 --decode > "$RUNNER_TEMP/ios-distribution.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/ios-distribution.p12" \
+            -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Archive Kraki for App Store Connect
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD_NUMBER: ${{ steps.version.outputs.build }}
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          cd packages/arm/ios
+          xcodebuild \
+            -project Kraki.xcodeproj \
+            -scheme Kraki \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/Kraki.xcarchive" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData-iOS" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8" \
+            -authenticationKeyID "$API_KEY_ID" \
+            -authenticationKeyIssuerID "$API_ISSUER_ID" \
+            DEVELOPMENT_TEAM=3A83X5JZ3S \
+            CODE_SIGN_STYLE=Automatic \
+            MARKETING_VERSION="$VERSION" \
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+            archive
+
+      - name: Validate archive metadata
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD_NUMBER: ${{ steps.version.outputs.build }}
+        run: |
+          set -euo pipefail
+          APP="$RUNNER_TEMP/Kraki.xcarchive/Products/Applications/Kraki.app"
+          test -d "$APP"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Info.plist")" = "$VERSION"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP/Info.plist")" = "$BUILD_NUMBER"
+          codesign --verify --strict --verbose=2 "$APP"
+          codesign --verify --strict --verbose=2 "$APP/PlugIns/KrakiNotification.appex"
+
+      - name: Export IPA
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -exportArchive \
+            -archivePath "$RUNNER_TEMP/Kraki.xcarchive" \
+            -exportPath "$RUNNER_TEMP/ios-export" \
+            -exportOptionsPlist packages/arm/ios/ExportOptions-AppStore.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8" \
+            -authenticationKeyID "$API_KEY_ID" \
+            -authenticationKeyIssuerID "$API_ISSUER_ID"
+          test -f "$RUNNER_TEMP/ios-export/Kraki.ipa"
+
+      - name: Upload IPA to TestFlight
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$RUNNER_TEMP/ios-export/Kraki.ipa" \
+            --apiKey "$API_KEY_ID" \
+            --apiIssuer "$API_ISSUER_ID"
+
+      - name: Upload release diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-testflight-${{ steps.version.outputs.version }}-${{ steps.version.outputs.build }}
+          path: |
+            ${{ runner.temp }}/ios-export
+            ${{ runner.temp }}/Kraki.xcarchive/Info.plist
+            ${{ runner.temp }}/DerivedData-iOS/Logs
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/ios-cicd.md
+++ b/docs/ios-cicd.md
@@ -1,0 +1,95 @@
+# iOS CI and TestFlight delivery
+
+Kraki has two independent GitHub Actions paths for iOS.
+
+## Pull-request and main-branch CI
+
+`.github/workflows/ci.yml` runs the `Test iOS (Kraki)` job on `macos-26`.
+It builds the native app and its notification service extension and runs the
+`KrakiTests` suite on an available iPhone Simulator. No Apple credentials or
+code-signing secrets are used.
+
+The job uploads its `.xcresult` bundle even when tests fail. Once the workflow
+has run successfully on the default branch, make `Test iOS (Kraki)` a required
+branch-protection check for `main`.
+
+## TestFlight CD
+
+`.github/workflows/ios-testflight.yml` archives, exports and uploads the iOS app
+to App Store Connect. It can be triggered in either of two ways:
+
+- Run **iOS TestFlight** manually and enter a semantic version such as `0.1.1`.
+- Push a tag such as `ios-v0.1.1`.
+
+The GitHub Actions run number is used as `CFBundleVersion`, so every upload from
+the repository has a monotonically increasing build number. The selected
+version and build number are applied to both the main app and
+`KrakiNotification` extension at archive time.
+
+The release job uses automatic provisioning through `xcodebuild` and an App
+Store Connect API key. A locally exported Apple Distribution certificate gives
+the runner the signing private key; Xcode downloads or creates the matching App
+Store provisioning profiles for these bundle identifiers:
+
+- `chat.kraki.ios`
+- `chat.kraki.ios.notification`
+
+Both identifiers must belong to Apple Developer team `3A83X5JZ3S` and retain
+the App Groups, Keychain Sharing, Associated Domains and Push Notifications
+capabilities declared by the checked-in entitlements.
+
+## GitHub environment and secrets
+
+Create a protected GitHub environment named `ios-release`. Requiring a reviewer
+is recommended because a successful job uploads a build to TestFlight.
+
+Configure these environment secrets:
+
+| Secret | Content |
+| --- | --- |
+| `APP_STORE_CONNECT_KEY_ID` | App Store Connect API key ID |
+| `APP_STORE_CONNECT_ISSUER_ID` | App Store Connect issuer UUID |
+| `APP_STORE_CONNECT_PRIVATE_KEY_BASE64` | Base64 of `AuthKey_<KEY_ID>.p8` |
+| `IOS_DISTRIBUTION_CERTIFICATE_BASE64` | Base64 of an exported Apple Distribution `.p12` |
+| `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` |
+
+Encode files without line wrapping on macOS:
+
+```bash
+base64 -i AuthKey_KEYID.p8 | pbcopy
+base64 -i Kraki-Apple-Distribution.p12 | pbcopy
+```
+
+The workflow writes the API key into the standard
+`~/.appstoreconnect/private_keys` location and creates an ephemeral keychain for
+the distribution certificate. Secrets and private keys are never committed.
+
+## First release checklist
+
+1. Ensure the Kraki app record exists in App Store Connect for bundle ID
+   `chat.kraki.ios`.
+2. Confirm the notification extension identifier exists in Certificates,
+   Identifiers & Profiles.
+3. Create an Apple Distribution certificate for team `3A83X5JZ3S`, import it
+   into the login keychain and export it with its private key as a password-
+   protected `.p12`.
+4. Create an App Store Connect API key with App Manager access and access to the
+   Kraki app.
+5. Add the five secrets to the protected `ios-release` environment.
+6. Run the workflow manually with the intended marketing version.
+7. After App Store Connect finishes processing, add the build to an internal
+   TestFlight group. Automatic external distribution is intentionally not part
+   of this workflow.
+
+## Local unsigned verification
+
+```bash
+cd packages/arm/ios
+xcodebuild \
+  -project Kraki.xcodeproj \
+  -scheme Kraki \
+  -configuration Debug \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```

--- a/packages/arm/ios/ExportOptions-AppStore.plist
+++ b/packages/arm/ios/ExportOptions-AppStore.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>destination</key>
+    <string>export</string>
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>teamID</key>
+    <string>3A83X5JZ3S</string>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add native iOS Simulator build/test job to the main CI workflow
- add signed App Store archive/export and TestFlight upload workflow
- add App Store export options and setup documentation

## Local validation
- iOS Simulator: 280 tests executed, 2 skipped, 0 failures
- Hydrabird Release archive succeeded
- App Store Connect export with Apple Distribution signing succeeded
- YAML, plist, and git diff validation passed

## Release setup
- `ios-release` GitHub environment created
- App Store Connect API key secrets configured
- Hydrabird Apple Distribution certificate configured
- App Store profiles created for `chat.kraki.ios` and `chat.kraki.ios.notification`

The remaining external prerequisite is creating the Kraki app record in App Store Connect for `chat.kraki.ios`.