### PR TITLE
fix(ios): align Markdown code rendering with Mac

### DIFF
--- a/packages/arm/ios/Kraki/Core/Markdown/MessageBodyParser.swift
+++ b/packages/arm/ios/Kraki/Core/Markdown/MessageBodyParser.swift
@@ -255,10 +255,16 @@ enum MarkdownCodeSyntax {
         "html": "xml", "htm": "xml",
         "js": "javascript", "jsx": "javascript",
         "ts": "typescript", "tsx": "typescript",
-        "py": "python", "rb": "ruby", "rs": "rust",
+        "py": "python", "rb": "ruby", "rs": "rust", "golang": "go",
         "kt": "kotlin", "kts": "kotlin",
         "sh": "bash", "shell": "bash", "zsh": "bash",
-        "yml": "yaml", "objc": "objectivec", "objective-c": "objectivec",
+        "shell-session": "shell", "console": "shell", "terminal": "shell",
+        "yml": "yaml", "jsonc": "json", "json5": "json",
+        "md": "markdown", "mdown": "markdown", "mkdown": "markdown",
+        "docker": "dockerfile", "ps": "powershell", "ps1": "powershell", "pwsh": "powershell",
+        "gql": "graphql", "postgres": "pgsql", "postgresql": "pgsql",
+        "make": "makefile", "patch": "diff", "objc": "objectivec",
+        "objective-c": "objectivec", "objc++": "objectivec", "objective-c++": "objectivec", "mm": "objectivec",
     ]
     private static let intentionallyPlainLanguages: Set<String> = [
         "text", "txt", "plaintext", "plain", "none",

--- a/packages/arm/ios/Kraki/Features/Chat/TextKit/TextKitBubble.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/TextKit/TextKitBubble.swift
@@ -10,6 +10,58 @@ private enum IOSMarkdownPalette {
     }
 }
 
+/// Fixed palette for the neutral code editor surface. Highlightr themes can
+/// emit light-mode or low-contrast token colors even when the surrounding
+/// bubble is dark; MacCodePalette applies this same readability contract.
+private enum IOSCodePalette {
+    static let background = UIColor(red: 0x18/255, green: 0x18/255, blue: 0x1B/255, alpha: 1)
+    static let foreground = UIColor(red: 0xF4/255, green: 0xF4/255, blue: 0xF5/255, alpha: 1)
+
+    static func ensuringReadableForeground(in string: NSMutableAttributedString) {
+        guard string.length > 0 else { return }
+        var unreadableRanges: [NSRange] = []
+        string.enumerateAttribute(
+            .foregroundColor,
+            in: NSRange(location: 0, length: string.length)
+        ) { value, range, _ in
+            guard let color = value as? UIColor,
+                  contrastRatio(foreground: color, background: background) >= 4.5 else {
+                unreadableRanges.append(range)
+                return
+            }
+        }
+        for range in unreadableRanges {
+            string.addAttribute(.foregroundColor, value: foreground, range: range)
+        }
+    }
+
+    static func contrastRatio(foreground: UIColor, background: UIColor) -> CGFloat {
+        let resolvedForeground = foreground.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+        let resolvedBackground = background.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+        var fr: CGFloat = 0, fg: CGFloat = 0, fb: CGFloat = 0, fa: CGFloat = 0
+        var br: CGFloat = 0, bg: CGFloat = 0, bb: CGFloat = 0, ba: CGFloat = 0
+        guard resolvedForeground.getRed(&fr, green: &fg, blue: &fb, alpha: &fa),
+              resolvedBackground.getRed(&br, green: &bg, blue: &bb, alpha: &ba) else { return 1 }
+
+        func luminance(_ r: CGFloat, _ g: CGFloat, _ b: CGFloat) -> CGFloat {
+            func linear(_ value: CGFloat) -> CGFloat {
+                value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+            }
+            return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
+        }
+
+        // Blend translucent token colors over the actual code surface before
+        // measuring, matching what the user sees rather than raw RGBA values.
+        let blendedR = fr * fa + br * (1 - fa)
+        let blendedG = fg * fa + bg * (1 - fa)
+        let blendedB = fb * fa + bb * (1 - fa)
+        let foregroundLuminance = luminance(blendedR, blendedG, blendedB)
+        let backgroundLuminance = luminance(br, bg, bb)
+        return (max(foregroundLuminance, backgroundLuminance) + 0.05)
+            / (min(foregroundLuminance, backgroundLuminance) + 0.05)
+    }
+}
+
 // MARK: - TextKit2 bubble render path
 //
 // Landed pure-spine messages have one renderer and one identity: a TextKit
@@ -104,7 +156,7 @@ private enum TKCodeHighlighter {
     ) -> NSAttributedString {
         guard allowHighlighting else { return NSAttributedString(string: code) }
         if MarkdownCodeSyntax.isIntentionallyPlain(language) {
-            return NSAttributedString(string: code)
+            return NSAttributedString(string: code, attributes: [.foregroundColor: IOSCodePalette.foreground])
         }
         let normalized = normalizedLanguage(language)
         let key = tkContentCacheKey(prefix: normalized ?? "auto", content: code)
@@ -148,16 +200,20 @@ private enum TKCodeHighlighter {
         let raw = MarkdownCodeSyntax.rawLanguage(language)
         let normalized = normalizedLanguage(language)
         let highlighted = makeEngine()?.highlight(code, as: normalized, fastRender: true)
-            ?? NSAttributedString(string: code)
+            ?? NSAttributedString(string: code, attributes: [.foregroundColor: IOSCodePalette.foreground])
         guard foregroundColorCount(in: highlighted) <= 1,
-              let fallbackLanguage = normalized ?? raw else { return highlighted }
+              let fallbackLanguage = normalized ?? raw else {
+            let readable = NSMutableAttributedString(attributedString: highlighted)
+            IOSCodePalette.ensuringReadableForeground(in: readable)
+            return readable
+        }
         return lexicalFallback(code: code, language: fallbackLanguage)
     }
 
     private static func lexicalFallback(code: String, language: String) -> NSAttributedString {
         let result = NSMutableAttributedString(
             string: code,
-            attributes: [.foregroundColor: UIColor.label]
+            attributes: [.foregroundColor: IOSCodePalette.foreground]
         )
         let fullRange = NSRange(location: 0, length: result.length)
         var occupied = IndexSet()
@@ -714,6 +770,9 @@ enum TKMarkdown {
                 allowHighlighting: allowHighlighting
             )
         )
+        // Match Mac: keep valid syntax colors, but replace missing or
+        // low-contrast Highlightr output before TextKit draws on #18181B.
+        IOSCodePalette.ensuringReadableForeground(in: highlighted)
         if highlighted.length > 0 {
             let paragraph = NSMutableParagraphStyle()
             paragraph.firstLineHeadIndent = 12

--- a/packages/arm/ios/KrakiTests/TextKitPureSpineTests.swift
+++ b/packages/arm/ios/KrakiTests/TextKitPureSpineTests.swift
@@ -307,6 +307,10 @@ final class TextKitPureSpineTests: XCTestCase {
         XCTAssertEqual(normalizeMarkdownQuoteWhitespace("\nStart\n\n\nEnd\n"), "Start\n\nEnd")
         XCTAssertEqual(MarkdownCodeSyntax.normalizedLanguage("TSX"), "typescript")
         XCTAssertEqual(MarkdownCodeSyntax.normalizedLanguage("c++"), "cpp")
+        XCTAssertEqual(MarkdownCodeSyntax.normalizedLanguage("jsonc"), "json")
+        XCTAssertEqual(MarkdownCodeSyntax.normalizedLanguage("shell-session"), "shell")
+        XCTAssertEqual(MarkdownCodeSyntax.normalizedLanguage("objective-c++"), "objectivec")
+        XCTAssertEqual(MarkdownCodeSyntax.normalizedLanguage("postgresql"), "pgsql")
         XCTAssertTrue(MarkdownCodeSyntax.isIntentionallyPlain("text"))
         XCTAssertFalse(MarkdownCodeSyntax.isIntentionallyPlain("swift"))
     }
@@ -477,6 +481,52 @@ final class TextKitPureSpineTests: XCTestCase {
         XCTAssertGreaterThan(colors.count, 1)
         XCTAssertEqual(TKMarkdown.plainText(rendered), "struct Bubble { let state: String }")
         XCTAssertFalse(TKMarkdown.plainText(rendered)?.contains("\u{200B}") ?? true)
+    }
+
+    func testCodeForegroundAlwaysMeetsMacEditorContrastContract() {
+        let samples = [
+            ("text", "plain output with no syntax tokens"),
+            ("swift", "let value: String = \"hello\""),
+            ("not-a-real-language", "const value = 42 // fallback"),
+        ]
+        let background = UIColor(red: 0x18/255, green: 0x18/255, blue: 0x1B/255, alpha: 1)
+
+        func luminance(_ color: UIColor) -> CGFloat {
+            let resolved = color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+            var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+            guard resolved.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return 0 }
+            func linear(_ value: CGFloat) -> CGFloat {
+                value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+            }
+            return 0.2126 * linear(red) + 0.7152 * linear(green) + 0.0722 * linear(blue)
+        }
+        let backgroundLuminance = luminance(background)
+
+        for (language, code) in samples {
+            TKMarkdown.prepareFinalHighlightForTesting(code: code, language: language)
+            let rendered = TKMarkdown.attributed(
+                "```\(language)\n\(code)\n```",
+                cacheKey: "contrast-\(language)"
+            )
+            var checkedGlyphs = 0
+            rendered.enumerateAttributes(
+                in: NSRange(location: 0, length: rendered.length)
+            ) { attributes, range, _ in
+                guard attributes[.tkDecorativeSpacer] == nil else { return }
+                let fragment = (rendered.string as NSString).substring(with: range)
+                guard fragment.rangeOfCharacter(from: .whitespacesAndNewlines.inverted) != nil else { return }
+                guard let color = attributes[.foregroundColor] as? UIColor else {
+                    return XCTFail("\(language) code glyphs must have an explicit foreground")
+                }
+                let foregroundLuminance = luminance(color)
+                let ratio = (max(foregroundLuminance, backgroundLuminance) + 0.05)
+                    / (min(foregroundLuminance, backgroundLuminance) + 0.05)
+                XCTAssertGreaterThanOrEqual(ratio, 4.5, "\(language) emitted unreadable code text")
+                checkedGlyphs += range.length
+            }
+            XCTAssertGreaterThan(checkedGlyphs, 0)
+            XCTAssertEqual(TKMarkdown.plainText(rendered), code)
+        }
     }
 
     func testCodeHighlightAliasesAndLexicalFallbackMatchMacBehavior() {


### PR DESCRIPTION
## Root cause
Mac and iOS share fence parsing and Highlightr, but only Mac normalized missing or low-contrast token colors against the fixed `#18181B` code surface. iOS could therefore render black/dark tokens that looked invisible or like an unsupported language.

## Fix
- port Mac’s fixed code foreground/background palette to iOS
- enforce WCAG 4.5:1 contrast for every visible code token while preserving valid syntax colors
- give plain and fallback code an explicit readable foreground
- add common AI-generated fence aliases (`jsonc`, `shell-session`, `docker`, `ps1`, `postgresql`, Objective-C++, and others) in the shared parser
- add a regression test covering plain, Swift, and unknown-language code

## Validation
- iOS full suite: 286 executed, 2 skipped, 0 failures
- contrast regression confirms every visible code run meets 4.5:1 against `#18181B`
- semantic copy remains code-only and excludes decorative spacers/language badges
- diff check passes