### PR TITLE
feat(mac): expose copyable Session ID in More

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.4;
+				MARKETING_VERSION = 0.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.4;
+				MARKETING_VERSION = 0.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatView.swift
@@ -597,6 +597,8 @@ private struct MacSessionInfoSheet: View {
     @State private var editingTitle = false
     @State private var titleDraft = ""
     @State private var showDeleteConfirmation = false
+    @State private var sessionIDCopied = false
+    @State private var sessionIDCopyFeedbackTask: Task<Void, Never>?
     @FocusState private var titleFocused: Bool
 
     private var currentMode: SessionMode {
@@ -647,6 +649,10 @@ private struct MacSessionInfoSheet: View {
         }
         .frame(width: 440, height: 580)
         .background(Color.surfacePrimary)
+        .onDisappear {
+            sessionIDCopyFeedbackTask?.cancel()
+            sessionIDCopyFeedbackTask = nil
+        }
         .confirmationDialog(
             "Delete Session",
             isPresented: $showDeleteConfirmation,
@@ -704,6 +710,7 @@ private struct MacSessionInfoSheet: View {
                     .buttonStyle(.plain)
                 }
             }
+            sessionIDRow
             infoRow("Agent", session.agent)
             infoRow(label: "Model") {
                 if availableModels.isEmpty {
@@ -720,6 +727,56 @@ private struct MacSessionInfoSheet: View {
                 }
             }
             infoRow("Created", session.createdAt.formatted(date: .abbreviated, time: .shortened))
+        }
+    }
+
+    private var sessionIDRow: some View {
+        infoRow(label: "Session ID") {
+            HStack(spacing: 7) {
+                Text(session.id)
+                    .font(.system(size: 12.5, weight: .regular, design: .monospaced))
+                    .foregroundStyle(Color.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+                    .help(session.id)
+                    .accessibilityLabel("Session ID \(session.id)")
+
+                Button(action: copySessionID) {
+                    HStack(spacing: 4) {
+                        Image(systemName: sessionIDCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 11, weight: .semibold))
+                        if sessionIDCopied {
+                            Text("Copied")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                    }
+                    .foregroundStyle(sessionIDCopied ? Color.green : Color.textSecondary)
+                    .frame(width: 64, height: 24, alignment: .trailing)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(sessionIDCopied ? "Session ID copied" : "Copy Session ID")
+                .accessibilityLabel(sessionIDCopied ? "Session ID copied" : "Copy Session ID")
+                .accessibilityHint("Copies the complete Session ID to the clipboard")
+            }
+            .frame(maxWidth: 285, alignment: .trailing)
+        }
+    }
+
+    private func copySessionID() {
+        KrakiPasteboard.setString(session.id)
+        sessionIDCopyFeedbackTask?.cancel()
+        withAnimation(.easeInOut(duration: 0.15)) {
+            sessionIDCopied = true
+        }
+        sessionIDCopyFeedbackTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.15)) {
+                sessionIDCopied = false
+            }
+            sessionIDCopyFeedbackTask = nil
         }
     }
 

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.4"
-        CURRENT_PROJECT_VERSION: 6
+        MARKETING_VERSION: "0.2.5"
+        CURRENT_PROJECT_VERSION: 7
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- add the complete Session ID to the macOS More / Session Info panel
- use a monospaced, selectable, middle-truncating presentation
- add one-click clipboard copy with stable-width green `Copied` feedback
- add VoiceOver labels, hint, and full-ID hover help
- prepare KrakiMac 0.2.5 (build 7)

## Self-review and local validation
- rebased onto latest `origin/main`
- KrakiMac Debug build passed
- KrakiMac Release build passed
- semantic AX opened More and found `Copy Session ID`
- clipboard result exactly matched the selected Session ID
- original multi-type clipboard contents were restored after the test
- before/after screenshots confirmed no clipping, squeezing, or row movement
- signed Dev app passed strict codesign verification

## Scope
- macOS only
- no protocol, Session persistence, message, or relay changes