### PR TITLE
fix(mac): refresh voice leases across UTC day boundaries

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
+++ b/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
@@ -198,6 +198,26 @@ final class KrakiVoiceInputController {
         self.host = host
     }
 
+    /// Lease validity has two independent boundaries: its signed expiry and
+    /// the UTC calendar day on which it was issued. Head's daily accounting
+    /// intentionally rejects activation after that day, even when `exp` has
+    /// not elapsed yet.
+    static func isLeaseUsable(_ lease: VoiceLease, nowUnixSec: Int) -> Bool {
+        guard lease.payload.exp > nowUnixSec + 5,
+              lease.payload.iat <= nowUnixSec + 30 else { return false }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let issuedDay = calendar.dateComponents(
+            [.era, .year, .month, .day],
+            from: Date(timeIntervalSince1970: TimeInterval(lease.payload.iat))
+        )
+        let currentDay = calendar.dateComponents(
+            [.era, .year, .month, .day],
+            from: Date(timeIntervalSince1970: TimeInterval(nowUnixSec))
+        )
+        return issuedDay == currentDay
+    }
+
     /// Ensure a signed and activated broker connection exists without touching
     /// microphone permission or the audio session.
     func prepare() {
@@ -211,7 +231,7 @@ final class KrakiVoiceInputController {
               audioPolicy.permission != .denied else { return }
 
         let now = Int(Date().timeIntervalSince1970)
-        if let lease, lease.payload.exp > now + 5 {
+        if let lease, Self.isLeaseUsable(lease, nowUnixSec: now) {
             openConnection(lease, capability: capability)
             return
         }
@@ -344,7 +364,7 @@ final class KrakiVoiceInputController {
               let deviceID = host.voiceDeviceID,
               lease.payload.did == deviceID,
               lease.payload.resource == capability.resource,
-              lease.payload.exp > Int(Date().timeIntervalSince1970) else { return }
+              Self.isLeaseUsable(lease, nowUnixSec: Int(Date().timeIntervalSince1970)) else { return }
         leaseRequestInFlight = false
         leaseTimeoutTask?.cancel()
         leaseTimeoutTask = nil
@@ -453,13 +473,15 @@ final class KrakiVoiceInputController {
     private func handleConnectionFailure(_ reason: String) {
         KLog.d("🎙️ [voice] stage=connection-failed reason=\(reason)")
         let quotaExhausted = reason.localizedCaseInsensitiveContains("quota_exhausted")
-        closeConnection(keepLease: !quotaExhausted)
+        let leaseDayChanged = reason.localizedCaseInsensitiveContains("wrong_day")
+        let requiresFreshLease = quotaExhausted || leaseDayChanged
+        closeConnection(keepLease: !requiresFreshLease)
         if isBusy {
             let message = Self.userFacingGatewayError(reason)
             recordingCleanup(clearHandlers: true)
             state = .failed(message)
         }
-        if warmConnectionDesired { scheduleReconnect(immediate: quotaExhausted) }
+        if warmConnectionDesired { scheduleReconnect(immediate: requiresFreshLease) }
     }
 
     private func scheduleLeaseTimeout() {
@@ -495,7 +517,16 @@ final class KrakiVoiceInputController {
     private func scheduleRefresh() {
         refreshTask?.cancel()
         guard let lease else { return }
-        let delay = max(1, lease.payload.exp - Int(Date().timeIntervalSince1970) - 60)
+        let now = Int(Date().timeIntervalSince1970)
+        let expiryDelay = max(1, lease.payload.exp - now - 60)
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+        let nowDate = Date(timeIntervalSince1970: TimeInterval(now))
+        let startOfToday = utc.startOfDay(for: nowDate)
+        let nextDay = utc.date(byAdding: .day, value: 1, to: startOfToday)
+            ?? nowDate.addingTimeInterval(86_400)
+        let dayBoundaryDelay = max(1, Int(ceil(nextDay.timeIntervalSince(nowDate))) + 1)
+        let delay = min(expiryDelay, dayBoundaryDelay)
         refreshTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled, let self, self.warmConnectionDesired else { return }

--- a/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
+++ b/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
@@ -127,15 +127,21 @@ private final class SuspendedVoiceAudioPolicy: VoiceInputAudioPolicy {
 
 @MainActor
 final class KrakiVoiceInputTests: XCTestCase {
-    private func lease(expiryOffset: Int = 600, jti: String = "lease-1") -> VoiceLease {
-        VoiceLease(
+    private func lease(
+        expiryOffset: Int = 600,
+        jti: String = "lease-1",
+        issuedAt: Int? = nil,
+        expiration: Int? = nil
+    ) -> VoiceLease {
+        let now = Int(Date().timeIntervalSince1970)
+        return VoiceLease(
             payload: VoiceLeasePayload(
                 ver: 1,
                 iss: "kraki-head",
                 sub: "user-1",
                 did: "device-1",
-                iat: Int(Date().timeIntervalSince1970),
-                exp: Int(Date().timeIntervalSince1970) + expiryOffset,
+                iat: issuedAt ?? now,
+                exp: expiration ?? now + expiryOffset,
                 quotaSeconds: 600,
                 resource: "voice/doubao",
                 jti: jti
@@ -458,6 +464,22 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertTrue(finals.isEmpty)
     }
 
+    func testLeaseFromPreviousUTCDateIsRejectedEvenBeforeExpiry() {
+        let now = Int(Date().timeIntervalSince1970)
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+        let today = utc.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(now)))
+        let previousDay = utc.date(byAdding: .second, value: -1, to: today)!
+        let previousDayLease = lease(
+            issuedAt: Int(previousDay.timeIntervalSince1970),
+            expiration: now + 600
+        )
+
+        XCTAssertFalse(
+            KrakiVoiceInputController.isLeaseUsable(previousDayLease, nowUnixSec: now)
+        )
+    }
+
     func testForegroundWarmConnectionIsReusedAcrossRecordings() async {
         let host = FakeVoiceHost()
         let factory = FakeVoiceFactory()
@@ -490,6 +512,32 @@ final class KrakiVoiceInputTests: XCTestCase {
         factory.sessions[0].emit(.final("second", rawText: nil))
         await Task.yield()
         XCTAssertEqual(finals, ["first", "second"])
+    }
+
+    func testWrongDayConnectionDiscardsLeaseAndRequestsReplacement() async {
+        let host = FakeVoiceHost()
+        let factory = FakeVoiceFactory()
+        let controller = KrakiVoiceInputController(
+            host: host,
+            sessionFactory: factory,
+            audioPolicy: FakeVoiceAudioPolicy()
+        )
+        controller.prepare()
+        controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+
+        await controller.begin(sessionID: "session-1", context: context()) { _ in }
+        XCTAssertEqual(controller.state, .recording)
+        factory.sessions[0].emit(.failed("denied: lease_wrong_day"))
+        for _ in 0..<20 where host.requestedResources.count < 2 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(controller.state, .failed("The voice session authorization was rejected. Please try again."))
+        XCTAssertEqual(host.requestedResources, ["voice/doubao", "voice/doubao"])
+        XCTAssertEqual(factory.sessions[0].closeCount, 1)
+        XCTAssertEqual(factory.sessions.count, 1)
     }
 
     func testQuotaExhaustedConnectionDiscardsLeaseAndRequestsReplacement() async {

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.9"
-        CURRENT_PROJECT_VERSION: 11
+        MARKETING_VERSION: "0.2.10"
+        CURRENT_PROJECT_VERSION: 12
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- reject warm voice leases issued on a previous UTC calendar day, even when `exp` has not elapsed
- refresh warm connections at the next UTC day boundary
- discard and reacquire leases after `wrong_day` / `lease_wrong_day`
- bump KrakiMac to `0.2.10 (build 12)`

## Verification
- `KrakiMac` Debug build passed
- `KrakiVoiceInputTests`: 18 passed, 0 failed

This fixes the production failure where a long-running macOS client reused a lease that was valid by `exp` but rejected by the broker's daily accounting policy.
