### PR TITLE
fix(ios): make TestFlight signing deterministic

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -71,13 +71,17 @@ jobs:
           echo "$API_KEY_BASE64" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8"
           chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8"
 
-      - name: Import Apple Distribution certificate
+      - name: Install App Store signing assets
         env:
           CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          APP_PROFILE_BASE64: ${{ secrets.IOS_APP_STORE_PROFILE_BASE64 }}
+          NOTIFICATION_PROFILE_BASE64: ${{ secrets.IOS_NOTIFICATION_APP_STORE_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
           test -n "$CERTIFICATE_BASE64"
+          test -n "$APP_PROFILE_BASE64"
+          test -n "$NOTIFICATION_PROFILE_BASE64"
           KEYCHAIN_PATH="$RUNNER_TEMP/ios-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
           echo "$CERTIFICATE_BASE64" | base64 --decode > "$RUNNER_TEMP/ios-distribution.p12"
@@ -91,12 +95,16 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          echo "$APP_PROFILE_BASE64" | base64 --decode \
+            > "$HOME/Library/MobileDevice/Provisioning Profiles/Kraki-App-Store-CI.mobileprovision"
+          echo "$NOTIFICATION_PROFILE_BASE64" | base64 --decode \
+            > "$HOME/Library/MobileDevice/Provisioning Profiles/Kraki-Notification-App-Store-CI.mobileprovision"
+
       - name: Archive Kraki for App Store Connect
         env:
           VERSION: ${{ steps.version.outputs.version }}
           BUILD_NUMBER: ${{ steps.version.outputs.build }}
-          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           set -euo pipefail
           cd packages/arm/ios
@@ -107,12 +115,7 @@ jobs:
             -destination 'generic/platform=iOS' \
             -archivePath "$RUNNER_TEMP/Kraki.xcarchive" \
             -derivedDataPath "$RUNNER_TEMP/DerivedData-iOS" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8" \
-            -authenticationKeyID "$API_KEY_ID" \
-            -authenticationKeyIssuerID "$API_ISSUER_ID" \
             DEVELOPMENT_TEAM=3A83X5JZ3S \
-            CODE_SIGN_STYLE=Automatic \
             MARKETING_VERSION="$VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             archive
@@ -131,20 +134,13 @@ jobs:
           codesign --verify --strict --verbose=2 "$APP/PlugIns/KrakiNotification.appex"
 
       - name: Export IPA
-        env:
-          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           set -euo pipefail
           xcodebuild \
             -exportArchive \
             -archivePath "$RUNNER_TEMP/Kraki.xcarchive" \
             -exportPath "$RUNNER_TEMP/ios-export" \
-            -exportOptionsPlist packages/arm/ios/ExportOptions-AppStore.plist \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8" \
-            -authenticationKeyID "$API_KEY_ID" \
-            -authenticationKeyIssuerID "$API_ISSUER_ID"
+            -exportOptionsPlist packages/arm/ios/ExportOptions-AppStore.plist
           test -f "$RUNNER_TEMP/ios-export/Kraki.ipa"
 
       - name: Upload IPA to TestFlight

--- a/docs/ios-cicd.md
+++ b/docs/ios-cicd.md
@@ -26,10 +26,10 @@ the repository has a monotonically increasing build number. The selected
 version and build number are applied to both the main app and
 `KrakiNotification` extension at archive time.
 
-The release job uses automatic provisioning through `xcodebuild` and an App
-Store Connect API key. A locally exported Apple Distribution certificate gives
-the runner the signing private key; Xcode downloads or creates the matching App
-Store provisioning profiles for these bundle identifiers:
+The release job uses deterministic manual App Store signing. A locally exported
+Apple Distribution certificate gives the runner the signing private key, and the
+matching App Store provisioning profiles are installed from protected GitHub
+environment secrets for these bundle identifiers:
 
 - `chat.kraki.ios`
 - `chat.kraki.ios.notification`
@@ -52,6 +52,8 @@ Configure these environment secrets:
 | `APP_STORE_CONNECT_PRIVATE_KEY_BASE64` | Base64 of `AuthKey_<KEY_ID>.p8` |
 | `IOS_DISTRIBUTION_CERTIFICATE_BASE64` | Base64 of an exported Apple Distribution `.p12` |
 | `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` |
+| `IOS_APP_STORE_PROFILE_BASE64` | Base64 of the `chat.kraki.ios` App Store profile |
+| `IOS_NOTIFICATION_APP_STORE_PROFILE_BASE64` | Base64 of the notification extension App Store profile |
 
 Encode files without line wrapping on macOS:
 
@@ -61,8 +63,9 @@ base64 -i Kraki-Apple-Distribution.p12 | pbcopy
 ```
 
 The workflow writes the API key into the standard
-`~/.appstoreconnect/private_keys` location and creates an ephemeral keychain for
-the distribution certificate. Secrets and private keys are never committed.
+`~/.appstoreconnect/private_keys` location, creates an ephemeral keychain for
+the distribution certificate, and installs both profiles into the runner's
+provisioning-profile directory. Secrets and private keys are never committed.
 
 ## First release checklist
 

--- a/packages/arm/ios/ExportOptions-AppStore.plist
+++ b/packages/arm/ios/ExportOptions-AppStore.plist
@@ -8,8 +8,17 @@
     <false/>
     <key>method</key>
     <string>app-store-connect</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>chat.kraki.ios</key>
+        <string>Kraki App Store CI</string>
+        <key>chat.kraki.ios.notification</key>
+        <string>Kraki Notification App Store CI</string>
+    </dict>
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
     <key>stripSwiftSymbols</key>
     <true/>
     <key>teamID</key>

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -945,11 +945,9 @@
 					};
 					8CF158A689FF2418C7E20679 = {
 						DevelopmentTeam = 3A83X5JZ3S;
-						ProvisioningStyle = Automatic;
 					};
 					EC0ED9322F6D2A73F356C1FC = {
 						DevelopmentTeam = 3A83X5JZ3S;
-						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -1424,8 +1422,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Kraki/Kraki.Release.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1445,6 +1443,7 @@
 				);
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.ios;
+				PROVISIONING_PROFILE_SPECIFIER = "Kraki App Store CI";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1527,7 +1526,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = KrakiNotification/KrakiNotification.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				INFOPLIST_FILE = KrakiNotification/Info.plist;
@@ -1538,6 +1538,7 @@
 				);
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.ios.notification;
+				PROVISIONING_PROFILE_SPECIFIER = "Kraki Notification App Store CI";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -79,6 +79,9 @@ targets:
           CODE_SIGN_ENTITLEMENTS: Kraki/Kraki.entitlements
         Release:
           CODE_SIGN_ENTITLEMENTS: Kraki/Kraki.Release.entitlements
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER: Kraki App Store CI
     dependencies:
       - target: KrakiNotification
         embed: true
@@ -104,6 +107,11 @@ targets:
         DEVELOPMENT_TEAM: 3A83X5JZ3S
         TARGETED_DEVICE_FAMILY: "1,2"
         CODE_SIGN_ENTITLEMENTS: KrakiNotification/KrakiNotification.entitlements
+      configs:
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER: Kraki Notification App Store CI
 
   KrakiTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
- archive both iOS targets directly with Apple Distribution signing
- install encrypted App Store profiles on the GitHub runner
- export with explicit manual provisioning profile mappings
- document the additional protected environment secrets

## Why
The first TestFlight run proved that Automatic Signing attempts to use an Apple Development identity during archive on a clean runner. Manual distribution signing avoids machine-specific development certificates and makes release output deterministic.

## Validation
- both App Store profiles are configured in the `ios-release` environment
- XcodeGen project regenerated
- Release build settings resolve to Apple Distribution + the expected profile
- workflow YAML, ExportOptions plist and diff checks pass