### PR TITLE
fix(mac): refresh exhausted voice lease

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.6;
+				MARKETING_VERSION = 0.2.7;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.6;
+				MARKETING_VERSION = 0.2.7;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
+++ b/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
@@ -452,13 +452,14 @@ final class KrakiVoiceInputController {
 
     private func handleConnectionFailure(_ reason: String) {
         KLog.d("🎙️ [voice] stage=connection-failed reason=\(reason)")
-        closeConnection(keepLease: true)
+        let quotaExhausted = reason.localizedCaseInsensitiveContains("quota_exhausted")
+        closeConnection(keepLease: !quotaExhausted)
         if isBusy {
             let message = Self.userFacingGatewayError(reason)
             recordingCleanup(clearHandlers: true)
             state = .failed(message)
         }
-        if warmConnectionDesired { scheduleReconnect() }
+        if warmConnectionDesired { scheduleReconnect(immediate: quotaExhausted) }
     }
 
     private func scheduleLeaseTimeout() {

--- a/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
+++ b/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
@@ -127,7 +127,7 @@ private final class SuspendedVoiceAudioPolicy: VoiceInputAudioPolicy {
 
 @MainActor
 final class KrakiVoiceInputTests: XCTestCase {
-    private func lease(expiryOffset: Int = 600) -> VoiceLease {
+    private func lease(expiryOffset: Int = 600, jti: String = "lease-1") -> VoiceLease {
         VoiceLease(
             payload: VoiceLeasePayload(
                 ver: 1,
@@ -138,7 +138,7 @@ final class KrakiVoiceInputTests: XCTestCase {
                 exp: Int(Date().timeIntervalSince1970) + expiryOffset,
                 quotaSeconds: 600,
                 resource: "voice/doubao",
-                jti: "lease-1"
+                jti: jti
             ),
             signature: "signature",
             alg: "RSA-SHA256"
@@ -490,6 +490,39 @@ final class KrakiVoiceInputTests: XCTestCase {
         factory.sessions[0].emit(.final("second", rawText: nil))
         await Task.yield()
         XCTAssertEqual(finals, ["first", "second"])
+    }
+
+    func testQuotaExhaustedConnectionDiscardsLeaseAndRequestsReplacement() async {
+        let host = FakeVoiceHost()
+        let factory = FakeVoiceFactory()
+        let controller = KrakiVoiceInputController(
+            host: host,
+            sessionFactory: factory,
+            audioPolicy: FakeVoiceAudioPolicy()
+        )
+        controller.prepare()
+        controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+
+        await controller.begin(sessionID: "session-1", context: context()) { _ in }
+        XCTAssertEqual(controller.state, .recording)
+        factory.sessions[0].emit(.failed("denied: quota_exhausted"))
+        for _ in 0..<20 where host.requestedResources.count < 2 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(controller.state, .failed("The voice-input quota was exhausted."))
+        XCTAssertEqual(host.requestedResources, ["voice/doubao", "voice/doubao"])
+        XCTAssertEqual(factory.sessions[0].closeCount, 1)
+        guard factory.sessions.count == 1 else { return }
+
+        controller.receiveLease(lease(jti: "lease-2"))
+        XCTAssertEqual(factory.sessions.count, 2)
+        guard factory.sessions.count == 2 else { return }
+        factory.sessions[1].emit(.connectionAuthorized)
+        await Task.yield()
+        XCTAssertTrue(controller.isConnectionWarm)
     }
 
     func testLeaseDenialsRemainDistinct() async {

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.6"
-        CURRENT_PROJECT_VERSION: 8
+        MARKETING_VERSION: "0.2.7"
+        CURRENT_PROJECT_VERSION: 9
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- discard the cached warm voice lease when the Broker reports `quota_exhausted`
- immediately request a replacement lease instead of reconnecting with the exhausted `jti`
- add regression coverage for quota exhaustion during an active recording
- prepare the Mac hotfix release as `0.2.7` (build `9`)

## Validation
- `KrakiVoiceInputTests`: 16/16 passed
- `KrakiMac` Debug build passed
