### PR TITLE
feat(voice): keep broker connections warm

### DIFF
--- a/packages/arm/ios/Kraki/App/AppState.swift
+++ b/packages/arm/ios/Kraki/App/AppState.swift
@@ -468,7 +468,7 @@ final class AppState {
         githubClientId = nil
         relayVersion = nil
         voiceCapability = nil
-        voiceInputController.cancel()
+        voiceInputController.suspendWarmConnection()
         #if os(iOS)
         pushManager?.syncApplicationBadge(unreadSessionIDs: [])
         #endif
@@ -492,6 +492,7 @@ final class AppState {
         #if os(iOS)
         Task { await pushManager?.handleForeground() }
         #endif
+        voiceInputController.resumeWarmConnection()
         guard hasCompletedInitialConnect else { return }
         guard connectionStatus != .connected else { return }
         wsClient?.resetBackoffAndReconnect()
@@ -518,6 +519,7 @@ final class AppState {
 
     func handleBackground() {
         updateReadVisibility(appForeground: false, conversationVisible: false)
+        voiceInputController.suspendWarmConnection()
         sessionStore.flushCache()
         deviceStore.flushCache()
         wsClient?.disconnect()
@@ -589,6 +591,7 @@ final class AppState {
         #if os(iOS)
         pushManager?.onAuthenticated()
         #endif
+        voiceInputController.prepare()
     }
 
     func onAuthFailed(error: String) {
@@ -807,10 +810,9 @@ extension AppState: KrakiVoiceInputHost {
             KLog.d("🎙️ Voice lease request blocked: transport unavailable")
             return false
         }
-        // The deployed Head's raw authenticated control path supports voice
-        // leases. Its @head Pulse self-channel historically omitted
-        // request_voice_lease from the whitelist, so use this non-retryable
-        // one-shot control frame; a new gesture always acquires a fresh lease.
+        // Voice authorization is connection-scoped. The controller requests a
+        // lease during foreground warm-up and reuses it across sequential
+        // recordings until expiry or reconnect replacement.
         wsClient.sendRaw(string)
         KLog.d("🎙️ Voice lease request sent resource=\(resource)")
         return true

--- a/packages/arm/ios/Kraki/App/Mac/MacApp.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacApp.swift
@@ -12,6 +12,7 @@
 /// daemon's status and exposes start/stop/connect actions to the UI.
 
 #if os(macOS)
+import AppKit
 import SwiftUI
 
 @main
@@ -92,6 +93,25 @@ struct MacApp: App {
                 // window, while the zoom divides the true window size.
                 .windowZoom()
                 .frame(minWidth: 800, idealWidth: 1100, minHeight: 600, idealHeight: 720)
+                .onReceive(NotificationCenter.default.publisher(
+                    for: NSApplication.didBecomeActiveNotification
+                )) { _ in
+                    // macOS keeps the broker connection optimistically warm;
+                    // activation bypasses any stale reconnect backoff.
+                    appState.handleForegroundRehydrate()
+                }
+                .onReceive(NotificationCenter.default.publisher(
+                    for: NSWindow.didBecomeKeyNotification
+                )) { _ in
+                    // Re-focus should recover immediately even if the app never
+                    // transitioned through an inactive scene phase.
+                    appState.handleForegroundRehydrate()
+                }
+                .onReceive(NSWorkspace.shared.notificationCenter.publisher(
+                    for: NSWorkspace.didWakeNotification
+                )) { _ in
+                    appState.handleForegroundRehydrate()
+                }
                 .task {
                     #if DEBUG
                     MacAutomationDriver.shared.start(appState: appState)

--- a/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
+++ b/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
@@ -146,6 +146,7 @@ final class KrakiVoiceInputController {
     private(set) var level: Float = 0
     private(set) var levels: [Float] = Array(repeating: 0, count: 8)
     private(set) var activeSessionID: String?
+    private(set) var isConnectionWarm = false
 
     var displayText: String {
         correctionText.isEmpty ? rawText : correctionText
@@ -165,16 +166,23 @@ final class KrakiVoiceInputController {
     private let sessionFactory: VoiceInputSessionFactory
     private let audioPolicy: VoiceInputAudioPolicy
     private var session: VoiceInputSessionProtocol?
-    private var generation = UUID()
+    private var connectionGeneration = UUID()
+    private var recordingGeneration = UUID()
+    private var lease: VoiceLease?
+    private var leaseRequestInFlight = false
     private var context: VoiceSessionContext?
     private var recordingStartedHandler: (() -> Void)?
     private var finalHandler: ((String) -> Void)?
     private var leaseTimeoutTask: Task<Void, Never>?
+    private var reconnectTask: Task<Void, Never>?
+    private var refreshTask: Task<Void, Never>?
     private var correctionDisplayTask: Task<Void, Never>?
     private var pendingCorrectionText: String?
     private var stableRawPrefix = ""
     private var currentRawSegment = ""
     private var metricStart: ContinuousClock.Instant?
+    private var reconnectAttempt = 0
+    private var warmConnectionDesired = false
 
     init(
         host: KrakiVoiceInputHost? = nil,
@@ -190,6 +198,53 @@ final class KrakiVoiceInputController {
         self.host = host
     }
 
+    /// Ensure a signed and activated broker connection exists without touching
+    /// microphone permission or the audio session.
+    func prepare() {
+        warmConnectionDesired = true
+        guard session == nil, !leaseRequestInFlight,
+              let host,
+              let capability = host.voiceCapability,
+              host.voiceTransportReady,
+              host.voiceUserID != nil,
+              host.voiceDeviceID != nil,
+              audioPolicy.permission != .denied else { return }
+
+        let now = Int(Date().timeIntervalSince1970)
+        if let lease, lease.payload.exp > now + 5 {
+            openConnection(lease, capability: capability)
+            return
+        }
+
+        lease = nil
+        leaseRequestInFlight = true
+        KLog.d("🎙️ [voice] stage=warm-lease-request")
+        guard host.requestVoiceLease(resource: capability.resource) else {
+            leaseRequestInFlight = false
+            scheduleReconnect()
+            return
+        }
+        scheduleLeaseTimeout()
+    }
+
+    func suspendWarmConnection() {
+        warmConnectionDesired = false
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        refreshTask?.cancel()
+        refreshTask = nil
+        leaseTimeoutTask?.cancel()
+        leaseTimeoutTask = nil
+        leaseRequestInFlight = false
+        closeConnection(keepLease: true)
+        recordingCleanup(clearHandlers: true)
+        state = .idle
+    }
+
+    func resumeWarmConnection() {
+        prepare()
+    }
+
     func begin(
         sessionID: String,
         context: VoiceSessionContext,
@@ -203,72 +258,58 @@ final class KrakiVoiceInputController {
             return
         }
         guard let host, host.voiceCapability != nil else {
-            fail(VoiceInputError.unavailable)
+            failRecording(VoiceInputError.unavailable, closeTransport: false)
             return
         }
         guard host.voiceTransportReady else {
-            fail(VoiceInputError.offline)
+            failRecording(VoiceInputError.offline, closeTransport: false)
             return
         }
 
-        cancelCurrent(resetState: false)
-        let current = UUID()
-        generation = current
+        let currentRecording = UUID()
+        recordingGeneration = currentRecording
+        resetPresentation()
         activeSessionID = sessionID
         self.context = context
         recordingStartedHandler = onRecordingStarted
         finalHandler = onFinal
-        rawText = ""
-        stableRawPrefix = ""
-        currentRawSegment = ""
-        correctionSource = ""
-        correctionText = ""
-        correctionSourceOffset = 0
-        level = 0
-        levels = Array(repeating: 0, count: 8)
         state = .requestingPermission
-        KLog.d("🎙️ [voice] stage=permission session=\(sessionID.prefix(12))")
+        KLog.d("🎙️ [voice] stage=permission session=\(sessionID.prefix(12)) warm=\(isConnectionWarm ? 1 : 0)")
 
         let wasUndetermined = audioPolicy.permission == .undetermined
-        guard await audioPolicy.requestPermission(), generation == current else {
-            if generation == current { fail(VoiceInputError.microphoneDenied) }
+        guard await audioPolicy.requestPermission() else {
+            if recordingGeneration == currentRecording {
+                failRecording(VoiceInputError.microphoneDenied, closeTransport: false)
+            }
             return
         }
+        guard recordingGeneration == currentRecording else { return }
         if wasUndetermined {
-            // The permission callback can win a short race with TCC's visible
-            // authorization state. Do not mint a billable lease until the same
-            // policy used by capture confirms that access is really granted.
             for _ in 0..<20 where audioPolicy.permission != .granted {
                 try? await Task.sleep(for: .milliseconds(50))
-                guard generation == current else { return }
+                guard recordingGeneration == currentRecording else { return }
             }
         }
         guard audioPolicy.permission == .granted else {
-            fail(VoiceInputError.microphoneDenied)
+            failRecording(VoiceInputError.microphoneDenied, closeTransport: false)
             return
         }
-        guard audioPolicy.activate(), generation == current else {
-            if generation == current {
-                fail(VoiceInputError.gateway("The microphone audio session couldn't be started."))
+        guard audioPolicy.activate(), recordingGeneration == currentRecording else {
+            if recordingGeneration == currentRecording {
+                failRecording(
+                    VoiceInputError.gateway("The microphone audio session couldn't be started."),
+                    closeTransport: false
+                )
             }
             return
         }
 
-        state = .obtainingLease
-        KLog.d("🎙️ [voice] stage=lease-request")
-        metricStart = .now
-        guard let resource = host.voiceCapability?.resource,
-              host.requestVoiceLease(resource: resource) else {
-            fail(VoiceInputError.offline)
-            return
-        }
-        leaseTimeoutTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(10))
-            guard !Task.isCancelled,
-                  let self,
-                  self.generation == current,
-                  self.state == .obtainingLease else { return }
-            self.fail(VoiceInputError.leaseTimedOut)
+        if isConnectionWarm, session != nil {
+            startPendingRecording()
+        } else {
+            state = .obtainingLease
+            metricStart = .now
+            prepare()
         }
     }
 
@@ -285,7 +326,10 @@ final class KrakiVoiceInputController {
     }
 
     func cancel() {
-        cancelCurrent(resetState: true)
+        closeConnection(keepLease: true)
+        recordingCleanup(clearHandlers: true)
+        state = .idle
+        if warmConnectionDesired { scheduleReconnect(immediate: true) }
     }
 
     func clearFailure() {
@@ -294,45 +338,69 @@ final class KrakiVoiceInputController {
     }
 
     func receiveLease(_ lease: VoiceLease) {
-        guard state == .obtainingLease,
+        guard leaseRequestInFlight,
               let host,
               let capability = host.voiceCapability,
-              let userID = host.voiceUserID,
               let deviceID = host.voiceDeviceID,
-              let context,
               lease.payload.did == deviceID,
               lease.payload.resource == capability.resource,
-              lease.payload.exp > Int(Date().timeIntervalSince1970),
-              let gatewayURL = try? capability.validatedBrokerURL() else {
-            return
-        }
+              lease.payload.exp > Int(Date().timeIntervalSince1970) else { return }
+        leaseRequestInFlight = false
         leaseTimeoutTask?.cancel()
         leaseTimeoutTask = nil
+        self.lease = lease
         KLog.d("🎙️ [voice] stage=lease-granted quota=\(lease.payload.quotaSeconds)s")
-        let current = generation
+        openConnection(lease, capability: capability)
+    }
+
+    func receiveLeaseDenied(reason: VoiceLeaseDeniedReason, detail: String?) {
+        guard leaseRequestInFlight else { return }
+        leaseRequestInFlight = false
+        leaseTimeoutTask?.cancel()
+        leaseTimeoutTask = nil
+        if state == .obtainingLease {
+            failRecording(VoiceInputError.leaseDenied(reason, detail), closeTransport: false)
+        } else if reason != .quotaExhausted {
+            scheduleReconnect()
+        }
+    }
+
+    private func openConnection(_ lease: VoiceLease, capability: VoiceCapability) {
+        guard session == nil,
+              let host,
+              let userID = host.voiceUserID,
+              let deviceID = host.voiceDeviceID,
+              let gatewayURL = try? capability.validatedBrokerURL() else { return }
+
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        isConnectionWarm = false
+        connectionGeneration = UUID()
+        let current = connectionGeneration
         let configuration = VoiceInputConfiguration(
             gatewayURL: gatewayURL,
             userID: userID,
             correctionEnabled: true,
-            context: context.fields,
-            vocabulary: context.vocabulary,
+            authorizationFields: [
+                "deviceId": .string(deviceID),
+                "authorization": lease.voiceInputJSONValue,
+            ],
             startFields: [
                 "deviceId": .string(deviceID),
                 "sampleRate": .number(16_000),
-                "lease": lease.voiceInputJSONValue,
             ]
         )
         session = sessionFactory.makeSession(
             configuration: configuration,
             onEvent: { [weak self] event in
                 Task { @MainActor in
-                    guard let self, self.generation == current else { return }
+                    guard let self, self.connectionGeneration == current else { return }
                     self.handle(event)
                 }
             },
             onMetric: { [weak self] metric in
                 Task { @MainActor in
-                    guard let self, self.generation == current else { return }
+                    guard let self, self.connectionGeneration == current else { return }
                     let elapsed = self.metricStart.map { $0.duration(to: .now) }
                     KLog.d("🎙️ [voice] metric=\(metric.rawValue) elapsed=\(elapsed.map(String.init(describing:)) ?? "-")")
                     if metric == .engineStarted,
@@ -343,17 +411,24 @@ final class KrakiVoiceInputController {
                 }
             }
         )
-        state = .recording
-        KLog.d("🎙️ [voice] stage=recording")
     }
 
-    func receiveLeaseDenied(reason: VoiceLeaseDeniedReason, detail: String?) {
-        guard state == .obtainingLease else { return }
-        fail(VoiceInputError.leaseDenied(reason, detail))
+    private func startPendingRecording() {
+        guard let session, let context, isConnectionWarm else { return }
+        state = .recording
+        metricStart = .now
+        KLog.d("🎙️ [voice] stage=recording warm=1")
+        session.startCapture(context: context.fields, vocabulary: context.vocabulary)
     }
 
     private func handle(_ event: VoiceInputEvent) {
         switch event {
+        case .connectionAuthorized:
+            isConnectionWarm = true
+            reconnectAttempt = 0
+            KLog.d("🎙️ [voice] stage=connection-authorized")
+            scheduleRefresh()
+            if state == .obtainingLease { startPendingRecording() }
         case .gatewayReady:
             break
         case .level(let value):
@@ -367,21 +442,99 @@ final class KrakiVoiceInputController {
         case .final(let text, let gatewayRawText):
             let finalText = resolvedFinalText(text, gatewayRawText: gatewayRawText)
             let handler = finalHandler
-            terminalCleanup()
+            recordingCleanup(clearHandlers: true)
             state = .idle
             if !finalText.isEmpty { handler?(finalText) }
         case .failed(let reason):
-            fail(VoiceInputError.gateway(Self.userFacingGatewayError(reason)))
+            handleConnectionFailure(reason)
         }
+    }
+
+    private func handleConnectionFailure(_ reason: String) {
+        KLog.d("🎙️ [voice] stage=connection-failed reason=\(reason)")
+        closeConnection(keepLease: true)
+        if isBusy {
+            let message = Self.userFacingGatewayError(reason)
+            recordingCleanup(clearHandlers: true)
+            state = .failed(message)
+        }
+        if warmConnectionDesired { scheduleReconnect() }
+    }
+
+    private func scheduleLeaseTimeout() {
+        leaseTimeoutTask?.cancel()
+        leaseTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(10))
+            guard !Task.isCancelled, let self, self.leaseRequestInFlight else { return }
+            self.leaseRequestInFlight = false
+            if self.state == .obtainingLease {
+                self.failRecording(VoiceInputError.leaseTimedOut, closeTransport: false)
+            } else {
+                self.scheduleReconnect()
+            }
+        }
+    }
+
+    private func scheduleReconnect(immediate: Bool = false) {
+        guard warmConnectionDesired, reconnectTask == nil else { return }
+        reconnectAttempt += 1
+        let exponent = min(5, max(0, reconnectAttempt - 1))
+        let base = immediate ? 0.0 : min(30.0, pow(2.0, Double(exponent)))
+        let jitter = immediate ? 0.0 : Double.random(in: 0...(base * 0.2))
+        reconnectTask = Task { @MainActor [weak self] in
+            if base + jitter > 0 {
+                try? await Task.sleep(for: .seconds(base + jitter))
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.reconnectTask = nil
+            self.prepare()
+        }
+    }
+
+    private func scheduleRefresh() {
+        refreshTask?.cancel()
+        guard let lease else { return }
+        let delay = max(1, lease.payload.exp - Int(Date().timeIntervalSince1970) - 60)
+        refreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled, let self, self.warmConnectionDesired else { return }
+            if self.state == .idle || self.state.failedMessage != nil {
+                self.closeConnection(keepLease: false)
+                self.prepare()
+            } else {
+                self.scheduleRefreshAfterRecording()
+            }
+        }
+    }
+
+    private func scheduleRefreshAfterRecording() {
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, let self, self.warmConnectionDesired else { return }
+            if self.state == .idle || self.state.failedMessage != nil {
+                self.closeConnection(keepLease: false)
+                self.prepare()
+            } else {
+                self.scheduleRefreshAfterRecording()
+            }
+        }
+    }
+
+    private func closeConnection(keepLease: Bool) {
+        connectionGeneration = UUID()
+        refreshTask?.cancel()
+        refreshTask = nil
+        session?.close()
+        session = nil
+        isConnectionWarm = false
+        if !keepLease { lease = nil }
     }
 
     private func resolvedFinalText(_ text: String, gatewayRawText: String?) -> String {
         guard !stableRawPrefix.isEmpty else { return text }
         let accumulatedLength = rawText.count
         let gatewayRawLength = gatewayRawText?.count ?? 0
-        // A segmented gateway may finish with only the newest ASR segment.
-        // If both corrected and gateway-raw finals are materially shorter than
-        // the accumulated HUD transcript, preserve the completed prefix.
         if text.count + 5 < accumulatedLength,
            gatewayRawLength + 5 < accumulatedLength {
             return VoiceDraftMerger.merge(existing: stableRawPrefix, final: text)
@@ -406,19 +559,14 @@ final class KrakiVoiceInputController {
         } else if text.hasPrefix(currentRawSegment)
                     || currentRawSegment.hasPrefix(text)
                     || Self.sharedPrefixLength(text, currentRawSegment) >= min(text.count, currentRawSegment.count) / 2 {
-            // Normal ASR growth or an in-place revision of the active segment.
             currentRawSegment = text
         } else if text.count + 5 < currentRawSegment.count {
-            // The gateway started a new ASR segment. Preserve the completed
-            // segment and append the new speech instead of erasing the HUD.
             stableRawPrefix = VoiceDraftMerger.merge(
                 existing: stableRawPrefix,
                 final: currentRawSegment
             )
             currentRawSegment = text
         } else {
-            // Ambiguous same-sized revision: the recognizer is still refining
-            // the active segment, so latest-wins without duplicating words.
             currentRawSegment = text
         }
         rawText = VoiceDraftMerger.merge(existing: stableRawPrefix, final: currentRawSegment)
@@ -437,8 +585,6 @@ final class KrakiVoiceInputController {
         }
         guard correctionDisplayTask == nil else { return }
         correctionDisplayTask = Task { @MainActor [weak self] in
-            // Later gateway deltas may arrive faster than the display refresh
-            // rate. Keep only the newest accumulated prefix.
             try? await Task.sleep(for: .milliseconds(16))
             guard !Task.isCancelled, let self else { return }
             self.correctionDisplayTask = nil
@@ -456,9 +602,6 @@ final class KrakiVoiceInputController {
         )
     }
 
-    /// Align the accumulated corrected prefix with the raw transcript prefix.
-    /// Whitespace and case are ignored; ties prefer the longer raw prefix so
-    /// filler-word deletions disappear as correction advances.
     static func alignedRawPrefixLength(corrected: String, raw: String) -> Int {
         let rawCharacters = Array(raw)
         var normalizedRaw: [Character] = []
@@ -497,21 +640,30 @@ final class KrakiVoiceInputController {
         return rawIndices[normalizedOffset - 1] + 1
     }
 
-    private func fail(_ error: VoiceInputError) {
+    private func failRecording(_ error: VoiceInputError, closeTransport: Bool) {
         KLog.d("🎙️ [voice] stage=failed reason=\(error.localizedDescription)")
-        terminalCleanup()
+        if closeTransport { closeConnection(keepLease: true) }
+        recordingCleanup(clearHandlers: true)
         state = .failed(error.localizedDescription)
     }
 
-    private func terminalCleanup() {
+    private func recordingCleanup(clearHandlers: Bool) {
+        recordingGeneration = UUID()
         correctionDisplayTask?.cancel()
         correctionDisplayTask = nil
         pendingCorrectionText = nil
-        leaseTimeoutTask?.cancel()
-        leaseTimeoutTask = nil
-        session?.close()
-        session = nil
         audioPolicy.deactivate()
+        resetPresentation()
+        activeSessionID = nil
+        context = nil
+        if clearHandlers {
+            recordingStartedHandler = nil
+            finalHandler = nil
+        }
+        metricStart = nil
+    }
+
+    private func resetPresentation() {
         rawText = ""
         stableRawPrefix = ""
         currentRawSegment = ""
@@ -520,24 +672,13 @@ final class KrakiVoiceInputController {
         correctionSourceOffset = 0
         level = 0
         levels = Array(repeating: 0, count: 8)
-        activeSessionID = nil
-        context = nil
-        recordingStartedHandler = nil
-        finalHandler = nil
-        metricStart = nil
-    }
-
-    private func cancelCurrent(resetState: Bool) {
-        generation = UUID()
-        terminalCleanup()
-        if resetState { state = .idle }
     }
 
     private static func userFacingGatewayError(_ reason: String) -> String {
         let lower = reason.lowercased()
         if lower.contains("permission") { return VoiceInputError.microphoneDenied.localizedDescription }
         if lower.contains("quota") { return "The voice-input quota was exhausted." }
-        if lower.contains("lease") || lower.contains("denied") {
+        if lower.contains("lease") || lower.contains("denied") || lower.contains("authorization") {
             return "The voice session authorization was rejected. Please try again."
         }
         if lower.contains("timed out") || lower.contains("timeout") {
@@ -548,5 +689,11 @@ final class KrakiVoiceInputController {
         }
         return "Voice input failed. Please try again."
     }
+}
 
+private extension KrakiVoiceInputController.State {
+    var failedMessage: String? {
+        if case .failed(let message) = self { return message }
+        return nil
+    }
 }

--- a/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
+++ b/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
@@ -28,6 +28,7 @@ private final class FakeVoiceSession: VoiceInputSessionProtocol {
     private let onMetric: (VoiceInputMetric) -> Void
     private(set) var stopCount = 0
     private(set) var closeCount = 0
+    private(set) var starts: [([String: VoiceInputJSONValue], [String])] = []
 
     init(
         correctionEnabled: Bool,
@@ -39,6 +40,12 @@ private final class FakeVoiceSession: VoiceInputSessionProtocol {
         self.onMetric = onMetric
     }
 
+    func startCapture(
+        context: [String: VoiceInputJSONValue],
+        vocabulary: [String]
+    ) {
+        starts.append((context, vocabulary))
+    }
     func stopCapture() { stopCount += 1 }
     func close() { closeCount += 1 }
     func emit(_ event: VoiceInputEvent) { onEvent(event) }
@@ -90,6 +97,30 @@ private final class FakeVoiceAudioPolicy: VoiceInputAudioPolicy {
         return activationSucceeds
     }
     func deactivate() { deactivationCount += 1 }
+}
+
+@MainActor
+private final class SuspendedVoiceAudioPolicy: VoiceInputAudioPolicy {
+    var permission: VoiceMicrophonePermission = .undetermined
+    private(set) var activationCount = 0
+    private var continuation: CheckedContinuation<Bool, Never>?
+
+    func requestPermission() async -> Bool {
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func resolvePermission(granted: Bool) {
+        permission = granted ? .granted : .denied
+        continuation?.resume(returning: granted)
+        continuation = nil
+    }
+
+    func activate() -> Bool {
+        activationCount += 1
+        return true
+    }
+
+    func deactivate() {}
 }
 
 @MainActor
@@ -187,8 +218,38 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertTrue(factory.sessions.isEmpty)
 
         controller.receiveLease(lease())
-        XCTAssertEqual(controller.state, .recording)
+        XCTAssertEqual(controller.state, .obtainingLease)
         XCTAssertEqual(factory.sessions.count, 1)
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+        XCTAssertEqual(controller.state, .recording)
+        XCTAssertEqual(factory.sessions[0].starts.count, 1)
+    }
+
+    func testCancelWhilePermissionPromptIsOpenDoesNotResumeRecordingSetup() async {
+        let host = FakeVoiceHost()
+        let factory = FakeVoiceFactory()
+        let audio = SuspendedVoiceAudioPolicy()
+        let controller = KrakiVoiceInputController(
+            host: host,
+            sessionFactory: factory,
+            audioPolicy: audio
+        )
+
+        let beginTask = Task {
+            await controller.begin(sessionID: "session-1", context: context()) { _ in }
+        }
+        await Task.yield()
+        XCTAssertEqual(controller.state, .requestingPermission)
+
+        controller.cancel()
+        audio.resolvePermission(granted: true)
+        await beginTask.value
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(audio.activationCount, 0)
+        XCTAssertTrue(host.requestedResources.isEmpty)
+        XCTAssertTrue(factory.sessions.isEmpty)
     }
 
     func testRecordingStartedCallbackFiresOnceForAudioEngineStart() async {
@@ -210,6 +271,8 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertEqual(recordingStartedCount, 0)
 
         controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
         XCTAssertEqual(controller.state, .recording)
         XCTAssertEqual(recordingStartedCount, 0)
 
@@ -239,16 +302,20 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertEqual(host.requestedResources, ["voice/doubao"])
 
         controller.receiveLease(lease())
-        XCTAssertEqual(controller.state, .recording)
         XCTAssertEqual(factory.sessions.count, 1)
-        let start = try XCTUnwrap(factory.configurations.first?.gatewayStartMessage())
-        XCTAssertEqual(start["deviceId"] as? String, "device-1")
-        XCTAssertEqual(start["sampleRate"] as? Double, 16_000)
-        let nested = try XCTUnwrap(start["lease"] as? [String: Any])
+        let authorize = try XCTUnwrap(factory.configurations.first?.gatewayAuthorizeMessage())
+        XCTAssertEqual(authorize["deviceId"] as? String, "device-1")
+        let nested = try XCTUnwrap(authorize["authorization"] as? [String: Any])
         XCTAssertEqual(nested["alg"] as? String, "RSA-SHA256")
         let payload = try XCTUnwrap(nested["payload"] as? [String: Any])
         XCTAssertEqual(payload["did"] as? String, "device-1")
         XCTAssertEqual(payload["resource"] as? String, "voice/doubao")
+
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+        XCTAssertEqual(controller.state, .recording)
+        XCTAssertEqual(factory.sessions[0].starts.count, 1)
+        XCTAssertEqual(factory.sessions[0].starts[0].1, ["Kraki"])
     }
 
     func testPartialAndCorrectionNeverCommitButFinalCommitsExactlyOnce() async {
@@ -262,6 +329,8 @@ final class KrakiVoiceInputTests: XCTestCase {
         var finals: [String] = []
         await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
         controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
         let session = factory.sessions[0]
 
         session.emit(.partial("raw Cracky Voice input controller tail"))
@@ -301,6 +370,8 @@ final class KrakiVoiceInputTests: XCTestCase {
         )
         await controller.begin(sessionID: "session-1", context: context()) { _ in }
         controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
         let session = factory.sessions[0]
 
         session.emit(.partial("This is the first completed spoken sentence"))
@@ -331,6 +402,8 @@ final class KrakiVoiceInputTests: XCTestCase {
         var finals: [String] = []
         await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
         controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
         let session = factory.sessions[0]
 
         session.emit(.partial("The first spoken segment is complete and should remain"))
@@ -369,16 +442,52 @@ final class KrakiVoiceInputTests: XCTestCase {
         await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
         controller.cancel()
         controller.receiveLease(lease())
-        XCTAssertTrue(factory.sessions.isEmpty)
+        XCTAssertEqual(factory.sessions.count, 1)
         XCTAssertEqual(controller.state, .idle)
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+        XCTAssertTrue(controller.isConnectionWarm)
 
         await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
-        controller.receiveLease(lease())
         let old = factory.sessions[0]
         controller.cancel()
         old.emit(.final("late", rawText: nil))
         await Task.yield()
         XCTAssertTrue(finals.isEmpty)
+    }
+
+    func testForegroundWarmConnectionIsReusedAcrossRecordings() async {
+        let host = FakeVoiceHost()
+        let factory = FakeVoiceFactory()
+        let controller = KrakiVoiceInputController(
+            host: host,
+            sessionFactory: factory,
+            audioPolicy: FakeVoiceAudioPolicy()
+        )
+        controller.prepare()
+        XCTAssertEqual(host.requestedResources, ["voice/doubao"])
+        controller.receiveLease(lease())
+        XCTAssertEqual(factory.sessions.count, 1)
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+        XCTAssertTrue(controller.isConnectionWarm)
+        XCTAssertEqual(controller.state, .idle)
+
+        var finals: [String] = []
+        await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
+        XCTAssertEqual(factory.sessions[0].starts.count, 1)
+        factory.sessions[0].emit(.final("first", rawText: nil))
+        await Task.yield()
+        XCTAssertEqual(finals, ["first"])
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(factory.sessions[0].closeCount, 0)
+
+        await controller.begin(sessionID: "session-2", context: context()) { finals.append($0) }
+        XCTAssertEqual(factory.sessions.count, 1)
+        XCTAssertEqual(factory.sessions[0].starts.count, 2)
+        factory.sessions[0].emit(.final("second", rawText: nil))
+        await Task.yield()
+        XCTAssertEqual(finals, ["first", "second"])
     }
 
     func testLeaseDenialsRemainDistinct() async {

--- a/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
+++ b/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
@@ -103,10 +103,12 @@ private final class FakeVoiceAudioPolicy: VoiceInputAudioPolicy {
 private final class SuspendedVoiceAudioPolicy: VoiceInputAudioPolicy {
     var permission: VoiceMicrophonePermission = .undetermined
     private(set) var activationCount = 0
+    private(set) var requestStarted = false
     private var continuation: CheckedContinuation<Bool, Never>?
 
     func requestPermission() async -> Bool {
-        await withCheckedContinuation { continuation = $0 }
+        requestStarted = true
+        return await withCheckedContinuation { continuation = $0 }
     }
 
     func resolvePermission(granted: Bool) {
@@ -239,7 +241,7 @@ final class KrakiVoiceInputTests: XCTestCase {
         let beginTask = Task {
             await controller.begin(sessionID: "session-1", context: context()) { _ in }
         }
-        await Task.yield()
+        while !audio.requestStarted { await Task.yield() }
         XCTAssertEqual(controller.state, .requestingPermission)
 
         controller.cancel()

--- a/packages/arm/ios/Vendor/VoiceInputCore/Sources/VoiceInputCore/VoiceInputCore.swift
+++ b/packages/arm/ios/Vendor/VoiceInputCore/Sources/VoiceInputCore/VoiceInputCore.swift
@@ -1,12 +1,7 @@
 import AVFoundation
 import Foundation
 
-/// Product-owned configuration for one voice-input session.
-///
-/// `VoiceInputCore` does not read environment variables, UserDefaults, account
-/// state, plans or UI settings. Each host app constructs this value from its
-/// own product configuration and authentication system.
-/// Sendable JSON value used for opaque per-session gateway context.
+/// Sendable JSON value used for opaque product-owned gateway fields.
 public enum VoiceInputJSONValue: Sendable, Equatable {
     case string(String)
     case number(Double)
@@ -27,6 +22,11 @@ public enum VoiceInputJSONValue: Sendable, Equatable {
     }
 }
 
+/// Product-owned configuration for one warm voice connection.
+///
+/// Authorization is connection-scoped. Per-recording correction context is
+/// supplied to `startCapture`, allowing one WebSocket to carry many sequential
+/// recordings without pinning stale chat context at foreground warm-up time.
 public struct VoiceInputConfiguration: Sendable {
     public var gatewayURL: URL
     public var apiKey: String?
@@ -34,13 +34,15 @@ public struct VoiceInputConfiguration: Sendable {
     public var correctionEnabled: Bool
     public var context: [String: VoiceInputJSONValue]
     public var vocabulary: [String]
-    /// Host-owned fields merged into the gateway start frame. Product auth
-    /// (for example a nested short-lived lease) belongs here; the reusable
-    /// core never obtains or interprets it.
+    /// Host-owned fields merged into the connection-level authorize frame.
+    public var authorizationFields: [String: VoiceInputJSONValue]
+    /// Host-owned fields merged into every per-recording start frame.
     public var startFields: [String: VoiceInputJSONValue]
     public var targetSampleRate: Double
+    public var authorizationTimeout: TimeInterval
     public var readyTimeout: TimeInterval
     public var finishTimeout: TimeInterval
+    public var pingInterval: TimeInterval
     public var pcmDumpPath: String?
 
     public init(
@@ -50,10 +52,13 @@ public struct VoiceInputConfiguration: Sendable {
         correctionEnabled: Bool = true,
         context: [String: VoiceInputJSONValue] = [:],
         vocabulary: [String] = [],
+        authorizationFields: [String: VoiceInputJSONValue] = [:],
         startFields: [String: VoiceInputJSONValue] = [:],
         targetSampleRate: Double = 16_000,
+        authorizationTimeout: TimeInterval = 10,
         readyTimeout: TimeInterval = 10,
         finishTimeout: TimeInterval = 25,
+        pingInterval: TimeInterval = 25,
         pcmDumpPath: String? = nil
     ) {
         self.gatewayURL = gatewayURL
@@ -62,27 +67,43 @@ public struct VoiceInputConfiguration: Sendable {
         self.correctionEnabled = correctionEnabled
         self.context = context
         self.vocabulary = vocabulary
+        self.authorizationFields = authorizationFields
         self.startFields = startFields
         self.targetSampleRate = targetSampleRate
+        self.authorizationTimeout = authorizationTimeout
         self.readyTimeout = readyTimeout
         self.finishTimeout = finishTimeout
+        self.pingInterval = pingInterval
         self.pcmDumpPath = pcmDumpPath
     }
 
-    public func gatewayStartMessage() -> [String: Any] {
-        // Host fields are installed first, then core protocol fields win. This
-        // preserves arbitrary nested authorization while preventing a host from
-        // accidentally replacing the lifecycle discriminator or opaque context.
+    public func gatewayAuthorizeMessage() -> [String: Any] {
+        var authorize = authorizationFields.mapValues { $0.foundationValue() }
+        authorize["type"] = "authorize"
+        authorize["uid"] = userID
+        return authorize
+    }
+
+    public func gatewayStartMessage(
+        context contextOverride: [String: VoiceInputJSONValue]? = nil,
+        vocabulary vocabularyOverride: [String]? = nil
+    ) -> [String: Any] {
         var start = startFields.mapValues { $0.foundationValue() }
         start["type"] = "start"
         start["uid"] = userID
         start["correction"] = correctionEnabled
-        start["context"] = gatewayContext()
+        start["context"] = gatewayContext(
+            context: contextOverride ?? context,
+            vocabulary: vocabularyOverride ?? vocabulary
+        )
         if let apiKey, !apiKey.isEmpty { start["apiKey"] = apiKey }
         return start
     }
 
-    func gatewayContext() -> [String: Any] {
+    private func gatewayContext(
+        context: [String: VoiceInputJSONValue],
+        vocabulary: [String]
+    ) -> [String: Any] {
         var output = context.mapValues { $0.foundationValue() }
         if !vocabulary.isEmpty { output["vocabulary"] = vocabulary }
         return output
@@ -91,7 +112,6 @@ public struct VoiceInputConfiguration: Sendable {
 
 public enum VoicePCMConverter {
     /// Downmix the first Float32 channel to mono Int16 PCM at `targetRate`.
-    /// Returns nil when the source format cannot satisfy the requested rate.
     public static func convert(
         samples: UnsafePointer<Float>,
         frameLength: Int,
@@ -123,11 +143,8 @@ public enum VoicePCMConverter {
     }
 }
 
-/// Events emitted by the reusable client engine.
-///
-/// The authoritative completion boundary is `.final`: `.correctionDelta` is
-/// display-only and must never be pasted or treated as a completed session.
 public enum VoiceInputEvent: Sendable, Equatable {
+    case connectionAuthorized
     case gatewayReady
     case level(Float)
     case partial(String)
@@ -136,9 +153,9 @@ public enum VoiceInputEvent: Sendable, Equatable {
     case failed(String)
 }
 
-/// Stable instrumentation hooks shared by VoiceType, Kraki and future hosts.
 public enum VoiceInputMetric: String, Sendable {
     case webSocketOpened = "ws_open"
+    case connectionAuthorized = "authorized"
     case engineStarted = "engine_started"
     case firstAudio = "first_audio"
     case gatewayReady = "ready"
@@ -151,16 +168,17 @@ public enum VoiceInputMetric: String, Sendable {
     case rawFinal = "raw_final"
 }
 
-/// Protocol seam used by host-app tests and future alternate capture engines.
 public protocol VoiceInputSessionProtocol: AnyObject {
     var correctionEnabled: Bool { get }
     var pcmDumpPath: String? { get }
+    func startCapture(
+        context: [String: VoiceInputJSONValue],
+        vocabulary: [String]
+    )
     func stopCapture()
     func close()
 }
 
-/// Platform-specific permission verification. Permission prompting and audio
-/// session policy stay in the host app.
 private enum VoiceCaptureAuthorization {
     static var isAuthorized: Bool {
         #if os(iOS)
@@ -180,10 +198,9 @@ private enum VoiceCaptureAuthorization {
     }
 }
 
-/// Native voice-input session: microphone → 16 kHz PCM → gateway events.
-///
-/// This type deliberately owns no SwiftUI/AppKit UI, hotkey, pasteboard,
-/// Accessibility, volume-ducking or account logic.
+/// Long-lived native voice connection: one authorized WebSocket, many capture
+/// cycles. Audio remains strictly sequential and each `startCapture` gets fresh
+/// product context.
 public final class VoiceInputSession: VoiceInputSessionProtocol {
     public typealias EventHandler = (VoiceInputEvent) -> Void
     public typealias Logger = (String) -> Void
@@ -202,8 +219,12 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
     private let engine = AVAudioEngine()
 
     private var receiveLoopRunning = true
+    private var connectionAuthorized = false
+    private var recordingActive = false
+    private var authorizationTimeoutWork: DispatchWorkItem?
     private var timeoutWork: DispatchWorkItem?
     private var readyTimeoutWork: DispatchWorkItem?
+    private var pingWork: DispatchWorkItem?
     private var terminalDelivered = false
     private var markedFirstAudio = false
     private var markedFirstPartial = false
@@ -211,7 +232,7 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
     private var lastPartial = ""
     private var captureEnded = false
     private var finishSent = false
-    private var wsReady = false
+    private var gatewayReady = false
     private var pendingAudio: [Data] = []
 
     private var dumpHandle: FileHandle?
@@ -236,25 +257,13 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
         self.partialObserved = onPartialObserved
         self.pcmDumpPath = configuration.pcmDumpPath
 
-        logger("session mode: correction=\(correctionEnabled ? "on" : "off (gateway-native)")")
-        metricHandler(.webSocketOpened)
         task = URLSession.shared.webSocketTask(with: configuration.gatewayURL)
         task.resume()
+        metricHandler(.webSocketOpened)
         receiveLoop()
-
-        send(json: configuration.gatewayStartMessage())
-
-        let readyTimeout = configuration.readyTimeout
-        let work = DispatchWorkItem { [weak self] in
-            guard let self, !self.wsReady else { return }
-            self.fail("gateway not ready after \(Int(readyTimeout))s")
-        }
-        readyTimeoutWork = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + readyTimeout, execute: work)
-
-        // Capture starts immediately. Audio produced before the gateway is
-        // ready is buffered and flushed in order after the ready frame.
-        startEngine()
+        send(json: configuration.gatewayAuthorizeMessage())
+        scheduleAuthorizationTimeout()
+        schedulePing()
     }
 
     private func emit(_ event: VoiceInputEvent) {
@@ -265,7 +274,7 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
         guard JSONSerialization.isValidJSONObject(dictionary),
               let data = try? JSONSerialization.data(withJSONObject: dictionary),
               let string = String(data: data, encoding: .utf8) else {
-            fail("invalid gateway start/control message")
+            fail("invalid gateway control message")
             return
         }
         task.send(.string(string)) { [weak self] error in
@@ -285,11 +294,89 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
         }
     }
 
-    private func startEngine() {
+    private func scheduleAuthorizationTimeout() {
+        let timeout = configuration.authorizationTimeout
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, !self.connectionAuthorized else { return }
+            self.fail("gateway authorization not ready after \(Int(timeout))s")
+        }
+        authorizationTimeoutWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: work)
+    }
+
+    private func schedulePing() {
+        guard configuration.pingInterval > 0, receiveLoopRunning else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.receiveLoopRunning else { return }
+            self.task.sendPing { [weak self] error in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    if let error {
+                        self.fail("ws ping error: \(error.localizedDescription)")
+                    } else {
+                        self.schedulePing()
+                    }
+                }
+            }
+        }
+        pingWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + configuration.pingInterval, execute: work)
+    }
+
+    public func startCapture(
+        context: [String: VoiceInputJSONValue],
+        vocabulary: [String]
+    ) {
+        guard receiveLoopRunning, connectionAuthorized, !recordingActive else {
+            fail("voice connection is not ready for a new recording")
+            return
+        }
         guard VoiceCaptureAuthorization.isAuthorized else {
             fail(VoiceCaptureAuthorization.failureDescription)
             return
         }
+
+        resetRecordingState()
+        recordingActive = true
+        send(json: configuration.gatewayStartMessage(context: context, vocabulary: vocabulary))
+        scheduleReadyTimeout()
+        startEngine()
+    }
+
+    private func resetRecordingState() {
+        timeoutWork?.cancel()
+        timeoutWork = nil
+        readyTimeoutWork?.cancel()
+        readyTimeoutWork = nil
+        terminalDelivered = false
+        markedFirstAudio = false
+        markedFirstPartial = false
+        markedCorrectionFirstToken = false
+        lastPartial = ""
+        captureEnded = false
+        finishSent = false
+        gatewayReady = false
+        pendingAudio.removeAll()
+        peakSample = 0
+        totalBytes = 0
+        chunkCount = 0
+        firstSendTimestamp = nil
+        lastStatTimestamp = Date()
+        dumpHandle?.closeFile()
+        dumpHandle = nil
+    }
+
+    private func scheduleReadyTimeout() {
+        let timeout = configuration.readyTimeout
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.recordingActive, !self.gatewayReady else { return }
+            self.fail("gateway not ready after \(Int(timeout))s")
+        }
+        readyTimeoutWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: work)
+    }
+
+    private func startEngine() {
         if let path = pcmDumpPath {
             FileManager.default.createFile(atPath: path, contents: nil)
             dumpHandle = FileHandle(forWritingAtPath: path)
@@ -313,7 +400,7 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
             firstSendTimestamp = Date()
             lastStatTimestamp = Date()
             metricHandler(.engineStarted)
-            logger("audio engine started (buffering until gateway ready)")
+            logger("audio engine started (buffering until recording ready)")
         } catch {
             fail("engine start failed: \(error.localizedDescription)")
         }
@@ -322,13 +409,10 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
     private func flushPending() {
         guard !pendingAudio.isEmpty else { return }
         metricHandler(.bufferFlushed)
-        logger("flushing \(pendingAudio.count) buffered audio chunks to gateway")
         for chunk in pendingAudio { sendPCM(chunk) }
         pendingAudio.removeAll()
     }
 
-    // AVAudioEngine tap thread: convert only, then confine mutable session
-    // state and callbacks to the main thread.
     private func handleBuffer(_ buffer: AVAudioPCMBuffer) {
         guard let channelData = buffer.floatChannelData?[0] else { return }
         guard let converted = VoicePCMConverter.convert(
@@ -343,7 +427,7 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
     }
 
     private func ingest(_ data: Data, peak: Float) {
-        guard receiveLoopRunning, !captureEnded else { return }
+        guard receiveLoopRunning, recordingActive, !captureEnded else { return }
         dumpHandle?.write(data)
         if !markedFirstAudio {
             markedFirstAudio = true
@@ -353,16 +437,17 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
         totalBytes += data.count
         peakSample = max(peakSample, Int(peak * 32768))
         emit(.level(peak))
-        if wsReady { sendPCM(data) } else { pendingAudio.append(data) }
+        if gatewayReady { sendPCM(data) } else { pendingAudio.append(data) }
 
         let now = Date()
         if now.timeIntervalSince(lastStatTimestamp) > 1 {
             lastStatTimestamp = now
-            logger("capture: chunks=\(chunkCount) bytes=\(totalBytes) peak=\(peakSample)/32768\(wsReady ? "" : " (buffering)")")
+            logger("capture: chunks=\(chunkCount) bytes=\(totalBytes) peak=\(peakSample)/32768\(gatewayReady ? "" : " (buffering)")")
         }
     }
 
     public func stopCapture() {
+        guard recordingActive else { return }
         if engine.isRunning {
             engine.inputNode.removeTap(onBus: 0)
             engine.stop()
@@ -371,21 +456,17 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
     }
 
     private func onCaptureEOF() {
-        guard receiveLoopRunning, !captureEnded else { return }
+        guard receiveLoopRunning, recordingActive, !captureEnded else { return }
         captureEnded = true
         let duration = firstSendTimestamp.map { Date().timeIntervalSince($0) } ?? 0
-        logger("capture end: chunks=\(chunkCount) bytes=\(totalBytes) peak=\(peakSample)/32768 dur=\(String(format: "%.2f", duration))s dump=\(pcmDumpPath ?? "-")")
+        logger("capture end: chunks=\(chunkCount) bytes=\(totalBytes) peak=\(peakSample)/32768 dur=\(String(format: "%.2f", duration))s")
 
         let work = DispatchWorkItem { [weak self] in
             self?.fail("timed out waiting for transcript")
         }
         timeoutWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + configuration.finishTimeout, execute: work)
-        if wsReady {
-            sendFinish()
-        } else {
-            logger("capture ended before gateway ready; finish deferred")
-        }
+        if gatewayReady { sendFinish() }
     }
 
     private func sendFinish() {
@@ -393,7 +474,6 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
         finishSent = true
         metricHandler(.finishSent)
         send(json: ["type": "finish"])
-        logger("finish sent")
     }
 
     private func receiveLoop() {
@@ -420,16 +500,24 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
               let type = message["type"] as? String else { return }
 
         switch type {
+        case "authorized":
+            guard !connectionAuthorized else { return }
+            connectionAuthorized = true
+            authorizationTimeoutWork?.cancel()
+            authorizationTimeoutWork = nil
+            metricHandler(.connectionAuthorized)
+            emit(.connectionAuthorized)
         case "ready":
-            logger("gateway ready")
+            guard recordingActive else { return }
             metricHandler(.gatewayReady)
             readyTimeoutWork?.cancel()
-            wsReady = true
+            readyTimeoutWork = nil
+            gatewayReady = true
             flushPending()
             emit(.gatewayReady)
             if captureEnded { sendFinish() }
         case "correction_delta":
-            guard correctionEnabled else { return }
+            guard correctionEnabled, recordingActive else { return }
             let text = message["text"] as? String ?? ""
             guard !text.isEmpty else { return }
             if !markedCorrectionFirstToken {
@@ -438,22 +526,14 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
             }
             emit(.correctionDelta(text))
         case "transcript":
+            guard recordingActive else { return }
             let text = message["text"] as? String ?? ""
             if message["sessionFinal"] as? Bool == true {
-                let rawText = message["rawText"] as? String
-                if let rawText, rawText != text {
-                    logger("correction changed transcript rawLen=\(rawText.count) correctedLen=\(text.count)")
-                } else if correctionEnabled {
-                    logger("correction left transcript unchanged")
-                }
-                complete(text, rawText: rawText)
+                complete(text, rawText: message["rawText"] as? String)
             } else {
                 if !markedFirstPartial {
                     markedFirstPartial = true
                     metricHandler(.firstPartial)
-                }
-                if text.count + 5 < lastPartial.count {
-                    logger("partial len dropped \(lastPartial.count)→\(text.count) (ASR segment reset?)")
                 }
                 lastPartial = text
                 partialObserved()
@@ -465,36 +545,53 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
             fail("gateway error: \(message["message"] ?? "?")")
         case "closed":
             metricHandler(.asrClosed)
-            logger("asr closed code=\(message["code"] ?? -1)")
         default:
             break
         }
     }
 
     private func complete(_ text: String, rawText: String?) {
-        guard !terminalDelivered else { return }
+        guard recordingActive, !terminalDelivered else { return }
         terminalDelivered = true
         metricHandler(correctionEnabled ? .final : .rawFinal)
-        logger("\(correctionEnabled ? "corrected" : "gateway raw") final len=\(text.count) (last partial len=\(lastPartial.count))")
-        if correctionEnabled, text.count * 2 < lastPartial.count, lastPartial.count - text.count > 10 {
-            logger("WARN: final much shorter than last partial partialLen=\(lastPartial.count) finalLen=\(text.count)")
-        }
-        finishTerminalTask(with: .normalClosure)
+        finishRecordingLocally()
         emit(.final(text, rawText: rawText))
+    }
+
+    private func finishRecordingLocally() {
+        timeoutWork?.cancel()
+        timeoutWork = nil
+        readyTimeoutWork?.cancel()
+        readyTimeoutWork = nil
+        dumpHandle?.closeFile()
+        dumpHandle = nil
+        if engine.isRunning {
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
+        }
+        recordingActive = false
+        gatewayReady = false
+        captureEnded = false
+        finishSent = false
+        pendingAudio.removeAll()
     }
 
     private func fail(_ reason: String) {
         guard receiveLoopRunning else { return }
-        finishTerminalTask(with: .goingAway)
-        // Defer so a synchronous startup failure arrives after the host stores
-        // its session reference.
+        closeConnection(with: .goingAway)
         DispatchQueue.main.async { [eventHandler] in eventHandler(.failed(reason)) }
     }
 
-    private func finishTerminalTask(with closeCode: URLSessionWebSocketTask.CloseCode) {
+    private func closeConnection(with closeCode: URLSessionWebSocketTask.CloseCode) {
         receiveLoopRunning = false
+        authorizationTimeoutWork?.cancel()
+        authorizationTimeoutWork = nil
         timeoutWork?.cancel()
+        timeoutWork = nil
         readyTimeoutWork?.cancel()
+        readyTimeoutWork = nil
+        pingWork?.cancel()
+        pingWork = nil
         dumpHandle?.closeFile()
         dumpHandle = nil
         if engine.isRunning {
@@ -506,7 +603,7 @@ public final class VoiceInputSession: VoiceInputSessionProtocol {
 
     public func close() {
         guard receiveLoopRunning else { return }
-        finishTerminalTask(with: .normalClosure)
+        closeConnection(with: .normalClosure)
     }
 
     deinit {

--- a/packages/arm/ios/Vendor/VoiceInputCore/Tests/VoiceInputCoreTests/VoiceInputCoreTests.swift
+++ b/packages/arm/ios/Vendor/VoiceInputCore/Tests/VoiceInputCoreTests/VoiceInputCoreTests.swift
@@ -32,18 +32,17 @@ final class VoiceInputCoreTests: XCTestCase {
         XCTAssertEqual(product["paid"] as? Bool, true)
     }
 
-    func testGatewayStartMessagePreservesNestedHostFieldsAndProtectsCoreKeys() throws {
+    func testGatewayAuthorizationKeepsLeaseOffPerRecordingStart() throws {
         let configuration = VoiceInputConfiguration(
             gatewayURL: try XCTUnwrap(URL(string: "wss://voice.example.test/voice")),
             userID: "kraki:user-42",
             correctionEnabled: true,
             context: ["product": .string("kraki")],
-            startFields: [
+            authorizationFields: [
                 "type": .string("host-must-not-win"),
                 "uid": .string("wrong-user"),
                 "deviceId": .string("device-1"),
-                "sampleRate": .number(16_000),
-                "lease": .object([
+                "authorization": .object([
                     "payload": .object([
                         "did": .string("device-1"),
                         "quota_seconds": .number(600),
@@ -51,19 +50,28 @@ final class VoiceInputCoreTests: XCTestCase {
                     "signature": .string("sig"),
                     "alg": .string("RSA-SHA256"),
                 ]),
+            ],
+            startFields: [
+                "deviceId": .string("device-1"),
+                "sampleRate": .number(16_000),
             ]
         )
 
-        let message = configuration.gatewayStartMessage()
-        XCTAssertEqual(message["type"] as? String, "start")
-        XCTAssertEqual(message["uid"] as? String, "kraki:user-42")
-        XCTAssertEqual(message["deviceId"] as? String, "device-1")
-        XCTAssertEqual(message["sampleRate"] as? Double, 16_000)
-        let lease = try XCTUnwrap(message["lease"] as? [String: Any])
+        let authorize = configuration.gatewayAuthorizeMessage()
+        XCTAssertEqual(authorize["type"] as? String, "authorize")
+        XCTAssertEqual(authorize["uid"] as? String, "kraki:user-42")
+        XCTAssertEqual(authorize["deviceId"] as? String, "device-1")
+        let lease = try XCTUnwrap(authorize["authorization"] as? [String: Any])
         XCTAssertEqual(lease["signature"] as? String, "sig")
         let payload = try XCTUnwrap(lease["payload"] as? [String: Any])
         XCTAssertEqual(payload["did"] as? String, "device-1")
         XCTAssertEqual(payload["quota_seconds"] as? Double, 600)
+
+        let start = configuration.gatewayStartMessage()
+        XCTAssertEqual(start["type"] as? String, "start")
+        XCTAssertEqual(start["deviceId"] as? String, "device-1")
+        XCTAssertEqual(start["sampleRate"] as? Double, 16_000)
+        XCTAssertNil(start["authorization"])
     }
 
     func testGatewayStartMessageOmitsEmptyApiKey() throws {

--- a/packages/head/src/__tests__/voice-lease.test.ts
+++ b/packages/head/src/__tests__/voice-lease.test.ts
@@ -93,7 +93,7 @@ describe('Storage voice_leases', () => {
   });
   afterEach(() => storage.close());
 
-  it('migrates v8 leases conservatively and prevents legacy replay', () => {
+  it('migrates v8 leases into resumable cumulative warm-connection accounting', () => {
     const dir = mkTmpLeaseDir();
     const dbPath = join(dir, 'legacy.db');
     const legacy = new Database(dbPath);
@@ -120,19 +120,20 @@ describe('Storage voice_leases', () => {
 
     const migrated = new Storage(dbPath);
     try {
-      expect(migrated.rawDb.pragma('user_version', { simple: true })).toBe(10);
+      expect(migrated.rawDb.pragma('user_version', { simple: true })).toBe(11);
       expect(migrated.getVoiceLease('legacy-lease')).toMatchObject({
         activationId: 'legacy:legacy-lease',
         activatedAt: '2026-06-15T10:00:00.000Z',
         usedSeconds: null,
+        reportedAudioSeconds: 0,
       });
       expect(migrated.sumVoiceLeaseQuotaIssuedToday(
         'u1', Math.floor(new Date('2026-06-15T23:00:00Z').getTime() / 1000)
-      )).toBe(300);
+      )).toBe(0);
       expect(migrated.activateVoiceLease({
         jti: 'legacy-lease', activationId: 'activation-replay',
         activatedAtUnixSec: Math.floor(new Date('2026-06-15T10:01:00Z').getTime() / 1000),
-      })).toEqual({ status: 'conflict' });
+      })).toEqual({ status: 'replaced', reportedAudioSeconds: 0 });
     } finally {
       migrated.close();
       rm(dir);
@@ -166,7 +167,7 @@ describe('Storage voice_leases', () => {
     })).toThrow();
   });
 
-  it('releases expired unsettled reservations but retains settled usage', () => {
+  it('reserves full quota through expiry grace, then retains cumulative actual usage', () => {
     storage.upsertUser('u1', 'a');
     const issued = Math.floor(new Date('2026-06-15T10:00:00Z').getTime() / 1000);
     storage.recordVoiceLease({
@@ -187,11 +188,11 @@ describe('Storage voice_leases', () => {
     storage.activateVoiceLease({ jti: 'used-expired', activationId: 'activation-used', activatedAtUnixSec: issued + 2 });
     storage.settleVoiceLease({ jti: 'used-expired', activationId: 'activation-used', audioSeconds: 4.1, settledAtUnixSec: issued + 10 });
 
-    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', issued + 100)).toBe(605);
-    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', issued + 500)).toBe(305);
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', issued + 100)).toBe(900);
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', issued + 500)).toBe(5);
   });
 
-  it('rejects activation after expiry and preserves one-time activation', () => {
+  it('rejects activation after expiry and replaces stale warm-connection owners', () => {
     storage.upsertUser('u1', 'a');
     const now = Math.floor(new Date('2026-06-15T10:00:00Z').getTime() / 1000);
     storage.recordVoiceLease({
@@ -208,13 +209,13 @@ describe('Storage voice_leases', () => {
     });
     expect(storage.activateVoiceLease({
       jti: 'single-use', activationId: 'activation-first', activatedAtUnixSec: now + 1,
-    })).toEqual({ status: 'activated' });
+    })).toEqual({ status: 'activated', reportedAudioSeconds: 0 });
     expect(storage.activateVoiceLease({
       jti: 'single-use', activationId: 'activation-first', activatedAtUnixSec: now + 2,
-    })).toEqual({ status: 'unchanged' });
+    })).toEqual({ status: 'unchanged', reportedAudioSeconds: 0 });
     expect(storage.activateVoiceLease({
       jti: 'single-use', activationId: 'activation-replay', activatedAtUnixSec: now + 2,
-    })).toEqual({ status: 'conflict' });
+    })).toEqual({ status: 'replaced', reportedAudioSeconds: 0 });
 
     const beforeMidnight = Math.floor(new Date('2026-06-15T23:59:30Z').getTime() / 1000);
     const afterMidnight = Math.floor(new Date('2026-06-16T00:00:10Z').getTime() / 1000);
@@ -227,7 +228,7 @@ describe('Storage voice_leases', () => {
     })).toEqual({ status: 'wrong_day' });
   });
 
-  it('settles reservations to actual audio seconds and preserves idempotency', () => {
+  it('stores monotonic cumulative checkpoints and preserves full quota until expiry', () => {
     storage.upsertUser('u1', 'a');
     const now = Math.floor(new Date('2026-06-15T10:00:00Z').getTime() / 1000);
     storage.recordVoiceLease({
@@ -242,12 +243,15 @@ describe('Storage voice_leases', () => {
 
     storage.activateVoiceLease({ jti: 'actual', activationId: 'activation-actual', activatedAtUnixSec: now + 2 });
     expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 5.01, settledAtUnixSec: now + 10 }))
-      .toEqual({ status: 'settled', usedSeconds: 6 });
-    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', now)).toBe(306);
+      .toEqual({ status: 'updated', usedSeconds: 6, reportedAudioSeconds: 5.01 });
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', now)).toBe(600);
     expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 5.01, settledAtUnixSec: now + 20 }))
-      .toEqual({ status: 'unchanged', usedSeconds: 6 });
-    expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 7, settledAtUnixSec: now + 20 }).status)
-      .toBe('conflict');
+      .toEqual({ status: 'unchanged', usedSeconds: 6, reportedAudioSeconds: 5.01 });
+    expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 7, settledAtUnixSec: now + 20 }))
+      .toEqual({ status: 'updated', usedSeconds: 7, reportedAudioSeconds: 7 });
+    expect(storage.settleVoiceLease({ jti: 'actual', activationId: 'activation-actual', audioSeconds: 6, settledAtUnixSec: now + 21 }))
+      .toEqual({ status: 'stale', usedSeconds: 7, reportedAudioSeconds: 7 });
+    expect(storage.sumVoiceLeaseQuotaIssuedToday('u1', now + 4000)).toBe(7);
   });
 
   it('clamps settled usage to the signed lease quota', () => {
@@ -259,7 +263,7 @@ describe('Storage voice_leases', () => {
     });
     storage.activateVoiceLease({ jti: 'clamp', activationId: 'activation-clamp' });
     expect(storage.settleVoiceLease({ jti: 'clamp', activationId: 'activation-clamp', audioSeconds: 999 }))
-      .toEqual({ status: 'settled', usedSeconds: 300 });
+      .toEqual({ status: 'updated', usedSeconds: 300, reportedAudioSeconds: 300 });
     expect(storage.settleVoiceLease({ jti: 'missing', activationId: 'activation-missing', audioSeconds: 1 }))
       .toEqual({ status: 'not_found' });
   });
@@ -323,7 +327,7 @@ describe('Voice settlement endpoint contract', () => {
       authorization: 'Bearer secret', body: activation,
     })).toEqual({
       status: 200,
-      body: { ok: true, activationStatus: 'activated' },
+      body: { ok: true, activationStatus: 'activated', reportedAudioSeconds: 0 },
     });
     expect(handleVoiceSettlement(storage, 'secret', {
       authorization: 'Bearer secret', body: activation,
@@ -333,7 +337,7 @@ describe('Voice settlement endpoint contract', () => {
       body: JSON.stringify({
         action: 'activate', jti: 'lease-12345678', activationId: 'different-activation',
       }),
-    }).status).toBe(409);
+    }).body.activationStatus).toBe('replaced');
 
     storage.recordVoiceLease({
       jti: 'expired-12345678', userId: 'u1', deviceId: 'd1',
@@ -348,20 +352,37 @@ describe('Voice settlement endpoint contract', () => {
     });
     expect(expired).toEqual({ status: 409, body: { error: 'lease_expired' } });
 
-    const first = handleVoiceSettlement(storage, 'secret', { authorization: 'Bearer secret', body });
+    // The replacement activation above owns the lease now, so stale usage from
+    // the original connection is rejected.
+    expect(handleVoiceSettlement(storage, 'secret', { authorization: 'Bearer secret', body }).status).toBe(409);
+
+    const replacementBody = JSON.stringify({
+      action: 'settle', jti: 'lease-12345678', activationId: 'different-activation',
+      audioSeconds: 5.2, reason: 'done',
+    });
+    const first = handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret', body: replacementBody,
+    });
     expect(first).toEqual({
       status: 200,
-      body: { ok: true, usedSeconds: 6, settlementStatus: 'settled' },
+      body: {
+        ok: true,
+        usedSeconds: 6,
+        reportedAudioSeconds: 5.2,
+        settlementStatus: 'updated',
+      },
     });
-    const retry = handleVoiceSettlement(storage, 'secret', { authorization: 'Bearer secret', body });
+    const retry = handleVoiceSettlement(storage, 'secret', {
+      authorization: 'Bearer secret', body: replacementBody,
+    });
     expect(retry.body.settlementStatus).toBe('unchanged');
-    const conflict = handleVoiceSettlement(storage, 'secret', {
+    const advanced = handleVoiceSettlement(storage, 'secret', {
       authorization: 'Bearer secret',
       body: JSON.stringify({
-        action: 'settle', jti: 'lease-12345678', activationId: 'activation-12345678', audioSeconds: 8,
+        action: 'settle', jti: 'lease-12345678', activationId: 'different-activation', audioSeconds: 8,
       }),
     });
-    expect(conflict.status).toBe(409);
+    expect(advanced.body.settlementStatus).toBe('updated');
   });
 });
 

--- a/packages/head/src/cli.ts
+++ b/packages/head/src/cli.ts
@@ -95,11 +95,11 @@ if (args.includes('--help') || args.includes('-h')) {
     VOICE_LEASE_ENABLED            Set to "1" to enable lease issuance (default: off).
     VOICE_LEASE_DIR                Directory for the lease signing keypair
                                    (default: $HOME/.kraki-head).
-    VOICE_LEASE_TTL_SEC            Authorization-start window in seconds
+    VOICE_LEASE_TTL_SEC            Warm-connection authorization lifetime
                                    (default: 600 = 10 min).
-    VOICE_LEASE_QUOTA_SEC          Per-recording audio budget in seconds
+    VOICE_LEASE_QUOTA_SEC          Cumulative audio budget per warm lease
                                    (default: 300 = 5 min).
-    VOICE_DAILY_QUOTA_SEC          Per-user-per-day cap on reserved/settled seconds
+    VOICE_DAILY_QUOTA_SEC          Per-user-per-day cap on reserved/actual seconds
                                    (default: 7200 = 2h).
     VOICE_SETTLEMENT_KEY           Shared secret for broker usage settlement.
                                    Required when voice leases are enabled.

--- a/packages/head/src/server.ts
+++ b/packages/head/src/server.ts
@@ -72,11 +72,11 @@ export interface HeadServerOptions {
   region?: string;
   /** Voice-broker lease signer. If absent, request_voice_lease is rejected with 'not_entitled'. */
   leaseIssuer?: LeaseIssuer;
-  /** Authorization-start window in seconds. Default 600 (10m). */
+  /** Warm-connection authorization lifetime in seconds. Default 600 (10m). */
   voiceLeaseTtlSec?: number;
-  /** Per-recording audio budget in seconds. Default 300 (5m). */
+  /** Cumulative audio budget per warm lease. Default 300 (5m). */
   voiceLeaseQuotaSec?: number;
-  /** Per-user-per-day cap on reserved/settled seconds. Default 7200 (2h). */
+  /** Per-user-per-day cap on reserved/actual seconds. Default 7200 (2h). */
   voiceDailyQuotaSec?: number;
   /**
    * Public WSS URL of the voice broker for this region (e.g.

--- a/packages/head/src/storage.ts
+++ b/packages/head/src/storage.ts
@@ -96,7 +96,7 @@ export interface StoredRegion {
   lastSeenAt?: string;
 }
 
-const SCHEMA_VERSION = 10;
+const SCHEMA_VERSION = 11;
 
 export class Storage {
   private db: Database.Database;
@@ -315,6 +315,25 @@ export class Storage {
         SET activation_id = 'legacy:' || jti,
             activated_at = issued_at
         WHERE activation_id IS NULL AND activated_at IS NULL
+      `);
+    }
+
+    if (currentVersion < 11) {
+      // Warm voice connections reuse one lease for many sequential recordings.
+      // Keep the broker's exact cumulative audio value so reconnects resume
+      // without rounding drift; `used_seconds` remains the rounded daily/audit
+      // projection. Existing one-shot settlements seed the cumulative value.
+      const columns = new Set(
+        (this.db.prepare('PRAGMA table_info(voice_leases)').all() as Array<{ name: string }>)
+          .map((column) => column.name)
+      );
+      if (!columns.has('reported_audio_seconds')) {
+        this.db.exec('ALTER TABLE voice_leases ADD COLUMN reported_audio_seconds REAL NOT NULL DEFAULT 0');
+      }
+      this.db.exec(`
+        UPDATE voice_leases
+        SET reported_audio_seconds = COALESCE(used_seconds, 0)
+        WHERE reported_audio_seconds = 0 AND used_seconds IS NOT NULL
       `);
     }
 
@@ -693,19 +712,18 @@ export class Storage {
   }
 
   /**
-   * Daily reserved/consumed voice seconds for a user. Unsettled leases reserve
-   * their full signed quota so concurrent sessions cannot bypass the cap.
-   * Settled leases count only trusted broker-reported audio seconds.
+   * Daily reserved/consumed voice seconds for a user. Every unexpired lease
+   * reserves its full signed quota even after usage checkpoints, because the
+   * same warm authorization can still consume the remainder. One minute after
+   * expiry the reservation collapses to trusted broker-reported actual usage.
    */
   sumVoiceLeaseQuotaIssuedToday(userId: string, nowUnixSec: number): number {
     const day = new Date(nowUnixSec * 1000).toISOString().slice(0, 10);
     const row = this.db.prepare(`
       SELECT COALESCE(SUM(
         CASE
-          WHEN settled_at IS NOT NULL THEN COALESCE(used_seconds, quota_seconds)
-          WHEN activated_at IS NOT NULL THEN quota_seconds
           WHEN unixepoch(expires_at) + 60 > ? THEN quota_seconds
-          ELSE 0
+          ELSE COALESCE(used_seconds, 0)
         END
       ), 0) AS total
       FROM voice_leases
@@ -715,20 +733,26 @@ export class Storage {
   }
 
   /**
-   * Activate a signed lease exactly once before the broker accepts audio.
-   * Retries carrying the same activation id are idempotent; a different id is
-   * a replay attempt and conflicts.
+   * Activate a warm lease connection before the broker accepts recordings.
+   * The same activation id is an idempotent retry. A different activation id
+   * replaces the previous owner (last-writer-wins reconnect) and makes stale
+   * checkpoints fail closed. The exact cumulative usage is returned so a new
+   * broker connection can resume quota accounting without rounding drift.
    */
   activateVoiceLease(input: {
     jti: string;
     activationId: string;
     activatedAtUnixSec?: number;
-  }): { status: 'activated' | 'unchanged' | 'conflict' | 'expired' | 'wrong_day' | 'revoked' | 'not_found' } {
+  }): {
+    status: 'activated' | 'unchanged' | 'replaced' | 'expired' | 'wrong_day' | 'revoked' | 'not_found';
+    reportedAudioSeconds?: number;
+  } {
     const nowUnixSec = input.activatedAtUnixSec ?? Math.floor(Date.now() / 1000);
     const activationDay = new Date(nowUnixSec * 1000).toISOString().slice(0, 10);
     const lease = this.db.prepare(`
       SELECT activation_id, activated_at, issued_at,
-             unixepoch(expires_at) AS expires_at_unix, revoked_at
+             unixepoch(expires_at) AS expires_at_unix, revoked_at,
+             COALESCE(reported_audio_seconds, 0) AS reported_audio_seconds
       FROM voice_leases WHERE jti = ?
     `).get(input.jti) as {
       activation_id: string | null;
@@ -736,46 +760,35 @@ export class Storage {
       issued_at: string;
       expires_at_unix: number;
       revoked_at: string | null;
+      reported_audio_seconds: number;
     } | undefined;
     if (!lease) return { status: 'not_found' };
     if (lease.revoked_at !== null) return { status: 'revoked' };
-    if (lease.activated_at !== null) {
-      return { status: lease.activation_id === input.activationId ? 'unchanged' : 'conflict' };
-    }
     if (lease.expires_at_unix <= nowUnixSec) return { status: 'expired' };
     if (lease.issued_at.slice(0, 10) !== activationDay) return { status: 'wrong_day' };
+
+    const reportedAudioSeconds = Number(lease.reported_audio_seconds) || 0;
+    if (lease.activated_at !== null && lease.activation_id === input.activationId) {
+      return { status: 'unchanged', reportedAudioSeconds };
+    }
+
     const activatedAt = new Date(nowUnixSec * 1000).toISOString();
-    const result = this.db.prepare(`
+    this.db.prepare(`
       UPDATE voice_leases SET activation_id = ?, activated_at = ?
-      WHERE jti = ? AND activated_at IS NULL AND revoked_at IS NULL
+      WHERE jti = ? AND revoked_at IS NULL
         AND unixepoch(expires_at) > ? AND substr(issued_at, 1, 10) = ?
     `).run(input.activationId, activatedAt, input.jti, nowUnixSec, activationDay);
-    if (result.changes === 1) return { status: 'activated' };
-    const current = this.db.prepare(`
-      SELECT activation_id, activated_at, issued_at,
-             unixepoch(expires_at) AS expires_at_unix, revoked_at
-      FROM voice_leases WHERE jti = ?
-    `).get(input.jti) as {
-      activation_id: string | null;
-      activated_at: string | null;
-      issued_at: string;
-      expires_at_unix: number;
-      revoked_at: string | null;
-    } | undefined;
-    if (!current) return { status: 'not_found' };
-    if (current.revoked_at !== null) return { status: 'revoked' };
-    if (current.activated_at !== null) {
-      return { status: current.activation_id === input.activationId ? 'unchanged' : 'conflict' };
-    }
-    if (current.expires_at_unix <= nowUnixSec) return { status: 'expired' };
-    if (current.issued_at.slice(0, 10) !== activationDay) return { status: 'wrong_day' };
-    return { status: 'conflict' };
+    return {
+      status: lease.activated_at === null ? 'activated' : 'replaced',
+      reportedAudioSeconds,
+    };
   }
 
   /**
-   * Idempotently settle one lease to actual broker-observed audio seconds.
-   * First write wins; retries with the same value are accepted, while a
-   * conflicting replay is rejected instead of silently changing accounting.
+   * Store a monotonic cumulative usage checkpoint for one warm lease. Equal
+   * values are idempotent; lower out-of-order retries are stale but harmless;
+   * higher values advance both the exact cumulative value and rounded audit
+   * seconds. Checkpoints from a replaced activation are rejected.
    */
   settleVoiceLease(input: {
     jti: string;
@@ -783,47 +796,66 @@ export class Storage {
     audioSeconds: number;
     reason?: string;
     settledAtUnixSec?: number;
-  }): { status: 'settled' | 'unchanged' | 'conflict' | 'not_found' | 'not_activated'; usedSeconds?: number } {
+  }): {
+    status: 'updated' | 'unchanged' | 'stale' | 'conflict' | 'not_found' | 'not_activated';
+    usedSeconds?: number;
+    reportedAudioSeconds?: number;
+  } {
     const lease = this.db.prepare(`
-      SELECT quota_seconds, used_seconds, settled_at, activation_id, activated_at
+      SELECT quota_seconds, used_seconds, activation_id, activated_at,
+             COALESCE(reported_audio_seconds, 0) AS reported_audio_seconds
       FROM voice_leases WHERE jti = ?
     `).get(input.jti) as {
       quota_seconds: number;
       used_seconds: number | null;
-      settled_at: string | null;
       activation_id: string | null;
       activated_at: string | null;
+      reported_audio_seconds: number;
     } | undefined;
     if (!lease) return { status: 'not_found' };
     if (lease.activated_at === null) return { status: 'not_activated' };
     if (lease.activation_id !== input.activationId) return { status: 'conflict' };
 
-    const usedSeconds = Math.min(
+    const reportedAudioSeconds = Math.min(
       lease.quota_seconds,
-      Math.max(0, Math.ceil(input.audioSeconds))
+      Math.max(0, input.audioSeconds)
     );
-    if (lease.settled_at !== null) {
-      return lease.used_seconds === usedSeconds
-        ? { status: 'unchanged', usedSeconds }
-        : { status: 'conflict', usedSeconds: lease.used_seconds ?? undefined };
+    const currentReported = Number(lease.reported_audio_seconds) || 0;
+    const currentUsed = lease.used_seconds ?? Math.ceil(currentReported);
+    if (reportedAudioSeconds < currentReported) {
+      return {
+        status: 'stale',
+        usedSeconds: currentUsed,
+        reportedAudioSeconds: currentReported,
+      };
+    }
+    if (reportedAudioSeconds === currentReported) {
+      return {
+        status: 'unchanged',
+        usedSeconds: currentUsed,
+        reportedAudioSeconds: currentReported,
+      };
     }
 
+    const usedSeconds = Math.ceil(reportedAudioSeconds);
     const settledAt = new Date(
       (input.settledAtUnixSec ?? Math.floor(Date.now() / 1000)) * 1000
     ).toISOString();
-    const result = this.db.prepare(`
+    this.db.prepare(`
       UPDATE voice_leases
-      SET used_seconds = ?, settled_at = ?, settlement_reason = ?
-      WHERE jti = ? AND settled_at IS NULL
-    `).run(usedSeconds, settledAt, input.reason?.slice(0, 64) ?? null, input.jti);
-    if (result.changes === 1) return { status: 'settled', usedSeconds };
-
-    const current = this.db.prepare(`
-      SELECT used_seconds FROM voice_leases WHERE jti = ?
-    `).get(input.jti) as { used_seconds: number | null } | undefined;
-    return current?.used_seconds === usedSeconds
-      ? { status: 'unchanged', usedSeconds }
-      : { status: 'conflict', usedSeconds: current?.used_seconds ?? undefined };
+      SET reported_audio_seconds = ?, used_seconds = ?, settled_at = ?, settlement_reason = ?
+      WHERE jti = ? AND activation_id = ?
+        AND COALESCE(reported_audio_seconds, 0) < ?
+    `).run(
+      reportedAudioSeconds,
+      usedSeconds,
+      settledAt,
+      input.reason?.slice(0, 64) ?? null,
+      input.jti,
+      input.activationId,
+      reportedAudioSeconds,
+    );
+    return { status: 'updated', usedSeconds, reportedAudioSeconds };
   }
 
   /** Fetch a single lease by jti (audit / debug). Returns undefined if unknown. */
@@ -839,19 +871,21 @@ export class Storage {
     usedSeconds: number | null;
     settledAt: string | null;
     settlementReason: string | null;
+    reportedAudioSeconds: number;
     activationId: string | null;
     activatedAt: string | null;
   } | undefined {
     const row = this.db.prepare(`
       SELECT jti, user_id, device_id, resource, quota_seconds, issued_at,
              expires_at, revoked_at, used_seconds, settled_at, settlement_reason,
+             COALESCE(reported_audio_seconds, 0) AS reported_audio_seconds,
              activation_id, activated_at
       FROM voice_leases WHERE jti = ?
     `).get(jti) as {
       jti: string; user_id: string; device_id: string; resource: string;
       quota_seconds: number; issued_at: string; expires_at: string; revoked_at: string | null;
       used_seconds: number | null; settled_at: string | null; settlement_reason: string | null;
-      activation_id: string | null; activated_at: string | null;
+      reported_audio_seconds: number; activation_id: string | null; activated_at: string | null;
     } | undefined;
     if (!row) return undefined;
     return {
@@ -866,6 +900,7 @@ export class Storage {
       usedSeconds: row.used_seconds,
       settledAt: row.settled_at,
       settlementReason: row.settlement_reason,
+      reportedAudioSeconds: Number(row.reported_audio_seconds) || 0,
       activationId: row.activation_id,
       activatedAt: row.activated_at,
     };

--- a/packages/head/src/voice-settlement.ts
+++ b/packages/head/src/voice-settlement.ts
@@ -51,8 +51,14 @@ export function handleVoiceSettlement(
     if (result.status === 'expired') return { status: 409, body: { error: 'lease_expired' } };
     if (result.status === 'wrong_day') return { status: 409, body: { error: 'lease_wrong_day' } };
     if (result.status === 'revoked') return { status: 409, body: { error: 'lease_revoked' } };
-    if (result.status === 'conflict') return { status: 409, body: { error: 'activation_conflict' } };
-    return { status: 200, body: { ok: true, activationStatus: result.status } };
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        activationStatus: result.status,
+        reportedAudioSeconds: result.reportedAudioSeconds ?? 0,
+      },
+    };
   }
 
   if (typeof input.audioSeconds !== 'number' || !Number.isFinite(input.audioSeconds)
@@ -77,6 +83,11 @@ export function handleVoiceSettlement(
   }
   return {
     status: 200,
-    body: { ok: true, usedSeconds: result.usedSeconds, settlementStatus: result.status },
+    body: {
+      ok: true,
+      usedSeconds: result.usedSeconds,
+      reportedAudioSeconds: result.reportedAudioSeconds,
+      settlementStatus: result.status,
+    },
   };
 }

--- a/packages/protocol/src/voice.ts
+++ b/packages/protocol/src/voice.ts
@@ -20,7 +20,7 @@ export type VoiceLeaseDeniedReason =
   | 'not_entitled'
   | 'invalid_request';
 
-/** lease 的签名 payload。一个 lease = 一份 payload + 一段签名。 */
+/** lease 的签名 payload。一张 lease 授权一个短期 warm voice connection。 */
 export interface VoiceLeasePayload {
   /** Schema version. */
   ver: VoiceLeaseVersion;
@@ -34,7 +34,7 @@ export interface VoiceLeasePayload {
   iat: number;
   /** Expires-at, unix seconds. */
   exp: number;
-  /** 本 lease 允许的音频秒数。broker 按 session 扣。 */
+  /** 本 lease 生命周期内所有顺序录音共享的累计音频秒数上限。 */
   quota_seconds: number;
   /** 授权访问的后端服务。 */
   resource: VoiceResource;
@@ -112,18 +112,31 @@ export interface VoiceLeaseDeniedMessage {
 }
 
 // ============================================================
-// arm ↔ voice-broker — start 消息扩展
+// arm ↔ voice-broker — warm connection + sequential recordings
 // ============================================================
 
-/** broker 入口握手。BROKER_DEV_NO_AUTH=1 时 lease 可省；否则必传。 */
+/** WebSocket 建立后先完成一次连接级授权，成功后可重复 start/finish。 */
+export interface VoiceAuthorizeMessage {
+  type: 'authorize';
+  /** User/device fields are checked against the signed lease for diagnostics. */
+  uid?: string;
+  deviceId?: string;
+  /** Product authorization remains opaque to the generic voice gateway. */
+  authorization: VoiceLease;
+}
+
+/** broker 对连接级授权的确认。 */
+export interface VoiceAuthorizedMessage {
+  type: 'authorized';
+}
+
+/** 单段录音开始；lease 已由同一 WebSocket 上的 authorize 验证。 */
 export interface VoiceStartMessage {
   type: 'start';
-  /** User id (informational; 真相来自 lease.sub)。 */
+  /** User id (informational; truth comes from the authorized lease). */
   uid?: string;
-  /** Arm 的设备 id (必须等于 lease.did)。 */
+  /** Arm device id (informational; truth comes from the authorized lease). */
   deviceId?: string;
   /** PCM 流采样率。默认 16000。 */
   sampleRate?: number;
-  /** 已签 lease — 非 dev-no-auth 模式下必传。 */
-  lease?: VoiceLease;
 }

--- a/packages/tests/src/voice-lease-integration.test.ts
+++ b/packages/tests/src/voice-lease-integration.test.ts
@@ -94,19 +94,27 @@ describe('voice lease: real head issuer ↔ real broker verifier', () => {
     });
     ws.on('close', (code) => { closeCode = code; });
 
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1', lease }));
+    ws.send(JSON.stringify({
+      type: 'authorize', uid: 'u1', deviceId: 'dev_arm_1', authorization: lease,
+    }));
 
-    const deadline = Date.now() + 3000;
-    while (Date.now() < deadline) {
-      if (events.some((e) => e.type === 'ready')) break;
+    const authorizationDeadline = Date.now() + 3000;
+    while (Date.now() < authorizationDeadline) {
+      if (events.some((e) => e.type === 'authorized')) break;
       if (events.some((e) => e.type === 'session_denied')) break;
       if (closeCode !== undefined) break;
       await new Promise((r) => setTimeout(r, 25));
     }
-
     const denied = events.find((e) => e.type === 'session_denied');
     if (denied) {
       throw new Error(`broker rejected head-issued lease: ${JSON.stringify(denied)}`);
+    }
+    expect(events.find((e) => e.type === 'authorized')).toBeDefined();
+
+    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1' }));
+    const readyDeadline = Date.now() + 3000;
+    while (Date.now() < readyDeadline && !events.some((e) => e.type === 'ready')) {
+      await new Promise((r) => setTimeout(r, 25));
     }
     expect(events.find((e) => e.type === 'ready')).toBeDefined();
 
@@ -130,7 +138,9 @@ describe('voice lease: real head issuer ↔ real broker verifier', () => {
     });
     ws.on('close', (code) => { closeCode = code; });
 
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_2', lease }));
+    ws.send(JSON.stringify({
+      type: 'authorize', deviceId: 'dev_arm_2', authorization: lease,
+    }));
 
     const deadline = Date.now() + 3000;
     while (Date.now() < deadline && closeCode === undefined) {

--- a/packages/voice-broker/README.md
+++ b/packages/voice-broker/README.md
@@ -20,10 +20,10 @@ This package currently delivers:
 
 - ✅ Doubao binary wire protocol, client, mock server and standalone broker
 - ✅ Offline RSA verification of Head-issued, user/device/resource-bound leases
-- ✅ Per-session audio limits from signed `quota_seconds`
+- ✅ One signed lease authorizes a warm WebSocket with many sequential recordings
+- ✅ Cumulative `quota_seconds` enforcement and reconnect-safe Head checkpoints
 - ✅ Production Coinfra adapter with correction deltas and authoritative final
-- ✅ Migration-safe legacy API-key compatibility for non-Kraki clients; a frame
-  carrying a bad lease is never allowed to downgrade to the legacy key path
+- ✅ Legacy API-key compatibility for non-Kraki clients on a separate start path
 - ✅ File probe and browser microphone test page
 
 ---
@@ -77,22 +77,26 @@ KRAKI_VOICE_SETTLEMENT_TIMEOUT_MS=2000
 VOICE_API_KEY=<legacy server-only migration key>
 ```
 
-Start frames containing `lease` are verified exclusively as Kraki leases:
-signature, algorithm, issuer, user, device, resource, time window, and quota
-must all match. Frames without `lease` may use the legacy key while older
-VoiceType clients migrate. Never ship `VOICE_API_KEY` in Kraki arm builds.
+Kraki clients send the signed lease once in a connection-level `authorize`
+frame. Signature, algorithm, issuer, user, device, resource, time window, and
+cumulative quota must all match. After `authorized`, the same WebSocket accepts
+many sequential `start` / audio / `finish` cycles. Legacy VoiceType clients use
+the separate per-start API-key authorizer. Never ship `VOICE_API_KEY` in Kraki
+arm builds.
 
-The gateway first activates each `jti` with a random `activationId`; Head accepts
-that pair exactly once, preventing lease replay. It then reports trusted
-`audioSeconds` exactly once per Kraki session with the same pair. Head reserves
-the full lease budget while an activated session is unsettled, then atomically
-replaces that reservation with rounded-up actual audio seconds. An expired
-never-activated lease releases its reservation; an activated lease whose final
-report is lost remains conservatively reserved. Settlement retries are
-idempotent and conflicting replays are rejected. Each Head request has a
-bounded timeout (2 seconds by default) plus bounded retries, so activation
-fails closed and graceful shutdown cannot hang forever when Head is unhealthy.
-Legacy-key VoiceType sessions have no `jti` and are not reported.
+The gateway activates the lease while the app is warming the connection, before
+the microphone path. A reconnect installs a new random `activationId` as the
+last-writer-wins owner and restores Head's exact cumulative audio checkpoint.
+A same-process takeover also transfers any audio not yet checkpointed before it
+closes the stale socket. The Broker reports monotonic cumulative `audioSeconds`
+during long recordings and after each final transcript. Head reserves the full signed quota while the
+lease remains valid, then collapses it to rounded-up actual usage after expiry
+plus a one-minute grace period. Lower/out-of-order checkpoints are harmless;
+checkpoints from replaced owners are rejected. Authorized sockets use standard
+WebSocket ping/pong with a 25-second ping cadence and 10-second pong timeout;
+there is no application-level keepalive frame. Each Head request has a bounded
+timeout (2 seconds by default) plus bounded retries, so authorization fails
+closed and graceful shutdown cannot hang forever when Head is unhealthy.
 
 Validate the deployment adapter with:
 
@@ -104,13 +108,16 @@ pnpm --filter @kraki/voice-broker test:deploy
 
 ## Coordinated release requirement
 
-Head settlement and the Broker activation adapter are one rollout unit. Do not
-release only one side while the public voice endpoint remains available: an old
-Broker does not activate sessions, and a new Broker cannot settle against an old
+Publish the `@coinfra/voice` minor release containing `authorizeConnection`
+first, then rebuild the Broker's `deploy/coinfra/` distribution from that exact
+version. Head settlement, the rebuilt Broker adapter, and the Apple clients are
+one protocol rollout unit. Do not release only one side while the public voice
+endpoint remains available: an old Broker does not activate sessions, and a new
+Broker cannot settle against an old
 Head. For production rollout, first stop accepting new voice connections, then
 upgrade both components and configure the matching settlement secret. Start
 Head, start the Broker, verify one activation/settlement probe, and only then
-restore the public voice route. Database backup and schema-v10 verification are
+restore the public voice route. Database backup and schema-v11 verification are
 required before reopening traffic.
 
 ## Going live
@@ -158,11 +165,14 @@ JSON control + binary audio over a single WebSocket. Path: `/voice`.
 
 ```
 arm → broker
-  { "type": "start", "uid": "u-1234", "config": { ... overrides ... } }
+  { "type": "authorize", "uid": "u-1234", "deviceId": "d-1", "authorization": { ...signed lease... } }
+  { "type": "start", "uid": "u-1234", "context": { ... } }
   <binary>   16 kHz mono int16 little-endian PCM, ~200ms per chunk
   { "type": "finish" }
+  # after sessionFinal, repeat start/audio/finish on the same WebSocket
 
 broker → arm
+  { "type": "authorized" }
   { "type": "ready" }
   { "type": "transcript", "text": "...", "finalSegment": false, "sessionFinal": false, "raw": {...} }
   { "type": "transcript", "text": "...", "finalSegment": true,  "sessionFinal": true,  "raw": {...} }
@@ -183,8 +193,8 @@ word-level breakdowns.
   process and trust boundary**. Not merged into head (would enlarge blast
   radius and couple bursty audio load to the latency-critical relay).
 - **Audio plane never touches core.** arm → nearest regional broker → Doubao,
-  all in-region. Control plane (lease minting) is the only thing that hits
-  core — and only once per session.
+  all in-region. Control-plane lease minting and activation happen once per
+  warm connection; cumulative usage checkpoints are asynchronous.
 - MVP cuts all auth/IAP/multi-region. Phase 0-3 prove the vertical slice;
   4-6 layer on after.
 

--- a/packages/voice-broker/deploy/coinfra-lease-serve.mjs
+++ b/packages/voice-broker/deploy/coinfra-lease-serve.mjs
@@ -8,7 +8,11 @@
  * migration; Kraki lease frames never downgrade to that path.
  */
 import { readFileSync } from 'node:fs';
-import { createKrakiOrLegacyAuthorizer, createKrakiSettlementClient } from './kraki-lease-authorizer.mjs';
+import {
+  createKrakiConnectionAuthorizer,
+  createKrakiSettlementClient,
+  createLegacyApiKeyAuthorizer,
+} from './kraki-lease-authorizer.mjs';
 import {
   createDoubaoAsrProvider,
   createLogger,
@@ -68,18 +72,17 @@ async function main() {
     asr,
     corrector,
     correctOn: correctionEnabled ? 'final' : 'never',
-    authorize: createKrakiOrLegacyAuthorizer(
-      publicKey,
-      required('VOICE_API_KEY'),
-      { activate: settlement.activate },
-    ),
+    authorizeConnection: createKrakiConnectionAuthorizer(publicKey, {
+      activate: settlement.activate,
+    }),
+    authorize: createLegacyApiKeyAuthorizer(required('VOICE_API_KEY')),
     onUsage: settlement.onUsage,
   });
   log.info('Kraki lease gateway ready', {
     url: gateway.url,
     correction: correctionEnabled,
-    authorization: 'kraki-signed-lease+legacy-api-key',
-    settlement: 'actual-audio-seconds',
+    authorization: 'warm-kraki-lease+legacy-api-key',
+    settlement: 'cumulative-audio-checkpoints',
   });
 
   let closing = false;

--- a/packages/voice-broker/deploy/kraki-lease-authorizer.mjs
+++ b/packages/voice-broker/deploy/kraki-lease-authorizer.mjs
@@ -24,51 +24,68 @@ function validLeaseShape(value) {
     typeof payload.jti === 'string' && payload.jti.length > 0;
 }
 
-export function createKrakiLeaseAuthorizer(publicKeyPem, options = {}) {
+function verifyKrakiLease(lease, publicKeyPem, now, clockSkewSec) {
+  if (!validLeaseShape(lease)) {
+    return { ok: false, reason: 'malformed_lease', detail: 'missing or malformed Kraki lease' };
+  }
+  const current = now();
+  if (lease.payload.iat > current + clockSkewSec) {
+    return { ok: false, reason: 'not_yet_valid', detail: 'lease is not active yet' };
+  }
+  if (lease.payload.exp <= current) {
+    return { ok: false, reason: 'expired', detail: 'lease expired' };
+  }
+  try {
+    const verifier = createVerify('SHA256');
+    verifier.update(canonicalLeasePayload(lease.payload));
+    if (!verifier.verify(publicKeyPem, lease.signature, 'base64')) {
+      return { ok: false, reason: 'bad_signature', detail: 'lease signature invalid' };
+    }
+  } catch {
+    return { ok: false, reason: 'bad_signature', detail: 'lease signature invalid' };
+  }
+  return { ok: true, lease };
+}
+
+/**
+ * Warm-connection authorizer. The signed lease is verified offline, then Head
+ * installs this WebSocket as the latest activation owner and returns the exact
+ * cumulative usage checkpoint needed to resume quota accounting.
+ */
+export function createKrakiConnectionAuthorizer(publicKeyPem, options = {}) {
   if (!publicKeyPem?.trim()) throw new Error('Kraki lease public key must not be empty');
   const now = options.now ?? (() => Math.floor(Date.now() / 1000));
   const clockSkewSec = options.clockSkewSec ?? 30;
   const activate = options.activate;
-  return ({ start }) => {
-    const lease = start?.lease;
-    if (!validLeaseShape(lease)) {
-      return { ok: false, reason: 'malformed_lease', detail: 'missing or malformed Kraki lease' };
-    }
-    if (typeof start.deviceId !== 'string' || start.deviceId !== lease.payload.did) {
-      return { ok: false, reason: 'wrong_device', detail: 'lease does not match device' };
-    }
-    if (typeof start.uid !== 'string' || start.uid !== lease.payload.sub) {
+  return ({ authorize }) => {
+    const lease = authorize?.authorization;
+    const verified = verifyKrakiLease(lease, publicKeyPem, now, clockSkewSec);
+    if (!verified.ok) return verified;
+    if (authorize.uid !== undefined && authorize.uid !== lease.payload.sub) {
       return { ok: false, reason: 'wrong_user', detail: 'lease does not match user' };
     }
-    const current = now();
-    if (lease.payload.iat > current + clockSkewSec) {
-      return { ok: false, reason: 'not_yet_valid', detail: 'lease is not active yet' };
+    if (authorize.deviceId !== undefined && authorize.deviceId !== lease.payload.did) {
+      return { ok: false, reason: 'wrong_device', detail: 'lease does not match device' };
     }
-    if (lease.payload.exp <= current) {
-      return { ok: false, reason: 'expired', detail: 'lease expired' };
-    }
-    try {
-      const verifier = createVerify('SHA256');
-      verifier.update(canonicalLeasePayload(lease.payload));
-      if (!verifier.verify(publicKeyPem, lease.signature, 'base64')) {
-        return { ok: false, reason: 'bad_signature', detail: 'lease signature invalid' };
-      }
-    } catch {
-      return { ok: false, reason: 'bad_signature', detail: 'lease signature invalid' };
-    }
+
     const activationId = randomUUID();
-    const success = () => ({
+    const success = (reportedAudioSeconds = 0) => ({
       ok: true,
       quotaSeconds: lease.payload.quota_seconds,
+      usedSeconds: reportedAudioSeconds,
+      expiresAtUnixSec: lease.payload.exp,
+      connectionKey: lease.payload.jti,
       usageContext: { jti: lease.payload.jti, activationId },
     });
-    if (activate) {
-      return Promise.resolve(activate({ jti: lease.payload.jti, activationId }))
-        .then((activated) => activated.ok
-          ? success()
-          : { ok: false, reason: activated.reason ?? 'activation_failed', detail: activated.detail });
-    }
-    return success();
+    if (!activate) return success();
+    return Promise.resolve(activate({ jti: lease.payload.jti, activationId }))
+      .then((activated) => activated.ok
+        ? success(activated.reportedAudioSeconds ?? 0)
+        : {
+            ok: false,
+            reason: activated.reason ?? 'activation_failed',
+            detail: activated.detail,
+          });
   };
 }
 
@@ -94,10 +111,15 @@ export function createKrakiSettlementClient(settleUrl, settlementKey, options = 
           body: JSON.stringify(payload),
           signal: AbortSignal.timeout(timeoutMs),
         });
-        if (response.ok) return { ok: true };
+        const body = await response.json().catch(() => ({}));
+        if (response.ok) return { ok: true, ...body };
         lastError = new Error(`settlement returned ${response.status}`);
         if (response.status >= 400 && response.status < 500 && response.status !== 429) {
-          return { ok: false, reason: 'settlement_rejected', detail: lastError.message };
+          return {
+            ok: false,
+            reason: typeof body?.error === 'string' ? body.error : 'settlement_rejected',
+            detail: lastError.message,
+          };
         }
       } catch (error) {
         lastError = error;
@@ -107,12 +129,19 @@ export function createKrakiSettlementClient(settleUrl, settlementKey, options = 
     throw lastError ?? new Error('voice settlement failed');
   };
   return {
-    activate: ({ jti, activationId }) => post({ action: 'activate', jti, activationId }),
+    async activate({ jti, activationId }) {
+      const result = await post({ action: 'activate', jti, activationId });
+      if (!result.ok) return result;
+      return {
+        ok: true,
+        reportedAudioSeconds: Number(result.reportedAudioSeconds) || 0,
+      };
+    },
     async onUsage(input) {
       const jti = input?.authorization?.usageContext?.jti;
       const activationId = input?.authorization?.usageContext?.activationId;
-      if (typeof jti !== 'string' || jti.length === 0
-          || typeof activationId !== 'string' || activationId.length === 0) return;
+      if (typeof jti !== 'string' || jti.length === 0 ||
+          typeof activationId !== 'string' || activationId.length === 0) return;
       const result = await post({
         action: 'settle',
         jti,
@@ -136,16 +165,9 @@ function safeEqualSecret(actual, expected) {
   return left.length === right.length && timingSafeEqual(left, right);
 }
 
-/**
- * Migration authorizer: Kraki lease frames never fall back to the legacy key;
- * frames without a lease may still serve existing VoiceType clients.
- */
-export function createKrakiOrLegacyAuthorizer(publicKeyPem, legacyApiKey, options = {}) {
-  const authorizeLease = createKrakiLeaseAuthorizer(publicKeyPem, options);
-  return (input) => {
-    if (input?.start?.lease !== undefined) return authorizeLease(input);
-    return safeEqualSecret(input?.start?.apiKey, legacyApiKey)
-      ? { ok: true }
-      : { ok: false, reason: 'missing_authorization', detail: 'missing Kraki lease or legacy API key' };
-  };
+/** Legacy static-key authorizer for non-Kraki clients during migration. */
+export function createLegacyApiKeyAuthorizer(legacyApiKey) {
+  return ({ start }) => safeEqualSecret(start?.apiKey, legacyApiKey)
+    ? { ok: true }
+    : { ok: false, reason: 'missing_authorization', detail: 'missing legacy API key' };
 }

--- a/packages/voice-broker/deploy/kraki-lease-authorizer.test.mjs
+++ b/packages/voice-broker/deploy/kraki-lease-authorizer.test.mjs
@@ -3,10 +3,10 @@ import { generateKeyPairSync, createSign } from 'node:crypto';
 import test from 'node:test';
 import {
   canonicalLeasePayload,
-  createKrakiLeaseAuthorizer,
-  createKrakiOrLegacyAuthorizer,
+  createKrakiConnectionAuthorizer,
   createKrakiSettlementClient,
   createKrakiUsageReporter,
+  createLegacyApiKeyAuthorizer,
 } from './kraki-lease-authorizer.mjs';
 
 const NOW = 1_800_000_000;
@@ -38,22 +38,33 @@ function signedLease(overrides = {}) {
   };
 }
 
-function authorize(lease = signedLease(), start = {}) {
-  return createKrakiLeaseAuthorizer(keys.publicKey, { now: () => NOW })({
-    start: {
-      type: 'start',
+function authorize(lease = signedLease(), fields = {}) {
+  return createKrakiConnectionAuthorizer(keys.publicKey, { now: () => NOW })({
+    authorize: {
+      type: 'authorize',
       uid: 'user-1',
       deviceId: 'device-1',
-      lease,
-      ...start,
+      authorization: lease,
+      ...fields,
     },
   });
 }
 
-test('accepts a Head-compatible signed lease and returns its audio quota', () => {
+function response(status, body = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return body; },
+  };
+}
+
+test('accepts a Head-compatible signed lease as a reusable connection authorization', () => {
   const result = authorize();
   assert.equal(result.ok, true);
   assert.equal(result.quotaSeconds, 300);
+  assert.equal(result.usedSeconds, 0);
+  assert.equal(result.expiresAtUnixSec, NOW + 300);
+  assert.equal(result.connectionKey, 'lease-1');
   assert.equal(result.usageContext.jti, 'lease-1');
   assert.equal(typeof result.usageContext.activationId, 'string');
   assert.ok(result.usageContext.activationId.length > 8);
@@ -73,48 +84,46 @@ test('rejects wrong user, device, resource and time window', () => {
   assert.equal(authorize(signedLease({ iat: NOW + 31 })).reason, 'not_yet_valid');
 });
 
-test('migration authorizer preserves legacy clients without allowing lease downgrade', () => {
-  const mixed = createKrakiOrLegacyAuthorizer(keys.publicKey, 'legacy-secret', { now: () => NOW });
-  assert.deepEqual(mixed({ start: { type: 'start', apiKey: 'legacy-secret' } }), { ok: true });
-  assert.equal(mixed({ start: { type: 'start', apiKey: 'wrong' } }).reason, 'missing_authorization');
-  const badLease = signedLease();
-  badLease.payload.quota_seconds = 7200;
-  assert.equal(mixed({
-    start: {
-      type: 'start', uid: 'user-1', deviceId: 'device-1',
-      apiKey: 'legacy-secret', lease: badLease,
-    },
-  }).reason, 'bad_signature');
+test('legacy API-key clients remain a separate per-start path', () => {
+  const legacy = createLegacyApiKeyAuthorizer('legacy-secret');
+  assert.deepEqual(legacy({ start: { type: 'start', apiKey: 'legacy-secret' } }), { ok: true });
+  assert.equal(legacy({ start: { type: 'start', apiKey: 'wrong' } }).reason, 'missing_authorization');
 });
 
-test('production activation precedes acceptance and settlement binds the activation id', async () => {
+test('activation precedes acceptance and restores cumulative usage for reconnect', async () => {
   const requests = [];
   const client = createKrakiSettlementClient('https://head/internal/voice/settle', 'secret', {
     wait: async () => {},
     fetch: async (url, init) => {
       requests.push({ url, init, body: JSON.parse(init.body) });
-      return { ok: true, status: 200 };
+      return response(200, requests.length === 1 ? { reportedAudioSeconds: 4.75 } : {});
     },
   });
-  const authorizer = createKrakiLeaseAuthorizer(keys.publicKey, {
+  const authorizer = createKrakiConnectionAuthorizer(keys.publicKey, {
     now: () => NOW,
     activate: client.activate,
   });
   const verdict = await authorizer({
-    start: { type: 'start', uid: 'user-1', deviceId: 'device-1', lease: signedLease() },
+    authorize: {
+      type: 'authorize',
+      uid: 'user-1',
+      deviceId: 'device-1',
+      authorization: signedLease(),
+    },
   });
   assert.equal(verdict.ok, true);
+  assert.equal(verdict.usedSeconds, 4.75);
   assert.equal(requests[0].body.action, 'activate');
   assert.equal(requests[0].body.jti, 'lease-1');
   assert.equal(requests[0].body.activationId, verdict.usageContext.activationId);
 
-  await client.onUsage({ authorization: verdict, audioSeconds: 5.25, reason: 'asr closed' });
+  await client.onUsage({ authorization: verdict, audioSeconds: 9.25, reason: 'session_final' });
   assert.equal(requests[1].body.action, 'settle');
   assert.equal(requests[1].body.activationId, verdict.usageContext.activationId);
-  assert.equal(requests[1].body.audioSeconds, 5.25);
+  assert.equal(requests[1].body.audioSeconds, 9.25);
 });
 
-test('usage reporter settles Kraki leases with retries and skips legacy sessions', async () => {
+test('usage reporter sends cumulative checkpoints with retries and skips legacy sessions', async () => {
   const requests = [];
   let attempts = 0;
   const reporter = createKrakiUsageReporter('https://head/internal/voice/settle', 'secret', {
@@ -122,13 +131,13 @@ test('usage reporter settles Kraki leases with retries and skips legacy sessions
     fetch: async (url, init) => {
       attempts += 1;
       requests.push({ url, init });
-      return { ok: attempts > 1, status: attempts > 1 ? 200 : 503 };
+      return attempts > 1 ? response(200) : response(503);
     },
   });
   await reporter({
     authorization: { usageContext: { jti: 'lease-1', activationId: 'activation-1' } },
     audioSeconds: 5.25,
-    reason: 'asr closed',
+    reason: 'checkpoint',
   });
   assert.equal(requests.length, 2);
   assert.equal(requests[0].url, 'https://head/internal/voice/settle');
@@ -136,7 +145,7 @@ test('usage reporter settles Kraki leases with retries and skips legacy sessions
   assert.ok(requests[0].init.signal instanceof AbortSignal);
   assert.deepEqual(JSON.parse(requests[0].init.body), {
     action: 'settle', jti: 'lease-1', activationId: 'activation-1',
-    audioSeconds: 5.25, reason: 'asr closed',
+    audioSeconds: 5.25, reason: 'checkpoint',
   });
 
   await reporter({ authorization: { ok: true }, audioSeconds: 10, reason: 'legacy' });
@@ -156,7 +165,7 @@ test('usage reporter rejects permanent settlement failures', async () => {
   let attempts = 0;
   const reporter = createKrakiUsageReporter('https://head/internal/voice/settle', 'secret', {
     wait: async () => {},
-    fetch: async () => { attempts += 1; return { ok: false, status: 401 }; },
+    fetch: async () => { attempts += 1; return response(401, { error: 'unauthorized' }); },
   });
   await assert.rejects(() => reporter({
     authorization: { usageContext: { jti: 'lease-1', activationId: 'activation-1' } },
@@ -167,8 +176,8 @@ test('usage reporter rejects permanent settlement failures', async () => {
 });
 
 test('rejects missing, zero-quota and unknown-algorithm leases', () => {
-  const authorizer = createKrakiLeaseAuthorizer(keys.publicKey, { now: () => NOW });
-  assert.equal(authorizer({ start: { type: 'start', uid: 'user-1', deviceId: 'device-1' } }).reason, 'malformed_lease');
+  const authorizer = createKrakiConnectionAuthorizer(keys.publicKey, { now: () => NOW });
+  assert.equal(authorizer({ authorize: { type: 'authorize' } }).reason, 'malformed_lease');
   assert.equal(authorize(signedLease({ quota_seconds: 0 })).reason, 'malformed_lease');
   const lease = signedLease();
   lease.alg = 'none';

--- a/packages/voice-broker/src/__tests__/lease-e2e.test.ts
+++ b/packages/voice-broker/src/__tests__/lease-e2e.test.ts
@@ -131,7 +131,11 @@ describe('broker — lease enforcement', () => {
     const rec = attach(ws);
 
     const lease = mintLease(keys.priv, { did: 'dev_arm_1' });
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1', lease }));
+    ws.send(JSON.stringify({
+      type: 'authorize', deviceId: 'dev_arm_1', uid: 'u1', authorization: lease,
+    }));
+    await waitFor(() => rec.events.some((e) => e.type === 'authorized'), 3000, 'authorized');
+    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1' }));
 
     await waitFor(() => rec.events.some((e) => e.type === 'ready'), 3000, 'ready');
 
@@ -148,10 +152,68 @@ describe('broker — lease enforcement', () => {
     ws.close();
   });
 
-  it('refuses connection with no lease in start (1008)', async () => {
+  it('reuses one authorized connection for multiple recordings', async () => {
     const ws = await open(broker.url);
     const rec = attach(ws);
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1' }));
+    const lease = mintLease(keys.priv, { did: 'dev_arm_1' });
+    ws.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1', authorization: lease }));
+    await waitFor(() => rec.events.some((e) => e.type === 'authorized'), 3000, 'authorized');
+
+    for (let recording = 0; recording < 2; recording += 1) {
+      const finalsBefore = rec.events.filter(
+        (e) => e.type === 'transcript' && e.sessionFinal === true,
+      ).length;
+      ws.send(JSON.stringify({ type: 'start', uid: `recording-${recording}` }));
+      await waitFor(
+        () => rec.events.filter((e) => e.type === 'ready').length > recording,
+        3000,
+        `ready ${recording}`,
+      );
+      ws.send(Buffer.alloc(6400, 0));
+      ws.send(JSON.stringify({ type: 'finish' }));
+      await waitFor(
+        () => rec.events.filter(
+          (e) => e.type === 'transcript' && e.sessionFinal === true,
+        ).length > finalsBefore,
+        4000,
+        `final ${recording}`,
+      );
+    }
+
+    expect(rec.events.filter((e) => e.type === 'transcript' && e.sessionFinal === true)).toHaveLength(2);
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+
+  it('transfers unfinalized usage when a duplicate lease connection replaces the owner', async () => {
+    const lease = mintLease(keys.priv, { did: 'dev_arm_1', quota: 0.3 });
+    const first = await open(broker.url);
+    const firstRec = attach(first);
+    first.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1', authorization: lease }));
+    await waitFor(() => firstRec.events.some((e) => e.type === 'authorized'), 3000, 'first authorized');
+    first.send(JSON.stringify({ type: 'start' }));
+    await waitFor(() => firstRec.events.some((e) => e.type === 'ready'), 3000, 'first ready');
+    first.send(Buffer.alloc(6400, 0)); // 0.2s, not finalized.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const second = await open(broker.url);
+    const secondRec = attach(second);
+    second.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1', authorization: lease }));
+    await waitFor(() => secondRec.events.some((e) => e.type === 'authorized'), 3000, 'second authorized');
+    await waitFor(() => firstRec.closeCode === 4001, 3000, 'first replaced');
+
+    second.send(JSON.stringify({ type: 'start' }));
+    await waitFor(() => secondRec.events.some((e) => e.type === 'ready'), 3000, 'second ready');
+    second.send(Buffer.alloc(6400, 0));
+    await waitFor(() => secondRec.closeCode !== undefined, 3000, 'quota close');
+    expect(secondRec.closeCode).toBe(1008);
+    expect(secondRec.events.find((e) => e.type === 'session_denied')?.reason).toBe('quota_exhausted');
+  });
+
+  it('refuses connection with no lease in authorize (1008)', async () => {
+    const ws = await open(broker.url);
+    const rec = attach(ws);
+    ws.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1' }));
 
     await waitFor(() => rec.closeCode !== undefined, 2000, 'close');
     expect(rec.closeCode).toBe(1008);
@@ -162,7 +224,7 @@ describe('broker — lease enforcement', () => {
     const ws = await open(broker.url);
     const rec = attach(ws);
     const lease = mintLease(keys.priv, { did: 'dev_other' });
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1', lease }));
+    ws.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1', authorization: lease }));
 
     await waitFor(() => rec.closeCode !== undefined, 2000, 'close');
     expect(rec.closeCode).toBe(1008);
@@ -184,7 +246,7 @@ describe('broker — lease enforcement', () => {
       signature: signChallenge(canonicalJson(payload as unknown as Record<string, unknown>), keys.priv),
       alg: 'RSA-SHA256',
     };
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1', lease }));
+    ws.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1', authorization: lease }));
 
     await waitFor(() => rec.closeCode !== undefined, 2000, 'close');
     expect(rec.closeCode).toBe(1008);
@@ -196,7 +258,7 @@ describe('broker — lease enforcement', () => {
     const rec = attach(ws);
     const other = genKeys();
     const lease = mintLease(other.priv, { did: 'dev_arm_1' });
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1', lease }));
+    ws.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1', authorization: lease }));
 
     await waitFor(() => rec.closeCode !== undefined, 2000, 'close');
     expect(rec.closeCode).toBe(1008);
@@ -209,7 +271,9 @@ describe('broker — lease enforcement', () => {
     // 1 second of audio at 16kHz mono int16 = 32_000 bytes. Set quota = 1s
     // and stream 2s worth (64_000 bytes).
     const lease = mintLease(keys.priv, { did: 'dev_arm_1', quota: 1 });
-    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1', lease }));
+    ws.send(JSON.stringify({ type: 'authorize', deviceId: 'dev_arm_1', authorization: lease }));
+    await waitFor(() => rec.events.some((e) => e.type === 'authorized'), 3000, 'authorized');
+    ws.send(JSON.stringify({ type: 'start', deviceId: 'dev_arm_1' }));
     await waitFor(() => rec.events.some((e) => e.type === 'ready'), 3000, 'ready');
 
     // Stream 2 seconds of audio in 200ms chunks → should hit quota after ~1s.

--- a/packages/voice-broker/src/server.ts
+++ b/packages/voice-broker/src/server.ts
@@ -1,25 +1,12 @@
 /**
- * Broker WSS server (Phase 1).
+ * Standalone Kraki voice broker used by local development and direct Doubao
+ * tests. Production uses the matching @coinfra/voice gateway adapter.
  *
- * arm clients connect here. Per connection lifecycle:
- *
- *   ws.send({type:"start", uid?, config?})           — open a Doubao session
- *   ws.send(<binary chunk>)                          — raw PCM (16k mono int16)
- *   ws.send({type:"finish"})                         — stop dictating
- *
- * The broker replies with control + transcript messages, all JSON:
- *
- *   {type:"ready"}                                   — Doubao session live
- *   {type:"transcript", text, finalSegment, sessionFinal, raw}
- *   {type:"error", message, code?}
- *   {type:"closed", code, reason}                    — Doubao closed
- *
- * Note: NO auth in this phase. That's deliberate — handover §5 says auth is
- * post-MVP. When the lease layer is added it will sit in front of `start`,
- * verifying the lease signature with core's public key (offline).
+ * A signed lease authorizes the WebSocket once; the connection then carries
+ * many sequential start / binary PCM / finish cycles.
  */
 
-import { createServer, type Server as HttpServer } from 'node:http';
+import { createServer } from 'node:http';
 import { WebSocketServer, WebSocket, type RawData } from 'ws';
 import { DoubaoClient } from './doubao-client.js';
 import type { ClientConfigRequest } from './doubao.js';
@@ -30,31 +17,19 @@ import type { VoiceLease, VoiceResource } from '@kraki/protocol';
 export interface BrokerOptions {
   port?: number;
   host?: string;
-  /** Doubao endpoint (real or mock). */
   doubaoEndpoint: string;
-  /** Optional — only needed for the legacy "old console" auth scheme. */
   doubaoAppKey?: string;
   doubaoAccessKey: string;
   doubaoResourceId: string;
   logger?: Logger;
-  /** Optional path the WSS listens on. Defaults to "/voice". */
   path?: string;
-  /**
-   * Pinned public key (PEM) of the kraki-head lease signer. When set, every
-   * `start` request must include a valid lease bound to this resource. When
-   * unset, the broker requires `devNoAuth: true` or refuses all connections.
-   */
   leasePublicKeyPem?: string;
-  /**
-   * Disable lease enforcement entirely (DEV ONLY). When true, the broker
-   * accepts any `start` and treats quota as unlimited. The CLI prints a
-   * loud warning at startup.
-   */
   devNoAuth?: boolean;
-  /** Resource the broker serves. Default 'voice/doubao'. */
   resource?: VoiceResource;
-  /** Audio sample rate, used to convert bytes → seconds. Default 16000. */
   sampleRateHz?: number;
+  pingIntervalMs?: number;
+  pongTimeoutMs?: number;
+  expiryGraceSeconds?: number;
 }
 
 export interface BrokerServer {
@@ -63,24 +38,32 @@ export interface BrokerServer {
   close(): Promise<void>;
 }
 
+interface ClientAuthorizeMessage {
+  type: 'authorize';
+  uid?: string;
+  deviceId?: string;
+  authorization?: VoiceLease;
+}
+
 interface ClientStartMessage {
   type: 'start';
   uid?: string;
-  config?: Partial<ClientConfigRequest>;
-  /** Required when broker enforces leases. */
   deviceId?: string;
-  lease?: VoiceLease;
+  config?: Partial<ClientConfigRequest>;
 }
+
 interface ClientFinishMessage {
   type: 'finish';
 }
-type ClientControlMessage = ClientStartMessage | ClientFinishMessage;
 
-// Wire-level reasons broker sends when refusing a session. Mirrors the
-// verifier reasons but flattened for the client.
-function closeCodeFor(reason: VerifyReason | 'missing_lease' | 'no_pubkey' | 'quota_exhausted'): number {
-  // 1008 = Policy Violation; we use it broadly for auth/quota failures so
-  // the client can present a unified "session refused" UX.
+type ClientControlMessage = ClientAuthorizeMessage | ClientStartMessage | ClientFinishMessage;
+
+interface ConnectionOwner {
+  replace(): void;
+  audioBytes(): number;
+}
+
+function closeCodeFor(_reason: VerifyReason | 'missing_lease' | 'no_pubkey' | 'quota_exhausted'): number {
   return 1008;
 }
 
@@ -91,21 +74,21 @@ export async function startBroker(opts: BrokerOptions): Promise<BrokerServer> {
   const logger = opts.logger ?? createLogger('broker');
   const expectedResource: VoiceResource = opts.resource ?? 'voice/doubao';
   const sampleRateHz = opts.sampleRateHz ?? 16000;
-  const bytesPerSecond = sampleRateHz * 2; // 16-bit mono PCM
+  const bytesPerSecond = sampleRateHz * 2;
+  const pingIntervalMs = opts.pingIntervalMs ?? 25_000;
+  const pongTimeoutMs = opts.pongTimeoutMs ?? 10_000;
+  const expiryGraceSeconds = opts.expiryGraceSeconds ?? 60;
 
-  // Startup auth interlock — keep ops from accidentally deploying an open
-  // broker into production. Exactly one of {leasePublicKeyPem, devNoAuth}
-  // must be set; both-on is the dangerous case we explicitly forbid.
   if (opts.devNoAuth && opts.leasePublicKeyPem) {
     throw new Error(
       'voice-broker refusing to start: both devNoAuth=true and leasePublicKeyPem are set. ' +
-      'Pick one — devNoAuth disables auth entirely (local dev only).'
+      'Pick one — devNoAuth disables auth entirely (local dev only).',
     );
   }
   if (!opts.devNoAuth && !opts.leasePublicKeyPem) {
     throw new Error(
       'voice-broker refusing to start: no leasePublicKeyPem configured and devNoAuth!=true. ' +
-      'Set BROKER_LEASE_PUBLIC_KEY_PEM (or _PATH) to the head\'s public key, or BROKER_DEV_NO_AUTH=1 for local dev.'
+      'Set BROKER_LEASE_PUBLIC_KEY_PEM (or _PATH) to the head\'s public key, or BROKER_DEV_NO_AUTH=1 for local dev.',
     );
   }
   if (opts.devNoAuth) {
@@ -115,7 +98,6 @@ export async function startBroker(opts: BrokerOptions): Promise<BrokerServer> {
   }
 
   const http = createServer((req, res) => {
-    // Tiny health endpoint for ops.
     if (req.url === '/healthz') {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ ok: true, role: 'voice-broker' }));
@@ -126,77 +108,211 @@ export async function startBroker(opts: BrokerOptions): Promise<BrokerServer> {
   });
 
   const wss = new WebSocketServer({ server: http, path });
+  const owners = new Map<string, ConnectionOwner>();
+  const pongTimeouts = new Map<WebSocket, ReturnType<typeof setTimeout>>();
+  const closeConnections = new Set<() => void>();
+
+  const pingTimer = pingIntervalMs > 0
+    ? setInterval(() => {
+        for (const ws of wss.clients) {
+          const previousTimeout = pongTimeouts.get(ws);
+          if (previousTimeout) {
+            clearTimeout(previousTimeout);
+            pongTimeouts.delete(ws);
+            ws.terminate();
+            continue;
+          }
+          try {
+            ws.ping();
+            const timeout = setTimeout(() => {
+              pongTimeouts.delete(ws);
+              ws.terminate();
+            }, Math.max(1, pongTimeoutMs));
+            timeout.unref();
+            pongTimeouts.set(ws, timeout);
+          } catch {
+            ws.terminate();
+          }
+        }
+      }, pingIntervalMs)
+    : null;
+  pingTimer?.unref();
 
   wss.on('connection', (ws: WebSocket, req) => {
     const remote = req.socket.remoteAddress ?? 'unknown';
     const clientLog = logger.child(`c:${remote}`);
     clientLog.info('client connected');
+    ws.on('pong', () => {
+      const timeout = pongTimeouts.get(ws);
+      if (timeout) clearTimeout(timeout);
+      pongTimeouts.delete(ws);
+    });
 
     let doubao: DoubaoClient | null = null;
-    let started = false;          // arm client has sent {type:'start'} AND lease verified
-    let doubaoReady = false;      // doubao WS is open AND start frame sent
-    const audioBuffer: Buffer[] = []; // chunks that arrived before doubao was ready
+    let recordingToken = 0;
+    let started = false;
+    let finishing = false;
+    let doubaoReady = false;
+    let sessionFinal = false;
+    const audioBuffer: Buffer[] = [];
     let closed = false;
-    let quotaSecondsRemaining = Number.POSITIVE_INFINITY;
-    let bytesConsumed = 0; // for quota accounting
-    let sessionDeviceId: string | undefined;
-    let sessionJti: string | undefined;
+    let authorized = opts.devNoAuth === true;
+    let quotaSeconds = Number.POSITIVE_INFINITY;
+    let bytesConsumed = 0;
+    let leaseJti: string | undefined;
+    let leaseExp: number | undefined;
+    let expiryTimer: ReturnType<typeof setTimeout> | null = null;
 
     const sendJson = (obj: unknown) => {
       if (ws.readyState !== WebSocket.OPEN) return;
-      try {
-        ws.send(JSON.stringify(obj));
-      } catch (err) {
+      try { ws.send(JSON.stringify(obj)); } catch (err) {
         clientLog.warn('send failed', { error: (err as Error).message });
       }
+    };
+
+    const closeDoubao = () => {
+      const client = doubao;
+      doubao = null;
+      doubaoReady = false;
+      try { client?.close(); } catch { /* ignore */ }
+    };
+
+    const resetRecording = () => {
+      closeDoubao();
+      started = false;
+      finishing = false;
+      sessionFinal = false;
+      audioBuffer.length = 0;
     };
 
     const closeAll = (code = 1000, reason = 'done') => {
       if (closed) return;
       closed = true;
-      try {
-        doubao?.finish();
-      } catch {
-        // ignore
+      expiryTimer && clearTimeout(expiryTimer);
+      expiryTimer = null;
+      try { doubao?.finish(); } catch { /* ignore */ }
+      closeDoubao();
+      if (leaseJti && owners.get(leaseJti) === connectionOwner) owners.delete(leaseJti);
+      try { ws.close(code, reason); } catch { /* ignore */ }
+    };
+
+    const connectionOwner: ConnectionOwner = {
+      replace: () => {
+        sendJson({ type: 'session_denied', reason: 'connection_replaced' });
+        closeAll(4001, 'connection_replaced');
+      },
+      audioBytes: () => bytesConsumed,
+    };
+
+    const deny = (reason: string, detail?: string) => {
+      sendJson({ type: 'session_denied', reason, detail });
+      closeAll(1008, reason);
+    };
+
+    const scheduleExpiry = () => {
+      if (leaseExp === undefined) return;
+      const delayMs = Math.max(0, (leaseExp + expiryGraceSeconds - Date.now() / 1000) * 1000);
+      expiryTimer = setTimeout(() => closeAll(1008, 'authorization_expired'), delayMs);
+      expiryTimer.unref?.();
+    };
+
+    const startRecording = async (msg: ClientStartMessage) => {
+      if (!authorized) {
+        deny('missing_lease', 'authorize the connection before start');
+        return;
       }
-      setTimeout(() => doubao?.close(), 500);
+      if (started) {
+        sendJson({ type: 'error', message: 'recording already active' });
+        return;
+      }
+      if (leaseExp !== undefined && Date.now() / 1000 >= leaseExp) {
+        deny('expired', 'lease expired');
+        return;
+      }
+
+      started = true;
+      finishing = false;
+      sessionFinal = false;
+      doubaoReady = false;
+      audioBuffer.length = 0;
+      recordingToken += 1;
+      const token = recordingToken;
+      const client = new DoubaoClient({
+        appKey: opts.doubaoAppKey || undefined,
+        accessKey: opts.doubaoAccessKey,
+        resourceId: opts.doubaoResourceId,
+        endpoint: opts.doubaoEndpoint,
+        logger: clientLog.child('doubao'),
+      });
+      doubao = client;
+      client.on('transcript', (u) => {
+        if (token !== recordingToken || closed) return;
+        sendJson({
+          type: 'transcript',
+          text: u.text,
+          finalSegment: u.finalSegment,
+          sessionFinal: u.sessionFinal,
+          raw: u.raw,
+        });
+        if (u.sessionFinal) {
+          sessionFinal = true;
+          resetRecording();
+        }
+      });
+      client.on('error', (err) => {
+        if (token !== recordingToken || sessionFinal) return;
+        sendJson({ type: 'error', message: err.message });
+        resetRecording();
+      });
+      client.on('close', (code, reason) => {
+        if (token !== recordingToken) return;
+        sendJson({ type: 'closed', code, reason });
+        if (!sessionFinal && started) resetRecording();
+      });
+
       try {
-        ws.close(code, reason);
-      } catch {
-        // ignore
+        await client.connect();
+        if (token !== recordingToken || closed) {
+          client.close();
+          return;
+        }
+        client.start({ uid: msg.uid, ...msg.config });
+        doubaoReady = true;
+        for (const chunk of audioBuffer) client.sendAudio(chunk);
+        audioBuffer.length = 0;
+        sendJson({ type: 'ready' });
+        if (finishing) client.finish();
+      } catch (err) {
+        sendJson({ type: 'error', message: `doubao connect failed: ${(err as Error).message}` });
+        resetRecording();
       }
     };
 
     ws.on('message', async (data: RawData, isBinary: boolean) => {
       if (closed) return;
       if (isBinary) {
-        if (!started) {
-          sendJson({ type: 'error', message: 'audio sent before start' });
+        if (!started || finishing) {
+          sendJson({ type: 'error', message: !started ? 'audio sent before start' : 'audio sent after finish' });
           return;
         }
         const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
-        // Quota accounting: convert bytes → seconds and refuse mid-stream
-        // once exhausted. Always check before forwarding so we never bill
-        // Doubao for over-quota audio.
-        bytesConsumed += chunk.length;
-        if (bytesConsumed / bytesPerSecond > quotaSecondsRemaining) {
+        const prospectiveBytes = bytesConsumed + chunk.length;
+        if (prospectiveBytes / bytesPerSecond > quotaSeconds) {
           clientLog.info('lease quota exhausted mid-stream', {
-            jti: sessionJti, usedSec: (bytesConsumed / bytesPerSecond).toFixed(1), quotaSec: quotaSecondsRemaining,
+            jti: leaseJti,
+            usedSec: (bytesConsumed / bytesPerSecond).toFixed(1),
+            quotaSec: quotaSeconds,
           });
-          sendJson({ type: 'session_denied', reason: 'quota_exhausted', detail: 'lease seconds exhausted' });
-          closeAll(closeCodeFor('quota_exhausted'), 'quota_exhausted');
+          deny('quota_exhausted', 'lease seconds exhausted');
           return;
         }
-        // Doubao might still be handshaking — buffer until ready, then flush.
-        if (!doubaoReady || !doubao) {
-          audioBuffer.push(chunk);
-          return;
-        }
-        try {
-          doubao.sendAudio(chunk);
-        } catch (err) {
-          sendJson({ type: 'error', message: (err as Error).message });
-          closeAll(1011, 'doubao send failed');
+        bytesConsumed = prospectiveBytes;
+        if (!doubaoReady || !doubao) audioBuffer.push(chunk);
+        else {
+          try { doubao.sendAudio(chunk); } catch (err) {
+            sendJson({ type: 'error', message: (err as Error).message });
+            resetRecording();
+          }
         }
         return;
       }
@@ -210,126 +326,64 @@ export async function startBroker(opts: BrokerOptions): Promise<BrokerServer> {
         return;
       }
 
-      if (msg.type === 'start') {
-        if (started) {
-          sendJson({ type: 'error', message: 'already started' });
+      if (msg.type === 'authorize') {
+        if (opts.devNoAuth) {
+          authorized = true;
+          sendJson({ type: 'authorized' });
           return;
         }
-
-        // --- Lease verification (skipped in devNoAuth mode) ---
-        if (!opts.devNoAuth) {
-          if (!opts.leasePublicKeyPem) {
-            // Should be unreachable (startup interlock), but defensive.
-            sendJson({ type: 'session_denied', reason: 'no_pubkey', detail: 'broker misconfigured' });
-            closeAll(closeCodeFor('no_pubkey'), 'no_pubkey');
-            return;
-          }
-          if (!msg.lease) {
-            sendJson({ type: 'session_denied', reason: 'missing_lease', detail: 'no lease in start' });
-            closeAll(closeCodeFor('missing_lease'), 'missing_lease');
-            return;
-          }
-          if (typeof msg.deviceId !== 'string' || msg.deviceId.length === 0) {
-            sendJson({ type: 'session_denied', reason: 'missing_lease', detail: 'no deviceId in start' });
-            closeAll(closeCodeFor('missing_lease'), 'missing_lease');
-            return;
-          }
-          const result = verifyLease(msg.lease, opts.leasePublicKeyPem, {
-            resource: expectedResource,
-            deviceId: msg.deviceId,
-          });
-          if (!result.ok) {
-            clientLog.info('lease rejected', { reason: result.reason, detail: result.detail });
-            sendJson({ type: 'session_denied', reason: result.reason, detail: result.detail });
-            closeAll(closeCodeFor(result.reason), result.reason);
-            return;
-          }
-          quotaSecondsRemaining = result.payload.quota_seconds;
-          sessionDeviceId = result.payload.did;
-          sessionJti = result.payload.jti;
-          clientLog.info('lease accepted', {
-            jti: sessionJti, did: sessionDeviceId, quotaSec: quotaSecondsRemaining,
-            exp: result.payload.exp,
-          });
+        if (authorized || started) {
+          deny('already_authorized');
+          return;
         }
-
-        started = true;
-        doubao = new DoubaoClient({
-          appKey: opts.doubaoAppKey || undefined,
-          accessKey: opts.doubaoAccessKey,
-          resourceId: opts.doubaoResourceId,
-          endpoint: opts.doubaoEndpoint,
-          logger: clientLog.child('doubao'),
-        });
-        doubao.on('transcript', (u) => {
-          sendJson({
-            type: 'transcript',
-            text: u.text,
-            finalSegment: u.finalSegment,
-            sessionFinal: u.sessionFinal,
-            raw: u.raw,
-          });
-        });
-        doubao.on('error', (err) => {
-          sendJson({ type: 'error', message: err.message });
-          closeAll(1011, 'doubao error');
-        });
-        doubao.on('close', (code, reason) => {
-          sendJson({ type: 'closed', code, reason });
-          closeAll(1000, 'doubao closed');
-        });
-
-        try {
-          await doubao.connect();
-          doubao.start({ uid: msg.uid, ...msg.config });
-          doubaoReady = true;
-          // Flush any audio chunks that arrived during the handshake.
-          if (audioBuffer.length > 0) {
-            clientLog.debug('flushing buffered audio', { chunks: audioBuffer.length });
-            for (const chunk of audioBuffer) {
-              try {
-                doubao.sendAudio(chunk);
-              } catch (err) {
-                sendJson({ type: 'error', message: (err as Error).message });
-                closeAll(1011, 'doubao send failed');
-                return;
-              }
-            }
-            audioBuffer.length = 0;
-          }
-          sendJson({ type: 'ready' });
-        } catch (err) {
-          sendJson({ type: 'error', message: `doubao connect failed: ${(err as Error).message}` });
-          closeAll(1011, 'doubao connect failed');
+        if (!opts.leasePublicKeyPem) {
+          deny('no_pubkey', 'broker misconfigured');
+          return;
         }
+        if (!msg.authorization) {
+          deny('missing_lease', 'missing authorization lease');
+          return;
+        }
+        const deviceId = msg.deviceId ?? msg.authorization.payload.did;
+        const result = verifyLease(msg.authorization, opts.leasePublicKeyPem, {
+          resource: expectedResource,
+          deviceId,
+        });
+        if (!result.ok) {
+          deny(result.reason, result.detail);
+          return;
+        }
+        if (msg.uid !== undefined && msg.uid !== result.payload.sub) {
+          deny('wrong_user', 'lease does not match user');
+          return;
+        }
+        authorized = true;
+        quotaSeconds = result.payload.quota_seconds;
+        leaseJti = result.payload.jti;
+        leaseExp = result.payload.exp;
+        const previous = owners.get(leaseJti);
+        if (previous && previous !== connectionOwner) {
+          bytesConsumed = Math.max(bytesConsumed, previous.audioBytes());
+        }
+        owners.set(leaseJti, connectionOwner);
+        if (previous && previous !== connectionOwner) previous.replace();
+        scheduleExpiry();
+        sendJson({ type: 'authorized' });
+        return;
+      }
+
+      if (msg.type === 'start') {
+        await startRecording(msg);
         return;
       }
 
       if (msg.type === 'finish') {
-        // If we're mid-handshake, wait for it to complete (the buffered audio
-        // will be flushed first by the start handler) then finish.
-        const tryFinish = () => {
-          try {
-            doubao?.finish();
-          } catch (err) {
+        if (!started || finishing) return;
+        finishing = true;
+        if (doubaoReady) {
+          try { doubao?.finish(); } catch (err) {
             sendJson({ type: 'error', message: (err as Error).message });
           }
-        };
-        if (doubaoReady) tryFinish();
-        else {
-          // Defer until ready; cheap poll because handshake completes in <1s.
-          const t = setInterval(() => {
-            if (closed) {
-              clearInterval(t);
-              return;
-            }
-            if (doubaoReady) {
-              clearInterval(t);
-              tryFinish();
-            }
-          }, 50);
-          // Safety timeout.
-          setTimeout(() => clearInterval(t), 10_000);
         }
         return;
       }
@@ -337,9 +391,20 @@ export async function startBroker(opts: BrokerOptions): Promise<BrokerServer> {
       sendJson({ type: 'error', message: `unknown control type: ${(msg as { type: string }).type}` });
     });
 
+    const closeForShutdown = () => closeAll(1001, 'server_shutdown');
+    closeConnections.add(closeForShutdown);
     ws.on('close', (code, reason) => {
+      closeConnections.delete(closeForShutdown);
+      const pongTimeout = pongTimeouts.get(ws);
+      if (pongTimeout) clearTimeout(pongTimeout);
+      pongTimeouts.delete(ws);
+      expiryTimer && clearTimeout(expiryTimer);
+      if (leaseJti && owners.get(leaseJti) === connectionOwner) owners.delete(leaseJti);
       clientLog.info('client disconnected', { code, reason: reason?.toString('utf-8') });
-      closeAll(code, reason?.toString('utf-8') ?? '');
+      if (!closed) {
+        closed = true;
+        closeDoubao();
+      }
     });
     ws.on('error', (err) => clientLog.warn('client error', { error: err.message }));
   });
@@ -353,15 +418,18 @@ export async function startBroker(opts: BrokerOptions): Promise<BrokerServer> {
   return {
     port: boundPort,
     url,
-    close: () =>
-      new Promise<void>((resolve, reject) => {
-        wss.close((err) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          http.close((err2) => (err2 ? reject(err2) : resolve()));
-        });
-      }),
+    close: () => new Promise<void>((resolve, reject) => {
+      pingTimer && clearInterval(pingTimer);
+      for (const timeout of pongTimeouts.values()) clearTimeout(timeout);
+      pongTimeouts.clear();
+      for (const closeConnection of [...closeConnections]) closeConnection();
+      wss.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        http.close((err2) => (err2 ? reject(err2) : resolve()));
+      });
+    }),
   };
 }


### PR DESCRIPTION
## Summary
- authorize the voice WebSocket before microphone capture and reuse it across recordings
- make one lease carry cumulative quota and monotonic usage checkpoints
- add reconnect ownership replacement, exact usage resume, and schema-v11 accounting
- keep only the Broker socket warm; create a fresh ASR provider session per recording
- add iOS foreground/background and macOS activation/focus/wake lifecycle handling
- use WebSocket ping/pong and refresh leases before expiry
- update cross-package, Broker, Head, VoiceInputCore, and Apple tests

## Release dependency
Requires `@coinfra/voice@0.2.0`. This PR must not be released until that package is visible on npm and the production Broker distribution is rebuilt from that exact version.

## Validation
- `pnpm lint`
- `pnpm build`
- Head 261 tests
- Voice Broker 42 tests + 9 deploy adapter tests
- cross-package integration 44 tests
- VoiceInputCore 6 tests
- iOS KrakiVoiceInputTests 15 tests
- full KrakiMac build
- Head + Kraki authorizer + Coinfra gateway + mock Doubao process E2E
