### PR TITLE
fix(mac): capture question clicks before hit frames settle

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.7;
+				MARKETING_VERSION = 0.2.8;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.7;
+				MARKETING_VERSION = 0.2.8;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
@@ -1311,6 +1311,25 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             eventNumber += 2
         }
 
+        let fallbackProbeTopY = ((correctedFirst.first ?? 0) + (correctedFirst.last ?? 0)) / 2
+        let fallbackProbePoint = NSPoint(
+            x: visualX,
+            y: zoomSize.height - fallbackProbeTopY
+        )
+        let fallbackCaptureBefore = zoomCell.actionCapture(
+            atWindowPoint: fallbackProbePoint
+        ) == .question("question-hit")
+        zoomCell.clearActionHitFramesForRegression()
+        let fallbackTargetMissing = zoomCell.questionChoiceHitTarget(
+            atWindowPoint: fallbackProbePoint
+        ) == nil
+        let fallbackCaptureAfter = zoomCell.actionCapture(
+            atWindowPoint: fallbackProbePoint
+        ) == .question("question-hit")
+        let fallbackCapturePassed = fallbackCaptureBefore
+            && fallbackTargetMissing
+            && fallbackCaptureAfter
+
         zoomWindow.close()
 
         // Permission buttons use the same rendered-frame interception as
@@ -1470,10 +1489,11 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         let passed = directPassed
             && correctedPassed
             && permissionPassed
+            && fallbackCapturePassed
             && directCaptured
             && zoomCaptured
         NSLog(
-            "[question-hit-regression] directFirst=%@ directSecond=%@ rawZoomFirst=%@ rawZoomSecond=%@ correctedFirst=%@ correctedSecond=%@ rawAligned=%d correctedAligned=%d permissionDirect=%@ permissionZoom=%@ permissionAligned=%d directCapture=%d zoomCapture=%d passed=%d paths=%@,%@",
+            "[question-hit-regression] directFirst=%@ directSecond=%@ rawZoomFirst=%@ rawZoomSecond=%@ correctedFirst=%@ correctedSecond=%@ rawAligned=%d correctedAligned=%d permissionDirect=%@ permissionZoom=%@ permissionAligned=%d fallbackCapture=%d directCapture=%d zoomCapture=%d passed=%d paths=%@,%@",
             range(directFirst),
             range(directSecond),
             range(zoomFirst),
@@ -1485,6 +1505,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             String(describing: directPermissionRects),
             String(describing: zoomPermissionRects),
             permissionPassed ? 1 : 0,
+            fallbackCapturePassed ? 1 : 0,
             directCaptured ? 1 : 0,
             zoomCaptured ? 1 : 0,
             passed ? 1 : 0,

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatBubbleCell.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatBubbleCell.swift
@@ -892,6 +892,11 @@ enum MacBubbleActionHitTarget: Equatable {
     case permission(MacPermissionButtonHitTarget)
 }
 
+enum MacBubbleActionCapture: Equatable {
+    case question(String)
+    case permission(String)
+}
+
 final class MacChatBubbleCell: NSView {
     override var isFlipped: Bool { true }
     private let contentClipView = MacFlippedContentClipView()
@@ -1001,6 +1006,11 @@ final class MacChatBubbleCell: NSView {
     var bubbleHiddenForRegression: Bool { bubbleBG.isHidden }
     var contentClipIsFlippedForRegression: Bool { contentClipView.isFlipped }
 
+    func clearActionHitFramesForRegression() {
+        questionChoiceFrames.removeAll(keepingCapacity: true)
+        permissionButtonFrames.removeAll(keepingCapacity: true)
+    }
+
     func openFirstImageForRegression() -> (found: Bool, hitTested: Bool) {
         imageHost.layoutSubtreeIfNeeded()
         func collectButtons(in view: NSView, into result: inout [NSButton]) {
@@ -1034,6 +1044,26 @@ final class MacChatBubbleCell: NSView {
             return .permission(permission)
         }
         return nil
+    }
+
+    func actionCapture(atWindowPoint point: NSPoint) -> MacBubbleActionCapture? {
+        guard let action = content?.action,
+              !actionHost.isHidden,
+              actionHost.bounds.contains(actionHost.convert(point, from: nil)) else { return nil }
+        switch action.type {
+        case "question":
+            guard !action.cancelled,
+                  action.answer == nil,
+                  !(action.choices?.isEmpty ?? true),
+                  let questionId = action.questionId else { return nil }
+            return .question(questionId)
+        case "permission":
+            guard action.payload["decision"]?.stringValue == nil,
+                  let permissionId = action.permissionId else { return nil }
+            return .permission(permissionId)
+        default:
+            return nil
+        }
     }
 
     func questionChoiceHitTarget(

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
@@ -1257,6 +1257,16 @@ final class MacChatDocumentView: NSView {
         return nil
     }
 
+    func actionCapture(atWindowPoint point: NSPoint) -> MacBubbleActionCapture? {
+        for (_, cell) in visibleCells.sorted(by: { $0.key > $1.key })
+        where !cell.isHidden && !cell.isPlaceholderFlag {
+            if let capture = cell.actionCapture(atWindowPoint: point) {
+                return capture
+            }
+        }
+        return nil
+    }
+
     @discardableResult
     func openVisibleHTMLArtifact(id: String? = nil) -> Bool {
         let viewport = enclosingScrollView?.contentView.bounds ?? bounds
@@ -1732,7 +1742,8 @@ final class MacChatScrollView: MacSmoothScrollView {
     private var geometryAnchorLock: (key: String, delta: CGFloat)?
     private var bubbleActionMouseMonitor: Any?
     private var pendingBubbleActionClick: (
-        target: MacBubbleActionHitTarget,
+        target: MacBubbleActionHitTarget?,
+        capture: MacBubbleActionCapture,
         start: NSPoint,
         cancelled: Bool
     )?
@@ -1880,13 +1891,15 @@ final class MacChatScrollView: MacSmoothScrollView {
 
         switch event.type {
         case .leftMouseDown:
-            guard let target = chatDocumentView.actionHitTarget(
-                atWindowPoint: windowPoint
-            ) else {
+            guard let capture = chatDocumentView.actionCapture(atWindowPoint: windowPoint) else {
                 pendingBubbleActionClick = nil
                 return event
             }
-            pendingBubbleActionClick = (target, windowPoint, false)
+            let target = chatDocumentView.actionHitTarget(atWindowPoint: windowPoint)
+            // SwiftUI propagates rendered choice frames asynchronously. Capture
+            // the whole interactive action region while that cache is empty so
+            // a zoomed click never falls through to SwiftUI's shifted hit test.
+            pendingBubbleActionClick = (target, capture, windowPoint, false)
             return nil
 
         case .leftMouseDragged:
@@ -1901,23 +1914,57 @@ final class MacChatScrollView: MacSmoothScrollView {
             guard let pending = pendingBubbleActionClick else { return event }
             pendingBubbleActionClick = nil
             guard !pending.cancelled,
-                  chatDocumentView.actionHitTarget(
-                    atWindowPoint: windowPoint
-                  ) == pending.target else { return nil }
-            let answerCallback = chatDocumentView.onAnswerQuestion
-            let permissionCallback = chatDocumentView.onResolvePermission
-            DispatchQueue.main.async {
-                switch pending.target {
-                case .question(let target):
-                    answerCallback?(target.questionId, target.answer)
-                case .permission(let target):
-                    permissionCallback?(target.permissionId, target.toolName, target.decision)
+                  chatDocumentView.actionCapture(atWindowPoint: windowPoint) == pending.capture else {
+                return nil
+            }
+            if let expectedTarget = pending.target {
+                guard chatDocumentView.actionHitTarget(atWindowPoint: windowPoint) == expectedTarget else {
+                    return nil
                 }
+                dispatchBubbleAction(expectedTarget)
+            } else {
+                dispatchBubbleActionWhenReady(
+                    atWindowPoint: windowPoint,
+                    expectedCapture: pending.capture
+                )
             }
             return nil
 
         default:
             return event
+        }
+    }
+
+    private func dispatchBubbleAction(_ target: MacBubbleActionHitTarget) {
+        let answerCallback = chatDocumentView.onAnswerQuestion
+        let permissionCallback = chatDocumentView.onResolvePermission
+        DispatchQueue.main.async {
+            switch target {
+            case .question(let target):
+                answerCallback?(target.questionId, target.answer)
+            case .permission(let target):
+                permissionCallback?(target.permissionId, target.toolName, target.decision)
+            }
+        }
+    }
+
+    private func dispatchBubbleActionWhenReady(
+        atWindowPoint point: NSPoint,
+        expectedCapture: MacBubbleActionCapture,
+        attemptsRemaining: Int = 8
+    ) {
+        guard chatDocumentView.actionCapture(atWindowPoint: point) == expectedCapture else { return }
+        if let target = chatDocumentView.actionHitTarget(atWindowPoint: point) {
+            dispatchBubbleAction(target)
+            return
+        }
+        guard attemptsRemaining > 0 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0 / 120.0) { [weak self] in
+            self?.dispatchBubbleActionWhenReady(
+                atWindowPoint: point,
+                expectedCapture: expectedCapture,
+                attemptsRemaining: attemptsRemaining - 1
+            )
         }
     }
 

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.7"
-        CURRENT_PROJECT_VERSION: 9
+        MARKETING_VERSION: "0.2.8"
+        CURRENT_PROJECT_VERSION: 10
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- keep AppKit in charge of question/permission card mouse events while SwiftUI rendered-frame preferences are still settling
- defer unresolved clicks briefly instead of falling through to SwiftUI's known shifted hit testing under UI zoom
- bind deferred resolution to the original question/permission ID so session/card replacement cannot submit to a new card
- extend the question-hit regression to clear the rendered-frame cache and prove the interaction region remains captured
- prepare Mac `0.2.8` (build `10`)

## Root cause
The existing fix correctly mapped rendered frames, but those frames arrive asynchronously through a SwiftUI `PreferenceKey`. Immediately after card insertion, cell reuse, resize, or relayout the cache can be empty. The local monitor then returned the event to SwiftUI, whose raw button hit bands remain shifted at the production 1.2x zoom.

## Validation
- KrakiMac Debug build passed
- question-hit regression passed, including `fallbackCapture=1`
- `git diff --check` clean
