### PR TITLE
feat(mac): add shared launch and signed-out gate

### DIFF
--- a/docs/mac-launch-flow.md
+++ b/docs/mac-launch-flow.md
@@ -1,0 +1,54 @@
+# macOS Launch and Signed-Out Flow
+
+Kraki's production Mac window uses a shared full-window entry gate before the authenticated application surface is created.
+
+The production main scene is a single `Window(id: "main")`, not a `WindowGroup`. macOS may restore its geometry, but it cannot resurrect multiple historical main-window instances.
+
+## User-visible contract
+
+### Cold process launch
+
+1. Show the Kraki launch gate immediately.
+2. Resolve local CLI/stored credential availability behind the gate.
+3. Keep the gate visible for at least 350 ms to avoid a one-frame flash.
+4. Route to one of:
+   - authenticated `MainWindowView`, landing on Welcome with no Session selected;
+   - the signed-out entry gate, with `kraki connect` instructions.
+5. Relay authentication and Tentacle status may continue after the authenticated shell appears. Network readiness never blocks the full-window gate indefinitely.
+
+### Warm window reopen
+
+When the process is still running in the menu bar, reopening the main window restores the process-local selected Session and does not replay the cold-launch gate.
+
+### Signed out
+
+Launch and Signed Out use the same brand shell. Signed Out replaces the launch status with:
+
+- the `kraki connect` command and a native Copy action;
+- a `Check Again` action;
+- automatic credential discovery when the user returns to Kraki from Terminal;
+- in-place checking/failure status.
+
+Neither entry mode mounts Sidebar, Chat, Composer, CoreText cells, image preview, or HTML artifact state behind the gate.
+
+## Restore policy
+
+| State | Cold launch | Warm window reopen |
+| --- | --- | --- |
+| Window geometry | Restore | Restore |
+| Sidebar visibility | Restore | Restore |
+| Selected Session | Clear | Restore process-local selection |
+| Drafts/history/unread/pinned | Preserve | Preserve |
+| Preview/sheet/scroll position | Clear | Keep only while owning view remains alive |
+| Connection state | Reconcile | Continue/reconnect |
+
+## Debug visual fixtures
+
+The Debug Mac target can render either entry state without auth or Relay traffic:
+
+```bash
+KRAKI_MAC_ENTRY_GATE_PAGE=launching "/path/to/Kraki Dev.app/Contents/MacOS/Kraki Dev"
+KRAKI_MAC_ENTRY_GATE_PAGE=signed-out "/path/to/Kraki Dev.app/Contents/MacOS/Kraki Dev"
+KRAKI_MAC_ENTRY_GATE_PAGE=signed-out-checking "/path/to/Kraki Dev.app/Contents/MacOS/Kraki Dev"
+KRAKI_MAC_ENTRY_GATE_PAGE=signed-out-failed "/path/to/Kraki Dev.app/Contents/MacOS/Kraki Dev"
+```

--- a/packages/arm/ios/Kraki/App/Mac/MacApp.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacApp.swift
@@ -13,7 +13,151 @@
 
 #if os(macOS)
 import AppKit
+import Observation
 import SwiftUI
+
+/// Process-scoped launch routing for the production Mac window.
+///
+/// The coordinator deliberately lives above MainWindowView: neither Chat nor
+/// the signed-out page is mounted behind the launch surface. A cold process
+/// starts with no selected Session; closing and reopening the window while the
+/// menu-bar process remains alive reuses `lastSelectedSessionId` instead.
+@Observable
+@MainActor
+final class MacLaunchCoordinator {
+    enum Phase: Equatable {
+        case launching
+        case authenticated
+        case signedOut
+    }
+
+    private(set) var phase: Phase = .launching
+    private(set) var isCheckingCredentials = false
+    private(set) var loginCheckFailed = false
+    var lastSelectedSessionId: String?
+
+    @ObservationIgnored private var hasStarted = false
+    @ObservationIgnored private var servicesStarted = false
+
+    func bootstrap(
+        appState: AppState,
+        tentacleCLI: TentacleCLIManager,
+        devLocal: Bool,
+        mock: Bool,
+        bypassProductionLaunch: Bool
+    ) async {
+        guard !hasStarted else { return }
+        hasStarted = true
+
+        if bypassProductionLaunch {
+            phase = .authenticated
+            return
+        }
+
+        let startedAt = Date()
+        KLog.diag("[MacLaunch] gate presented")
+        if !servicesStarted {
+            servicesStarted = true
+            Task { @MainActor in
+                await tentacleCLI.refreshInstallState()
+                await tentacleCLI.refreshDaemonState()
+                tentacleCLI.startPolling()
+            }
+        }
+
+        #if DEBUG
+        let forceSignedOut = ProcessInfo.processInfo.environment["KRAKI_MAC_FORCE_SIGNED_OUT"] == "1"
+        #else
+        let forceSignedOut = false
+        #endif
+
+        let canEnterAuthenticatedRoot: Bool
+        if forceSignedOut {
+            canEnterAuthenticatedRoot = false
+        } else if devLocal {
+            appState.devConnect()
+            canEnterAuthenticatedRoot = true
+        } else if mock {
+            canEnterAuthenticatedRoot = true
+        } else {
+            // Keep the launch gate mounted while the app resolves its preferred
+            // CLI credential. This removes the old signed-out-page flash before
+            // a returning CLI user was recognised.
+            let usedCLILogin = await appState.attemptCLILogin()
+            if !usedCLILogin, appState.hasStoredCredentials {
+                appState.connect()
+            }
+            canEnterAuthenticatedRoot = usedCLILogin || appState.hasStoredCredentials
+        }
+
+        // A very fast cache/auth path should still look intentional rather than
+        // flashing one frame of branding. This is a short visual floor, never a
+        // network wait: Relay authentication continues in the destination UI.
+        #if DEBUG
+        let minimumVisibleSeconds = ProcessInfo.processInfo.environment["KRAKI_MAC_LAUNCH_MIN_MS"]
+            .flatMap(Double.init)
+            .map { max(0, $0 / 1_000) }
+            ?? 0.35
+        #else
+        let minimumVisibleSeconds = 0.35
+        #endif
+        let remaining = minimumVisibleSeconds - Date().timeIntervalSince(startedAt)
+        if remaining > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+        }
+        guard !Task.isCancelled else {
+            // Closing the only window can cancel its SwiftUI `.task` while the
+            // menu-bar process stays alive. Permit the warm reopen to bootstrap
+            // again instead of leaving the process permanently on Launch.
+            hasStarted = false
+            return
+        }
+        phase = canEnterAuthenticatedRoot ? .authenticated : .signedOut
+        let elapsedMs = Date().timeIntervalSince(startedAt) * 1_000
+        KLog.diag(
+            "[MacLaunch] destination=\(canEnterAuthenticatedRoot ? "authenticated" : "signedOut") "
+                + String(format: "elapsedMs=%.1f", elapsedMs)
+        )
+    }
+
+    func retryLogin(appState: AppState) async {
+        guard !isCheckingCredentials else { return }
+        isCheckingCredentials = true
+        loginCheckFailed = false
+        defer { isCheckingCredentials = false }
+
+        KLog.diag("[MacLaunch] retrying CLI credential discovery")
+        let usedCLILogin = await appState.attemptCLILogin()
+        if usedCLILogin || appState.hasStoredCredentials {
+            if !usedCLILogin, appState.connectionStatus == .awaitingLogin {
+                appState.connect()
+            }
+            phase = .authenticated
+        } else {
+            loginCheckFailed = true
+        }
+    }
+
+    func reconcileAuthentication(
+        hasStoredCredentials: Bool,
+        connectionStatus: ConnectionStatus
+    ) {
+        guard phase != .launching else { return }
+        if hasStoredCredentials {
+            loginCheckFailed = false
+            phase = .authenticated
+        } else if connectionStatus == .awaitingLogin, phase == .authenticated {
+            // Explicit logout or a failed first authentication returns to the
+            // shared entry gate and drops process-local navigation state.
+            lastSelectedSessionId = nil
+            phase = .signedOut
+        }
+    }
+
+    func recordSelectedSession(_ sessionId: String?) {
+        lastSelectedSessionId = sessionId
+    }
+}
 
 @main
 struct MacApp: App {
@@ -21,6 +165,7 @@ struct MacApp: App {
 
     @State private var appState: AppState
     @State private var tentacleCLI = TentacleCLIManager()
+    @State private var launchCoordinator = MacLaunchCoordinator()
     @AppStorage("colorScheme") private var colorScheme: AppColorScheme = .system
 
     init() {
@@ -69,18 +214,24 @@ struct MacApp: App {
     }
 
     var body: some Scene {
-        WindowGroup("Kraki", id: "main") {
+        Window("Kraki", id: "main") {
             Group {
                 #if DEBUG
                 if ProcessInfo.processInfo.environment["KRAKI_MAC_CHAT_SCENARIO_PAGE"] == "1" {
                     MacChatScenarioTestView()
                 } else if ProcessInfo.processInfo.environment["KRAKI_MAC_CHAT_PERF_PAGE"] == "1" {
                     MacChatPerfTestView()
+                } else if let fixture = ProcessInfo.processInfo.environment["KRAKI_MAC_ENTRY_GATE_PAGE"] {
+                    MacEntryGateView(
+                        mode: fixture.hasPrefix("signed-out") ? .signedOut : .launching,
+                        isCheckingCredentials: fixture == "signed-out-checking",
+                        loginCheckFailed: fixture == "signed-out-failed"
+                    )
                 } else {
-                    MainWindowView()
+                    productionRoot
                 }
                 #else
-                MainWindowView()
+                productionRoot
                 #endif
             }
                 .environment(appState)
@@ -96,12 +247,49 @@ struct MacApp: App {
                 // window, while the zoom divides the true window size.
                 .windowZoom()
                 .frame(minWidth: 800, idealWidth: 1100, minHeight: 600, idealHeight: 720)
+                .animation(.easeInOut(duration: 0.16), value: launchCoordinator.phase)
+                .onReceive(NotificationCenter.default.publisher(for: .macSelectSession)) { note in
+                    // Explicit user/deep-link navigation is allowed to cross the
+                    // cold-launch gate. Scenario-window notifications are scoped
+                    // and must never seed the production window.
+                    guard note.userInfo?["scope"] as? String == nil,
+                          let sessionId = note.userInfo?["sessionId"] as? String else { return }
+                    launchCoordinator.recordSelectedSession(sessionId)
+                }
+                #if DEBUG
+                .onReceive(NotificationCenter.default.publisher(for: .macNativeAutomationAction)) { note in
+                    guard MacAutomationDriver.shared.enabled,
+                          note.userInfo?["action"] as? String == "selectSession",
+                          let sessionId = note.userInfo?["sessionId"] as? String else { return }
+                    launchCoordinator.recordSelectedSession(sessionId)
+                }
+                #endif
+                .onChange(of: appState.hasStoredCredentials) { _, hasStoredCredentials in
+                    launchCoordinator.reconcileAuthentication(
+                        hasStoredCredentials: hasStoredCredentials,
+                        connectionStatus: appState.connectionStatus
+                    )
+                }
+                .onChange(of: appState.connectionStatus) { _, connectionStatus in
+                    launchCoordinator.reconcileAuthentication(
+                        hasStoredCredentials: appState.hasStoredCredentials,
+                        connectionStatus: connectionStatus
+                    )
+                }
                 .onReceive(NotificationCenter.default.publisher(
                     for: NSApplication.didBecomeActiveNotification
                 )) { _ in
-                    // macOS keeps the broker connection optimistically warm;
-                    // activation bypasses any stale reconnect backoff.
-                    appState.handleForegroundRehydrate()
+                    if launchCoordinator.phase == .signedOut {
+                        // Returning from Terminal after `kraki connect` should
+                        // discover the new CLI login without requiring a relaunch.
+                        Task {
+                            await launchCoordinator.retryLogin(appState: appState)
+                        }
+                    } else {
+                        // macOS keeps the broker connection optimistically warm;
+                        // activation bypasses any stale reconnect backoff.
+                        appState.handleForegroundRehydrate()
+                    }
                 }
                 .onReceive(NotificationCenter.default.publisher(
                     for: NSWindow.didBecomeKeyNotification
@@ -119,35 +307,18 @@ struct MacApp: App {
                     #if DEBUG
                     MacAutomationDriver.shared.start(appState: appState)
                     #endif
-                    let snapshotTest = ProcessInfo.processInfo.environment["KRAKI_MAC_CHAT_SNAPSHOT_TEST"] == "1"
-                        || ProcessInfo.processInfo.environment["KRAKI_MAC_CHAT_PERF_PAGE"] == "1"
-                        || ProcessInfo.processInfo.environment["KRAKI_MAC_CHAT_SCENARIO_PAGE"] == "1"
-                    if snapshotTest {
-                        // The snapshot harness runs the production UI and local
-                        // data stack unchanged against an isolated KRAKI_DATA_DIR.
-                        // Never authenticate, connect, poll daemons, or mutate a
-                        // real Tentacle from this process.
-                        return
-                    }
-                    let isMock = ProcessInfo.processInfo.environment["KRAKI_MAC_MOCK"] == "1"
-                    if appState.devLocalActive {
-                        appState.devConnect()
-                    } else if !isMock {
-                        // Prefer the existing CLI login on macOS. It is an
-                        // independent credential and can recover from a
-                        // denied/stale Keychain ACL without clearing the
-                        // user's stored device identity.
-                        let usedCLILogin = await appState.attemptCLILogin()
-                        if !usedCLILogin, appState.hasStoredCredentials {
-                            // No CLI credential available: returning-user
-                            // fallback is challenge auth against the stored
-                            // device and its Keychain signing key.
-                            appState.connect()
-                        }
-                    }
-                    await tentacleCLI.refreshInstallState()
-                    await tentacleCLI.refreshDaemonState()
-                    tentacleCLI.startPolling()
+                    let environment = ProcessInfo.processInfo.environment
+                    let bypassProductionLaunch = environment["KRAKI_MAC_CHAT_SNAPSHOT_TEST"] == "1"
+                        || environment["KRAKI_MAC_CHAT_PERF_PAGE"] == "1"
+                        || environment["KRAKI_MAC_CHAT_SCENARIO_PAGE"] == "1"
+                        || environment["KRAKI_MAC_ENTRY_GATE_PAGE"] != nil
+                    await launchCoordinator.bootstrap(
+                        appState: appState,
+                        tentacleCLI: tentacleCLI,
+                        devLocal: appState.devLocalActive,
+                        mock: environment["KRAKI_MAC_MOCK"] == "1",
+                        bypassProductionLaunch: bypassProductionLaunch
+                    )
                 }
         }
         .windowStyle(.hiddenTitleBar)
@@ -194,6 +365,34 @@ struct MacApp: App {
             Label("Kraki", systemImage: tentacleCLI.menuBarSymbolName)
         }
         .menuBarExtraStyle(.menu)
+    }
+
+    @ViewBuilder
+    private var productionRoot: some View {
+        switch launchCoordinator.phase {
+        case .launching:
+            MacEntryGateView(mode: .launching)
+                .transition(.opacity)
+        case .authenticated:
+            MainWindowView(
+                initialSelectedSessionId: launchCoordinator.lastSelectedSessionId,
+                onSelectedSessionChanged: { sessionId in
+                    launchCoordinator.recordSelectedSession(sessionId)
+                }
+            )
+            .transition(.opacity)
+        case .signedOut:
+            LoginView(
+                isCheckingCredentials: launchCoordinator.isCheckingCredentials,
+                loginCheckFailed: launchCoordinator.loginCheckFailed,
+                onRetry: {
+                    Task {
+                        await launchCoordinator.retryLogin(appState: appState)
+                    }
+                }
+            )
+            .transition(.opacity)
+        }
     }
 }
 

--- a/packages/arm/ios/Kraki/App/Mac/MainWindowView.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MainWindowView.swift
@@ -261,18 +261,21 @@ struct MainWindowView: View {
     @SceneStorage("mac.sidebarVisible")
     private var sidebarVisible: Bool = true
 
-    @SceneStorage("mac.selectedSessionId")
-    private var selectedSessionId: String?
+    @State private var selectedSessionId: String?
 
     private let initialSelectedSessionId: String?
     private let selectionNotificationScope: String?
+    private let onSelectedSessionChanged: (String?) -> Void
 
     init(
         initialSelectedSessionId: String? = nil,
-        selectionNotificationScope: String? = nil
+        selectionNotificationScope: String? = nil,
+        onSelectedSessionChanged: @escaping (String?) -> Void = { _ in }
     ) {
         self.initialSelectedSessionId = initialSelectedSessionId
         self.selectionNotificationScope = selectionNotificationScope
+        self.onSelectedSessionChanged = onSelectedSessionChanged
+        _selectedSessionId = State(initialValue: initialSelectedSessionId)
     }
 
     @AppStorage("mac.inspectorShown")
@@ -291,16 +294,10 @@ struct MainWindowView: View {
     private let desktopRailHeight: CGFloat = 40
 
     var body: some View {
-        // Gate: render the authenticated root when we have stored
-        // credentials (normal/mock path) OR when dev-local mode is
-        // active (KRAKI_DEV_LOCAL=1) — in that mode credentials only
-        // materialise after the open-auth handshake, so we skip
-        // LoginView up front to avoid a flash.
-        if appState.hasStoredCredentials || appState.devLocalActive {
-            authenticatedRoot
-        } else {
-            LoginView()
-        }
+        // Authentication and cold-launch routing live above this view in
+        // MacApp. MainWindowView is the authenticated application surface only,
+        // so Chat is never mounted behind Launch or Signed Out entry gates.
+        authenticatedRoot
     }
 
     private var authenticatedRoot: some View {
@@ -441,6 +438,7 @@ struct MainWindowView: View {
             Button("Cancel", role: .cancel) { pendingDeleteSessionId = nil }
         }
         .onChange(of: selectedSessionId) { oldValue, newValue in
+            onSelectedSessionChanged(newValue)
             if let oldValue, oldValue != newValue {
                 appState.endViewingSession(oldValue)
             }
@@ -465,6 +463,14 @@ struct MainWindowView: View {
             appState.sessionStore.navigateToSession = nil
         }
         .onChange(of: appState.sessionStore.sessions) { _, sessions in
+            // A deep link can cross the launch gate before the authoritative
+            // session_list has arrived. Keep its semantic selection and mount
+            // Chat as soon as that Session becomes known.
+            if let selectedSessionId,
+               chatPresentation?.sessionId != selectedSessionId,
+               sessions[selectedSessionId] != nil {
+                prepareSelectedSession(selectedSessionId)
+            }
             #if DEBUG
             if let target = ProcessInfo.processInfo.environment["KRAKI_OPEN_SESSION_ID"],
                selectedSessionId != target,

--- a/packages/arm/ios/Kraki/Core/Networking/AuthManager.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/AuthManager.swift
@@ -129,7 +129,12 @@ final class AuthManager {
     /// (gh CLI) first, then the saved device-flow token at ~/.kraki/github-token.
     /// The Mac app is not sandboxed, so `~/.kraki` is readable and `gh` spawnable.
     static func loadCLICredentials() async -> (relay: String, token: String)? {
+        #if DEBUG
+        let krakiHome = ProcessInfo.processInfo.environment["KRAKI_CLI_CREDENTIAL_DIR"]
+            ?? (NSHomeDirectory() + "/.kraki")
+        #else
         let krakiHome = NSHomeDirectory() + "/.kraki"
+        #endif
         guard let configData = try? Data(contentsOf: URL(fileURLWithPath: krakiHome + "/config.json")),
               let config = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
               let relay = config["relay"] as? String,
@@ -178,7 +183,11 @@ final class AuthManager {
         }
 
         return await Task.detached(priority: .userInitiated) {
+            // CLI discovery is part of the Mac launch gate. A broken shell/gh
+            // installation must not hold the entire window indefinitely.
+            let deadline = Date().addingTimeInterval(0.5)
             for executable in executables {
+                guard Date() < deadline else { break }
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: executable)
                 process.arguments = ["auth", "token"]
@@ -188,7 +197,12 @@ final class AuthManager {
                 process.standardError = FileHandle.nullDevice
                 do {
                     try process.run()
-                    process.waitUntilExit()
+                    _ = waitForProcessExit(process, until: deadline)
+                    if process.isRunning {
+                        KLog.diag("Mac CLI login timed out while executing gh")
+                        process.terminate()
+                        break
+                    }
                     guard process.terminationStatus == 0 else { continue }
                     let data = pipe.fileHandleForReading.readDataToEndOfFile()
                     let token = String(data: data, encoding: .utf8)?
@@ -204,6 +218,16 @@ final class AuthManager {
             KLog.diag("Mac CLI login could not execute gh (candidates=\(executables.count))")
             return nil
         }.value
+    }
+
+    /// Synchronous process polling intentionally runs only inside the detached
+    /// CLI worker above. Keeping it out of the async closure avoids blocking an
+    /// executor thread with an async-unavailable `Thread.sleep` call.
+    private static func waitForProcessExit(_ process: Process, until deadline: Date) -> Bool {
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return !process.isRunning
     }
     #endif
 

--- a/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
@@ -1,113 +1,244 @@
-/// LoginView — Mac sign-in screen.
+/// Shared macOS entry gate for cold launch and signed-out states.
 ///
-/// Mirrors the iOS LoginView visual but uses native window-content
-/// layout (no fullScreenCover). Presents a centered card with the
-/// Kraki wordmark, a "Sign in with GitHub" button (when the relay
-/// advertises a client id), and pairing instructions for the
-/// `kraki connect` flow.
+/// Both modes own the full window surface and are selected above
+/// MainWindowView, so Sidebar, Chat, Composer, CoreText cells, and restored
+/// Session state are never mounted behind them.
 
 #if os(macOS)
+import AppKit
 import SwiftUI
 
-struct LoginView: View {
+enum MacEntryGateMode: Equatable {
+    case launching
+    case signedOut
+}
+
+struct MacEntryGateView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let mode: MacEntryGateMode
+    var isCheckingCredentials: Bool = false
+    var loginCheckFailed: Bool = false
+    var onRetry: () -> Void = {}
+
+    @State private var appeared = false
+    @State private var showDelayedLaunchStatus = false
 
     var body: some View {
         ZStack {
             Color.surfacePrimary
                 .ignoresSafeArea()
 
-            VStack(spacing: 24) {
-                Spacer()
+            entryBackdrop
 
-                Image("KrakiLogo")
-                    .resizable()
-                    .interpolation(.high)
-                    .frame(width: 140, height: 140)
-                    .clipShape(RoundedRectangle(cornerRadius: 32, style: .continuous))
-                    .shadow(color: Color.black.opacity(0.22), radius: 24, y: 12)
+            VStack(spacing: 0) {
+                Spacer(minLength: 48)
 
-                VStack(spacing: 6) {
-                    Text("KRAKI")
-                        .font(.system(size: 26, weight: .heavy, design: .monospaced))
-                        .tracking(4.5)
-                        .foregroundStyle(Color.textTitle)
-                    Text("Sign in to your relay")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(Color.textSecondary)
+                sharedBrand
+
+                Group {
+                    switch mode {
+                    case .launching:
+                        launchStatus
+                    case .signedOut:
+                        signedOutActions
+                    }
                 }
+                .frame(maxWidth: 420, minHeight: 210, alignment: .top)
+                .padding(.top, 24)
 
-                actionArea
-                    .padding(.top, 4)
+                Spacer(minLength: 36)
 
-                Spacer()
-
-                statusFooter
+                footerStatus
+                    .frame(minHeight: 24)
             }
-            .padding(48)
-            .frame(maxWidth: 460)
+            .padding(.horizontal, 48)
+            .padding(.vertical, 34)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier(mode == .launching ? "mac.entry.launching" : "mac.entry.signedOut")
+        .accessibilityElement(children: .contain)
+        .task(id: mode) {
+            if !appeared {
+                if reduceMotion {
+                    appeared = true
+                } else {
+                    withAnimation(.easeOut(duration: 0.24)) {
+                        appeared = true
+                    }
+                }
+            }
+
+            showDelayedLaunchStatus = false
+            guard mode == .launching else { return }
+            try? await Task.sleep(for: .milliseconds(550))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeIn(duration: 0.16)) {
+                showDelayedLaunchStatus = true
+            }
+        }
     }
 
-    // MARK: - Actions
+    private var entryBackdrop: some View {
+        ZStack {
+            Circle()
+                .fill(Color.krakiPrimary.opacity(0.09))
+                .frame(width: 520, height: 520)
+                .blur(radius: 80)
+                .offset(x: 220, y: -210)
+
+            Circle()
+                .fill(Color.cyan.opacity(0.055))
+                .frame(width: 440, height: 440)
+                .blur(radius: 90)
+                .offset(x: -260, y: 240)
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private var sharedBrand: some View {
+        VStack(spacing: 16) {
+            Image("KrakiLogo")
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 112, height: 112)
+                .clipShape(RoundedRectangle(cornerRadius: 27, style: .continuous))
+                .shadow(color: Color.black.opacity(0.24), radius: 26, y: 13)
+                .scaleEffect(appeared ? 1 : 0.97)
+                .opacity(appeared ? 1 : 0)
+
+            VStack(spacing: 5) {
+                Text("KRAKI")
+                    .font(.system(size: 24, weight: .heavy, design: .monospaced))
+                    .tracking(4.2)
+                    .foregroundStyle(Color.textTitle)
+
+                Text(mode == .launching ? "Your coding sessions, ready when you are." : "Connect this Mac to your relay")
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(Color.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .opacity(appeared ? 1 : 0)
+            .offset(y: appeared ? 0 : 5)
+        }
+    }
 
     @ViewBuilder
-    private var actionArea: some View {
-        // GitHub OAuth is iOS-only for now (ASWebAuthenticationSession
-        // wiring + Associated Domain claim hasn't been ported to mac).
-        // Mac users sign in via `kraki connect` pairing in Terminal,
-        // which is the supported flow anyway.
-        VStack(spacing: 12) {
-            Text("Pair this Mac as a tentacle")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.textPrimary)
+    private var launchStatus: some View {
+        if showDelayedLaunchStatus {
+            HStack(spacing: 9) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Opening Kraki…")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(Color.textMuted)
+            }
+            .padding(.top, 18)
+            .transition(.opacity)
+            .accessibilityLabel("Opening Kraki")
+        } else {
+            Color.clear
+                .frame(height: 42)
+                .accessibilityHidden(true)
+        }
+    }
 
-            VStack(spacing: 8) {
-                HStack(spacing: 6) {
-                    Text("Run")
-                        .font(.system(size: 12))
-                        .foregroundStyle(Color.textMuted)
-                    Text("kraki connect")
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundStyle(Color.textTitle)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(Color.surfaceSecondary)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .strokeBorder(Color.borderPrimary, lineWidth: 1)
-                        )
-                    Text("in Terminal")
-                        .font(.system(size: 12))
-                        .foregroundStyle(Color.textMuted)
-                }
+    private var signedOutActions: some View {
+        VStack(spacing: 16) {
+            VStack(spacing: 7) {
+                Text("Sign in with the Kraki CLI")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.textPrimary)
 
-                Text("Then scan or paste the URL into your phone, or another paired device.")
-                    .font(.system(size: 11))
+                Text("Run this command in Terminal, then return to Kraki.")
+                    .font(.system(size: 11.5))
                     .foregroundStyle(Color.textMuted)
                     .multilineTextAlignment(.center)
-                    .frame(maxWidth: 320)
             }
+
+            HStack(spacing: 8) {
+                Text("kraki connect")
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundStyle(Color.textTitle)
+
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString("kraki connect", forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 11, weight: .semibold))
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.textSecondary)
+                .help("Copy command")
+                .accessibilityLabel("Copy kraki connect command")
+            }
+            .padding(.leading, 13)
+            .padding(.trailing, 7)
+            .frame(height: 38)
+            .background(Color.surfaceSecondary, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .strokeBorder(Color.borderPrimary, lineWidth: 1)
+            )
+
+            Button {
+                onRetry()
+            } label: {
+                HStack(spacing: 8) {
+                    if isCheckingCredentials {
+                        ProgressView().controlSize(.small)
+                    }
+                    Text(isCheckingCredentials ? "Checking…" : "Check Again")
+                        .font(.system(size: 12.5, weight: .semibold))
+                }
+                .frame(minWidth: 116, minHeight: 30)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.krakiPrimary)
+            .disabled(isCheckingCredentials)
+            .accessibilityIdentifier("mac.login.checkAgain")
+
+            Text("Kraki also checks again automatically when you return from Terminal.")
+                .font(.system(size: 10.5))
+                .foregroundStyle(Color.textMuted)
+                .multilineTextAlignment(.center)
         }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 20)
+        .background(Color.surfaceSecondary.opacity(0.55), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color.borderPrimary.opacity(0.8), lineWidth: 1)
+        )
     }
 
     @ViewBuilder
-    private var statusFooter: some View {
-        if !statusSubline.isEmpty {
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text(statusSubline)
-                    .font(.system(size: 11))
+    private var footerStatus: some View {
+        if mode == .signedOut {
+            if isCheckingCredentials {
+                Text("Looking for a signed-in Kraki CLI…")
+                    .font(.system(size: 10.5))
                     .foregroundStyle(Color.textMuted)
+            } else if loginCheckFailed {
+                Text("No signed-in Kraki CLI was found.")
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundStyle(Color.orange)
+            } else if !connectionStatusText.isEmpty {
+                HStack(spacing: 7) {
+                    ProgressView().controlSize(.mini)
+                    Text(connectionStatusText)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(Color.textMuted)
+                }
             }
         }
     }
 
-    private var statusSubline: String {
+    private var connectionStatusText: String {
         switch appState.connectionStatus {
         case .connecting:
             return "Establishing a secure channel to your relay."
@@ -116,6 +247,24 @@ struct LoginView: View {
         default:
             return ""
         }
+    }
+}
+
+/// Compatibility wrapper used anywhere that explicitly requests the macOS
+/// login page. It intentionally reuses the exact same full-window entry gate as
+/// cold launch; only the center action block changes.
+struct LoginView: View {
+    var isCheckingCredentials: Bool = false
+    var loginCheckFailed: Bool = false
+    var onRetry: () -> Void = {}
+
+    var body: some View {
+        MacEntryGateView(
+            mode: .signedOut,
+            isCheckingCredentials: isCheckingCredentials,
+            loginCheckFailed: loginCheckFailed,
+            onRetry: onRetry
+        )
     }
 }
 

--- a/packages/arm/ios/Kraki/Features/Welcome/WelcomeView.swift
+++ b/packages/arm/ios/Kraki/Features/Welcome/WelcomeView.swift
@@ -276,13 +276,23 @@ struct WelcomeView: View {
     }
 
     private var selectSessionCard: some View {
-        VStack(spacing: 8) {
-            Text("Select a session in the sidebar")
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(Color.textSecondary)
-            Text("Or press ⌘N to start a new one.")
-                .font(.system(size: 11))
+        VStack(spacing: 10) {
+            Text("Ready when you are")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Color.textPrimary)
+            Text("Choose a session from the sidebar or start something new.")
+                .font(.system(size: 11.5))
                 .foregroundStyle(Color.textMuted)
+                .multilineTextAlignment(.center)
+
+            Button {
+                NotificationCenter.default.post(name: .macOpenNewSession, object: nil)
+            } label: {
+                Label("New Session", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.krakiPrimary)
+            .padding(.top, 4)
         }
     }
 


### PR DESCRIPTION
## Summary

- add a process-scoped macOS launch coordinator above `MainWindowView`
- render cold launch and signed-out states through one shared full-window Kraki entry gate
- do not mount Sidebar, Chat, Composer, CoreText cells, image preview, or HTML artifact state behind either gate
- clear persisted Session selection on cold process launch while preserving process-local selection for menu-bar warm reopen
- keep explicit notification/deep-link Session navigation queued across the gate
- add a CLI credential timeout so a hung `gh auth token` cannot hold the launch screen indefinitely
- update the authenticated Welcome state to land on “Ready when you are” with a native New Session action

## User flow

### Returning user

`Launch Gate → Sidebar + Ready Home → user chooses a Session`

Relay authentication may continue ambiently after the local authenticated shell is available. Cold launch never restores the previous Chat automatically.

### Signed out

`Launch Gate → shared Signed Out Gate`

The signed-out center block provides:

- `kraki connect` with a native Copy action
- `Check Again`
- automatic CLI credential discovery when returning from Terminal
- in-place checking/failure status

### Warm reopen

Closing the main window while Kraki remains in the menu bar preserves the process-local selected Session and does not replay cold-launch restoration semantics.

## Validation

- macOS Debug build passed
- iOS Simulator `build-for-testing` passed
- first process surface/socket available in approximately 186–210 ms across five isolated launches
- cold mock launch landed on Welcome with `selectedSessionId = nil`
- actual Launch → Signed Out route captured in one process with no Session/Chat state
- explicit Session selection queued during Launch opened the requested Session after the gate
- Scenario Test Page still selected/rendered production scenario 15
- CLI timeout regression terminated a hanging fake `gh` path in under 4 seconds; normal real credential discovery completed in about 0.44 seconds
- CoreText scroll regression: 240/240 moves, zero placeholders/TextKit cells
- Question/Permission zoom hit regression passed, including fallback capture from latest main
- release-polish regression passed

## Documentation

See `docs/mac-launch-flow.md` for the product-visible restore policy and Debug visual fixtures.
