### PR TITLE
release: @kraki/head@0.17.3

### DIFF
--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/head",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Kraki relay server — the brain that routes messages between tentacles and apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump `@kraki/head` to `0.17.3`
- publish the schema-v11 voice lease accounting and warm-connection settlement implementation merged in #238

This package release is required before the coordinated production Head/Broker rollout for Mac `0.2.5`.
