### PR TITLE
fix(mac): keep question hits stable while cards move

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
@@ -1316,9 +1316,36 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             x: visualX,
             y: zoomSize.height - fallbackProbeTopY
         )
-        let fallbackCaptureBefore = zoomCell.actionCapture(
+        let fallbackContext = zoomCell.actionCaptureContext(
             atWindowPoint: fallbackProbePoint
-        ) == .question("question-hit")
+        )
+        let fallbackCaptureBefore = fallbackContext?.capture == .question("question-hit")
+        let stableTargetBeforeMove = fallbackContext.flatMap {
+            zoomCell.actionHitTarget(
+                for: $0.capture,
+                atActionPoint: $0.actionPoint
+            )
+        } == .question(MacQuestionChoiceHitTarget(
+            questionId: "question-hit",
+            answer: "First visual choice"
+        ))
+        zoomCell.offsetActionHostForRegression(y: 40)
+        let movedWindowTarget = zoomCell.questionChoiceHitTarget(
+            atWindowPoint: fallbackProbePoint
+        )
+        let stableTargetAfterMove = fallbackContext.flatMap {
+            zoomCell.actionHitTarget(
+                for: $0.capture,
+                atActionPoint: $0.actionPoint
+            )
+        } == .question(MacQuestionChoiceHitTarget(
+            questionId: "question-hit",
+            answer: "First visual choice"
+        ))
+        let movingCardPassed = stableTargetBeforeMove
+            && movedWindowTarget?.answer != "First visual choice"
+            && stableTargetAfterMove
+        zoomCell.offsetActionHostForRegression(y: -40)
         zoomCell.clearActionHitFramesForRegression()
         let fallbackTargetMissing = zoomCell.questionChoiceHitTarget(
             atWindowPoint: fallbackProbePoint
@@ -1490,10 +1517,11 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             && correctedPassed
             && permissionPassed
             && fallbackCapturePassed
+            && movingCardPassed
             && directCaptured
             && zoomCaptured
         NSLog(
-            "[question-hit-regression] directFirst=%@ directSecond=%@ rawZoomFirst=%@ rawZoomSecond=%@ correctedFirst=%@ correctedSecond=%@ rawAligned=%d correctedAligned=%d permissionDirect=%@ permissionZoom=%@ permissionAligned=%d fallbackCapture=%d directCapture=%d zoomCapture=%d passed=%d paths=%@,%@",
+            "[question-hit-regression] directFirst=%@ directSecond=%@ rawZoomFirst=%@ rawZoomSecond=%@ correctedFirst=%@ correctedSecond=%@ rawAligned=%d correctedAligned=%d permissionDirect=%@ permissionZoom=%@ permissionAligned=%d fallbackCapture=%d movingCard=%d directCapture=%d zoomCapture=%d passed=%d paths=%@,%@",
             range(directFirst),
             range(directSecond),
             range(zoomFirst),
@@ -1506,6 +1534,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             String(describing: zoomPermissionRects),
             permissionPassed ? 1 : 0,
             fallbackCapturePassed ? 1 : 0,
+            movingCardPassed ? 1 : 0,
             directCaptured ? 1 : 0,
             zoomCaptured ? 1 : 0,
             passed ? 1 : 0,

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatBubbleCell.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatBubbleCell.swift
@@ -897,6 +897,11 @@ enum MacBubbleActionCapture: Equatable {
     case permission(String)
 }
 
+struct MacBubbleActionCaptureContext {
+    let capture: MacBubbleActionCapture
+    let actionPoint: NSPoint
+}
+
 final class MacChatBubbleCell: NSView {
     override var isFlipped: Bool { true }
     private let contentClipView = MacFlippedContentClipView()
@@ -1011,6 +1016,10 @@ final class MacChatBubbleCell: NSView {
         permissionButtonFrames.removeAll(keepingCapacity: true)
     }
 
+    func offsetActionHostForRegression(y: CGFloat) {
+        actionHost.frame.origin.y += y
+    }
+
     func openFirstImageForRegression() -> (found: Bool, hitTested: Bool) {
         imageHost.layoutSubtreeIfNeeded()
         func collectButtons(in view: NSView, into result: inout [NSButton]) {
@@ -1037,19 +1046,83 @@ final class MacChatBubbleCell: NSView {
     #endif
 
     func actionHitTarget(atWindowPoint point: NSPoint) -> MacBubbleActionHitTarget? {
-        if let question = questionChoiceHitTarget(atWindowPoint: point) {
-            return .question(question)
-        }
-        if let permission = permissionButtonHitTarget(atWindowPoint: point) {
-            return .permission(permission)
-        }
-        return nil
+        guard let context = actionCaptureContext(atWindowPoint: point) else { return nil }
+        return actionHitTarget(
+            for: context.capture,
+            atActionPoint: context.actionPoint
+        )
     }
 
     func actionCapture(atWindowPoint point: NSPoint) -> MacBubbleActionCapture? {
-        guard let action = content?.action,
-              !actionHost.isHidden,
-              actionHost.bounds.contains(actionHost.convert(point, from: nil)) else { return nil }
+        actionCaptureContext(atWindowPoint: point)?.capture
+    }
+
+    func actionCaptureContext(
+        atWindowPoint point: NSPoint
+    ) -> MacBubbleActionCaptureContext? {
+        guard let capture = actionCaptureIdentity,
+              !actionHost.isHidden else { return nil }
+        let local = actionHost.convert(point, from: nil)
+        guard actionHost.bounds.contains(local) else { return nil }
+        return MacBubbleActionCaptureContext(
+            capture: capture,
+            actionPoint: NSPoint(
+                x: local.x,
+                y: actionHost.isFlipped ? local.y : actionHost.bounds.height - local.y
+            )
+        )
+    }
+
+    func actionHitTarget(
+        for capture: MacBubbleActionCapture,
+        atActionPoint point: NSPoint
+    ) -> MacBubbleActionHitTarget? {
+        guard capture == actionCaptureIdentity,
+              let action = content?.action else { return nil }
+        switch capture {
+        case .question(let questionId):
+            guard action.type == "question",
+                  !action.cancelled,
+                  action.answer == nil,
+                  action.questionId == questionId,
+                  let frame = questionChoiceFrames.last(where: { $0.rect.contains(point) }) else {
+                return nil
+            }
+            return .question(MacQuestionChoiceHitTarget(
+                questionId: questionId,
+                answer: frame.answer
+            ))
+        case .permission(let permissionId):
+            guard action.type == "permission",
+                  action.payload["decision"]?.stringValue == nil,
+                  action.permissionId == permissionId,
+                  let frame = permissionButtonFrames.last(where: { $0.rect.contains(point) }) else {
+                return nil
+            }
+            return .permission(MacPermissionButtonHitTarget(
+                permissionId: permissionId,
+                toolName: action.toolName,
+                decision: frame.decision
+            ))
+        }
+    }
+
+    func questionChoiceHitTarget(
+        atWindowPoint point: NSPoint
+    ) -> MacQuestionChoiceHitTarget? {
+        guard case .question(let target)? = actionHitTarget(atWindowPoint: point) else { return nil }
+        return target
+    }
+
+    func permissionButtonHitTarget(
+        atWindowPoint point: NSPoint
+    ) -> MacPermissionButtonHitTarget? {
+        guard case .permission(let target)? = actionHitTarget(atWindowPoint: point) else { return nil }
+        return target
+    }
+
+    private var actionCaptureIdentity: MacBubbleActionCapture? {
+        guard let action = content?.action else { return nil }
         switch action.type {
         case "question":
             guard !action.cancelled,
@@ -1064,53 +1137,6 @@ final class MacChatBubbleCell: NSView {
         default:
             return nil
         }
-    }
-
-    func questionChoiceHitTarget(
-        atWindowPoint point: NSPoint
-    ) -> MacQuestionChoiceHitTarget? {
-        guard let action = content?.action,
-              action.type == "question",
-              !action.cancelled,
-              action.answer == nil,
-              let questionId = action.questionId,
-              !questionChoiceFrames.isEmpty,
-              !actionHost.isHidden,
-              let frame = actionFrame(containingWindowPoint: point, in: questionChoiceFrames.map {
-                  (rect: $0.rect, value: $0)
-              }) else { return nil }
-        return MacQuestionChoiceHitTarget(questionId: questionId, answer: frame.answer)
-    }
-
-    func permissionButtonHitTarget(
-        atWindowPoint point: NSPoint
-    ) -> MacPermissionButtonHitTarget? {
-        guard let action = content?.action,
-              action.type == "permission",
-              action.payload["decision"]?.stringValue == nil,
-              let permissionId = action.permissionId,
-              !permissionButtonFrames.isEmpty,
-              !actionHost.isHidden,
-              let frame = actionFrame(containingWindowPoint: point, in: permissionButtonFrames.map {
-                  (rect: $0.rect, value: $0)
-              }) else { return nil }
-        return MacPermissionButtonHitTarget(
-            permissionId: permissionId,
-            toolName: action.toolName,
-            decision: frame.decision
-        )
-    }
-
-    private func actionFrame<Value>(
-        containingWindowPoint point: NSPoint,
-        in frames: [(rect: CGRect, value: Value)]
-    ) -> Value? {
-        let local = actionHost.convert(point, from: nil)
-        let topLeadingPoint = NSPoint(
-            x: local.x,
-            y: actionHost.isFlipped ? local.y : actionHost.bounds.height - local.y
-        )
-        return frames.last(where: { $0.rect.contains(topLeadingPoint) })?.value
     }
 
     var htmlArtifactCount: Int { content?.htmlArtifacts.count ?? 0 }

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
@@ -1258,10 +1258,29 @@ final class MacChatDocumentView: NSView {
     }
 
     func actionCapture(atWindowPoint point: NSPoint) -> MacBubbleActionCapture? {
+        actionCaptureContext(atWindowPoint: point)?.capture
+    }
+
+    func actionCaptureContext(
+        atWindowPoint point: NSPoint
+    ) -> MacBubbleActionCaptureContext? {
         for (_, cell) in visibleCells.sorted(by: { $0.key > $1.key })
         where !cell.isHidden && !cell.isPlaceholderFlag {
-            if let capture = cell.actionCapture(atWindowPoint: point) {
-                return capture
+            if let context = cell.actionCaptureContext(atWindowPoint: point) {
+                return context
+            }
+        }
+        return nil
+    }
+
+    func actionHitTarget(
+        for capture: MacBubbleActionCapture,
+        atActionPoint point: NSPoint
+    ) -> MacBubbleActionHitTarget? {
+        for (_, cell) in visibleCells.sorted(by: { $0.key > $1.key })
+        where !cell.isHidden && !cell.isPlaceholderFlag {
+            if let target = cell.actionHitTarget(for: capture, atActionPoint: point) {
+                return target
             }
         }
         return nil
@@ -1882,20 +1901,25 @@ final class MacChatScrollView: MacSmoothScrollView {
     }
 
     private func interceptBubbleActionMouseEvent(_ event: NSEvent) -> NSEvent? {
-        guard event.window === window,
+        guard let window,
+              event.windowNumber == window.windowNumber,
               !isHidden,
               alphaValue > 0.01 else { return event }
         let windowPoint = event.locationInWindow
-        let localPoint = convert(windowPoint, from: nil)
-        guard bounds.contains(localPoint) else { return event }
 
         switch event.type {
         case .leftMouseDown:
-            guard let capture = chatDocumentView.actionCapture(atWindowPoint: windowPoint) else {
+            guard let context = chatDocumentView.actionCaptureContext(
+                atWindowPoint: windowPoint
+            ) else {
                 pendingBubbleActionClick = nil
                 return event
             }
-            let target = chatDocumentView.actionHitTarget(atWindowPoint: windowPoint)
+            let capture = context.capture
+            let target = chatDocumentView.actionHitTarget(
+                for: capture,
+                atActionPoint: context.actionPoint
+            )
             // SwiftUI propagates rendered choice frames asynchronously. Capture
             // the whole interactive action region while that cache is empty so
             // a zoomed click never falls through to SwiftUI's shifted hit test.
@@ -1914,17 +1938,21 @@ final class MacChatScrollView: MacSmoothScrollView {
             guard let pending = pendingBubbleActionClick else { return event }
             pendingBubbleActionClick = nil
             guard !pending.cancelled,
-                  chatDocumentView.actionCapture(atWindowPoint: windowPoint) == pending.capture else {
+                  let context = chatDocumentView.actionCaptureContext(
+                    atWindowPoint: windowPoint
+                  ),
+                  context.capture == pending.capture else {
                 return nil
             }
             if let expectedTarget = pending.target {
-                guard chatDocumentView.actionHitTarget(atWindowPoint: windowPoint) == expectedTarget else {
-                    return nil
-                }
+                guard chatDocumentView.actionHitTarget(
+                    for: pending.capture,
+                    atActionPoint: context.actionPoint
+                  ) == expectedTarget else { return nil }
                 dispatchBubbleAction(expectedTarget)
             } else {
                 dispatchBubbleActionWhenReady(
-                    atWindowPoint: windowPoint,
+                    atActionPoint: context.actionPoint,
                     expectedCapture: pending.capture
                 )
             }
@@ -1949,19 +1977,21 @@ final class MacChatScrollView: MacSmoothScrollView {
     }
 
     private func dispatchBubbleActionWhenReady(
-        atWindowPoint point: NSPoint,
+        atActionPoint point: NSPoint,
         expectedCapture: MacBubbleActionCapture,
         attemptsRemaining: Int = 8
     ) {
-        guard chatDocumentView.actionCapture(atWindowPoint: point) == expectedCapture else { return }
-        if let target = chatDocumentView.actionHitTarget(atWindowPoint: point) {
+        if let target = chatDocumentView.actionHitTarget(
+            for: expectedCapture,
+            atActionPoint: point
+        ) {
             dispatchBubbleAction(target)
             return
         }
         guard attemptsRemaining > 0 else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0 / 120.0) { [weak self] in
             self?.dispatchBubbleActionWhenReady(
-                atWindowPoint: point,
+                atActionPoint: point,
                 expectedCapture: expectedCapture,
                 attemptsRemaining: attemptsRemaining - 1
             )

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.8"
-        CURRENT_PROJECT_VERSION: 10
+        MARKETING_VERSION: "0.2.9"
+        CURRENT_PROJECT_VERSION: 11
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- preserve question/permission hit positions in action-host local coordinates instead of window coordinates
- keep delayed frame resolution stable while the chat auto-scrolls or card geometry settles
- remove the redundant scroll-view bounds early return that can be unreliable under the root SwiftUI zoom transform
- bind resolution to the original action identity
- extend the regression with a moving-card probe (`movingCard=1`)
- prepare Mac `0.2.9` (build `11`)

## Reproduction
A real production question-card test on `0.2.8` returned the fourth answer after the third was clicked. Accessibility sampling showed the card buttons moved about 198pt during insertion/auto-scroll and then adjusted another 3.5pt. The `0.2.8` fallback preserved a window point, so delayed frame resolution could map that point to the adjacent option after movement.

## Validation
- KrakiMac Debug build passed
- question-hit regression passed with `fallbackCapture=1 movingCard=1 passed=1`
- `git diff --check` clean
