### PR TITLE
fix(tentacle): fence agent turns and deduplicate inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "clean": "pnpm -r clean"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.19.0",
     "pnpm": ">=9.0.0"
   },
   "pnpm": {

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.156",
     "@coinfra/pulse": "^0.5.0",
-    "@earendil-works/pi-coding-agent": "0.80.2",
+    "@earendil-works/pi-coding-agent": "0.84.1",
     "@github/copilot-sdk": "^1.0.1",
     "@inquirer/prompts": "^8.3.2",
     "@kraki/crypto": "workspace:*",

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.16",
+  "version": "0.31.17",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/claude-error-finalization.test.ts
+++ b/packages/tentacle/src/__tests__/claude-error-finalization.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ClaudeAdapter, normalizeClaudeSDKError } from '../adapters/claude.js';
+
+type Entry = {
+  query: object | null;
+  inputChannel: { push: ReturnType<typeof vi.fn> };
+  pendingPermissions: Map<string, unknown>;
+  pendingQuestions: Map<string, unknown>;
+  pendingText?: string;
+  pendingError?: { message: string; quality: number };
+  turnFinalized?: boolean;
+};
+
+function setup() {
+  const adapter = new ClaudeAdapter();
+  const entry: Entry = {
+    query: {},
+    inputChannel: { push: vi.fn() },
+    pendingPermissions: new Map(),
+    pendingQuestions: new Map(),
+    pendingText: '',
+    turnFinalized: false,
+  };
+  (adapter as unknown as { sessions: Map<string, Entry> }).sessions.set('s1', entry);
+  const handle = (msg: Record<string, unknown>) =>
+    (adapter as unknown as { handleSDKMessage: (sessionId: string, msg: Record<string, unknown>) => void })
+      .handleSDKMessage('s1', msg);
+  return { adapter, entry, handle };
+}
+
+describe('Claude error finalization', () => {
+  it('extracts the concrete synthetic assistant API error instead of unknown', () => {
+    const normalized = normalizeClaudeSDKError({
+      error: 'unknown',
+      apiErrorStatus: 400,
+      message: {
+        content: [{ type: 'text', text: 'API Error: 400 Your input exceeds the context window of this model. (request id: req_123)' }],
+      },
+    });
+
+    expect(normalized.message).toContain('Your input exceeds the context window');
+    expect(normalized.message).not.toBe('Claude API error: unknown');
+    expect(normalized.status).toBe(400);
+  });
+
+  it('does not use result subtype success as an error message', () => {
+    const normalized = normalizeClaudeSDKError({ is_error: true, subtype: 'success', api_error_status: 400 });
+    expect(normalized.message).toBe('Claude API error (HTTP 400)');
+  });
+
+  it('emits one concrete terminal error and one idle for assistant error plus result', () => {
+    const { adapter, handle } = setup();
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    const onMessage = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    adapter.onMessage = onMessage;
+
+    handle({
+      type: 'assistant',
+      error: 'unknown',
+      apiErrorStatus: 400,
+      message: { content: [{ type: 'text', text: 'API Error: 400 Your input exceeds the context window.' }] },
+    });
+    expect(onError).not.toHaveBeenCalled();
+
+    handle({ type: 'result', is_error: true, subtype: 'success', api_error_status: 400, errors: [] });
+    handle({ type: 'result', is_error: true, subtype: 'success', api_error_status: 400, errors: [] });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[1].message).toContain('Your input exceeds the context window');
+    expect(onError.mock.calls[0]?.[1].message).not.toBe('success');
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a stale pending error when the authoritative result succeeds', () => {
+    const { adapter, entry, handle } = setup();
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    const onMessage = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    adapter.onMessage = onMessage;
+
+    entry.pendingText = 'recovered answer';
+    handle({ type: 'assistant', error: 'unknown', message: { content: [] } });
+    handle({ type: 'result', is_error: false, subtype: 'success' });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'recovered answer' });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(entry.pendingError).toBeUndefined();
+  });
+
+  it('re-arms the result boundary when a steer follows a completed turn', async () => {
+    const { adapter, entry } = setup();
+    entry.turnFinalized = true;
+
+    await adapter.sendMessage('s1', 'new prompt', undefined, { delivery: 'steer' });
+
+    expect(entry.turnFinalized).toBe(false);
+    expect(entry.inputChannel.push).toHaveBeenCalledWith({
+      type: 'user',
+      message: { role: 'user', content: 'new prompt' },
+      parent_tool_use_id: null,
+    });
+  });
+});

--- a/packages/tentacle/src/__tests__/claude-error-finalization.test.ts
+++ b/packages/tentacle/src/__tests__/claude-error-finalization.test.ts
@@ -8,6 +8,7 @@ type Entry = {
   pendingQuestions: Map<string, unknown>;
   pendingText?: string;
   pendingError?: { message: string; quality: number };
+  relayTurnId?: string;
   turnFinalized?: boolean;
 };
 
@@ -92,6 +93,21 @@ describe('Claude error finalization', () => {
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'recovered answer' });
     expect(onIdle).toHaveBeenCalledTimes(1);
     expect(entry.pendingError).toBeUndefined();
+  });
+
+  it('echoes relay turn identity on result-owned message and idle callbacks', () => {
+    const { adapter, entry, handle } = setup();
+    const onMessage = vi.fn();
+    const onIdle = vi.fn();
+    adapter.onMessage = onMessage;
+    adapter.onIdle = onIdle;
+    adapter.setTurnIdentity('s1', 's1:claude-turn');
+    entry.pendingText = 'completed';
+
+    handle({ type: 'result', is_error: false, subtype: 'success' });
+
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'completed', turnId: 's1:claude-turn' });
+    expect(onIdle).toHaveBeenCalledWith('s1', { turnId: 's1:claude-turn' });
   });
 
   it('re-arms the result boundary when a steer follows a completed turn', async () => {

--- a/packages/tentacle/src/__tests__/copilot-turn-identity.test.ts
+++ b/packages/tentacle/src/__tests__/copilot-turn-identity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CopilotAdapter } from '../adapters/copilot.js';
+
+describe('Copilot relay turn identity', () => {
+  it('echoes the accepted turn on terminal callbacks and reports settlement', () => {
+    const adapter = new CopilotAdapter();
+    const entry = {
+      session: {},
+      pendingPermissions: new Map(),
+      pendingQuestions: new Map(),
+      relayTurnId: undefined as string | undefined,
+      turnSettled: false,
+    };
+    (adapter as unknown as { sessions: Map<string, typeof entry> }).sessions.set('s1', entry);
+    const onMessage = vi.fn();
+    const onIdle = vi.fn();
+    adapter.onMessage = onMessage;
+    adapter.onIdle = onIdle;
+    adapter.setTurnIdentity('s1', 's1:copilot-turn');
+
+    (adapter as unknown as { emitMessage: (sessionId: string, content: string) => void })
+      .emitMessage('s1', 'done');
+    (adapter as unknown as { emitIdle: (sessionId: string) => void })
+      .emitIdle('s1');
+
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'done', turnId: 's1:copilot-turn' });
+    expect(onIdle).toHaveBeenCalledWith('s1', { turnId: 's1:copilot-turn' });
+    expect(adapter.isTurnSettled('s1')).toBe(true);
+  });
+});

--- a/packages/tentacle/src/__tests__/multi-adapter-wiring.test.ts
+++ b/packages/tentacle/src/__tests__/multi-adapter-wiring.test.ts
@@ -34,6 +34,8 @@ describe('MultiAgentAdapter.wireCallbacks forwards sub-adapter callbacks', () =>
       onSessionEvicted: null,
       onTitleChanged: null,
       onUsageUpdate: null,
+      setTurnIdentity: vi.fn(),
+      isTurnSettled: vi.fn(() => false),
     } as unknown as AgentAdapter;
   }
 
@@ -71,6 +73,31 @@ describe('MultiAgentAdapter.wireCallbacks forwards sub-adapter callbacks', () =>
     stub.onFinalizeDelta?.('s1', { content: '✅ done' });
 
     expect(seen).toHaveBeenCalledWith('s1', { content: '✅ done' });
+  });
+
+  it('forwards the relay turn identity on idle', () => {
+    const multi = new MultiAgentAdapter({ agentIds: ['pi'] });
+    const stub = makeStubAdapter();
+    (multi as unknown as { wireCallbacks(id: string, a: AgentAdapter): void }).wireCallbacks('pi', stub);
+
+    const seen = vi.fn();
+    multi.onIdle = seen;
+    stub.onIdle?.('s1', { turnId: 's1:9' });
+
+    expect(seen).toHaveBeenCalledWith('s1', { turnId: 's1:9' });
+  });
+
+  it('routes turn identity and settlement queries to the owning adapter', () => {
+    const multi = new MultiAgentAdapter({ agentIds: ['pi'] });
+    const stub = makeStubAdapter();
+    (multi as unknown as { adapters: Map<string, AgentAdapter> }).adapters.set('pi', stub);
+    (multi as unknown as { sessionAgent: Map<string, string> }).sessionAgent.set('s1', 'pi');
+    (stub.isTurnSettled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    multi.setTurnIdentity('s1', 's1:10');
+
+    expect(stub.setTurnIdentity).toHaveBeenCalledWith('s1', 's1:10');
+    expect(multi.isTurnSettled('s1')).toBe(true);
   });
 
   it('forwards transient compaction lifecycle events', () => {

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -54,6 +54,7 @@ function makeAdapter(promptWatchdog?: {
     mode: 'execute',
     usage: {},
     lastActivity: Date.now(),
+    relayTurnId: undefined as string | undefined,
     exitObserved: false,
     pendingPerms: new Map<string, string>(),
     pendingQuestions: new Map<string, string>(),
@@ -819,6 +820,46 @@ describe('pi finalize round (only when no trailing reply)', () => {
     expect(onMessage).not.toHaveBeenCalled();
     expect(proc.request).not.toHaveBeenCalledWith('prompt', expect.anything(), expect.anything());
     expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('echoes the relay turn identity on final message and idle callbacks', () => {
+    const { adapter, sid, emit, narrate } = makeAdapter();
+    const onMessage = vi.fn();
+    const onIdle = vi.fn();
+    adapter.onMessage = onMessage;
+    adapter.onIdle = onIdle;
+    adapter.setTurnIdentity(sid, 's1:turn-9');
+
+    narrate('done');
+    emit({ type: 'agent_settled' });
+
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'done', turnId: 's1:turn-9' });
+    expect(onIdle).toHaveBeenCalledWith('s1', { turnId: 's1:turn-9' });
+  });
+
+  it('flushes a pending provider error before process-exit idle', () => {
+    const { adapter, sid, session } = makeAdapter();
+    const events: string[] = [];
+    const onError = vi.fn((_sessionId: string, event: { message: string; turnId?: string }) => {
+      events.push(`error:${event.message}:${event.turnId}`);
+    });
+    const onIdle = vi.fn((_sessionId: string, event?: { turnId?: string }) => {
+      events.push(`idle:${event?.turnId}`);
+    });
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    adapter.setTurnIdentity(sid, 's1:turn-exit');
+    session.pendingError = 'provider failed before settlement';
+
+    (adapter as unknown as { handleProcessExit: (sessionId: string, value: typeof session) => void })
+      .handleProcessExit(sid, session);
+
+    expect(events).toEqual([
+      'error:provider failed before settlement:s1:turn-exit',
+      'idle:s1:turn-exit',
+    ]);
+    expect(session.pendingError).toBeUndefined();
+    expect(session.exitObserved).toBe(true);
   });
 
   it('aborted stopReason → no finalize round, just idle', () => {

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -4,7 +4,7 @@
  *  - ordinary assistant prose (message_end) → NARRATION: streams to the draft
  *    bubble (onMessageDelta) and is mirrored to the TRACE axis (onNarration).
  *  - the LAST narration is the kept draft; the agent's reply IS its prose.
- *  - at agent_end the adapter applies the SKIP-FINALIZE rule: exactly ONE
+ *  - at agent_settled the adapter applies the SKIP-FINALIZE rule: exactly ONE
  *    narration segment with no tool after it is already a clean trailing reply →
  *    crystallize it directly (onMessage) with NO finalize round. Any other shape
  *    (multi-segment, ends-on-tool, zero narration) injects a finalize round: a
@@ -62,8 +62,12 @@ function makeAdapter(promptWatchdog?: {
     lastNarration: '',
     pendingNarration: '',
     lastStopReason: undefined,
+    pendingError: undefined,
+    logicalTurn: 1,
+    settledTurn: undefined,
     aborting: false,
     finalizing: false,
+    finalizeAttempt: 0,
     finalizeResolved: false,
     finalizeNarration: '',
     finalizeStreamLen: 0,
@@ -118,7 +122,7 @@ describe('pi narration → draft + TRACE', () => {
     expect(session.narrationSegments).toBe(0);
   });
 
-  it('message_end stopReason error surfaces onError and does NOT narrate', () => {
+  it('message_end stopReason error stays provisional and does NOT narrate', () => {
     const { adapter, session, emit } = makeAdapter();
     const onNarration = vi.fn();
     const onError = vi.fn();
@@ -126,7 +130,8 @@ describe('pi narration → draft + TRACE', () => {
     adapter.onError = onError;
     emit({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }], stopReason: 'error', errorMessage: 'boom' } });
     expect(onNarration).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith('s1', { message: 'boom' });
+    expect(onError).not.toHaveBeenCalled();
+    expect(session.pendingError).toBe('boom');
     expect(session.narrationSegments).toBe(0);
   });
 
@@ -497,7 +502,7 @@ describe('pi outbound images (tool result → attachment store)', () => {
     (adapter as unknown as { sessions: Map<string, unknown> }).sessions.set(sid, {
       proc, cwd: '/tmp', model: 'm', mode: 'execute', usage: {}, lastActivity: Date.now(),
       pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0,
-      toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingNarration: '', aborting: false, finalizing: false,
+      toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingError: undefined, logicalTurn: 1, settledTurn: undefined, pendingNarration: '', aborting: false, finalizing: false, finalizeAttempt: 0,
       finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0,
     });
     const emit = async (e: Record<string, unknown>) =>
@@ -652,7 +657,7 @@ describe('pi skip-finalize rule (one trailing narration → direct reply)', () =
     adapter.onNarrationTrace = onNarrationTrace;
 
     narrate('Here is your answer.');
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
 
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'Here is your answer.' });
     // The trailing narration graduated INTO the bubble — it must NOT also be
@@ -672,7 +677,7 @@ describe('pi skip-finalize rule (one trailing narration → direct reply)', () =
     emit({ type: 'tool_execution_start', toolName: 'bash', args: { command: 'git status' }, toolCallId: 't1' });
     emit({ type: 'tool_execution_end', toolName: 'bash', result: 'clean', toolCallId: 't1', isError: false });
     narrate('Your tree is clean.'); // one narration AFTER the tool → trailing reply
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
 
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'Your tree is clean.' });
     // The explanation is the reply (bubble), not a Step.
@@ -695,7 +700,7 @@ describe('pi Steps dedup — trailing narration never traced as its own bubble',
     expect(onNarrationTrace).toHaveBeenCalledTimes(1);
     expect(onNarrationTrace).toHaveBeenCalledWith('s1', { content: 'First I will look around.' });
 
-    emit({ type: 'agent_end' }); // 2 segments, last is trailing → graduate directly, no finalize round
+    emit({ type: 'agent_settled' }); // 2 segments, last is trailing → graduate directly, no finalize round
 
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'Now here is the conclusion.' });
     // The concluding narration graduated into the bubble → still exactly ONE trace step.
@@ -715,7 +720,7 @@ describe('pi Steps dedup — trailing narration never traced as its own bubble',
     // A real tool follows → the narration is now an intermediate step, traced now.
     emit({ type: 'tool_execution_start', toolName: 'bash', args: { command: 'ls' }, toolCallId: 't1' });
     emit({ type: 'tool_execution_end', toolName: 'bash', result: 'x', toolCallId: 't1', isError: false });
-    emit({ type: 'agent_end' }); // ended on a tool, no trailing reply → finalize round
+    emit({ type: 'agent_settled' }); // ended on a tool, no trailing reply → finalize round
     emit({ type: 'tool_execution_start', toolName: 'finalize_reply', args: { resummarize: true, text: 'A tidy summary.' }, toolCallId: 'f1' });
 
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'A tidy summary.' });
@@ -734,7 +739,7 @@ describe('pi finalize round (only when no trailing reply)', () => {
 
     narrate('First I will look around.');
     narrate('Now here is the conclusion.');
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
 
     expect(session.finalizing).toBe(false);
     expect(onIdle).toHaveBeenCalledTimes(1);
@@ -748,9 +753,13 @@ describe('pi finalize round (only when no trailing reply)', () => {
     narrate('Let me run this.');
     emit({ type: 'tool_execution_start', toolName: 'bash', args: { command: 'ls' }, toolCallId: 't1' });
     emit({ type: 'tool_execution_end', toolName: 'bash', result: 'x', toolCallId: 't1', isError: false });
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
     expect(session.finalizing).toBe(true);
-    expect(proc.send).toHaveBeenCalledWith('prompt', expect.objectContaining({ message: expect.stringContaining('finalize_reply') }));
+    expect(proc.request).toHaveBeenCalledWith(
+      'prompt',
+      expect.objectContaining({ message: expect.stringContaining('finalize_reply') }),
+      { timeoutMs: null },
+    );
   });
 
   it('zero narration (tool only) → finalize round', () => {
@@ -758,12 +767,41 @@ describe('pi finalize round (only when no trailing reply)', () => {
     adapter.onIdle = vi.fn();
     emit({ type: 'tool_execution_start', toolName: 'bash', args: { command: 'ls' }, toolCallId: 't1' });
     emit({ type: 'tool_execution_end', toolName: 'bash', result: 'x', toolCallId: 't1', isError: false });
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
     expect(session.finalizing).toBe(true);
-    expect(proc.send).toHaveBeenCalledWith('prompt', expect.objectContaining({ message: expect.stringContaining('finalize_reply') }));
+    expect(proc.request).toHaveBeenCalledWith(
+      'prompt',
+      expect.objectContaining({ message: expect.stringContaining('finalize_reply') }),
+      { timeoutMs: null },
+    );
   });
 
-  it('backend error stopReason → no finalize round, no reply, just idle (error already surfaced)', () => {
+  it('rejected finalize prompt clears finalizing and idles exactly once', async () => {
+    const { adapter, proc, session, emit, narrate } = makeAdapter();
+    const onIdle = vi.fn();
+    const onMessage = vi.fn();
+    adapter.onIdle = onIdle;
+    adapter.onMessage = onMessage;
+    proc.request.mockImplementation((command: string) =>
+      command === 'prompt'
+        ? Promise.reject(new Error('not accepted'))
+        : Promise.resolve({}),
+    );
+    narrate('draft before tool');
+    emit({ type: 'tool_execution_start', toolName: 'bash', args: { command: 'ls' }, toolCallId: 't1' });
+    emit({ type: 'tool_execution_end', toolName: 'bash', result: 'x', toolCallId: 't1', isError: false });
+    emit({ type: 'agent_settled' });
+    await vi.waitFor(() => expect(session.finalizing).toBe(false));
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'draft before tool' });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+    const promptCalls = proc.request.mock.calls.filter(call => call[0] === 'prompt').length;
+    emit({ type: 'agent_settled' });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(proc.request.mock.calls.filter(call => call[0] === 'prompt')).toHaveLength(promptCalls);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('backend error stopReason → emits one error and one idle at terminal agent_settled', () => {
     const { adapter, proc, session, emit } = makeAdapter();
     const onIdle = vi.fn();
     const onMessage = vi.fn();
@@ -772,11 +810,14 @@ describe('pi finalize round (only when no trailing reply)', () => {
     adapter.onMessage = onMessage;
     adapter.onError = onError;
     emit({ type: 'message_end', message: { role: 'assistant', content: [], stopReason: 'error', errorMessage: 'quota exceeded' } });
-    emit({ type: 'agent_end' });
+    expect(onError).not.toHaveBeenCalled();
+    emit({ type: 'agent_settled' });
+    emit({ type: 'agent_settled' });
     expect(session.finalizing).toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith('s1', { message: 'quota exceeded' });
     expect(onMessage).not.toHaveBeenCalled();
-    expect(proc.send).not.toHaveBeenCalledWith('prompt', expect.anything());
+    expect(proc.request).not.toHaveBeenCalledWith('prompt', expect.anything(), expect.anything());
     expect(onIdle).toHaveBeenCalledTimes(1);
   });
 
@@ -787,7 +828,7 @@ describe('pi finalize round (only when no trailing reply)', () => {
     adapter.onIdle = onIdle;
     adapter.onMessage = onMessage;
     emit({ type: 'message_end', message: { role: 'assistant', content: [], stopReason: 'aborted', errorMessage: 'Request was aborted' } });
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
     expect(session.finalizing).toBe(false);
     expect(onMessage).not.toHaveBeenCalled();
     expect(proc.send).not.toHaveBeenCalledWith('prompt', expect.anything());
@@ -882,13 +923,13 @@ describe('pi finalize_reply crystallization', () => {
     expect(onToolComplete).not.toHaveBeenCalled();
   });
 
-  it('agent_end after the finalize round clears finalizing and idles', () => {
+  it('agent_settled after the finalize round clears finalizing and idles', () => {
     const { adapter, session, emit } = inFinalize();
     const onIdle = vi.fn();
     adapter.onMessage = vi.fn();
     adapter.onIdle = onIdle;
     emit({ type: 'tool_execution_start', toolName: 'finalize_reply', args: { resummarize: false }, toolCallId: 't1' });
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
     expect(session.finalizing).toBe(false);
     expect(onIdle).toHaveBeenCalledTimes(1);
   });
@@ -900,7 +941,7 @@ describe('pi finalize_reply crystallization', () => {
     adapter.onMessage = onMessage;
     adapter.onIdle = onIdle;
     session.finalizeNarration = 'model wrote this instead';
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'model wrote this instead' });
     expect(session.finalizing).toBe(false);
     expect(onIdle).toHaveBeenCalledTimes(1);
@@ -911,7 +952,7 @@ describe('pi finalize_reply crystallization', () => {
     const onMessage = vi.fn();
     adapter.onMessage = onMessage;
     adapter.onIdle = vi.fn();
-    emit({ type: 'agent_end' });
+    emit({ type: 'agent_settled' });
     expect(onMessage).toHaveBeenCalledWith('s1', { content: 'drafted closing line' });
   });
 });
@@ -1107,13 +1148,68 @@ describe('pi ask_user → question card', () => {
   });
 });
 
-describe('pi agent_end guards', () => {
-  it('does not idle prematurely on a willRetry agent_end', () => {
-    const { adapter, emit } = makeAdapter();
+describe('pi agent lifecycle boundaries', () => {
+  it('converts a post-settlement steer into a fresh prompt and settles its reply', async () => {
+    const { adapter, proc, session, emit } = makeAdapter();
+    const onMessage = vi.fn();
     const onIdle = vi.fn();
+    adapter.onMessage = onMessage;
     adapter.onIdle = onIdle;
-    emit({ type: 'agent_end', willRetry: true });
+    session.settledTurn = session.logicalTurn;
+
+    await adapter.sendMessage('s1', 'steer text', undefined, { delivery: 'steer' });
+    expect(proc.request).toHaveBeenCalledWith(
+      'prompt',
+      { message: 'steer text' },
+      { timeoutMs: null },
+    );
+    expect(session.logicalTurn).toBe(2);
+    expect(session.settledTurn).toBeUndefined();
+
+    await emit({
+      type: 'message_end',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'steered reply' }], stopReason: 'stop' },
+    });
+    await emit({ type: 'agent_end' });
+    expect(onMessage).not.toHaveBeenCalled();
     expect(onIdle).not.toHaveBeenCalled();
+
+    await emit({ type: 'agent_settled' });
+
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'steered reply' });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(session.settledTurn).toBe(session.logicalTurn);
+  });
+
+  it('does not terminalize a provisional error when agent_end will retry', () => {
+    const { adapter, session, emit } = makeAdapter();
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    emit({ type: 'message_end', message: { role: 'assistant', content: [], stopReason: 'error', errorMessage: 'temporary failure' } });
+    emit({ type: 'agent_end', willRetry: true });
+    expect(session.pendingError).toBe('temporary failure');
+    expect(onError).not.toHaveBeenCalled();
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it('successful retry clears the stale provisional error', () => {
+    const { adapter, session, emit } = makeAdapter();
+    const onError = vi.fn();
+    const onIdle = vi.fn();
+    const onMessage = vi.fn();
+    adapter.onError = onError;
+    adapter.onIdle = onIdle;
+    adapter.onMessage = onMessage;
+    emit({ type: 'message_end', message: { role: 'assistant', content: [], stopReason: 'error', errorMessage: 'temporary failure' } });
+    emit({ type: 'agent_end', willRetry: true });
+    emit({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'recovered' }], stopReason: 'stop' } });
+    expect(session.pendingError).toBeUndefined();
+    emit({ type: 'agent_settled' });
+    expect(onError).not.toHaveBeenCalled();
+    expect(onMessage).toHaveBeenCalledWith('s1', { content: 'recovered' });
+    expect(onIdle).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -380,7 +380,7 @@ describe('pi prompt recovery', () => {
       return Promise.reject(new Error('pi process exited'));
     });
 
-    await adapter.sendMessage('s1', 'will exit');
+    await expect(adapter.sendMessage('s1', 'will exit')).rejects.toThrow('pi process exited');
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onIdle).toHaveBeenCalledTimes(1);
   });
@@ -397,7 +397,7 @@ describe('pi prompt recovery', () => {
       return Promise.resolve({});
     });
 
-    await adapter.sendMessage('s1', 'one delivery');
+    await expect(adapter.sendMessage('s1', 'one delivery')).rejects.toThrow('could not be reconciled');
     expect(proc.request.mock.calls.filter(call => call[0] === 'prompt')).toHaveLength(1);
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]?.[1].message).toContain('could not be reconciled');
@@ -829,6 +829,10 @@ describe('pi finalize round (only when no trailing reply)', () => {
     adapter.onMessage = onMessage;
     adapter.onIdle = onIdle;
     adapter.setTurnIdentity(sid, 's1:turn-9');
+    emit({ type: 'agent_start' });
+    // A later Relay identity must not relabel callbacks already owned by this
+    // provider run.
+    adapter.setTurnIdentity(sid, 's1:turn-next');
 
     narrate('done');
     emit({ type: 'agent_settled' });

--- a/packages/tentacle/src/__tests__/pi-runtime-contract.test.ts
+++ b/packages/tentacle/src/__tests__/pi-runtime-contract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+describe('declared Pi runtime contract', () => {
+  it('installs the runtime version whose RPC implementation emits agent_settled', () => {
+    const testDir = dirname(fileURLToPath(import.meta.url));
+    const packageRoot = join(testDir, '..', '..', 'node_modules', '@earendil-works', 'pi-coding-agent');
+    const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as {
+      version?: string;
+    };
+    const rpcMode = readFileSync(join(packageRoot, 'dist', 'modes', 'rpc', 'rpc-mode.js'), 'utf8');
+
+    expect(packageJson.version).toBe('0.84.1');
+    expect(rpcMode).toContain('agent_settled');
+  });
+});

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -174,6 +174,10 @@ function createSessionManager(): Record<string, unknown> {
     updateContext: vi.fn(),
     getContext: vi.fn(() => null),
     getMeta: vi.fn(() => null),
+    getInputLedgerEntry: vi.fn(() => null),
+    findUserMessageSeqByClientId: vi.fn(() => null),
+    recordInputLedger: vi.fn(),
+    markInputLedgerSettled: vi.fn(),
     setTitle: vi.fn(),
     setAutoTitle: vi.fn(),
     setMode: vi.fn(),
@@ -2256,6 +2260,46 @@ describe('RelayClient pending-question digest', () => {
     });
   });
 
+  it('does not persist or deliver a duplicate clientId after reconnect-style replay', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    const ledger = new Map<string, Record<string, unknown>>();
+    smMock.getInputLedgerEntry.mockImplementation((_sessionId: string, clientId: string) => ledger.get(clientId) ?? null);
+    smMock.recordInputLedger.mockImplementation((_sessionId: string, entry: Record<string, unknown>) => {
+      ledger.set(String(entry.clientId), { ...entry });
+    });
+    const send = (seq: number) => ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq,
+      timestamp: new Date().toISOString(), payload: { text: 'once', clientId: 'cid-once' },
+    })));
+
+    send(700);
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    send(701);
+    await Promise.resolve();
+
+    expect(adapter.sendMessage).toHaveBeenCalledTimes(1);
+    const userMessages = smMock.appendMessage.mock.calls.filter((call) => call[1] === 'user_message');
+    expect(userMessages).toHaveLength(1);
+    expect(ledger.get('cid-once')?.status).toBe('delivered');
+  });
+
+  it('converts a post-idle steer into a new prompt before spine persistence', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 'sess_1', state: 'idle', lastSeq: 42, currentTurnStartSeq: 40 });
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 702,
+      timestamp: new Date().toISOString(), payload: { text: 'late steer', clientId: 'cid-late', delivery: 'steer' },
+    })));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    expect(adapter.sendMessage).toHaveBeenCalledWith('sess_1', 'late steer', undefined);
+    const userMessage = smMock.appendMessage.mock.calls.find((call) => call[1] === 'user_message');
+    expect(userMessage).toBeDefined();
+    expect(JSON.parse(userMessage![2]).payload).not.toHaveProperty('delivery', 'steer');
+  });
+
   it('reasserts active after steer acceptance when the preceding work idles during its ACK', async () => {
     const { adapter, ws, sm } = buildClient();
     let accept!: () => void;
@@ -2516,6 +2560,102 @@ describe('RelayClient pending-question digest', () => {
     expect(idleCall![3]).toBe(false);
     expect(sm.readCurrentTurnArtifacts).toHaveBeenCalledWith('sess_1');
     expect(adapter.abortSession).toHaveBeenCalledWith('sess_1');
+  });
+
+  it('lets a genuine final message clear a pending adapter error before idle', () => {
+    const { adapter, sm } = buildClient();
+    (adapter.onError as (sid: string, event: { message: string }) => void)(
+      'sess_1',
+      { message: '524 status code (no body)' },
+    );
+    (adapter.onMessage as (sid: string, event: { content: string }) => void)(
+      'sess_1',
+      { content: 'Recovered final reply' },
+    );
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+
+    const messages = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls;
+    const finalCalls = messages.filter((call) => call[1] === 'agent_message');
+    expect(finalCalls).toHaveLength(1);
+    expect(JSON.parse(finalCalls[0][2]).payload.content).toBe('Recovered final reply');
+    expect(messages.some((call) => call[1] === 'turn_status')).toBe(false);
+
+    const idleCalls = messages.filter((call) => call[1] === 'idle');
+    expect(idleCalls).toHaveLength(1);
+    expect(JSON.parse(idleCalls[0][2]).payload.reason).toBeUndefined();
+  });
+
+  it('keeps a concrete provider error when later callbacks report generic values', () => {
+    const { adapter, sm } = buildClient();
+    const onError = adapter.onError as (sid: string, event: { message: string }) => void;
+    onError('sess_1', { message: 'HTTP 400 invalid request (request id req_123)' });
+    onError('sess_1', { message: 'unknown' });
+    onError('sess_1', { message: 'success' });
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+
+    const messages = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls;
+    const errorMessages = messages
+      .filter((call) => call[1] === 'error')
+      .map((call) => JSON.parse(call[2]).payload.message);
+    expect(errorMessages).toEqual([
+      'HTTP 400 invalid request (request id req_123)',
+      'HTTP 400 invalid request (request id req_123)',
+      'HTTP 400 invalid request (request id req_123)',
+    ]);
+    expect(errorMessages).not.toContain('success');
+    expect(errorMessages).not.toContain('unknown');
+
+    const statusCalls = messages.filter((call) => call[1] === 'turn_status');
+    expect(statusCalls).toHaveLength(1);
+    expect(JSON.parse(statusCalls[0][2]).payload.action.payload.message).toBe(
+      'HTTP 400 invalid request (request id req_123)',
+    );
+  });
+
+  it('uses a safe fallback for a standalone invalid adapter error', () => {
+    const { adapter, sm } = buildClient();
+    (adapter.onError as (sid: string, event: { message: string }) => void)(
+      'sess_1',
+      { message: 'success' },
+    );
+    (adapter.onIdle as (sid: string) => void)('sess_1');
+
+    const messages = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls;
+    const errorCall = messages.find((call) => call[1] === 'error');
+    const statusCall = messages.find((call) => call[1] === 'turn_status');
+    expect(JSON.parse(errorCall![2]).payload.message).toBe('Agent request failed');
+    expect(JSON.parse(statusCall![2]).payload.action.payload.message).toBe(
+      'Agent request failed',
+    );
+  });
+
+  it('suppresses duplicate terminal callbacks until the next explicit turn starts', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const onError = adapter.onError as (sid: string, event: { message: string }) => void;
+    const onIdle = adapter.onIdle as (sid: string) => void;
+
+    onError('sess_1', { message: 'HTTP 524 status code (no body)' });
+    onIdle('sess_1');
+    onError('sess_1', { message: 'unknown' });
+    onIdle('sess_1');
+
+    let messages = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls;
+    expect(messages.filter((call) => call[1] === 'turn_status')).toHaveLength(1);
+    expect(messages.filter((call) => call[1] === 'idle')).toHaveLength(1);
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 509,
+      timestamp: new Date().toISOString(), payload: { text: 'start the next turn' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledWith(
+      'sess_1', 'start the next turn', undefined,
+    ));
+    onIdle('sess_1');
+    await vi.runAllTimersAsync();
+
+    messages = (sm.appendMessage as ReturnType<typeof vi.fn>).mock.calls;
+    expect(messages.filter((call) => call[1] === 'turn_status')).toHaveLength(1);
+    expect(messages.filter((call) => call[1] === 'idle')).toHaveLength(2);
   });
 
   it('freezes an adapter error as failed only when the turn reaches idle and stamps step count', async () => {

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2287,6 +2287,31 @@ describe('RelayClient pending-question digest', () => {
     expect(ledger.get('cid-once')?.status).toBe('delivered');
   });
 
+  it('retries a rejected adapter input with the same clientId without appending it twice', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    const ledger = new Map<string, Record<string, unknown>>();
+    smMock.getInputLedgerEntry.mockImplementation((_sessionId: string, clientId: string) => ledger.get(clientId) ?? null);
+    smMock.recordInputLedger.mockImplementation((_sessionId: string, entry: Record<string, unknown>) => {
+      ledger.set(String(entry.clientId), { ...entry });
+    });
+    (adapter.sendMessage as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('adapter did not accept input'))
+      .mockResolvedValue(undefined);
+    const send = (seq: number) => ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq,
+      timestamp: new Date().toISOString(), payload: { text: 'retryable', clientId: 'cid-rejected' },
+    })));
+
+    send(699);
+    await vi.waitFor(() => expect(ledger.get('cid-rejected')?.status).toBe('rejected'));
+    send(700);
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+
+    expect(smMock.appendMessage.mock.calls.filter((call) => call[1] === 'user_message')).toHaveLength(1);
+    expect(ledger.get('cid-rejected')?.status).toBe('delivered');
+  });
+
   it('recovers a transcript-persisted input after daemon restart without appending it twice', async () => {
     const { adapter, sm, ws } = buildClient();
     const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
@@ -2388,6 +2413,27 @@ describe('RelayClient pending-question digest', () => {
     expect(adapter.sendMessage).toHaveBeenCalledWith('sess_1', 'settled steer', undefined);
     const userMessage = smMock.appendMessage.mock.calls.find((call) => call[1] === 'user_message');
     expect(JSON.parse(userMessage![2]).payload).not.toHaveProperty('delivery', 'steer');
+  });
+
+  it('drops a same-turn final message arriving after idle settlement', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 704,
+      timestamp: new Date().toISOString(), payload: { text: 'one turn' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+
+    (adapter.onIdle as (sid: string, event: { turnId: string }) => void)(
+      'sess_1', { turnId: 'sess_1:1' },
+    );
+    smMock.appendMessage.mockClear();
+    (adapter.onMessage as (sid: string, event: { content: string; turnId: string }) => void)(
+      'sess_1', { content: 'late final', turnId: 'sess_1:1' },
+    );
+
+    expect(smMock.appendMessage).not.toHaveBeenCalled();
+    expect(smMock.markIdle).toHaveBeenCalledTimes(1);
   });
 
   it('drops terminal callbacks carrying an older relay turn identity', async () => {

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -77,6 +77,7 @@ vi.mock('@kraki/crypto', async () => {
 
 import { RelayClient } from '../relay-client.js';
 import { AttachmentStore } from '../attachment-store.js';
+import { createHash } from 'node:crypto';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -153,6 +154,8 @@ function createAdapter(): Record<string, unknown> {
     getSessionUsage: vi.fn(() => null),
     setSessionUsage: vi.fn(),
     registerSessionAgent: vi.fn(),
+    setTurnIdentity: vi.fn(),
+    isTurnSettled: vi.fn(() => false),
     sendMessage: vi.fn(async () => {}),
     respondToQuestion: vi.fn(async () => 'accepted'),
     respondToPermission: vi.fn(async () => {}),
@@ -2284,6 +2287,76 @@ describe('RelayClient pending-question digest', () => {
     expect(ledger.get('cid-once')?.status).toBe('delivered');
   });
 
+  it('recovers a transcript-persisted input after daemon restart without appending it twice', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    const ledger = new Map<string, Record<string, unknown>>([
+      ['cid-restart', {
+        version: 1,
+        clientId: 'cid-restart',
+        status: 'persisted',
+        requestedDelivery: 'prompt',
+        delivery: 'prompt',
+        turnId: 'sess_1:43',
+        contentLength: 13,
+        contentHash: 'ignored-by-mock',
+        userSeq: 43,
+        updatedAt: new Date().toISOString(),
+      }],
+    ]);
+    smMock.getInputLedgerEntry.mockImplementation((_sessionId: string, clientId: string) => ledger.get(clientId) ?? null);
+    smMock.recordInputLedger.mockImplementation((_sessionId: string, entry: Record<string, unknown>) => {
+      ledger.set(String(entry.clientId), { ...entry });
+    });
+    // Match the replay body fingerprint while retaining the persisted state.
+    ledger.get('cid-restart')!.contentHash = createHash('sha256')
+      .update(JSON.stringify({ text: 'restart-safe', attachments: [] }))
+      .digest('hex');
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 701,
+      timestamp: new Date().toISOString(), payload: { text: 'restart-safe', clientId: 'cid-restart' },
+    })));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    expect(adapter.sendMessage).toHaveBeenCalledWith('sess_1', 'restart-safe', undefined);
+    expect(smMock.appendMessage.mock.calls.filter((call) => call[1] === 'user_message')).toHaveLength(0);
+    expect(ledger.get('cid-restart')?.status).toBe('delivered');
+  });
+
+  it('replays a pending reservation when the daemon stopped before transcript persistence', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    const ledger = new Map<string, Record<string, unknown>>();
+    ledger.set('cid-pending', {
+      version: 1,
+      clientId: 'cid-pending',
+      status: 'pending',
+      requestedDelivery: 'prompt',
+      delivery: 'prompt',
+      turnId: 'sess_1:44',
+      contentLength: 13,
+      contentHash: createHash('sha256')
+        .update(JSON.stringify({ text: 'persist-again', attachments: [] }))
+        .digest('hex'),
+      updatedAt: new Date().toISOString(),
+    });
+    smMock.getInputLedgerEntry.mockImplementation((_sessionId: string, clientId: string) => ledger.get(clientId) ?? null);
+    smMock.recordInputLedger.mockImplementation((_sessionId: string, entry: Record<string, unknown>) => {
+      ledger.set(String(entry.clientId), { ...entry });
+    });
+    smMock.findUserMessageSeqByClientId.mockReturnValue(null);
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 702,
+      timestamp: new Date().toISOString(), payload: { text: 'persist-again', clientId: 'cid-pending' },
+    })));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    expect(smMock.appendMessage.mock.calls.filter((call) => call[1] === 'user_message')).toHaveLength(1);
+    expect(ledger.get('cid-pending')?.status).toBe('delivered');
+  });
+
   it('converts a post-idle steer into a new prompt before spine persistence', async () => {
     const { adapter, sm, ws } = buildClient();
     const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
@@ -2300,6 +2373,80 @@ describe('RelayClient pending-question digest', () => {
     expect(JSON.parse(userMessage![2]).payload).not.toHaveProperty('delivery', 'steer');
   });
 
+  it('converts steer to a new prompt when the adapter is settled but session metadata is still active', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    smMock.getMeta.mockReturnValue({ id: 'sess_1', state: 'active', lastSeq: 50, currentTurnStartSeq: 47 });
+    (adapter.isTurnSettled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 703,
+      timestamp: new Date().toISOString(), payload: { text: 'settled steer', delivery: 'steer' },
+    })));
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    expect(adapter.sendMessage).toHaveBeenCalledWith('sess_1', 'settled steer', undefined);
+    const userMessage = smMock.appendMessage.mock.calls.find((call) => call[1] === 'user_message');
+    expect(JSON.parse(userMessage![2]).payload).not.toHaveProperty('delivery', 'steer');
+  });
+
+  it('drops terminal callbacks carrying an older relay turn identity', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    const send = (seq: number, text: string) => ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq,
+      timestamp: new Date().toISOString(), payload: { text },
+    })));
+
+    send(704, 'first turn');
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    (adapter.onIdle as (sid: string, event: { turnId: string }) => void)('sess_1', { turnId: 'sess_1:1' });
+    send(705, 'second turn');
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+    expect(adapter.setTurnIdentity).toHaveBeenLastCalledWith('sess_1', 'sess_1:2');
+
+    smMock.appendMessage.mockClear();
+    smMock.markIdle.mockClear();
+    (adapter.onMessage as (sid: string, event: { content: string; turnId: string }) => void)(
+      'sess_1', { content: 'late reply', turnId: 'sess_1:1' },
+    );
+    (adapter.onError as (sid: string, event: { message: string; turnId: string }) => void)(
+      'sess_1', { message: 'late error', turnId: 'sess_1:1' },
+    );
+    (adapter.onIdle as (sid: string, event: { turnId: string }) => void)(
+      'sess_1', { turnId: 'sess_1:1' },
+    );
+
+    expect(smMock.appendMessage).not.toHaveBeenCalled();
+    expect(smMock.markIdle).not.toHaveBeenCalled();
+  });
+
+  it('does not freeze a staged error from an older turn when a settled adapter accepts new work', async () => {
+    const { adapter, sm, ws } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    const send = (seq: number, text: string, delivery?: 'steer') => ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq,
+      timestamp: new Date().toISOString(), payload: { text, ...(delivery && { delivery }) },
+    })));
+
+    send(706, 'first turn');
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    (adapter.onError as (sid: string, event: { message: string; turnId: string }) => void)(
+      'sess_1', { message: 'old provider error', turnId: 'sess_1:1' },
+    );
+    (adapter.isTurnSettled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    send(707, 'new work', 'steer');
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+
+    smMock.appendMessage.mockClear();
+    (adapter.onIdle as (sid: string, event: { turnId: string }) => void)(
+      'sess_1', { turnId: 'sess_1:2' },
+    );
+
+    expect(smMock.appendMessage.mock.calls.some((call) => call[1] === 'turn_status')).toBe(false);
+    expect(smMock.markIdle).toHaveBeenCalledWith('sess_1');
+  });
+
   it('reasserts active after steer acceptance when the preceding work idles during its ACK', async () => {
     const { adapter, ws, sm } = buildClient();
     let accept!: () => void;
@@ -2312,13 +2459,17 @@ describe('RelayClient pending-question digest', () => {
     })));
     await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
 
-    (adapter.onIdle as (sid: string) => void)('sess_1');
+    (adapter.onIdle as (sid: string, event: { turnId: string }) => void)(
+      'sess_1', { turnId: 'sess_1:0' },
+    );
     expect(sm.markIdle).not.toHaveBeenCalled();
     accept();
     await vi.waitFor(() => expect(sm.markActive).toHaveBeenCalledTimes(2));
     expect(sm.markIdle).not.toHaveBeenCalled();
 
-    (adapter.onIdle as (sid: string) => void)('sess_1');
+    (adapter.onIdle as (sid: string, event: { turnId: string }) => void)(
+      'sess_1', { turnId: 'sess_1:0' },
+    );
     expect(sm.markIdle).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -128,6 +128,17 @@ describe('SessionManager', () => {
       expect(compacted.some((entry) => entry.clientId === 'terminal-0')).toBe(false);
       expect(compacted.some((entry) => entry.clientId === 'still-persisted')).toBe(true);
       expect(compacted.some((entry) => entry.clientId === 'terminal-newest')).toBe(true);
+      // The bounded state file may evict the oldest terminal row, but the
+      // append-only identity index must still reject its clientId on replay.
+      expect(restarted.getInputLedgerEntry(sessionId, 'terminal-0')).toMatchObject({
+        clientId: 'terminal-0',
+        status: 'settled',
+      });
+      const afterRestart = new SessionManager(dir);
+      expect(afterRestart.getInputLedgerEntry(sessionId, 'terminal-0')).toMatchObject({
+        clientId: 'terminal-0',
+        status: 'settled',
+      });
     });
   });
 

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -59,6 +59,36 @@ describe('SessionManager', () => {
     });
   });
 
+  describe('durable input identity', () => {
+    it('recovers a clientId ledger and message sequence after a new manager loads the same directory', () => {
+      const { sessionId } = sm.createSession('pi');
+      const userPayload = JSON.stringify({ payload: { content: 'one', clientId: 'cid-1' } });
+      const userSeq = sm.appendMessage(sessionId, 'user_message', userPayload);
+      sm.recordInputLedger(sessionId, {
+        version: 1,
+        clientId: 'cid-1',
+        status: 'delivered',
+        requestedDelivery: 'prompt',
+        delivery: 'prompt',
+        turnId: `${sessionId}:${userSeq}`,
+        contentLength: 3,
+        contentHash: 'hash-1',
+        userSeq,
+        updatedAt: new Date().toISOString(),
+      });
+
+      const restarted = new SessionManager(dir);
+      expect(restarted.findUserMessageSeqByClientId(sessionId, 'cid-1')).toBe(userSeq);
+      expect(restarted.getInputLedgerEntry(sessionId, 'cid-1')).toMatchObject({
+        status: 'delivered',
+        userSeq,
+      });
+
+      restarted.markInputLedgerSettled(sessionId, `${sessionId}:${userSeq}`);
+      expect(restarted.getInputLedgerEntry(sessionId, 'cid-1')?.status).toBe('settled');
+    });
+  });
+
   describe('durable pending human action', () => {
     it('round-trips and clears a pending question sidecar', () => {
       const { sessionId } = sm.createSession('pi');

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { SessionManager } from '../session-manager.js';
+import { SessionManager, type InputLedgerEntry } from '../session-manager.js';
 import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync, appendFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -86,6 +86,48 @@ describe('SessionManager', () => {
 
       restarted.markInputLedgerSettled(sessionId, `${sessionId}:${userSeq}`);
       expect(restarted.getInputLedgerEntry(sessionId, 'cid-1')?.status).toBe('settled');
+    });
+
+    it('bounds terminal ledger history while preserving unresolved inputs', () => {
+      const { sessionId } = sm.createSession('pi');
+      const entries: InputLedgerEntry[] = Array.from({ length: 2055 }, (_, index) => ({
+        version: 1 as const,
+        clientId: `terminal-${index}`,
+        status: 'settled' as const,
+        requestedDelivery: 'prompt' as const,
+        delivery: 'prompt' as const,
+        turnId: `${sessionId}:${index + 1}`,
+        contentLength: 1,
+        contentHash: `hash-${index}`,
+        userSeq: index + 1,
+        updatedAt: new Date(index + 1).toISOString(),
+      }));
+      entries.push({
+        version: 1,
+        clientId: 'still-persisted',
+        status: 'persisted',
+        requestedDelivery: 'prompt',
+        delivery: 'prompt',
+        turnId: `${sessionId}:open`,
+        contentLength: 1,
+        contentHash: 'open-hash',
+        userSeq: 3000,
+        updatedAt: new Date().toISOString(),
+      });
+      writeFileSync(join(dir, sessionId, 'input-ledger.json'), JSON.stringify(entries));
+
+      const restarted = new SessionManager(dir);
+      restarted.recordInputLedger(sessionId, {
+        ...entries[2054],
+        clientId: 'terminal-newest',
+        updatedAt: new Date().toISOString(),
+      });
+
+      const compacted = restarted.getInputLedger(sessionId);
+      expect(compacted.filter((entry) => entry.status === 'settled')).toHaveLength(2048);
+      expect(compacted.some((entry) => entry.clientId === 'terminal-0')).toBe(false);
+      expect(compacted.some((entry) => entry.clientId === 'still-persisted')).toBe(true);
+      expect(compacted.some((entry) => entry.clientId === 'terminal-newest')).toBe(true);
     });
   });
 

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -19,7 +19,12 @@ export interface SessionCreatedEvent {
   model?: string;
 }
 
-export interface MessageEvent {
+export interface TurnLifecycleEvent {
+  /** Relay-assigned logical turn identity. Missing only for legacy callers/tests. */
+  turnId?: string;
+}
+
+export interface MessageEvent extends TurnLifecycleEvent {
   content: string;
 }
 
@@ -65,7 +70,7 @@ export interface SessionEndedEvent {
   reason: string;
 }
 
-export interface ErrorEvent {
+export interface ErrorEvent extends TurnLifecycleEvent {
   message: string;
 }
 
@@ -171,11 +176,19 @@ export abstract class AgentAdapter {
   /** Called immediately after onToolComplete when bytes need to be pushed
    *  (broadcast as `attachment_data` chunks) to connected devices. */
   onAttachmentBytes: ((sessionId: string, event: AttachmentBytesEvent) => void) | null = null;
-  onIdle: ((sessionId: string) => void) | null = null;
+  onIdle: ((sessionId: string, event?: TurnLifecycleEvent) => void) | null = null;
   /** Called when the adapter has finished all writes to the session's history file
    *  after a turn completes. Used by EventsWatcher to safely resume watching. */
   onFlushComplete: ((sessionId: string) => void) | null = null;
   onError: ((sessionId: string, event: ErrorEvent) => void) | null = null;
+  /** Set before a send is handed to an adapter. Terminal callbacks must echo
+   *  this identity so RelayClient can reject late events from an older turn. */
+  setTurnIdentity(_sessionId: string, _turnId: string): void { /* no-op by default */ }
+
+  /** True when the adapter has already reached its terminal boundary for the
+   *  currently selected turn, even if Relay missed the callback during a race. */
+  isTurnSettled(_sessionId: string): boolean { return false; }
+
   /** Transient agent-runtime compaction activity. Never persisted to the spine
    *  or TRACE; RelayClient maps it to the server-owned status-card slot. */
   onCompaction: ((sessionId: string, event: CompactionEvent) => void) | null = null;

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -28,30 +28,30 @@ export interface MessageEvent extends TurnLifecycleEvent {
   content: string;
 }
 
-export interface MessageDeltaEvent {
+export interface MessageDeltaEvent extends TurnLifecycleEvent {
   content: string;
 }
 
-export interface PermissionRequestEvent {
+export interface PermissionRequestEvent extends TurnLifecycleEvent {
   id: string;
   toolArgs: ToolArgs;
   description: string;
 }
 
-export interface QuestionRequestEvent {
+export interface QuestionRequestEvent extends TurnLifecycleEvent {
   id: string;
   question: string;
   choices?: string[];
   allowFreeform: boolean;
 }
 
-export interface ToolStartEvent {
+export interface ToolStartEvent extends TurnLifecycleEvent {
   toolName: string;
   args: Record<string, unknown>;
   toolCallId?: string;
 }
 
-export interface ToolCompleteEvent {
+export interface ToolCompleteEvent extends TurnLifecycleEvent {
   toolName: string;
   result: string;
   toolCallId?: string;
@@ -62,7 +62,7 @@ export interface ToolCompleteEvent {
 /** Emitted alongside a tool_complete that carries one or more
  *  `ContentRef`s. Tells the runtime (RelayClient) to broadcast the bytes
  *  to all connected devices as `attachment_data` chunks. */
-export interface AttachmentBytesEvent {
+export interface AttachmentBytesEvent extends TurnLifecycleEvent {
   refs: Array<import('@kraki/protocol').ContentRef>;
 }
 
@@ -76,7 +76,7 @@ export interface ErrorEvent extends TurnLifecycleEvent {
 
 export type CompactionReason = 'manual' | 'threshold' | 'overflow';
 
-export interface CompactionEvent {
+export interface CompactionEvent extends TurnLifecycleEvent {
   phase: 'start' | 'end';
   reason?: CompactionReason;
   aborted?: boolean;
@@ -86,7 +86,7 @@ export interface CompactionEvent {
 
 /** A Kraki-originated system notice (not the agent's words). See
  *  protocol `SystemMessage`. First use: `kind: 'no_reply'`. */
-export interface SystemMessageEvent {
+export interface SystemMessageEvent extends TurnLifecycleEvent {
   kind: string;
   content?: string;
 }

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -158,6 +158,8 @@ interface SessionEntry {
    */
   pendingText?: string;
   pendingError?: NormalizedClaudeError;
+  /** Relay-owned logical turn identity echoed by terminal callbacks. */
+  relayTurnId?: string;
   turnFinalized?: boolean;
 }
 
@@ -810,6 +812,32 @@ export class ClaudeAdapter extends AgentAdapter {
    * SDK gets its first user message, then starts the consumer loop for
    * multi-turn conversation.
    */
+  setTurnIdentity(sessionId: string, turnId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry) entry.relayTurnId = turnId;
+  }
+
+  isTurnSettled(sessionId: string): boolean {
+    return this.sessions.get(sessionId)?.turnFinalized === true;
+  }
+
+  private lifecycleEvent(entry: SessionEntry): { turnId?: string } {
+    return entry.relayTurnId ? { turnId: entry.relayTurnId } : {};
+  }
+
+  private emitMessage(sessionId: string, entry: SessionEntry, content: string): void {
+    this.onMessage?.(sessionId, { content, ...this.lifecycleEvent(entry) });
+  }
+
+  private emitError(sessionId: string, entry: SessionEntry, message: string): void {
+    this.onError?.(sessionId, { message, ...this.lifecycleEvent(entry) });
+  }
+
+  private emitIdle(sessionId: string, entry: SessionEntry): void {
+    if (entry.relayTurnId) this.onIdle?.(sessionId, { turnId: entry.relayTurnId });
+    else this.onIdle?.(sessionId);
+  }
+
   private async spawnQuery(sessionId: string, initialPrompt: string): Promise<void> {
     const entry = this.sessions.get(sessionId);
     if (!entry) return;
@@ -1143,10 +1171,14 @@ export class ClaudeAdapter extends AgentAdapter {
       // boundary; only fall back here when the SDK ended without one.
       const entry = this.sessions.get(sessionId);
       if (!entry?.turnFinalized) {
-        if (entry?.pendingError) this.onError?.(sessionId, { message: entry.pendingError.message });
+        if (entry?.pendingError) this.emitError(sessionId, entry, entry.pendingError.message);
         else this.flushConclusion(sessionId);
-        if (entry) entry.turnFinalized = true;
-        this.onIdle?.(sessionId);
+        if (entry) {
+          entry.turnFinalized = true;
+          this.emitIdle(sessionId, entry);
+        } else {
+          this.onIdle?.(sessionId);
+        }
       }
     } catch (err) {
       if ((err as Error).name === 'AbortError') {
@@ -1154,7 +1186,9 @@ export class ClaudeAdapter extends AgentAdapter {
         return;
       }
       logger.error({ err, sessionId }, 'Session consumer loop error');
-      this.onError?.(sessionId, { message: getErrorMessage(err) });
+      const entry = this.sessions.get(sessionId);
+      if (entry) this.emitError(sessionId, entry, getErrorMessage(err));
+      else this.onError?.(sessionId, { message: getErrorMessage(err) });
       this.onSessionEnded?.(sessionId, { reason: 'error' });
     }
   }
@@ -1183,7 +1217,7 @@ export class ClaudeAdapter extends AgentAdapter {
     if (!entry) return;
     const text = (entry.pendingText ?? '').trim();
     entry.pendingText = '';
-    if (text) this.onMessage?.(sessionId, { content: text });
+    if (text) this.emitMessage(sessionId, entry, text);
   }
 
   /**
@@ -1297,7 +1331,8 @@ export class ClaudeAdapter extends AgentAdapter {
             entry.pendingError = error;
             entry.pendingText = '';
           }
-          this.onError?.(sessionId, { message: error.message });
+          if (entry) this.emitError(sessionId, entry, error.message);
+          else this.onError?.(sessionId, { message: error.message });
         } else {
           if (entry) entry.pendingError = undefined;
           this.flushConclusion(sessionId);
@@ -1324,8 +1359,12 @@ export class ClaudeAdapter extends AgentAdapter {
         }
 
         // The result is the authoritative turn boundary.
-        if (entry) entry.turnFinalized = true;
-        this.onIdle?.(sessionId);
+        if (entry) {
+          entry.turnFinalized = true;
+          this.emitIdle(sessionId, entry);
+        } else {
+          this.onIdle?.(sessionId);
+        }
 
         // Poll for SDK-native title changes (the SDK auto-generates titles
         // but doesn't emit title events in the stream)

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -158,8 +158,11 @@ interface SessionEntry {
    */
   pendingText?: string;
   pendingError?: NormalizedClaudeError;
-  /** Relay-owned logical turn identity echoed by terminal callbacks. */
+  /** Relay-owned logical turn identity for the next accepted prompt. */
   relayTurnId?: string;
+  /** Identity captured when the SDK delivers the user message that starts
+   * the provider turn. */
+  eventTurnId?: string;
   turnFinalized?: boolean;
 }
 
@@ -656,6 +659,7 @@ export class ClaudeAdapter extends AgentAdapter {
       model: config.model,
       consumerLoop: Promise.resolve(),
       deferredConfig: config,
+      eventTurnId: undefined,
     };
 
     this.sessions.set(sessionId, entry);
@@ -698,6 +702,7 @@ export class ClaudeAdapter extends AgentAdapter {
       sessionId,
       model: meta?.model,
       consumerLoop: Promise.resolve(),
+      eventTurnId: undefined,
       deferredConfig: {
         resume: meta?.sdkSessionId ?? sessionId,
         ...(meta?.cwd && { cwd: meta.cwd }),
@@ -741,6 +746,7 @@ export class ClaudeAdapter extends AgentAdapter {
       pendingQuestions,
       sessionId: newSessionId,
       consumerLoop: Promise.resolve(),
+      eventTurnId: undefined,
       deferredConfig: {
         resume: resumeId,
         fork: true,
@@ -814,15 +820,19 @@ export class ClaudeAdapter extends AgentAdapter {
    */
   setTurnIdentity(sessionId: string, turnId: string): void {
     const entry = this.sessions.get(sessionId);
-    if (entry) entry.relayTurnId = turnId;
+    if (!entry) return;
+    entry.relayTurnId = turnId;
+    // Keep the previous provider-run snapshot until the next SDK user event;
+    // a late callback in the handoff window must not inherit this new ID.
   }
 
   isTurnSettled(sessionId: string): boolean {
     return this.sessions.get(sessionId)?.turnFinalized === true;
   }
 
-  private lifecycleEvent(entry: SessionEntry): { turnId?: string } {
-    return entry.relayTurnId ? { turnId: entry.relayTurnId } : {};
+  private lifecycleEvent(entry?: SessionEntry): { turnId?: string } {
+    const turnId = entry?.eventTurnId ?? entry?.relayTurnId;
+    return turnId ? { turnId } : {};
   }
 
   private emitMessage(sessionId: string, entry: SessionEntry, content: string): void {
@@ -834,7 +844,8 @@ export class ClaudeAdapter extends AgentAdapter {
   }
 
   private emitIdle(sessionId: string, entry: SessionEntry): void {
-    if (entry.relayTurnId) this.onIdle?.(sessionId, { turnId: entry.relayTurnId });
+    const event = this.lifecycleEvent(entry);
+    if (event.turnId) this.onIdle?.(sessionId, event);
     else this.onIdle?.(sessionId);
   }
 
@@ -1203,8 +1214,8 @@ export class ClaudeAdapter extends AgentAdapter {
     const text = (entry.pendingText ?? '').trim();
     entry.pendingText = '';
     if (text) {
-      this.onNarration?.(sessionId, { content: text });
-      this.onNarrationTrace?.(sessionId, { content: text });
+      this.onNarration?.(sessionId, { content: text, ...this.lifecycleEvent(entry) });
+      this.onNarrationTrace?.(sessionId, { content: text, ...this.lifecycleEvent(entry) });
     }
   }
 
@@ -1291,6 +1302,7 @@ export class ClaudeAdapter extends AgentAdapter {
             sessionTools.set(toolBlock.id, { toolName: canonicalToolName, args });
 
             this.onToolStart?.(sessionId, {
+              ...this.lifecycleEvent(entry),
               toolName: canonicalToolName,
               args,
               toolCallId: toolBlock.id,
@@ -1312,7 +1324,7 @@ export class ClaudeAdapter extends AgentAdapter {
         if (event.type === 'content_block_delta') {
           const delta = event.delta as Record<string, unknown> | undefined;
           if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
-            this.onMessageDelta?.(sessionId, { content: delta.text });
+            this.onMessageDelta?.(sessionId, { content: delta.text, ...this.lifecycleEvent(this.sessions.get(sessionId)) });
           }
         }
         break;
@@ -1373,6 +1385,8 @@ export class ClaudeAdapter extends AgentAdapter {
       }
 
       case 'user': {
+        const entry = this.sessions.get(sessionId);
+        if (entry) entry.eventTurnId = entry.relayTurnId;
         // User messages include tool_result content blocks when tools complete.
         // Extract tool results and fire tool_complete callbacks.
         const userMsg = msg as SDKUserMessage;
@@ -1428,6 +1442,7 @@ export class ClaudeAdapter extends AgentAdapter {
               }
 
               this.onToolComplete?.(sessionId, {
+                ...this.lifecycleEvent(entry),
                 toolName: tracked?.toolName ?? 'tool',
                 result,
                 toolCallId,
@@ -1441,7 +1456,7 @@ export class ClaudeAdapter extends AgentAdapter {
                   (a): a is import('@kraki/protocol').ContentRef => a.type === 'content_ref',
                 );
                 if (refs.length > 0) {
-                  this.onAttachmentBytes?.(sessionId, { refs });
+                  this.onAttachmentBytes?.(sessionId, { refs, ...this.lifecycleEvent(entry) });
                 }
               }
 
@@ -1562,6 +1577,7 @@ export class ClaudeAdapter extends AgentAdapter {
       }, 'permission requested');
 
       this.onPermissionRequest?.(sessionId, {
+        ...this.lifecycleEvent(this.sessions.get(sessionId)),
         id: permId,
         ...parsed,
       });
@@ -1607,6 +1623,7 @@ export class ClaudeAdapter extends AgentAdapter {
         // best-effort prompt so the user isn't stuck, resolve empty.
         const qId = makeId('q');
         this.onQuestionRequest?.(sessionId, {
+          ...this.lifecycleEvent(this.sessions.get(sessionId)),
           id: qId,
           question: (input.question as string) ?? 'The agent has a question',
           choices: undefined,
@@ -1647,6 +1664,7 @@ export class ClaudeAdapter extends AgentAdapter {
     }, 'question requested');
 
     this.onQuestionRequest?.(sessionId, {
+      ...this.lifecycleEvent(this.sessions.get(sessionId)),
       id: qId,
       question: q?.question ?? 'The agent has a question',
       choices,

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -131,6 +131,13 @@ interface InputChannel {
   end(): void;
 }
 
+interface NormalizedClaudeError {
+  message: string;
+  status?: number;
+  requestId?: string;
+  quality: number;
+}
+
 /** Everything we track per session. */
 interface SessionEntry {
   query: Query | null;
@@ -150,6 +157,8 @@ interface SessionEntry {
    * the single conclusion bubble (onMessage) when the turn ends.
    */
   pendingText?: string;
+  pendingError?: NormalizedClaudeError;
+  turnFinalized?: boolean;
 }
 
 // ── Helpers ─────────────────────────────────────────────
@@ -161,6 +170,52 @@ function makeId(prefix: string): string {
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+function meaningfulClaudeErrorText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  if (!text || /^(success|unknown|error_during_execution)$/i.test(text)) return undefined;
+  return text;
+}
+
+function assistantText(message: unknown): string | undefined {
+  const content = (message as { content?: unknown } | null)?.content;
+  if (!Array.isArray(content)) return undefined;
+  const text = content
+    .filter((block): block is { type: string; text: string } =>
+      !!block && typeof block === 'object' && (block as { type?: unknown }).type === 'text'
+      && typeof (block as { text?: unknown }).text === 'string')
+    .map((block) => block.text)
+    .join('\n')
+    .trim();
+  return meaningfulClaudeErrorText(text);
+}
+
+export function normalizeClaudeSDKError(value: Record<string, unknown>): NormalizedClaudeError {
+  const errors = Array.isArray(value.errors)
+    ? value.errors.map(meaningfulClaudeErrorText).filter((item): item is string => !!item)
+    : [];
+  const text = errors.join('; ')
+    || assistantText(value.message)
+    || meaningfulClaudeErrorText(value.result)
+    || meaningfulClaudeErrorText(value.error_message);
+  const statusCandidate = value.api_error_status ?? value.apiErrorStatus ?? value.status ?? value.statusCode;
+  const status = typeof statusCandidate === 'number' ? statusCandidate : undefined;
+  const requestIdCandidate = value.request_id ?? value.requestId;
+  const requestId = typeof requestIdCandidate === 'string' ? requestIdCandidate : undefined;
+  const category = meaningfulClaudeErrorText(value.error);
+  const fallback = status ? `Claude API error (HTTP ${status})` : category ? `Claude API error: ${category}` : 'Claude API request failed';
+  const message = text ?? fallback;
+  const quality = text ? (status ? 4 : 3) : status ? 2 : category ? 1 : 0;
+  return { message, ...(status ? { status } : {}), ...(requestId ? { requestId } : {}), quality };
+}
+
+function preferClaudeError(
+  current: NormalizedClaudeError | undefined,
+  candidate: NormalizedClaudeError,
+): NormalizedClaudeError {
+  return !current || candidate.quality > current.quality ? candidate : current;
 }
 
 /**
@@ -718,9 +773,14 @@ export class ClaudeAdapter extends AgentAdapter {
     }
 
     // Streaming input accepts another user message while the query is running.
-    // Keep the active draft for an interjection; only a normal prompt opens a
-    // fresh turn and resets the draft-bubble prose buffer.
-    if (options?.delivery !== 'steer') entry.pendingText = '';
+    // Keep the active draft for an interjection. A steer arriving after the
+    // authoritative result belongs to a new logical turn and must re-arm the
+    // terminal callback guard before it enters the SDK input channel.
+    if (options?.delivery !== 'steer' || entry.turnFinalized) {
+      entry.pendingText = '';
+      entry.pendingError = undefined;
+      entry.turnFinalized = false;
+    }
 
     // Prepend mode-switch signal if mode changed since last message
     const pendingMode = this.pendingModeSignals.get(sessionId);
@@ -1079,9 +1139,15 @@ export class ClaudeAdapter extends AgentAdapter {
         }
       }
 
-      // Query completed normally
-      this.flushConclusion(sessionId);
-      this.onIdle?.(sessionId);
+      // Query completed normally. A result event is the authoritative turn
+      // boundary; only fall back here when the SDK ended without one.
+      const entry = this.sessions.get(sessionId);
+      if (!entry?.turnFinalized) {
+        if (entry?.pendingError) this.onError?.(sessionId, { message: entry.pendingError.message });
+        else this.flushConclusion(sessionId);
+        if (entry) entry.turnFinalized = true;
+        this.onIdle?.(sessionId);
+      }
     } catch (err) {
       if ((err as Error).name === 'AbortError') {
         logger.debug({ sessionId }, 'Session query aborted');
@@ -1152,9 +1218,9 @@ export class ClaudeAdapter extends AgentAdapter {
       case 'assistant': {
         const assistantMsg = msg as SDKAssistantMessage;
         if (assistantMsg.error) {
-          this.onError?.(sessionId, {
-            message: `Claude API error: ${typeof assistantMsg.error === 'string' ? assistantMsg.error : JSON.stringify(assistantMsg.error)}`,
-          });
+          const entry = this.sessions.get(sessionId);
+          const normalized = normalizeClaudeSDKError(assistantMsg as unknown as Record<string, unknown>);
+          if (entry) entry.pendingError = preferClaudeError(entry.pendingError, normalized);
           break;
         }
 
@@ -1221,11 +1287,20 @@ export class ClaudeAdapter extends AgentAdapter {
       case 'result': {
         const result = msg as SDKResultMessage;
         const resultAny = result as unknown as Record<string, unknown>;
+        const entry = this.sessions.get(sessionId);
+        if (entry?.turnFinalized) break;
 
         if (resultAny.is_error) {
-          const errors = resultAny.errors as string[] | undefined;
-          const errorMsg = errors?.join('; ') || (resultAny.subtype as string) || 'Unknown error';
-          this.onError?.(sessionId, { message: errorMsg });
+          const normalized = normalizeClaudeSDKError(resultAny);
+          const error = preferClaudeError(entry?.pendingError, normalized);
+          if (entry) {
+            entry.pendingError = error;
+            entry.pendingText = '';
+          }
+          this.onError?.(sessionId, { message: error.message });
+        } else {
+          if (entry) entry.pendingError = undefined;
+          this.flushConclusion(sessionId);
         }
 
         // Update final usage
@@ -1248,9 +1323,8 @@ export class ClaudeAdapter extends AgentAdapter {
           this.onUsageUpdate?.(sessionId, updated);
         }
 
-        // Flush any buffered prose as the turn's single conclusion bubble
-        // before going idle (draft-bubble model).
-        this.flushConclusion(sessionId);
+        // The result is the authoritative turn boundary.
+        if (entry) entry.turnFinalized = true;
         this.onIdle?.(sessionId);
 
         // Poll for SDK-native title changes (the SDK auto-generates titles

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -111,8 +111,11 @@ interface SessionEntry {
   session: CopilotSession;
   pendingPermissions: Map<string, PendingPermission>;
   pendingQuestions: Map<string, PendingQuestion>;
-  /** Relay-owned logical turn identity echoed by terminal callbacks. */
+  /** Relay-owned logical turn identity for the next accepted prompt. */
   relayTurnId?: string;
+  /** Identity captured at assistant.turn_start and used by all events in that
+   * provider cycle. */
+  eventTurnId?: string;
   turnSettled?: boolean;
 }
 
@@ -517,6 +520,8 @@ export class CopilotAdapter extends AgentAdapter {
     const entry = this.sessions.get(sessionId);
     if (entry) {
       entry.relayTurnId = turnId;
+      // Keep the previous provider-run snapshot until assistant.turn_start;
+      // callbacks in the handoff window must not inherit the new ID.
       entry.turnSettled = false;
     }
   }
@@ -526,7 +531,8 @@ export class CopilotAdapter extends AgentAdapter {
   }
 
   private lifecycleEvent(sessionId: string): { turnId?: string } {
-    const turnId = this.sessions.get(sessionId)?.relayTurnId;
+    const entry = this.sessions.get(sessionId);
+    const turnId = entry?.eventTurnId ?? entry?.relayTurnId;
     return turnId ? { turnId } : {};
   }
 
@@ -541,7 +547,8 @@ export class CopilotAdapter extends AgentAdapter {
   private emitIdle(sessionId: string): void {
     const entry = this.sessions.get(sessionId);
     if (entry) entry.turnSettled = true;
-    if (entry?.relayTurnId) this.onIdle?.(sessionId, { turnId: entry.relayTurnId });
+    const event = this.lifecycleEvent(sessionId);
+    if (event.turnId) this.onIdle?.(sessionId, event);
     else this.onIdle?.(sessionId);
   }
 
@@ -1003,7 +1010,7 @@ export class CopilotAdapter extends AgentAdapter {
     const session = await this.client!.createSession(sessionConfig);
     const sid = session.sessionId;
 
-    this.sessions.set(sid, { session, pendingPermissions, pendingQuestions, relayTurnId: undefined });
+    this.sessions.set(sid, { session, pendingPermissions, pendingQuestions, relayTurnId: undefined, eventTurnId: undefined });
     this.touchSession(sid);
     this.wireEvents(sid, session);
     this.linkCopilotStore(sid);
@@ -1539,7 +1546,7 @@ export class CopilotAdapter extends AgentAdapter {
       sessionId,
       this.makeResumeConfig(sessionId, pendingPermissions, pendingQuestions),
     );
-    const entry = { session, pendingPermissions, pendingQuestions, relayTurnId: undefined };
+    const entry = { session, pendingPermissions, pendingQuestions, relayTurnId: undefined, eventTurnId: undefined };
 
     this.sessions.set(sessionId, entry);
     this.touchSession(sessionId);
@@ -1634,8 +1641,8 @@ export class CopilotAdapter extends AgentAdapter {
     const text = (this.pendingNarration.get(sessionId) ?? '').trim();
     this.pendingNarration.delete(sessionId);
     if (text) {
-      this.onNarration?.(sessionId, { content: text });
-      this.onNarrationTrace?.(sessionId, { content: text });
+      this.onNarration?.(sessionId, { content: text, ...this.lifecycleEvent(sessionId) });
+      this.onNarrationTrace?.(sessionId, { content: text, ...this.lifecycleEvent(sessionId) });
     }
   }
 
@@ -1661,7 +1668,7 @@ export class CopilotAdapter extends AgentAdapter {
     }
 
     session.on('assistant.message_delta', (event) => {
-      this.onMessageDelta?.(sessionId, { content: event.data.deltaContent });
+      this.onMessageDelta?.(sessionId, { content: event.data.deltaContent, ...this.lifecycleEvent(sessionId) });
     });
 
     session.on('assistant.message', (event) => {
@@ -1715,6 +1722,7 @@ export class CopilotAdapter extends AgentAdapter {
         data.mcpToolName as string | undefined,
       );
       this.onToolStart?.(sessionId, {
+        ...this.lifecycleEvent(sessionId),
         toolName: protocolToolName,
         args,
         toolCallId,
@@ -1799,6 +1807,7 @@ export class CopilotAdapter extends AgentAdapter {
       clearInflight();
 
       this.onToolComplete?.(sessionId, {
+        ...this.lifecycleEvent(sessionId),
         toolName,
         result,
         toolCallId,
@@ -1813,7 +1822,7 @@ export class CopilotAdapter extends AgentAdapter {
           (a): a is import('@kraki/protocol').ContentRef => a.type === 'content_ref',
         );
         if (refs.length > 0) {
-          this.onAttachmentBytes?.(sessionId, { refs });
+          this.onAttachmentBytes?.(sessionId, { refs, ...this.lifecycleEvent(sessionId) });
         }
       }
     });
@@ -1845,6 +1854,8 @@ export class CopilotAdapter extends AgentAdapter {
     });
 
     session.on('assistant.turn_start', () => {
+      const entry = this.sessions.get(sessionId);
+      if (entry) entry.eventTurnId = entry.relayTurnId;
       this.clearIdleTimer(sessionId);
       this.turnHasOutput.set(sessionId, false);
       // Only reset if no error was reported before this turn started
@@ -2029,6 +2040,7 @@ export class CopilotAdapter extends AgentAdapter {
       }, 'permission requested');
 
       this.onPermissionRequest?.(sessionId, {
+        ...this.lifecycleEvent(sessionId),
         id: permId,
         ...parsed,
       });
@@ -2064,6 +2076,7 @@ export class CopilotAdapter extends AgentAdapter {
       }, 'question requested');
 
       this.onQuestionRequest?.(sessionId, {
+        ...this.lifecycleEvent(sessionId),
         id: qId,
         question: req.question ?? '',
         choices: req.choices ?? undefined,

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -111,6 +111,9 @@ interface SessionEntry {
   session: CopilotSession;
   pendingPermissions: Map<string, PendingPermission>;
   pendingQuestions: Map<string, PendingQuestion>;
+  /** Relay-owned logical turn identity echoed by terminal callbacks. */
+  relayTurnId?: string;
+  turnSettled?: boolean;
 }
 
 // ── Helpers ─────────────────────────────────────────────
@@ -508,6 +511,38 @@ export class CopilotAdapter extends AgentAdapter {
     this.cliPath = options.cliPath;
     this.attachmentStore = options.attachmentStore;
     this.krakiMcp = options.krakiMcp;
+  }
+
+  setTurnIdentity(sessionId: string, turnId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry) {
+      entry.relayTurnId = turnId;
+      entry.turnSettled = false;
+    }
+  }
+
+  isTurnSettled(sessionId: string): boolean {
+    return this.sessions.get(sessionId)?.turnSettled === true;
+  }
+
+  private lifecycleEvent(sessionId: string): { turnId?: string } {
+    const turnId = this.sessions.get(sessionId)?.relayTurnId;
+    return turnId ? { turnId } : {};
+  }
+
+  private emitMessage(sessionId: string, content: string): void {
+    this.onMessage?.(sessionId, { content, ...this.lifecycleEvent(sessionId) });
+  }
+
+  private emitError(sessionId: string, message: string): void {
+    this.onError?.(sessionId, { message, ...this.lifecycleEvent(sessionId) });
+  }
+
+  private emitIdle(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry) entry.turnSettled = true;
+    if (entry?.relayTurnId) this.onIdle?.(sessionId, { turnId: entry.relayTurnId });
+    else this.onIdle?.(sessionId);
   }
 
   private readonly attachmentStore?: import('../attachment-store.js').AttachmentStore;
@@ -968,7 +1003,7 @@ export class CopilotAdapter extends AgentAdapter {
     const session = await this.client!.createSession(sessionConfig);
     const sid = session.sessionId;
 
-    this.sessions.set(sid, { session, pendingPermissions, pendingQuestions });
+    this.sessions.set(sid, { session, pendingPermissions, pendingQuestions, relayTurnId: undefined });
     this.touchSession(sid);
     this.wireEvents(sid, session);
     this.linkCopilotStore(sid);
@@ -1504,7 +1539,7 @@ export class CopilotAdapter extends AgentAdapter {
       sessionId,
       this.makeResumeConfig(sessionId, pendingPermissions, pendingQuestions),
     );
-    const entry = { session, pendingPermissions, pendingQuestions };
+    const entry = { session, pendingPermissions, pendingQuestions, relayTurnId: undefined };
 
     this.sessions.set(sessionId, entry);
     this.touchSession(sessionId);
@@ -1541,12 +1576,10 @@ export class CopilotAdapter extends AgentAdapter {
   private handleUnavailableSession(sessionId: string, err: unknown): void {
     this.broadcastPendingResolutions(sessionId);
 
-    this.sessions.delete(sessionId);
     this.cleanupSessionPermissions(sessionId);
     logger.warn({ err, sessionId }, 'Session became unavailable');
-    this.onError?.(sessionId, {
-      message: 'Session is no longer active in Copilot. Please start a new session.',
-    });
+    this.emitError(sessionId, 'Session is no longer active in Copilot. Please start a new session.');
+    this.sessions.delete(sessionId);
     this.onSessionEnded?.(sessionId, { reason: 'session unavailable' });
   }
 
@@ -1588,9 +1621,7 @@ export class CopilotAdapter extends AgentAdapter {
   private fireAuthError(sessionId: string, err: unknown): void {
     const raw = getErrorMessage(err);
     logger.error({ sessionId, err }, 'Authentication error detected');
-    this.onError?.(sessionId, {
-      message: `GitHub credential expired or invalid: ${raw}\n\nRun one of the following on the host machine to re-authenticate:\n• \`copilot /login\`\n• \`gh auth login\``,
-    });
+    this.emitError(sessionId, `GitHub credential expired or invalid: ${raw}\n\nRun one of the following on the host machine to re-authenticate:\n• \`copilot /login\`\n• \`gh auth login\``);
   }
 
   // ── SDK → callback wiring ─────────────────────────
@@ -1615,7 +1646,7 @@ export class CopilotAdapter extends AgentAdapter {
   private flushConclusion(sessionId: string): void {
     const text = (this.pendingNarration.get(sessionId) ?? '').trim();
     this.pendingNarration.delete(sessionId);
-    if (text) this.onMessage?.(sessionId, { content: text });
+    if (text) this.emitMessage(sessionId, text);
   }
 
   private wireEvents(sessionId: string, session: CopilotSession): void {
@@ -1800,9 +1831,7 @@ export class CopilotAdapter extends AgentAdapter {
       const wasAborted = this.cycleUserAborted.get(sessionId);
       if (hasOutput === false && !hadError && !wasAborted) {
         logger.warn({ sessionId }, 'Empty cycle detected — agent produced no output for entire user message');
-        this.onError?.(sessionId, {
-          message: 'Agent produced no output. The session may need to be restarted or the model may be unavailable.',
-        });
+        this.emitError(sessionId, 'Agent produced no output. The session may need to be restarted or the model may be unavailable.');
       }
       // Clear the abort flag — next sendMessage starts a fresh cycle anyway,
       // but clearing here keeps state tidy if no new sendMessage follows.
@@ -1811,7 +1840,7 @@ export class CopilotAdapter extends AgentAdapter {
       // Flush any buffered prose as the turn's single conclusion bubble
       // before going idle (draft-bubble model).
       this.flushConclusion(sessionId);
-      this.onIdle?.(sessionId);
+      this.emitIdle(sessionId);
       this.signalFlushComplete(sessionId);
     });
 
@@ -1835,7 +1864,7 @@ export class CopilotAdapter extends AgentAdapter {
         if (await this.probeRuntime() === 'auth_error') {
           this.fireAuthError(sessionId, message);
         } else {
-          this.onError?.(sessionId, { message });
+          this.emitError(sessionId, message);
         }
       }
     });
@@ -1859,15 +1888,13 @@ export class CopilotAdapter extends AgentAdapter {
       if (entry) {
         entry.session.abort().catch(() => {});
         entry.session.disconnect().catch(() => {});
-        this.sessions.delete(sessionId);
       }
 
-      this.onError?.(sessionId, {
-        message: `${requested} is currently unavailable. Session paused — send a message to retry.`,
-      });
+      this.emitError(sessionId, `${requested} is currently unavailable. Session paused — send a message to retry.`);
       // Discard any buffered prose — the turn is being torn down, not concluded.
       this.pendingNarration.delete(sessionId);
-      this.onIdle?.(sessionId);
+      this.emitIdle(sessionId);
+      if (entry) this.sessions.delete(sessionId);
       this.signalFlushComplete(sessionId);
       this.cleanupSessionPermissions(sessionId);
     });
@@ -1897,7 +1924,7 @@ export class CopilotAdapter extends AgentAdapter {
         if (await this.probeRuntime() === 'auth_error') {
           this.fireAuthError(sessionId, errorMsg);
         } else {
-          this.onError?.(sessionId, { message: errorMsg });
+          this.emitError(sessionId, errorMsg);
         }
       }
 
@@ -1913,7 +1940,7 @@ export class CopilotAdapter extends AgentAdapter {
         this.idleTimers.delete(sessionId);
         logger.info({ sessionId }, 'Idle fallback fired (session.idle not received after turn_end)');
         this.flushConclusion(sessionId);
-        this.onIdle?.(sessionId);
+        this.emitIdle(sessionId);
         this.signalFlushComplete(sessionId);
       }, CopilotAdapter.IDLE_FALLBACK_MS));
     });

--- a/packages/tentacle/src/adapters/multi.ts
+++ b/packages/tentacle/src/adapters/multi.ts
@@ -405,7 +405,7 @@ export class MultiAgentAdapter extends AgentAdapter {
     adapter.onToolStart = (sid, e) => this.onToolStart?.(sid, e);
     adapter.onToolComplete = (sid, e) => this.onToolComplete?.(sid, e);
     adapter.onAttachmentBytes = (sid, e) => this.onAttachmentBytes?.(sid, e);
-    adapter.onIdle = (sid) => this.onIdle?.(sid);
+    adapter.onIdle = (sid, e) => this.onIdle?.(sid, e);
     adapter.onFlushComplete = (sid) => this.onFlushComplete?.(sid);
     adapter.onError = (sid, e) => this.onError?.(sid, e);
     adapter.onCompaction = (sid, e) => this.onCompaction?.(sid, e);
@@ -424,5 +424,13 @@ export class MultiAgentAdapter extends AgentAdapter {
     };
     adapter.onTitleChanged = (sid, t) => this.onTitleChanged?.(sid, t);
     adapter.onUsageUpdate = (sid, u) => this.onUsageUpdate?.(sid, u);
+  }
+
+  setTurnIdentity(sessionId: string, turnId: string): void {
+    this.getSessionAdapter(sessionId).setTurnIdentity(sessionId, turnId);
+  }
+
+  isTurnSettled(sessionId: string): boolean {
+    return this.getSessionAdapter(sessionId).isTurnSettled(sessionId);
   }
 }

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -356,6 +356,13 @@ interface PiSession {
    *  'error' | 'aborted' | 'toolUse' | …). 'error'/'aborted' mean the run did
    *  NOT produce a real answer → no finalize round, just idle. */
   lastStopReason: string | undefined;
+  /** Backend error held until agent_end says whether Pi will retry. */
+  pendingError: string | undefined;
+  /** Monotonic logical turn identity. Active-turn steer keeps this identity;
+   * post-settlement steer opens a new one. */
+  logicalTurn: number;
+  /** The logical turn whose terminal callbacks have been emitted, if any. */
+  settledTurn: number | undefined;
   /** The most recent narration segment whose TRACE mirror is still DEFERRED —
    *  not yet emitted as an `agent_narration` step because it might still
    *  graduate verbatim into the concluding bubble (skip-finalize / finalize
@@ -371,6 +378,9 @@ interface PiSession {
    *  finalize prompt and the following agent_end). During it, ordinary narration
    *  is suppressed so the draft stays frozen at `lastNarration`. */
   finalizing: boolean;
+  /** Monotonic identity for finalize prompt attempts. A late rejection from an
+   *  older request must not clear a newer finalize round. */
+  finalizeAttempt: number;
   /** True once finalize_reply was called in the finalize round (so agent_end
    *  doesn't fall back to a generated reply). */
   finalizeResolved: boolean;
@@ -765,7 +775,7 @@ export class PiAdapter extends AgentAdapter {
       extensionPath: this.ensureToolsExtension(),
       env,
     });
-    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), exitObserved: false, pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingNarration: '', aborting: false, finalizing: false, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
+    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), exitObserved: false, pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingError: undefined, logicalTurn: 0, settledTurn: 0, pendingNarration: '', aborting: false, finalizing: false, finalizeAttempt: 0, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
     proc.onEvent = (e) => this.handleEvent(sessionId, e);
     proc.onExit = () => {
       // Process gone (crash/kill) → no agent_end will arrive. Permissions cannot
@@ -775,7 +785,7 @@ export class PiAdapter extends AgentAdapter {
       sess.exitObserved = true;
       this.clearPendingPerms(sessionId);
       this.pendingModeSignals.delete(sessionId);
-      this.onIdle?.(sessionId);
+      this.emitIdleOnce(sessionId, sess);
       this.onSessionEvicted?.(sessionId);
     };
     proc.start();
@@ -842,11 +852,20 @@ export class PiAdapter extends AgentAdapter {
     return value === 'manual' || value === 'threshold' || value === 'overflow' ? value : undefined;
   }
 
+  private emitIdleOnce(sessionId: string, s: PiSession): void {
+    if (s.settledTurn === s.logicalTurn) return;
+    s.settledTurn = s.logicalTurn;
+    this.onIdle?.(sessionId);
+  }
+
   private resetTurnTracking(s: PiSession): void {
+    s.logicalTurn += 1;
+    s.settledTurn = undefined;
     s.narrationSegments = 0;
     s.toolSinceLastNarration = false;
     s.lastNarration = '';
     s.lastStopReason = undefined;
+    s.pendingError = undefined;
     s.pendingNarration = '';
     s.aborting = false;
     s.finalizing = false;
@@ -990,13 +1009,16 @@ export class PiAdapter extends AgentAdapter {
           const s = this.sessions.get(sessionId);
           // A backend failure (bad model, 400, quota, rate-limit) surfaces here
           // as stopReason:'error' with an empty content[] and an errorMessage.
-          // Without this the session would just go idle with no response — the
-          // exact silent-failure bug we guard against. agent_end still fires
-          // afterwards, so idle clears normally.
-          if (m.stopReason === 'error' && m.errorMessage) {
-            this.onError?.(sessionId, { message: m.errorMessage });
+          // Hold it until agent_end says whether Pi will retry; a later successful
+          // message_end supersedes this provisional failure.
+          if (s) {
+            s.lastStopReason = m.stopReason;
+            if (m.stopReason === 'error') {
+              s.pendingError = m.errorMessage;
+            } else {
+              s.pendingError = undefined;
+            }
           }
-          if (s) s.lastStopReason = m.stopReason;
           const prose = (m.content ?? [])
             .filter((c) => c.type === 'text' && typeof c.text === 'string')
             .map((c) => c.text as string)
@@ -1160,16 +1182,36 @@ export class PiAdapter extends AgentAdapter {
         // into a single turn. Idle is only the run boundary (agent_end).
         void this.refreshUsage(sessionId);
         break;
-      case 'agent_end': {
+      case 'agent_end':
         void this.refreshUsage(sessionId);
-        // pi fires agent_end again after an auto-retry/compaction continuation;
-        // willRetry === true means "not actually done" — skip the premature idle.
-        if (e.willRetry === true) break;
+        logger.info({
+          sessionId,
+          turnId: this.sessions.get(sessionId)?.logicalTurn,
+          phase: 'agent_end',
+          attempt: typeof e.attempt === 'number' ? e.attempt : undefined,
+          willRetry: e.willRetry === true,
+        }, 'pi agent lifecycle');
+        // agent_end only closes one low-level provider run. Pi may still perform
+        // retry, compaction recovery, or queued continuation work. Terminal
+        // Kraki callbacks are handled exclusively by agent_settled below.
+        break;
+      case 'agent_settled': {
+        void this.refreshUsage(sessionId);
+        logger.info({
+          sessionId,
+          turnId: this.sessions.get(sessionId)?.logicalTurn,
+          phase: 'agent_settled',
+          attempt: typeof e.attempt === 'number' ? e.attempt : undefined,
+          willRetry: false,
+        }, 'pi agent lifecycle');
         const s = this.sessions.get(sessionId);
         if (!s) {
           this.onIdle?.(sessionId);
           break;
         }
+        // A duplicate settled callback must not crystallize the same logical turn
+        // twice. The identity is reset only when a new prompt is accepted.
+        if (s.settledTurn === s.logicalTurn) break;
         if (s.aborting) {
           // abortSession owns the terminal idle(reason=aborted) notification.
           // Pi emits agent_end before acknowledging the abort RPC; do not turn
@@ -1204,15 +1246,18 @@ export class PiAdapter extends AgentAdapter {
             }
           }
           s.finalizing = false;
-          this.onIdle?.(sessionId);
+          this.emitIdleOnce(sessionId, s);
           break;
         }
-        // A backend failure / cancellation already surfaced via onError at
-        // message_end. Don't synthesize a closing reply and don't start a
-        // finalize round that re-runs the model on a dead/broken turn.
+        // Resolve a provisional backend failure only at this authoritative run
+        // boundary. Recoverable attempts were suppressed by willRetry above.
         if (s.lastStopReason === 'error' || s.lastStopReason === 'aborted') {
           s.pendingNarration = '';
-          this.onIdle?.(sessionId);
+          if (s.lastStopReason === 'error' && s.pendingError) {
+            this.onError?.(sessionId, { message: s.pendingError });
+            s.pendingError = undefined;
+          }
+          this.emitIdleOnce(sessionId, s);
           break;
         }
         // The run produced a natural closing answer: the last narration was not
@@ -1230,17 +1275,37 @@ export class PiAdapter extends AgentAdapter {
           // the deferred trace so it isn't ALSO shown as the last Step.
           s.pendingNarration = '';
           this.onMessage?.(sessionId, { content: s.lastNarration.trim() });
-          this.onIdle?.(sessionId);
+          this.emitIdleOnce(sessionId, s);
           break;
         }
         if (s.proc.alive) {
           s.finalizing = true;
+          const finalizeAttempt = ++s.finalizeAttempt;
           s.finalizeResolved = false;
           s.finalizeNarration = '';
           s.finalizeStreamId = undefined;
           s.finalizeStreamLen = 0;
           logger.debug({ sessionId, segments: s.narrationSegments }, 'injecting finalize round');
-          s.proc.send('prompt', { message: finalizePrompt(s.lastNarration) });
+          void s.proc.request(
+            'prompt',
+            { message: finalizePrompt(s.lastNarration) },
+            { timeoutMs: null },
+          ).catch((err: unknown) => {
+            // Ignore a stale rejection after this finalize round ended or a newer
+            // attempt took ownership of the session.
+            if (!s.finalizing || s.finalizeAttempt !== finalizeAttempt || s.exitObserved) return;
+            s.finalizing = false;
+            s.finalizeResolved = false;
+            s.finalizeNarration = '';
+            s.finalizeStreamId = undefined;
+            s.finalizeStreamLen = 0;
+            s.pendingNarration = '';
+            const fallback = s.lastNarration.trim();
+            if (fallback) this.onMessage?.(sessionId, { content: fallback });
+            else this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
+            logger.warn({ sessionId, err: (err as Error).message }, 'pi finalize prompt rejected');
+            this.emitIdleOnce(sessionId, s);
+          });
           break;
         }
         // Process gone before we could finalize — best-effort crystallize the
@@ -1248,7 +1313,7 @@ export class PiAdapter extends AgentAdapter {
         s.pendingNarration = '';
         const fallback = s.lastNarration.trim();
         if (fallback) this.onMessage?.(sessionId, { content: fallback });
-        this.onIdle?.(sessionId);
+        this.emitIdleOnce(sessionId, s);
         break;
       }
       case 'session_shutdown':
@@ -1421,12 +1486,17 @@ export class PiAdapter extends AgentAdapter {
     const promptPayload: Record<string, unknown> = { message: text, ...(images.length > 0 && { images }) };
 
     if (options?.delivery === 'steer') {
-      // `prompt + streamingBehavior: steer` is race-safe: while active it queues
-      // before the next LLM call; if Pi became idle between the app's state read
-      // and delivery, it starts a normal prompt instead of rejecting the input.
-      // It remains part of the current Kraki lifecycle, so do not reset/finalize
-      // local turn tracking or synthesize another idle.
-      await s.proc.request('prompt', { ...promptPayload, streamingBehavior: 'steer' }, { timeoutMs: null });
+      // A steer is only an interjection while this logical turn is active. Once
+      // Pi has settled it, explicitly convert the late steer into a fresh prompt
+      // so it cannot inherit the previous turn's narration/finalization state.
+      if (s.settledTurn === s.logicalTurn) {
+        this.resetTurnTracking(s);
+        await s.proc.request('prompt', promptPayload, { timeoutMs: null });
+      } else {
+        // While active, Pi queues the interjection before the next LLM call and
+        // it remains part of the current logical turn.
+        await s.proc.request('prompt', { ...promptPayload, streamingBehavior: 'steer' }, { timeoutMs: null });
+      }
       return;
     }
 

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -330,6 +330,8 @@ interface PiSession {
   sessionFile?: string;
   usage: SessionUsage;
   lastActivity: number;
+  /** Relay-owned logical turn identity echoed by terminal callbacks. */
+  relayTurnId?: string;
   /** Set before the process-exit callback publishes idle, so an in-flight
    *  prompt rejection cannot publish the same terminal idle a second time. */
   exitObserved: boolean;
@@ -775,25 +777,33 @@ export class PiAdapter extends AgentAdapter {
       extensionPath: this.ensureToolsExtension(),
       env,
     });
-    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), exitObserved: false, pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingError: undefined, logicalTurn: 0, settledTurn: 0, pendingNarration: '', aborting: false, finalizing: false, finalizeAttempt: 0, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
+    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), relayTurnId: undefined, exitObserved: false, pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingError: undefined, logicalTurn: 0, settledTurn: 0, pendingNarration: '', aborting: false, finalizing: false, finalizeAttempt: 0, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
     proc.onEvent = (e) => this.handleEvent(sessionId, e);
-    proc.onExit = () => {
-      // Process gone (crash/kill) → no agent_end will arrive. Permissions cannot
-      // be reconstructed, but ask_user is durable at RelayClient/CardManager:
-      // keep its id/card so the next answer can transparently use a recovery
-      // prompt after lazy resume.
-      sess.exitObserved = true;
-      this.clearPendingPerms(sessionId);
-      this.pendingModeSignals.delete(sessionId);
-      this.emitIdleOnce(sessionId, sess);
-      this.onSessionEvicted?.(sessionId);
-    };
+    proc.onExit = () => this.handleProcessExit(sessionId, sess);
     proc.start();
     this.sessions.set(sessionId, sess);
     // Write the meta sidecar up front so KRAKI_META_FILE points at a real file
     // (kraki_get_mode reads it) before the first turn runs.
     this.persistMeta(sessionId, sess);
     return sess;
+  }
+
+  private handleProcessExit(sessionId: string, sess: PiSession): void {
+    // Process gone (crash/kill) means agent_settled may never arrive.
+    // Permissions cannot be reconstructed, but ask_user is durable at
+    // RelayClient/CardManager: keep its id/card so the next answer can use a
+    // recovery prompt after lazy resume.
+    sess.exitObserved = true;
+    this.clearPendingPerms(sessionId);
+    this.pendingModeSignals.delete(sessionId);
+    // A concrete provider error must cross the adapter boundary before idle;
+    // otherwise Relay would freeze the turn as successful on process death.
+    if (sess.pendingError) {
+      this.emitError(sessionId, sess, sess.pendingError);
+      sess.pendingError = undefined;
+    }
+    this.emitIdleOnce(sessionId, sess);
+    this.onSessionEvicted?.(sessionId);
   }
 
   /** Drop any outstanding permission cards for a session (child died / respawn)
@@ -852,10 +862,33 @@ export class PiAdapter extends AgentAdapter {
     return value === 'manual' || value === 'threshold' || value === 'overflow' ? value : undefined;
   }
 
+  private lifecycleEvent(s: PiSession): { turnId?: string } {
+    return s.relayTurnId ? { turnId: s.relayTurnId } : {};
+  }
+
+  private emitMessage(sessionId: string, s: PiSession, content: string): void {
+    this.onMessage?.(sessionId, { content, ...this.lifecycleEvent(s) });
+  }
+
+  private emitError(sessionId: string, s: PiSession, message: string): void {
+    this.onError?.(sessionId, { message, ...this.lifecycleEvent(s) });
+  }
+
   private emitIdleOnce(sessionId: string, s: PiSession): void {
     if (s.settledTurn === s.logicalTurn) return;
     s.settledTurn = s.logicalTurn;
-    this.onIdle?.(sessionId);
+    if (s.relayTurnId) this.onIdle?.(sessionId, { turnId: s.relayTurnId });
+    else this.onIdle?.(sessionId);
+  }
+
+  setTurnIdentity(sessionId: string, turnId: string): void {
+    const s = this.sessions.get(sessionId);
+    if (s) s.relayTurnId = turnId;
+  }
+
+  isTurnSettled(sessionId: string): boolean {
+    const s = this.sessions.get(sessionId);
+    return !!s && s.settledTurn === s.logicalTurn;
   }
 
   private resetTurnTracking(s: PiSession): void {
@@ -1080,7 +1113,7 @@ export class PiAdapter extends AgentAdapter {
               // For resummarize the streamed text already replaced the draft; for
               // keep (resummarize:false) the draft is still the frozen narration.
               // onMessage clears the draft and lands the permanent bubble in place.
-              this.onMessage?.(sessionId, { content: reply });
+              this.emitMessage(sessionId, s, reply);
             } else {
               this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
             }
@@ -1237,11 +1270,11 @@ export class PiAdapter extends AgentAdapter {
             const finalizeProse = s.finalizeNarration.trim();
             if (finalizeProse) {
               this.flushPendingNarration(sessionId, s);
-              this.onMessage?.(sessionId, { content: finalizeProse });
+              this.emitMessage(sessionId, s, finalizeProse);
             } else {
               s.pendingNarration = '';
               const draft = s.lastNarration.trim();
-              if (draft) this.onMessage?.(sessionId, { content: draft });
+              if (draft) this.emitMessage(sessionId, s, draft);
               else this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
             }
           }
@@ -1254,7 +1287,7 @@ export class PiAdapter extends AgentAdapter {
         if (s.lastStopReason === 'error' || s.lastStopReason === 'aborted') {
           s.pendingNarration = '';
           if (s.lastStopReason === 'error' && s.pendingError) {
-            this.onError?.(sessionId, { message: s.pendingError });
+            this.emitError(sessionId, s, s.pendingError);
             s.pendingError = undefined;
           }
           this.emitIdleOnce(sessionId, s);
@@ -1274,7 +1307,7 @@ export class PiAdapter extends AgentAdapter {
           // The trailing narration graduates verbatim into the bubble — discard
           // the deferred trace so it isn't ALSO shown as the last Step.
           s.pendingNarration = '';
-          this.onMessage?.(sessionId, { content: s.lastNarration.trim() });
+          this.emitMessage(sessionId, s, s.lastNarration.trim());
           this.emitIdleOnce(sessionId, s);
           break;
         }
@@ -1301,7 +1334,7 @@ export class PiAdapter extends AgentAdapter {
             s.finalizeStreamLen = 0;
             s.pendingNarration = '';
             const fallback = s.lastNarration.trim();
-            if (fallback) this.onMessage?.(sessionId, { content: fallback });
+            if (fallback) this.emitMessage(sessionId, s, fallback);
             else this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
             logger.warn({ sessionId, err: (err as Error).message }, 'pi finalize prompt rejected');
             this.emitIdleOnce(sessionId, s);
@@ -1312,7 +1345,7 @@ export class PiAdapter extends AgentAdapter {
         // kept draft, which graduates into the bubble → discard its deferred trace.
         s.pendingNarration = '';
         const fallback = s.lastNarration.trim();
-        if (fallback) this.onMessage?.(sessionId, { content: fallback });
+        if (fallback) this.emitMessage(sessionId, s, fallback);
         this.emitIdleOnce(sessionId, s);
         break;
       }
@@ -1548,10 +1581,10 @@ export class PiAdapter extends AgentAdapter {
         return;
       }
       logger.warn({ sessionId, err: message }, 'pi prompt request failed');
-      this.onError?.(sessionId, { message });
+      this.emitError(sessionId, s, message);
       // Unexpected process exit owns its terminal idle in proc.onExit. Other
       // transport/watchdog failures still need to release the active UI here.
-      if (!s.exitObserved) this.onIdle?.(sessionId);
+      if (!s.exitObserved) this.emitIdleOnce(sessionId, s);
     }
   }
 

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -330,8 +330,10 @@ interface PiSession {
   sessionFile?: string;
   usage: SessionUsage;
   lastActivity: number;
-  /** Relay-owned logical turn identity echoed by terminal callbacks. */
+  /** Relay-owned logical turn identity for the next accepted prompt. */
   relayTurnId?: string;
+  /** Identity captured when the provider run started. */
+  eventTurnId?: string;
   /** Set before the process-exit callback publishes idle, so an in-flight
    *  prompt rejection cannot publish the same terminal idle a second time. */
   exitObserved: boolean;
@@ -777,7 +779,7 @@ export class PiAdapter extends AgentAdapter {
       extensionPath: this.ensureToolsExtension(),
       env,
     });
-    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), relayTurnId: undefined, exitObserved: false, pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingError: undefined, logicalTurn: 0, settledTurn: 0, pendingNarration: '', aborting: false, finalizing: false, finalizeAttempt: 0, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
+    const sess: PiSession = { proc, cwd, model, mode, thinking, sessionFile, usage: this.blankUsage(), lastActivity: Date.now(), relayTurnId: undefined, eventTurnId: undefined, exitObserved: false, pendingPerms: new Map(), pendingQuestions: new Map(), narrationSegments: 0, toolSinceLastNarration: false, lastNarration: '', lastStopReason: undefined, pendingError: undefined, logicalTurn: 0, settledTurn: 0, pendingNarration: '', aborting: false, finalizing: false, finalizeAttempt: 0, finalizeResolved: false, finalizeNarration: '', finalizeStreamLen: 0 };
     proc.onEvent = (e) => this.handleEvent(sessionId, e);
     proc.onExit = () => this.handleProcessExit(sessionId, sess);
     proc.start();
@@ -838,7 +840,7 @@ export class PiAdapter extends AgentAdapter {
    *  so it can never be the graduating reply. Clears the pending slot. */
   private flushPendingNarration(sessionId: string, s: PiSession): void {
     if (s.pendingNarration) {
-      this.onNarrationTrace?.(sessionId, { content: s.pendingNarration });
+      this.onNarrationTrace?.(sessionId, { content: s.pendingNarration, ...this.lifecycleEvent(s) });
       s.pendingNarration = '';
     }
   }
@@ -851,19 +853,20 @@ export class PiAdapter extends AgentAdapter {
     if (active) {
       if (this.compactingSessions.has(sessionId)) return;
       this.compactingSessions.add(sessionId);
-      this.onCompaction?.(sessionId, { phase: 'start', ...event });
+      this.onCompaction?.(sessionId, { phase: 'start', ...event, ...this.lifecycleEvent(this.sessions.get(sessionId)) });
       return;
     }
     if (!this.compactingSessions.delete(sessionId)) return;
-    this.onCompaction?.(sessionId, { phase: 'end', ...event });
+    this.onCompaction?.(sessionId, { phase: 'end', ...event, ...this.lifecycleEvent(this.sessions.get(sessionId)) });
   }
 
   private normalizeCompactionReason(value: unknown): import('./base.js').CompactionReason | undefined {
     return value === 'manual' || value === 'threshold' || value === 'overflow' ? value : undefined;
   }
 
-  private lifecycleEvent(s: PiSession): { turnId?: string } {
-    return s.relayTurnId ? { turnId: s.relayTurnId } : {};
+  private lifecycleEvent(s?: PiSession): { turnId?: string } {
+    const turnId = s?.eventTurnId ?? s?.relayTurnId;
+    return turnId ? { turnId } : {};
   }
 
   private emitMessage(sessionId: string, s: PiSession, content: string): void {
@@ -877,13 +880,18 @@ export class PiAdapter extends AgentAdapter {
   private emitIdleOnce(sessionId: string, s: PiSession): void {
     if (s.settledTurn === s.logicalTurn) return;
     s.settledTurn = s.logicalTurn;
-    if (s.relayTurnId) this.onIdle?.(sessionId, { turnId: s.relayTurnId });
+    const event = this.lifecycleEvent(s);
+    if (event.turnId) this.onIdle?.(sessionId, event);
     else this.onIdle?.(sessionId);
   }
 
   setTurnIdentity(sessionId: string, turnId: string): void {
     const s = this.sessions.get(sessionId);
-    if (s) s.relayTurnId = turnId;
+    if (!s) return;
+    s.relayTurnId = turnId;
+    // A new prompt captures its identity at agent_start. Keep the previous
+    // snapshot until that boundary so a late callback from the old run cannot
+    // fall back to this newly assigned relayTurnId.
   }
 
   isTurnSettled(sessionId: string): boolean {
@@ -992,11 +1000,14 @@ export class PiAdapter extends AgentAdapter {
           errorMessage: typeof e.errorMessage === 'string' ? e.errorMessage : undefined,
         });
         break;
-      case 'agent_start':
+      case 'agent_start': {
+        const s = this.sessions.get(sessionId);
+        if (s) s.eventTurnId = s.relayTurnId;
         // Streaming proves any preceding compaction is over even if its end
         // event was missed during resume/reconciliation.
         this.setCompacting(sessionId, false);
         break;
+      }
       case 'message_update': {
         // Real model/tool activity also proves a stale compaction indicator is
         // no longer current. Clear only the adapter-owned compaction lifecycle;
@@ -1009,7 +1020,7 @@ export class PiAdapter extends AgentAdapter {
           // at the kept closing line (lastNarration) — any pre-thinking prose the
           // model emits before calling finalize_reply is suppressed so the draft
           // doesn't churn. Outside the finalize round, narration streams normally.
-          if (!s?.finalizing) this.onMessageDelta?.(sessionId, { content: am.delta });
+          if (!s?.finalizing) this.onMessageDelta?.(sessionId, { content: am.delta, ...this.lifecycleEvent(s) });
           break;
         }
         // finalize_reply streams its `text` arg like prose: pi parses the partial
@@ -1030,7 +1041,7 @@ export class PiAdapter extends AgentAdapter {
             if (txt.length > s.finalizeStreamLen) {
               const suffix = txt.slice(s.finalizeStreamLen);
               s.finalizeStreamLen = txt.length;
-              this.onFinalizeDelta?.(sessionId, { content: suffix });
+              this.onFinalizeDelta?.(sessionId, { content: suffix, ...this.lifecycleEvent(s) });
             }
           }
         }
@@ -1074,7 +1085,7 @@ export class PiAdapter extends AgentAdapter {
               // confirmed intermediate (a newer narration or a tool follows) —
               // never the trailing reply. Flush the PREVIOUS pending here (a new
               // segment supersedes it). Tracked for the skip-finalize rule.
-              this.onNarration?.(sessionId, { content: prose });
+              this.onNarration?.(sessionId, { content: prose, ...this.lifecycleEvent(s) });
               this.flushPendingNarration(sessionId, s);
               s.pendingNarration = prose;
               s.narrationSegments += 1;
@@ -1115,7 +1126,7 @@ export class PiAdapter extends AgentAdapter {
               // onMessage clears the draft and lands the permanent bubble in place.
               this.emitMessage(sessionId, s, reply);
             } else {
-              this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
+              this.onSystemMessage?.(sessionId, { kind: 'no_reply', ...this.lifecycleEvent(s) });
             }
           }
           break;
@@ -1133,6 +1144,7 @@ export class PiAdapter extends AgentAdapter {
           s.toolSinceLastNarration = true;
         }
         this.onToolStart?.(sessionId, {
+          ...this.lifecycleEvent(s),
           toolName,
           args: (e.args as Record<string, unknown>) ?? {},
           toolCallId: e.toolCallId as string | undefined,
@@ -1195,6 +1207,7 @@ export class PiAdapter extends AgentAdapter {
         }
         if (outputAttachments.length > 0 && !resultText) resultText = 'Output is ready.';
         this.onToolComplete?.(sessionId, {
+          ...this.lifecycleEvent(this.sessions.get(sessionId)),
           toolName,
           result: resultText,
           toolCallId: e.toolCallId as string | undefined,
@@ -1205,7 +1218,7 @@ export class PiAdapter extends AgentAdapter {
           const refs = outputAttachments.filter(
             (a): a is import('@kraki/protocol').ContentRef => a.type === 'content_ref',
           );
-          if (refs.length > 0) this.onAttachmentBytes?.(sessionId, { refs });
+          if (refs.length > 0) this.onAttachmentBytes?.(sessionId, { refs, ...this.lifecycleEvent(this.sessions.get(sessionId)) });
         }
         break;
       }
@@ -1275,7 +1288,7 @@ export class PiAdapter extends AgentAdapter {
               s.pendingNarration = '';
               const draft = s.lastNarration.trim();
               if (draft) this.emitMessage(sessionId, s, draft);
-              else this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
+              else this.onSystemMessage?.(sessionId, { kind: 'no_reply', ...this.lifecycleEvent(s) });
             }
           }
           s.finalizing = false;
@@ -1335,7 +1348,7 @@ export class PiAdapter extends AgentAdapter {
             s.pendingNarration = '';
             const fallback = s.lastNarration.trim();
             if (fallback) this.emitMessage(sessionId, s, fallback);
-            else this.onSystemMessage?.(sessionId, { kind: 'no_reply' });
+            else this.onSystemMessage?.(sessionId, { kind: 'no_reply', ...this.lifecycleEvent(s) });
             logger.warn({ sessionId, err: (err as Error).message }, 'pi finalize prompt rejected');
             this.emitIdleOnce(sessionId, s);
           });
@@ -1364,6 +1377,7 @@ export class PiAdapter extends AgentAdapter {
           s.pendingQuestions.set(qid, qid);
           const choices = Array.isArray(e.options) ? (e.options as string[]) : undefined;
           this.onQuestionRequest?.(sessionId, {
+            ...this.lifecycleEvent(s),
             id: qid,
             question: String(e.title ?? 'The agent has a question'),
             choices,
@@ -1404,7 +1418,7 @@ export class PiAdapter extends AgentAdapter {
         s.pendingPerms.set(permId, permId);
         const { toolArgs, description } = parsePiPermission(toolName, inputJson);
         logger.debug({ sessionId, permId, toolName: toolArgs.toolName }, 'pi permission requested');
-        this.onPermissionRequest?.(sessionId, { id: permId, toolArgs, description });
+        this.onPermissionRequest?.(sessionId, { ...this.lifecycleEvent(s), id: permId, toolArgs, description });
         break;
       }
       default:
@@ -1585,6 +1599,10 @@ export class PiAdapter extends AgentAdapter {
       // Unexpected process exit owns its terminal idle in proc.onExit. Other
       // transport/watchdog failures still need to release the active UI here.
       if (!s.exitObserved) this.emitIdleOnce(sessionId, s);
+      // RelayClient records this as rejected, making a replay with the same
+      // clientId retry the already-persisted transcript row. Do not turn an
+      // unacknowledged adapter request into a falsely delivered input.
+      throw err;
     }
   }
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -255,6 +255,24 @@ export class RelayClient {
     return false;
   }
 
+  /** Non-terminal events must not mutate a turn after its terminal boundary.
+   * Legacy untagged callbacks retain compatibility; real adapters tag every
+   * turn-scoped event so a same-turn late callback is rejected here. */
+  private acceptsAdapterEvent(sessionId: string, turnId?: string): boolean {
+    if (!this.acceptsAdapterTurn(sessionId, turnId)) return false;
+    if (turnId && this.settledAdapterTurnIds.get(sessionId) === turnId) {
+      traceLog.info({
+        ns: process.hrtime.bigint().toString(),
+        comp: 'tentacle',
+        evt: 'ADAPTER-SETTLED-CALLBACK',
+        sessionId,
+        turnId,
+      });
+      return false;
+    }
+    return true;
+  }
+
   private inputFingerprint(
     text: string,
     attachments?: import('@kraki/protocol').Attachment[],
@@ -303,7 +321,12 @@ export class RelayClient {
       ? proposedAnchor
       : Math.max(proposedAnchor, (this.nextInputTurnAnchors.get(sessionId) ?? 0) + 1);
     if (effectiveDelivery === 'prompt') this.nextInputTurnAnchors.set(sessionId, turnAnchor);
-    const turnId = `${sessionId}:${turnAnchor}`;
+    // An accepted active-turn steer stays inside the provider run that is
+    // already in flight. Reuse its identity so provider callbacks captured at
+    // that run boundary remain admissible; only a stale steer opens a new turn.
+    const turnId = effectiveDelivery === 'steer' && !staleSteer
+      ? this.activeInputTurnIds.get(sessionId) ?? `${sessionId}:${turnAnchor}`
+      : `${sessionId}:${turnAnchor}`;
     if (!clientId) return { duplicate: false, conflict: false, recovery: false, effectiveDelivery, turnId };
 
     const fingerprint = this.inputFingerprint(text, attachments);
@@ -320,7 +343,11 @@ export class RelayClient {
       // sending the replayed payload again. `dispatching` is deliberately
       // treated as at-most-once: the daemon may have crossed the adapter
       // boundary before it crashed, so replaying it could duplicate the turn.
-      if (existing.status === 'persisted' && existing.userSeq !== undefined) {
+      if ((existing.status === 'persisted' || existing.status === 'rejected') && existing.userSeq !== undefined) {
+        // A rejected adapter call is known not to have been acknowledged. The
+        // transcript row already exists, so retry the same clientId without
+        // appending another user_message. `dispatching` remains at-most-once:
+        // a crash may have crossed the adapter boundary before the state write.
         return { duplicate: false, conflict: false, recovery: true, effectiveDelivery: existing.delivery === 'steer' ? 'steer' : 'prompt', turnId: existing.turnId, entry: existing };
       }
       if (existing.status === 'pending') {
@@ -729,6 +756,7 @@ export class RelayClient {
     pending: PendingHumanAction,
     answer: { text: string; attachments?: import('@kraki/protocol').Attachment[] },
     wasFreeform: boolean,
+    turnId?: string,
   ): Promise<void> {
     await this.ensureSessionResumed(sessionId);
     const result = await this.adapter.respondToQuestion(sessionId, pending.questionId, answer, wasFreeform);
@@ -744,7 +772,7 @@ export class RelayClient {
         'Continue the previous task using this answer. Do not ask the same question again unless the answer is genuinely insufficient.',
       ].join('\n');
       this.send({ type: 'active', sessionId, payload: {} });
-      this.beginAdapterTurn(sessionId);
+      this.beginAdapterTurn(sessionId, turnId);
       this.sessionManager.markActive(sessionId);
       await this.adapter.sendMessage(sessionId, recoveryPrompt, answer.attachments);
     }
@@ -1318,11 +1346,11 @@ export class RelayClient {
 
           const pendingAtArrival = this.soleOpenQuestion(sessionId);
           if (pendingAtArrival) {
+            this.updateInputLedger(sessionId, clientId, 'dispatching');
             const delivery = this.deliverQuestionAnswer(sessionId, pendingAtArrival, {
               text: msg.payload.text === '[image]' ? '' : msg.payload.text,
               attachments: msg.payload.attachments,
-            }, true);
-            this.updateInputLedger(sessionId, clientId, 'dispatching');
+            }, true, reservation.turnId);
             void delivery.then(() => {
               this.updateInputLedger(sessionId, clientId, 'delivered');
             }).catch((err) => {
@@ -1348,8 +1376,8 @@ export class RelayClient {
               this.beginAdapterTurn(sessionId, reservation.turnId);
               this.sessionManager.markActive(sessionId);
               traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-STEER', sessionId, clientId, turnId: reservation.turnId });
-              const delivery = this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'steer' });
               this.updateInputLedger(sessionId, clientId, 'dispatching');
+              const delivery = this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'steer' });
               await delivery;
               this.updateInputLedger(sessionId, clientId, 'delivered');
               traceLog.info({
@@ -1390,10 +1418,10 @@ export class RelayClient {
                 this.beginAdapterTurn(sessionId, reservation.turnId);
                 traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId, queueBehindMaintenance, turnId: reservation.turnId });
                 this.sessionManager.markActive(sessionId);
+                this.updateInputLedger(sessionId, clientId, 'dispatching');
                 const delivery = queueBehindMaintenance
                   ? this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'follow_up' })
                   : this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
-                this.updateInputLedger(sessionId, clientId, 'dispatching');
                 await delivery;
                 this.updateInputLedger(sessionId, clientId, 'delivered');
                 traceLog.info({
@@ -1976,7 +2004,7 @@ export class RelayClient {
     };
 
     this.adapter.onMessage = (sessionId, event) => {
-      if (!this.acceptsAdapterTurn(sessionId, event.turnId)) return;
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       // A genuine final reply is authoritative for the turn. Any provider error
       // broadcast before recovery must not be frozen as the outcome at idle.
       this.pendingTerminalErrors.delete(sessionId);
@@ -1997,6 +2025,7 @@ export class RelayClient {
     };
 
     this.adapter.onMessageDelta = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       // Streaming narration/progress prose → the draft bubble (coalesced in
       // send()). Rendered as a clean in-flow spine bubble, kept-last per segment.
       this.card.onDelta(sessionId, event.content);
@@ -2006,6 +2035,7 @@ export class RelayClient {
     // the frozen final narration in place so it morphs seamlessly into the final
     // reply. Finalizes into the agent_message spine bubble at idle.
     this.adapter.onFinalizeDelta = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       this.card.onDelta(sessionId, event.content);
     };
 
@@ -2018,13 +2048,16 @@ export class RelayClient {
     //    intermediate steps — never the trailing one that graduates into the
     //    bubble — so a reply never shows duplicated (last Step + bubble).
     this.adapter.onNarration = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       this.card.onNarrationFinal(sessionId, event.content);
     };
     this.adapter.onNarrationTrace = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       this.recordTrace({ type: 'agent_narration', sessionId, payload: { content: event.content } });
     };
 
     this.adapter.onPermissionRequest = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       const action = {
         type: 'permission' as const,
         payload: { ...event.toolArgs, id: event.id, description: event.description },
@@ -2060,6 +2093,7 @@ export class RelayClient {
     };
 
     this.adapter.onQuestionRequest = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       const action = {
         type: 'question' as const,
         payload: {
@@ -2087,6 +2121,7 @@ export class RelayClient {
     };
 
     this.adapter.onToolStart = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       const headline = makeHeadline(event.toolName, event.args);
       const argsRef = this.offloadArgs(sessionId, event.toolName, event.args);
       // Ship args inline when below the offload floor so clients always have source data
@@ -2140,6 +2175,7 @@ export class RelayClient {
     };
 
     this.adapter.onToolComplete = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       // Recompute headline from the args we stashed at start; falls back to
       // toolName if args aren't available.
       const stashedArgs = this.lastArgsByToolCallId.get(event.toolCallId ?? '');
@@ -2189,7 +2225,9 @@ export class RelayClient {
     // Bytes remain in AttachmentStore until an Arm actually renders the
     // ContentRef. Broadcasting large results to every Arm blocked unrelated
     // control and live messages in Pulse's ordered stream.
-    this.adapter.onAttachmentBytes = () => {};
+    this.adapter.onAttachmentBytes = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
+    };
 
     this.adapter.onIdle = (sessionId, event) => {
       if (!this.acceptsAdapterTurn(sessionId, event?.turnId)) return;
@@ -2209,16 +2247,14 @@ export class RelayClient {
     };
 
     this.adapter.onCompaction = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       if (event.phase === 'start') this.setCompacting(sessionId, true, event.reason);
       else this.setCompacting(sessionId, false);
     };
 
     this.adapter.onError = (sessionId, event) => {
-      if (!this.acceptsAdapterTurn(sessionId, event.turnId)) return;
-      // A settled idle owns terminalization for this turn. Ignore late duplicate
-      // adapter errors until a different accepted turn identity is active.
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       const activeTurnId = event.turnId ?? this.activeInputTurnIds.get(sessionId) ?? '__unidentified__';
-      if (this.settledAdapterTurnIds.get(sessionId) === activeTurnId) return;
 
       // Stage as the terminal outcome so idle freezes it as a `failed` card,
       // AND broadcast the error immediately so apps surface it without waiting
@@ -2251,6 +2287,7 @@ export class RelayClient {
     // bubble so the turn — which produced no final reply — still has an
     // anchor for its "Steps" history.
     this.adapter.onSystemMessage = (sessionId, event) => {
+      if (!this.acceptsAdapterEvent(sessionId, event.turnId)) return;
       this.card.onBubble(sessionId);
       this.send({
         type: 'system_message',

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -221,7 +221,7 @@ export class RelayClient {
   private turnIdleWaiters = new Map<string, { promise: Promise<void>; resolve: () => void }>();
   /** Adapter errors become terminal only when the same logical turn reaches
    *  idle. Keeping them pending avoids freezing recoverable tool failures. */
-  private pendingTerminalErrors = new Map<string, { message: string; code?: string; source: 'adapter' | 'backend' | 'process' }>();
+  private pendingTerminalErrors = new Map<string, { message: string; code?: string; source: 'adapter' | 'backend' | 'process'; turnId?: string }>();
   /** Last adapter idle boundary per logical turn. The old implementation used
    *  one Session-wide boolean, which let a late callback cross a turn boundary. */
   private settledAdapterTurnIds = new Map<string, string>();
@@ -229,10 +229,30 @@ export class RelayClient {
   private activeInputTurnIds = new Map<string, string>();
   private nextInputTurnAnchors = new Map<string, number>();
 
-  private beginAdapterTurn(sessionId: string, turnId?: string): void {
+  private beginAdapterTurn(sessionId: string, turnId?: string): string {
     const resolvedTurnId = turnId ?? `${sessionId}:${(this.nextInputTurnAnchors.get(sessionId) ?? 0) + 1}`;
     if (!turnId) this.nextInputTurnAnchors.set(sessionId, (this.nextInputTurnAnchors.get(sessionId) ?? 0) + 1);
     this.activeInputTurnIds.set(sessionId, resolvedTurnId);
+    this.adapter.setTurnIdentity?.(sessionId, resolvedTurnId);
+    return resolvedTurnId;
+  }
+
+  /** A terminal adapter event must identify the accepted turn it belongs to.
+   *  Legacy adapters/tests may omit the token; those events retain the old
+   *  fallback behavior, while tokenized events are strictly fenced. */
+  private acceptsAdapterTurn(sessionId: string, turnId?: string): boolean {
+    if (!turnId) return true;
+    const activeTurnId = this.activeInputTurnIds.get(sessionId);
+    if (activeTurnId === turnId) return true;
+    traceLog.info({
+      ns: process.hrtime.bigint().toString(),
+      comp: 'tentacle',
+      evt: 'ADAPTER-LATE-CALLBACK',
+      sessionId,
+      turnId,
+      activeTurnId,
+    });
+    return false;
   }
 
   private inputFingerprint(
@@ -259,10 +279,22 @@ export class RelayClient {
     requestedDelivery: 'prompt' | 'steer',
     text: string,
     attachments?: import('@kraki/protocol').Attachment[],
-  ): { duplicate: boolean; conflict: boolean; effectiveDelivery: 'prompt' | 'steer'; turnId: string; entry?: InputLedgerEntry } {
+  ): { duplicate: boolean; conflict: boolean; recovery: boolean; effectiveDelivery: 'prompt' | 'steer'; turnId: string; entry?: InputLedgerEntry } {
     const meta = this.sessionManager.getMeta(sessionId);
+    const adapterSettled = this.adapter.isTurnSettled?.(sessionId) === true;
     const staleSteer = requestedDelivery === 'steer'
-      && (meta?.state === 'idle' || meta?.state === 'disconnected');
+      && (
+        meta?.state === 'idle'
+        || meta?.state === 'disconnected'
+        || adapterSettled
+      );
+    if (requestedDelivery === 'steer' && adapterSettled && meta?.state === 'active') {
+      // Reconcile a terminal callback that Relay missed before opening the new
+      // prompt. Otherwise the prior normal-input chain remains blocked forever
+      // waiting for an idle the adapter has already crossed.
+      const settledTurnId = this.activeInputTurnIds.get(sessionId);
+      this.settleAdapterIdle(sessionId, settledTurnId ? { turnId: settledTurnId } : undefined);
+    }
     const effectiveDelivery = staleSteer ? 'prompt' : requestedDelivery;
     const proposedAnchor = effectiveDelivery === 'steer'
       ? (meta?.currentTurnStartSeq ?? meta?.lastSeq ?? 0)
@@ -272,35 +304,67 @@ export class RelayClient {
       : Math.max(proposedAnchor, (this.nextInputTurnAnchors.get(sessionId) ?? 0) + 1);
     if (effectiveDelivery === 'prompt') this.nextInputTurnAnchors.set(sessionId, turnAnchor);
     const turnId = `${sessionId}:${turnAnchor}`;
-    if (!clientId) return { duplicate: false, conflict: false, effectiveDelivery, turnId };
+    if (!clientId) return { duplicate: false, conflict: false, recovery: false, effectiveDelivery, turnId };
 
     const fingerprint = this.inputFingerprint(text, attachments);
-    const existing = this.sessionManager.getInputLedgerEntry(sessionId, clientId);
+    const ledgerEntries = this.sessionManager.getInputLedger?.(sessionId) ?? [];
+    const existing = this.sessionManager.getInputLedgerEntry?.(sessionId, clientId)
+      ?? ledgerEntries.find((entry) => entry.clientId === clientId)
+      ?? null;
     if (existing) {
       if (existing.contentHash !== fingerprint.contentHash) {
-        return { duplicate: true, conflict: true, effectiveDelivery, turnId };
+        return { duplicate: true, conflict: true, recovery: false, effectiveDelivery, turnId };
       }
-      if (existing.status !== 'pending' || this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId) !== null) {
-        return { duplicate: true, conflict: false, effectiveDelivery, turnId, entry: existing };
+      // `persisted` means the user_message is durable but adapter dispatch has
+      // not started. It is the only restart state that is safe to recover by
+      // sending the replayed payload again. `dispatching` is deliberately
+      // treated as at-most-once: the daemon may have crossed the adapter
+      // boundary before it crashed, so replaying it could duplicate the turn.
+      if (existing.status === 'persisted' && existing.userSeq !== undefined) {
+        return { duplicate: false, conflict: false, recovery: true, effectiveDelivery: existing.delivery === 'steer' ? 'steer' : 'prompt', turnId: existing.turnId, entry: existing };
       }
-    } else {
-      const recoveredSeq = this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId);
-      if (recoveredSeq !== null) {
-        const recovered: InputLedgerEntry = {
-          version: 1,
-          clientId,
-          status: 'persisted',
-          requestedDelivery,
-          delivery: effectiveDelivery,
-          turnId,
-          contentLength: fingerprint.contentLength,
-          contentHash: fingerprint.contentHash,
-          userSeq: recoveredSeq,
-          updatedAt: new Date().toISOString(),
-        };
-        this.sessionManager.recordInputLedger(sessionId, recovered);
-        return { duplicate: true, conflict: false, effectiveDelivery, turnId, entry: recovered };
+      if (existing.status === 'pending') {
+        const recoveredSeq = this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId);
+        if (recoveredSeq !== null) {
+          const recovered: InputLedgerEntry = {
+            ...existing,
+            status: 'persisted',
+            userSeq: recoveredSeq,
+            updatedAt: new Date().toISOString(),
+          };
+          this.sessionManager.recordInputLedger(sessionId, recovered);
+          return { duplicate: false, conflict: false, recovery: true, effectiveDelivery: recovered.delivery === 'steer' ? 'steer' : 'prompt', turnId: recovered.turnId, entry: recovered };
+        }
+        // The reservation survived but the transcript append did not. Reuse
+        // its identity and perform the normal persistence path exactly once.
+        return { duplicate: false, conflict: false, recovery: false, effectiveDelivery: existing.delivery === 'steer' ? 'steer' : 'prompt', turnId: existing.turnId, entry: existing };
       }
+      return { duplicate: true, conflict: false, recovery: false, effectiveDelivery, turnId, entry: existing };
+    }
+
+    // Only legacy sessions with no ledger need the compatibility transcript
+    // scan. Once the durable index exists, the hot input path is O(1) in the
+    // number of historical messages.
+    const recoveredSeq = ledgerEntries.length === 0
+      ? this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId)
+      : null;
+    if (recoveredSeq !== null) {
+      const recovered: InputLedgerEntry = {
+        version: 1,
+        clientId,
+        status: 'persisted',
+        requestedDelivery,
+        delivery: effectiveDelivery,
+        turnId,
+        contentLength: fingerprint.contentLength,
+        contentHash: fingerprint.contentHash,
+        userSeq: recoveredSeq,
+        updatedAt: new Date().toISOString(),
+      };
+      this.sessionManager.recordInputLedger(sessionId, recovered);
+      // Without a matching ledger entry we cannot prove the replayed body is
+      // the original body, so preserve at-most-once behavior for legacy data.
+      return { duplicate: true, conflict: false, recovery: false, effectiveDelivery, turnId, entry: recovered };
     }
 
     const entry: InputLedgerEntry = {
@@ -315,7 +379,7 @@ export class RelayClient {
       updatedAt: new Date().toISOString(),
     };
     this.sessionManager.recordInputLedger(sessionId, entry);
-    return { duplicate: false, conflict: false, effectiveDelivery, turnId, entry };
+    return { duplicate: false, conflict: false, recovery: false, effectiveDelivery, turnId, entry };
   }
 
   private updateInputLedger(
@@ -369,14 +433,20 @@ export class RelayClient {
     }
   }
 
-  private settleAdapterIdle(sessionId: string): void {
-    // Adapter idle callbacks do not carry a turn id. Use the relay's accepted
-    // input turn as a fence and suppress only a repeat for that same identity.
-    // Pi additionally suppresses duplicate agent_settled callbacks at the source.
-    const turnId = this.activeInputTurnIds.get(sessionId);
+  private settleAdapterIdle(sessionId: string, event?: { turnId?: string }): void {
+    if (!this.acceptsAdapterTurn(sessionId, event?.turnId)) return;
+    // Tokenized callbacks use their source identity. Only legacy callbacks fall
+    // back to the currently active relay turn.
+    const turnId = event?.turnId ?? this.activeInputTurnIds.get(sessionId);
     const idleTurnId = turnId ?? '__unidentified__';
     if (this.settledAdapterTurnIds.get(sessionId) === idleTurnId) return;
-    const terminalError = this.pendingTerminalErrors.get(sessionId);
+    const stagedError = this.pendingTerminalErrors.get(sessionId);
+    const terminalError = stagedError && (!stagedError.turnId || stagedError.turnId === idleTurnId)
+      ? stagedError
+      : undefined;
+    if (stagedError?.turnId && stagedError.turnId !== idleTurnId) {
+      this.pendingTerminalErrors.delete(sessionId);
+    }
     if (this.soleOpenQuestion(sessionId) && !terminalError) return;
     this.settledAdapterTurnIds.set(sessionId, idleTurnId);
     if (turnId) {
@@ -392,10 +462,11 @@ export class RelayClient {
     }
     if (terminalError) {
       this.pendingTerminalErrors.delete(sessionId);
+      const { turnId: _turnId, ...terminalPayload } = terminalError;
       this.finishTurnWithStatus(sessionId, {
         type: 'failed',
         payload: {
-          ...terminalError,
+          ...terminalPayload,
           failedAt: new Date().toISOString(),
         },
       });
@@ -1204,6 +1275,7 @@ export class RelayClient {
             requestedDelivery,
             delivery: reservation.effectiveDelivery,
             turnId: reservation.turnId,
+            recovery: reservation.recovery,
             contentHash: reservation.entry?.contentHash,
           });
           if (reservation.conflict) {
@@ -1214,20 +1286,24 @@ export class RelayClient {
 
           const inputEntry = reservation.entry;
           const effectiveDelivery = reservation.effectiveDelivery;
-          this.send({
-            type: 'user_message',
-            sessionId,
-            payload: {
-              content: msg.payload.text,
-              ...(msg.payload.attachments?.length && { attachments: msg.payload.attachments }),
-              ...(msg.payload.clientId && { clientId: msg.payload.clientId }),
-              ...(effectiveDelivery === 'steer' && { delivery: 'steer' as const }),
-            },
-          });
-          const persistedSeq = clientId
-            ? this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId)
-            : null;
-          this.updateInputLedger(sessionId, clientId, 'persisted', persistedSeq ?? undefined);
+          let persistedSeq = inputEntry?.userSeq;
+          if (!reservation.recovery) {
+            const userMessage = {
+              type: 'user_message' as const,
+              sessionId,
+              payload: {
+                content: msg.payload.text,
+                ...(msg.payload.attachments?.length && { attachments: msg.payload.attachments }),
+                ...(msg.payload.clientId && { clientId: msg.payload.clientId }),
+                ...(effectiveDelivery === 'steer' && { delivery: 'steer' as const }),
+              },
+            };
+            this.send(userMessage);
+            // send() assigns the per-session sequence by mutating the outbound
+            // message. Reuse it instead of rescanning messages.jsonl.
+            persistedSeq = (userMessage as typeof userMessage & { seq?: number }).seq;
+            this.updateInputLedger(sessionId, clientId, 'persisted', persistedSeq);
+          }
           traceLog.info({
             ns: process.hrtime.bigint().toString(),
             comp: 'tentacle',
@@ -1242,10 +1318,12 @@ export class RelayClient {
 
           const pendingAtArrival = this.soleOpenQuestion(sessionId);
           if (pendingAtArrival) {
-            void this.deliverQuestionAnswer(sessionId, pendingAtArrival, {
+            const delivery = this.deliverQuestionAnswer(sessionId, pendingAtArrival, {
               text: msg.payload.text === '[image]' ? '' : msg.payload.text,
               attachments: msg.payload.attachments,
-            }, true).then(() => {
+            }, true);
+            this.updateInputLedger(sessionId, clientId, 'dispatching');
+            void delivery.then(() => {
               this.updateInputLedger(sessionId, clientId, 'delivered');
             }).catch((err) => {
               this.updateInputLedger(sessionId, clientId, 'rejected');
@@ -1270,7 +1348,9 @@ export class RelayClient {
               this.beginAdapterTurn(sessionId, reservation.turnId);
               this.sessionManager.markActive(sessionId);
               traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-STEER', sessionId, clientId, turnId: reservation.turnId });
-              await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'steer' });
+              const delivery = this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'steer' });
+              this.updateInputLedger(sessionId, clientId, 'dispatching');
+              await delivery;
               this.updateInputLedger(sessionId, clientId, 'delivered');
               traceLog.info({
                 ns: process.hrtime.bigint().toString(),
@@ -1310,11 +1390,11 @@ export class RelayClient {
                 this.beginAdapterTurn(sessionId, reservation.turnId);
                 traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId, queueBehindMaintenance, turnId: reservation.turnId });
                 this.sessionManager.markActive(sessionId);
-                if (queueBehindMaintenance) {
-                  await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'follow_up' });
-                } else {
-                  await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
-                }
+                const delivery = queueBehindMaintenance
+                  ? this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'follow_up' })
+                  : this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
+                this.updateInputLedger(sessionId, clientId, 'dispatching');
+                await delivery;
                 this.updateInputLedger(sessionId, clientId, 'delivered');
                 traceLog.info({
                   ns: process.hrtime.bigint().toString(),
@@ -1896,6 +1976,7 @@ export class RelayClient {
     };
 
     this.adapter.onMessage = (sessionId, event) => {
+      if (!this.acceptsAdapterTurn(sessionId, event.turnId)) return;
       // A genuine final reply is authoritative for the turn. Any provider error
       // broadcast before recovery must not be frozen as the outcome at idle.
       this.pendingTerminalErrors.delete(sessionId);
@@ -2110,12 +2191,13 @@ export class RelayClient {
     // control and live messages in Pulse's ordered stream.
     this.adapter.onAttachmentBytes = () => {};
 
-    this.adapter.onIdle = (sessionId) => {
+    this.adapter.onIdle = (sessionId, event) => {
+      if (!this.acceptsAdapterTurn(sessionId, event?.turnId)) return;
       if (this.steerAcceptanceInFlight.has(sessionId)) {
         this.idleDuringSteerAcceptance.add(sessionId);
         return;
       }
-      this.settleAdapterIdle(sessionId);
+      this.settleAdapterIdle(sessionId, event);
     };
 
     this.adapter.onFlushComplete = (sessionId) => {
@@ -2132,9 +2214,10 @@ export class RelayClient {
     };
 
     this.adapter.onError = (sessionId, event) => {
+      if (!this.acceptsAdapterTurn(sessionId, event.turnId)) return;
       // A settled idle owns terminalization for this turn. Ignore late duplicate
       // adapter errors until a different accepted turn identity is active.
-      const activeTurnId = this.activeInputTurnIds.get(sessionId) ?? '__unidentified__';
+      const activeTurnId = event.turnId ?? this.activeInputTurnIds.get(sessionId) ?? '__unidentified__';
       if (this.settledAdapterTurnIds.get(sessionId) === activeTurnId) return;
 
       // Stage as the terminal outcome so idle freezes it as a `failed` card,
@@ -2144,12 +2227,13 @@ export class RelayClient {
       // fallback rather than surfacing `success` or `unknown` as an error.
       const candidate = normalizeTerminalErrorMessage(event.message);
       const current = this.pendingTerminalErrors.get(sessionId);
-      const currentQuality = current
-        ? normalizeTerminalErrorMessage(current.message).quality
+      const currentForTurn = current?.turnId === activeTurnId ? current : undefined;
+      const currentQuality = currentForTurn
+        ? normalizeTerminalErrorMessage(currentForTurn.message).quality
         : -1;
-      const selected = !current || candidate.quality > currentQuality
-        ? { message: candidate.message, source: 'backend' as const }
-        : current;
+      const selected = !currentForTurn || candidate.quality > currentQuality
+        ? { message: candidate.message, source: 'backend' as const, turnId: activeTurnId }
+        : currentForTurn;
       this.pendingTerminalErrors.set(sessionId, selected);
       this.recordTrace({
         type: 'error',

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -8,6 +8,7 @@
 
 import { WebSocket } from 'ws';
 import { appendFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type {
@@ -20,7 +21,7 @@ import { HEAD_PULSE_TARGET } from '@kraki/protocol';
 import { importPublicKey, encryptToBlob, decryptFromBlob, signChallenge } from '@kraki/crypto';
 import type { RecipientKey } from '@kraki/crypto';
 import type { AgentAdapter } from './adapters/base.js';
-import { toWellFormedText, type SessionManager, type SessionContext, type PendingHumanAction } from './session-manager.js';
+import { toWellFormedText, type SessionManager, type SessionContext, type PendingHumanAction, type InputLedgerEntry } from './session-manager.js';
 import type { KeyManager } from './key-manager.js';
 import { scanLocalSessions, filterSessions } from './session-scanner.js';
 import { parseSessionHistory } from './history-parser.js';
@@ -42,6 +43,28 @@ const traceLog = {
     ? (obj: Record<string, unknown>) => traceLogger.info(obj)
     : (_obj: Record<string, unknown>) => { /* no-op */ },
 };
+
+const GENERIC_TERMINAL_ERROR = 'Agent request failed';
+
+function normalizeTerminalErrorMessage(
+  value: unknown,
+): { message: string; quality: number } {
+  if (typeof value !== 'string') {
+    return { message: GENERIC_TERMINAL_ERROR, quality: 0 };
+  }
+  const message = value.trim();
+  if (
+    !message ||
+    /^(success|unknown|error_during_execution)$/i.test(message)
+  ) {
+    return { message: GENERIC_TERMINAL_ERROR, quality: 0 };
+  }
+  const concrete =
+    /\b(?:HTTP\s*)?[45]\d\d\b|status code|request id|provider|API error/i.test(
+      message,
+    );
+  return { message, quality: concrete ? 2 : 1 };
+}
 
 export interface RelayClientOptions {
   /** Relay WebSocket URL (e.g., wss://relay.kraki.chat) */
@@ -199,6 +222,118 @@ export class RelayClient {
   /** Adapter errors become terminal only when the same logical turn reaches
    *  idle. Keeping them pending avoids freezing recoverable tool failures. */
   private pendingTerminalErrors = new Map<string, { message: string; code?: string; source: 'adapter' | 'backend' | 'process' }>();
+  /** Last adapter idle boundary per logical turn. The old implementation used
+   *  one Session-wide boolean, which let a late callback cross a turn boundary. */
+  private settledAdapterTurnIds = new Map<string, string>();
+
+  private activeInputTurnIds = new Map<string, string>();
+  private nextInputTurnAnchors = new Map<string, number>();
+
+  private beginAdapterTurn(sessionId: string, turnId?: string): void {
+    const resolvedTurnId = turnId ?? `${sessionId}:${(this.nextInputTurnAnchors.get(sessionId) ?? 0) + 1}`;
+    if (!turnId) this.nextInputTurnAnchors.set(sessionId, (this.nextInputTurnAnchors.get(sessionId) ?? 0) + 1);
+    this.activeInputTurnIds.set(sessionId, resolvedTurnId);
+  }
+
+  private inputFingerprint(
+    text: string,
+    attachments?: import('@kraki/protocol').Attachment[],
+  ): { contentLength: number; contentHash: string } {
+    const attachmentShape = (attachments ?? []).map((attachment) => ({
+      type: attachment.type,
+      mimeType: 'mimeType' in attachment ? attachment.mimeType : undefined,
+      id: 'id' in attachment ? attachment.id : undefined,
+      size: 'size' in attachment ? attachment.size : undefined,
+      data: 'data' in attachment ? attachment.data : undefined,
+    }));
+    const content = JSON.stringify({ text, attachments: attachmentShape });
+    return {
+      contentLength: text.length,
+      contentHash: createHash('sha256').update(content).digest('hex'),
+    };
+  }
+
+  private reserveInput(
+    sessionId: string,
+    clientId: string | undefined,
+    requestedDelivery: 'prompt' | 'steer',
+    text: string,
+    attachments?: import('@kraki/protocol').Attachment[],
+  ): { duplicate: boolean; conflict: boolean; effectiveDelivery: 'prompt' | 'steer'; turnId: string; entry?: InputLedgerEntry } {
+    const meta = this.sessionManager.getMeta(sessionId);
+    const staleSteer = requestedDelivery === 'steer'
+      && (meta?.state === 'idle' || meta?.state === 'disconnected');
+    const effectiveDelivery = staleSteer ? 'prompt' : requestedDelivery;
+    const proposedAnchor = effectiveDelivery === 'steer'
+      ? (meta?.currentTurnStartSeq ?? meta?.lastSeq ?? 0)
+      : (meta?.lastSeq ?? 0) + 1;
+    const turnAnchor = effectiveDelivery === 'steer'
+      ? proposedAnchor
+      : Math.max(proposedAnchor, (this.nextInputTurnAnchors.get(sessionId) ?? 0) + 1);
+    if (effectiveDelivery === 'prompt') this.nextInputTurnAnchors.set(sessionId, turnAnchor);
+    const turnId = `${sessionId}:${turnAnchor}`;
+    if (!clientId) return { duplicate: false, conflict: false, effectiveDelivery, turnId };
+
+    const fingerprint = this.inputFingerprint(text, attachments);
+    const existing = this.sessionManager.getInputLedgerEntry(sessionId, clientId);
+    if (existing) {
+      if (existing.contentHash !== fingerprint.contentHash) {
+        return { duplicate: true, conflict: true, effectiveDelivery, turnId };
+      }
+      if (existing.status !== 'pending' || this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId) !== null) {
+        return { duplicate: true, conflict: false, effectiveDelivery, turnId, entry: existing };
+      }
+    } else {
+      const recoveredSeq = this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId);
+      if (recoveredSeq !== null) {
+        const recovered: InputLedgerEntry = {
+          version: 1,
+          clientId,
+          status: 'persisted',
+          requestedDelivery,
+          delivery: effectiveDelivery,
+          turnId,
+          contentLength: fingerprint.contentLength,
+          contentHash: fingerprint.contentHash,
+          userSeq: recoveredSeq,
+          updatedAt: new Date().toISOString(),
+        };
+        this.sessionManager.recordInputLedger(sessionId, recovered);
+        return { duplicate: true, conflict: false, effectiveDelivery, turnId, entry: recovered };
+      }
+    }
+
+    const entry: InputLedgerEntry = {
+      version: 1,
+      clientId,
+      status: 'pending',
+      requestedDelivery,
+      delivery: effectiveDelivery,
+      turnId,
+      contentLength: fingerprint.contentLength,
+      contentHash: fingerprint.contentHash,
+      updatedAt: new Date().toISOString(),
+    };
+    this.sessionManager.recordInputLedger(sessionId, entry);
+    return { duplicate: false, conflict: false, effectiveDelivery, turnId, entry };
+  }
+
+  private updateInputLedger(
+    sessionId: string,
+    clientId: string | undefined,
+    status: InputLedgerEntry['status'],
+    userSeq?: number,
+  ): void {
+    if (!clientId) return;
+    const existing = this.sessionManager.getInputLedgerEntry(sessionId, clientId);
+    if (!existing) return;
+    this.sessionManager.recordInputLedger(sessionId, {
+      ...existing,
+      status,
+      ...(userSeq !== undefined && { userSeq }),
+      updatedAt: new Date().toISOString(),
+    });
+  }
 
   private waitForTurnIdle(sessionId: string): Promise<void> {
     const existing = this.turnIdleWaiters.get(sessionId);
@@ -235,11 +370,26 @@ export class RelayClient {
   }
 
   private settleAdapterIdle(sessionId: string): void {
-    // Idle carries no run/turn identity. Never let a late idle callback erase
-    // a newer card. Permanent bubble boundaries retire settled card state;
-    // explicit abort owns its own freeze+clear path; pending questions stay.
+    // Adapter idle callbacks do not carry a turn id. Use the relay's accepted
+    // input turn as a fence and suppress only a repeat for that same identity.
+    // Pi additionally suppresses duplicate agent_settled callbacks at the source.
+    const turnId = this.activeInputTurnIds.get(sessionId);
+    const idleTurnId = turnId ?? '__unidentified__';
+    if (this.settledAdapterTurnIds.get(sessionId) === idleTurnId) return;
     const terminalError = this.pendingTerminalErrors.get(sessionId);
     if (this.soleOpenQuestion(sessionId) && !terminalError) return;
+    this.settledAdapterTurnIds.set(sessionId, idleTurnId);
+    if (turnId) {
+      this.sessionManager.markInputLedgerSettled(sessionId, turnId);
+      traceLog.info({
+        ns: process.hrtime.bigint().toString(),
+        comp: 'tentacle',
+        evt: 'INPUT-SETTLED',
+        sessionId,
+        turnId,
+        willRetry: false,
+      });
+    }
     if (terminalError) {
       this.pendingTerminalErrors.delete(sessionId);
       this.finishTurnWithStatus(sessionId, {
@@ -523,6 +673,7 @@ export class RelayClient {
         'Continue the previous task using this answer. Do not ask the same question again unless the answer is genuinely insufficient.',
       ].join('\n');
       this.send({ type: 'active', sessionId, payload: {} });
+      this.beginAdapterTurn(sessionId);
       this.sessionManager.markActive(sessionId);
       await this.adapter.sendMessage(sessionId, recoveryPrompt, answer.attachments);
     }
@@ -1034,15 +1185,35 @@ export class RelayClient {
       switch (msg.type) {
         case 'send_input': {
           const clientId = msg.payload.clientId as string | undefined;
+          const requestedDelivery = msg.payload.delivery === 'steer' ? 'steer' as const : 'prompt' as const;
+          const reservation = this.reserveInput(
+            sessionId,
+            clientId,
+            requestedDelivery,
+            msg.payload.text,
+            msg.payload.attachments,
+          );
           traceLog.info({
             ns: process.hrtime.bigint().toString(),
             comp: 'tentacle',
-            evt: 'APP-SEND-INPUT',
+            evt: reservation.conflict ? 'INPUT-REJECTED' : reservation.duplicate ? 'INPUT-DUPLICATE' : 'APP-SEND-INPUT',
             sessionId,
             clientId,
             textLen: (msg.payload.text || '').length,
             hasAttachments: !!msg.payload.attachments?.length,
+            requestedDelivery,
+            delivery: reservation.effectiveDelivery,
+            turnId: reservation.turnId,
+            contentHash: reservation.entry?.contentHash,
           });
+          if (reservation.conflict) {
+            this.send({ type: 'error', sessionId, payload: { message: 'Input clientId was already used for different content.' } });
+            break;
+          }
+          if (reservation.duplicate) break;
+
+          const inputEntry = reservation.entry;
+          const effectiveDelivery = reservation.effectiveDelivery;
           this.send({
             type: 'user_message',
             sessionId,
@@ -1050,8 +1221,23 @@ export class RelayClient {
               content: msg.payload.text,
               ...(msg.payload.attachments?.length && { attachments: msg.payload.attachments }),
               ...(msg.payload.clientId && { clientId: msg.payload.clientId }),
-              ...(msg.payload.delivery === 'steer' && { delivery: 'steer' as const }),
+              ...(effectiveDelivery === 'steer' && { delivery: 'steer' as const }),
             },
+          });
+          const persistedSeq = clientId
+            ? this.sessionManager.findUserMessageSeqByClientId(sessionId, clientId)
+            : null;
+          this.updateInputLedger(sessionId, clientId, 'persisted', persistedSeq ?? undefined);
+          traceLog.info({
+            ns: process.hrtime.bigint().toString(),
+            comp: 'tentacle',
+            evt: 'INPUT-PERSISTED',
+            sessionId,
+            clientId,
+            seq: persistedSeq ?? undefined,
+            turnId: reservation.turnId,
+            textLen: msg.payload.text.length,
+            contentHash: inputEntry?.contentHash,
           });
 
           const pendingAtArrival = this.soleOpenQuestion(sessionId);
@@ -1059,27 +1245,42 @@ export class RelayClient {
             void this.deliverQuestionAnswer(sessionId, pendingAtArrival, {
               text: msg.payload.text === '[image]' ? '' : msg.payload.text,
               attachments: msg.payload.attachments,
-            }, true).catch((err) => {
+            }, true).then(() => {
+              this.updateInputLedger(sessionId, clientId, 'delivered');
+            }).catch((err) => {
+              this.updateInputLedger(sessionId, clientId, 'rejected');
               logger.error({ err, sessionId }, 'question answer from composer failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver answer: ${(err as Error).message}` } });
             });
             break;
           }
           if ((this.openQuestions.get(sessionId)?.size ?? 0) > 1) {
+            this.updateInputLedger(sessionId, clientId, 'rejected');
             this.send({ type: 'error', sessionId, payload: { message: 'Multiple questions are pending. Answer the intended question card directly.' } });
             break;
           }
 
-          if (msg.payload.delivery === 'steer') {
+          if (effectiveDelivery === 'steer') {
             void this.dispatchInput(sessionId, async () => {
               this.beginSteerAcceptance(sessionId);
               await this.ensureSessionResumed(sessionId);
               // Reassert active after resume so an idle/send race cannot leave a
               // successfully accepted interjection running behind an idle UI.
               this.send({ type: 'active', sessionId, payload: {} });
+              this.beginAdapterTurn(sessionId, reservation.turnId);
               this.sessionManager.markActive(sessionId);
-              traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-STEER', sessionId, clientId });
+              traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-STEER', sessionId, clientId, turnId: reservation.turnId });
               await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'steer' });
+              this.updateInputLedger(sessionId, clientId, 'delivered');
+              traceLog.info({
+                ns: process.hrtime.bigint().toString(),
+                comp: 'tentacle',
+                evt: 'INPUT-DELIVERED',
+                sessionId,
+                clientId,
+                turnId: reservation.turnId,
+                delivery: 'steer',
+              });
               // The adapter ACK is the ownership boundary for the interjection.
               // Reassert active so an idle from the pre-steer work that raced the
               // ACK cannot become the final visible state. A later provider idle
@@ -1088,6 +1289,7 @@ export class RelayClient {
               this.send({ type: 'active', sessionId, payload: {} });
               this.sessionManager.markActive(sessionId);
             }).catch((err) => {
+              this.updateInputLedger(sessionId, clientId, 'rejected');
               this.finishSteerAcceptance(sessionId, false);
               logger.error({ err, sessionId }, 'steer input failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to steer agent: ${(err as Error).message}` } });
@@ -1105,14 +1307,25 @@ export class RelayClient {
                 const queueBehindMaintenance = this.sessionManager.getMeta(sessionId)?.state === 'idle'
                   && (compactionReason === 'threshold' || compactionReason === 'manual');
                 this.send({ type: 'active', sessionId, payload: {} });
-                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId, queueBehindMaintenance });
+                this.beginAdapterTurn(sessionId, reservation.turnId);
+                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-SEND', sessionId, clientId, queueBehindMaintenance, turnId: reservation.turnId });
                 this.sessionManager.markActive(sessionId);
                 if (queueBehindMaintenance) {
                   await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments, { delivery: 'follow_up' });
                 } else {
                   await this.adapter.sendMessage(sessionId, msg.payload.text, msg.payload.attachments);
                 }
-                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-DONE', sessionId, clientId });
+                this.updateInputLedger(sessionId, clientId, 'delivered');
+                traceLog.info({
+                  ns: process.hrtime.bigint().toString(),
+                  comp: 'tentacle',
+                  evt: 'INPUT-DELIVERED',
+                  sessionId,
+                  clientId,
+                  turnId: reservation.turnId,
+                  delivery: queueBehindMaintenance ? 'follow_up' : 'prompt',
+                });
+                traceLog.info({ ns: process.hrtime.bigint().toString(), comp: 'tentacle', evt: 'APP-ADAPTER-DONE', sessionId, clientId, turnId: reservation.turnId });
               });
               await idle;
             } catch (err) {
@@ -1122,6 +1335,7 @@ export class RelayClient {
           };
           const next = (previous ? previous.catch(() => {}).then(deliver) : deliver())
             .catch((err) => {
+              this.updateInputLedger(sessionId, clientId, 'rejected');
               logger.error({ err, sessionId }, 'send input failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to deliver message: ${(err as Error).message}` } });
             })
@@ -1210,6 +1424,9 @@ export class RelayClient {
                 this.card.clear(sessionId);
               }
               this.pendingTerminalErrors.delete(sessionId);
+              const turnId = this.activeInputTurnIds.get(sessionId);
+              this.settledAdapterTurnIds.set(sessionId, turnId ?? '__unidentified__');
+              if (turnId) this.sessionManager.markInputLedgerSettled(sessionId, turnId);
               this.resolveTurnIdle(sessionId);
               this.sessionManager.markIdle(sessionId);
               this.clearCompacting(sessionId);
@@ -1231,6 +1448,10 @@ export class RelayClient {
           this.sessionManager.removeLinkByKrakiId(sessionId);
           this.sessionManager.deleteSession(sessionId);
           this.lastAgentContent.delete(sessionId);
+          this.pendingTerminalErrors.delete(sessionId);
+          this.settledAdapterTurnIds.delete(sessionId);
+          this.activeInputTurnIds.delete(sessionId);
+          this.nextInputTurnAnchors.delete(sessionId);
           this.purgeSessionToolState(sessionId);
           this.send({ type: 'session_deleted', sessionId, payload: {} });
           this.eventsWatcher?.unwatch(sessionId);
@@ -1353,6 +1574,7 @@ export class RelayClient {
       // Otherwise mark idle — the SDK only fires session.idle after a turn
       // completes, so without a prompt the session would stay 'active' forever.
       if (prompt && result.sessionId) {
+        this.beginAdapterTurn(result.sessionId);
         await this.adapter.sendMessage(result.sessionId, prompt);
       } else if (result.sessionId) {
         this.sessionManager.markIdle(result.sessionId);
@@ -1674,6 +1896,9 @@ export class RelayClient {
     };
 
     this.adapter.onMessage = (sessionId, event) => {
+      // A genuine final reply is authoritative for the turn. Any provider error
+      // broadcast before recovery must not be frozen as the outcome at idle.
+      this.pendingTerminalErrors.delete(sessionId);
       // Clear the server-side draft state FIRST so a reconnect snapshot doesn't
       // re-seed a stale draft; arms clear the live draft in the SAME store update
       // that lands this permanent bubble (no double-render flash). onBubble does
@@ -1907,23 +2132,34 @@ export class RelayClient {
     };
 
     this.adapter.onError = (sessionId, event) => {
+      // A settled idle owns terminalization for this turn. Ignore late duplicate
+      // adapter errors until a different accepted turn identity is active.
+      const activeTurnId = this.activeInputTurnIds.get(sessionId) ?? '__unidentified__';
+      if (this.settledAdapterTurnIds.get(sessionId) === activeTurnId) return;
+
       // Stage as the terminal outcome so idle freezes it as a `failed` card,
       // AND broadcast the error immediately so apps surface it without waiting
-      // for the turn to settle. A recoverable error that never reaches idle just
-      // shows the transient notice — no frozen card.
-      this.pendingTerminalErrors.set(sessionId, {
-        message: event.message,
-        source: 'backend',
-      });
+      // for the turn to settle. Keep the best available text: concrete provider
+      // failures outrank generic enum values, and invalid values use a safe
+      // fallback rather than surfacing `success` or `unknown` as an error.
+      const candidate = normalizeTerminalErrorMessage(event.message);
+      const current = this.pendingTerminalErrors.get(sessionId);
+      const currentQuality = current
+        ? normalizeTerminalErrorMessage(current.message).quality
+        : -1;
+      const selected = !current || candidate.quality > currentQuality
+        ? { message: candidate.message, source: 'backend' as const }
+        : current;
+      this.pendingTerminalErrors.set(sessionId, selected);
       this.recordTrace({
         type: 'error',
         sessionId,
-        payload: { message: event.message },
+        payload: { message: selected.message },
       });
       this.send({
         type: 'error',
         sessionId,
-        payload: { message: event.message },
+        payload: { message: selected.message },
       });
     };
 
@@ -1945,6 +2181,10 @@ export class RelayClient {
       this.turnStepCounts.delete(sessionId);
       this.titleGenerationInFlight.delete(sessionId);
       this.lastAgentContent.delete(sessionId);
+      this.pendingTerminalErrors.delete(sessionId);
+      this.settledAdapterTurnIds.delete(sessionId);
+      this.activeInputTurnIds.delete(sessionId);
+      this.nextInputTurnAnchors.delete(sessionId);
       this.purgeSessionToolState(sessionId);
       this.steerAcceptanceInFlight.delete(sessionId);
       this.idleDuringSteerAcceptance.delete(sessionId);

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -167,6 +167,21 @@ export interface PendingHumanAction {
   createdAt: string;
 }
 
+/** Restart-safe identity record for an Arm send_input request. Never stores
+ * message body; the hash is only used to detect clientId reuse with different input. */
+export interface InputLedgerEntry {
+  version: 1;
+  clientId: string;
+  status: 'pending' | 'persisted' | 'delivered' | 'settled' | 'rejected';
+  requestedDelivery: 'prompt' | 'steer';
+  delivery: 'prompt' | 'steer' | 'follow_up';
+  turnId: string;
+  contentLength: number;
+  contentHash: string;
+  userSeq?: number;
+  updatedAt: string;
+}
+
 // ── Session Manager ─────────────────────────────────────
 
 export class SessionManager {
@@ -764,6 +779,74 @@ export class SessionManager {
 
   clearPendingHumanAction(sessionId: string): void {
     rmSync(this.pendingActionPath(sessionId), { force: true });
+  }
+
+  // ── Durable input identity state ───────────────────────
+
+  private inputLedgerPath(sessionId: string): string {
+    return join(this.sessionDir(sessionId), 'input-ledger.json');
+  }
+
+  getInputLedger(sessionId: string): InputLedgerEntry[] {
+    const path = this.inputLedgerPath(sessionId);
+    if (!existsSync(path)) return [];
+    try {
+      const value = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+      if (!Array.isArray(value)) return [];
+      return value.filter((entry): entry is InputLedgerEntry =>
+        !!entry && typeof entry === 'object'
+        && (entry as InputLedgerEntry).version === 1
+        && typeof (entry as InputLedgerEntry).clientId === 'string'
+        && typeof (entry as InputLedgerEntry).contentHash === 'string',
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  getInputLedgerEntry(sessionId: string, clientId: string): InputLedgerEntry | null {
+    return this.getInputLedger(sessionId).find((entry) => entry.clientId === clientId) ?? null;
+  }
+
+  recordInputLedger(sessionId: string, entry: InputLedgerEntry): void {
+    const path = this.inputLedgerPath(sessionId);
+    const entries = this.getInputLedger(sessionId).filter((item) => item.clientId !== entry.clientId);
+    entries.push(entry);
+    atomicWrite(path, JSON.stringify(entries, null, 2));
+  }
+
+  findUserMessageSeqByClientId(sessionId: string, clientId: string): number | null {
+    const logPath = join(this.sessionDir(sessionId), 'messages.jsonl');
+    if (!existsSync(logPath)) return null;
+    try {
+      for (const line of readFileSync(logPath, 'utf8').split('\n')) {
+        if (!line) continue;
+        try {
+          const entry = JSON.parse(line) as LoggedMessage;
+          if (entry.type !== 'user_message') continue;
+          const payload = JSON.parse(entry.payload) as { payload?: { clientId?: string } };
+          if (payload.payload?.clientId === clientId) return entry.seq;
+        } catch {
+          // Ignore an unrelated malformed line while recovering the ledger.
+        }
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  markInputLedgerSettled(sessionId: string, turnId: string): void {
+    const entries = this.getInputLedger(sessionId);
+    let changed = false;
+    const now = new Date().toISOString();
+    for (const entry of entries) {
+      if (entry.turnId !== turnId || (entry.status !== 'persisted' && entry.status !== 'delivered')) continue;
+      entry.status = 'settled';
+      entry.updatedAt = now;
+      changed = true;
+    }
+    if (changed) atomicWrite(this.inputLedgerPath(sessionId), JSON.stringify(entries, null, 2));
   }
 
   // ── Message log ────────────────────────────────────────

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -189,6 +189,10 @@ export class SessionManager {
 
   private sessionsDir: string;
   private inputLedgerCache = new Map<string, InputLedgerEntry[]>();
+  /** Uncompacted clientId index. The bounded ledger remains the hot state
+   * machine, while this metadata-only log preserves replay deduplication for
+   * older terminal inputs without rescanning messages.jsonl. */
+  private inputClientIndexCache = new Map<string, Map<string, InputLedgerEntry>>();
 
   constructor(sessionsDir?: string) {
     this.sessionsDir = sessionsDir ?? join(getConfigDir(), 'sessions');
@@ -791,6 +795,42 @@ export class SessionManager {
     return join(this.sessionDir(sessionId), 'input-ledger.json');
   }
 
+  private inputClientIndexPath(sessionId: string): string {
+    return join(this.sessionDir(sessionId), 'input-client-index.jsonl');
+  }
+
+  private loadInputClientIndex(sessionId: string): Map<string, InputLedgerEntry> {
+    const existing = this.inputClientIndexCache.get(sessionId);
+    if (existing) return existing;
+    const index = new Map<string, InputLedgerEntry>();
+    const path = this.inputClientIndexPath(sessionId);
+    if (existsSync(path)) {
+      try {
+        for (const line of readFileSync(path, 'utf8').split('\n')) {
+          if (!line) continue;
+          try {
+            const entry = JSON.parse(line) as InputLedgerEntry;
+            if (entry?.version === 1 && typeof entry.clientId === 'string' && typeof entry.contentHash === 'string') {
+              index.set(entry.clientId, entry);
+            }
+          } catch {
+            // Ignore a truncated final index row after an interrupted write.
+          }
+        }
+      } catch {
+        // The bounded ledger remains the fallback if the index is unavailable.
+      }
+    }
+    this.inputClientIndexCache.set(sessionId, index);
+    return index;
+  }
+
+  private persistInputClientIndex(sessionId: string, entry: InputLedgerEntry): void {
+    const index = this.loadInputClientIndex(sessionId);
+    index.set(entry.clientId, { ...entry });
+    appendFileSync(this.inputClientIndexPath(sessionId), `${JSON.stringify(entry)}\n`);
+  }
+
   private loadInputLedger(sessionId: string): InputLedgerEntry[] {
     const path = this.inputLedgerPath(sessionId);
     if (!existsSync(path)) return [];
@@ -810,13 +850,21 @@ export class SessionManager {
 
   getInputLedger(sessionId: string): InputLedgerEntry[] {
     if (!this.inputLedgerCache.has(sessionId)) {
-      this.inputLedgerCache.set(sessionId, this.loadInputLedger(sessionId));
+      const entries = this.loadInputLedger(sessionId);
+      this.inputLedgerCache.set(sessionId, entries);
+      const index = this.loadInputClientIndex(sessionId);
+      // Seed indexes created before this file existed, including entries that
+      // will be compacted by the first subsequent ledger transition.
+      for (const entry of entries) index.set(entry.clientId, { ...entry });
     }
     return this.inputLedgerCache.get(sessionId)!.map((entry) => ({ ...entry }));
   }
 
   getInputLedgerEntry(sessionId: string, clientId: string): InputLedgerEntry | null {
-    return this.getInputLedger(sessionId).find((entry) => entry.clientId === clientId) ?? null;
+    const current = this.getInputLedger(sessionId).find((entry) => entry.clientId === clientId);
+    if (current) return current;
+    const indexed = this.loadInputClientIndex(sessionId).get(clientId);
+    return indexed ? { ...indexed } : null;
   }
 
   private compactInputLedger(entries: InputLedgerEntry[]): InputLedgerEntry[] {
@@ -834,10 +882,18 @@ export class SessionManager {
     const path = this.inputLedgerPath(sessionId);
     const entries = (this.inputLedgerCache.get(sessionId) ?? this.loadInputLedger(sessionId))
       .filter((item) => item.clientId !== entry.clientId);
+    const indexPath = this.inputClientIndexPath(sessionId);
+    const index = this.loadInputClientIndex(sessionId);
+    const indexWasMissing = !existsSync(indexPath);
+    for (const existing of entries) index.set(existing.clientId, { ...existing });
+    if (indexWasMissing && entries.length > 0) {
+      appendFileSync(indexPath, `${entries.map((existing) => JSON.stringify(existing)).join('\n')}\n`);
+    }
     entries.push({ ...entry });
     const compacted = this.compactInputLedger(entries);
     this.inputLedgerCache.set(sessionId, compacted);
     atomicWrite(path, JSON.stringify(compacted, null, 2));
+    this.persistInputClientIndex(sessionId, entry);
   }
 
   findUserMessageSeqByClientId(sessionId: string, clientId: string): number | null {
@@ -864,17 +920,20 @@ export class SessionManager {
   markInputLedgerSettled(sessionId: string, turnId: string): void {
     const entries = this.getInputLedger(sessionId);
     let changed = false;
+    const changedEntries: InputLedgerEntry[] = [];
     const now = new Date().toISOString();
     for (const entry of entries) {
       if (entry.turnId !== turnId || (entry.status !== 'persisted' && entry.status !== 'dispatching' && entry.status !== 'delivered')) continue;
       entry.status = 'settled';
       entry.updatedAt = now;
       changed = true;
+      changedEntries.push(entry);
     }
     if (changed) {
       const compacted = this.compactInputLedger(entries);
       this.inputLedgerCache.set(sessionId, compacted);
       atomicWrite(this.inputLedgerPath(sessionId), JSON.stringify(compacted, null, 2));
+      for (const entry of changedEntries) this.persistInputClientIndex(sessionId, entry);
     }
   }
 

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -172,7 +172,7 @@ export interface PendingHumanAction {
 export interface InputLedgerEntry {
   version: 1;
   clientId: string;
-  status: 'pending' | 'persisted' | 'delivered' | 'settled' | 'rejected';
+  status: 'pending' | 'persisted' | 'dispatching' | 'delivered' | 'settled' | 'rejected';
   requestedDelivery: 'prompt' | 'steer';
   delivery: 'prompt' | 'steer' | 'follow_up';
   turnId: string;
@@ -185,7 +185,10 @@ export interface InputLedgerEntry {
 // ── Session Manager ─────────────────────────────────────
 
 export class SessionManager {
+  private static readonly INPUT_LEDGER_TERMINAL_LIMIT = 2048;
+
   private sessionsDir: string;
+  private inputLedgerCache = new Map<string, InputLedgerEntry[]>();
 
   constructor(sessionsDir?: string) {
     this.sessionsDir = sessionsDir ?? join(getConfigDir(), 'sessions');
@@ -520,6 +523,7 @@ export class SessionManager {
    * Delete a session permanently. Removes all files for this session.
    */
   deleteSession(sessionId: string): void {
+    this.inputLedgerCache.delete(sessionId);
     const dir = this.sessionDir(sessionId);
     if (existsSync(dir)) {
       rmSync(dir, { recursive: true });
@@ -787,7 +791,7 @@ export class SessionManager {
     return join(this.sessionDir(sessionId), 'input-ledger.json');
   }
 
-  getInputLedger(sessionId: string): InputLedgerEntry[] {
+  private loadInputLedger(sessionId: string): InputLedgerEntry[] {
     const path = this.inputLedgerPath(sessionId);
     if (!existsSync(path)) return [];
     try {
@@ -804,15 +808,36 @@ export class SessionManager {
     }
   }
 
+  getInputLedger(sessionId: string): InputLedgerEntry[] {
+    if (!this.inputLedgerCache.has(sessionId)) {
+      this.inputLedgerCache.set(sessionId, this.loadInputLedger(sessionId));
+    }
+    return this.inputLedgerCache.get(sessionId)!.map((entry) => ({ ...entry }));
+  }
+
   getInputLedgerEntry(sessionId: string, clientId: string): InputLedgerEntry | null {
     return this.getInputLedger(sessionId).find((entry) => entry.clientId === clientId) ?? null;
   }
 
+  private compactInputLedger(entries: InputLedgerEntry[]): InputLedgerEntry[] {
+    const isOpen = (entry: InputLedgerEntry) =>
+      entry.status === 'pending' || entry.status === 'persisted' || entry.status === 'dispatching';
+    const retainedTerminalIds = new Set(
+      entries.filter((entry) => !isOpen(entry))
+        .slice(-SessionManager.INPUT_LEDGER_TERMINAL_LIMIT)
+        .map((entry) => entry.clientId),
+    );
+    return entries.filter((entry) => isOpen(entry) || retainedTerminalIds.has(entry.clientId));
+  }
+
   recordInputLedger(sessionId: string, entry: InputLedgerEntry): void {
     const path = this.inputLedgerPath(sessionId);
-    const entries = this.getInputLedger(sessionId).filter((item) => item.clientId !== entry.clientId);
-    entries.push(entry);
-    atomicWrite(path, JSON.stringify(entries, null, 2));
+    const entries = (this.inputLedgerCache.get(sessionId) ?? this.loadInputLedger(sessionId))
+      .filter((item) => item.clientId !== entry.clientId);
+    entries.push({ ...entry });
+    const compacted = this.compactInputLedger(entries);
+    this.inputLedgerCache.set(sessionId, compacted);
+    atomicWrite(path, JSON.stringify(compacted, null, 2));
   }
 
   findUserMessageSeqByClientId(sessionId: string, clientId: string): number | null {
@@ -841,12 +866,16 @@ export class SessionManager {
     let changed = false;
     const now = new Date().toISOString();
     for (const entry of entries) {
-      if (entry.turnId !== turnId || (entry.status !== 'persisted' && entry.status !== 'delivered')) continue;
+      if (entry.turnId !== turnId || (entry.status !== 'persisted' && entry.status !== 'dispatching' && entry.status !== 'delivered')) continue;
       entry.status = 'settled';
       entry.updatedAt = now;
       changed = true;
     }
-    if (changed) atomicWrite(this.inputLedgerPath(sessionId), JSON.stringify(entries, null, 2));
+    if (changed) {
+      const compacted = this.compactInputLedger(entries);
+      this.inputLedgerCache.set(sessionId, compacted);
+      atomicWrite(this.inputLedgerPath(sessionId), JSON.stringify(compacted, null, 2));
+    }
   }
 
   // ── Message log ────────────────────────────────────────

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -16,7 +16,7 @@
     "@kraki/protocol": "workspace:*",
     "@kraki/tentacle": "workspace:*",
     "@kraki/voice-broker": "workspace:*",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "13.0.3",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/packages/tests/vitest.config.ts
+++ b/packages/tests/vitest.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
       '@kraki/voice-broker/mock': resolve(__dirname, '../voice-broker/src/mock-doubao.ts'),
       '@kraki/voice-broker/logger': resolve(__dirname, '../voice-broker/src/logger.ts'),
       '@kraki/voice-broker': resolve(__dirname, '../voice-broker/src/index.ts'),
+      // Integration tests run on Node 24; force their native SQLite import to
+      // the test-only compatible version instead of Head's published 11.x line.
+      'better-sqlite3': resolve(__dirname, 'node_modules/better-sqlite3/lib/index.js'),
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,8 +288,8 @@ importers:
         specifier: workspace:*
         version: link:../voice-broker
       better-sqlite3:
-        specifier: ^11.0.0
-        version: 11.10.0
+        specifier: 13.0.3
+        version: 13.0.3
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -2158,6 +2158,10 @@ packages:
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
+  better-sqlite3@13.0.3:
+    resolution: {integrity: sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==}
+    engines: {node: '>=22'}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -3252,6 +3256,10 @@ packages:
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  node-addon-api@8.9.2:
+    resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -6028,6 +6036,10 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  better-sqlite3@13.0.3:
+    dependencies:
+      node-addon-api: 8.9.2
+
   bignumber.js@9.3.1: {}
 
   bindings@1.5.0:
@@ -7312,6 +7324,8 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+
+  node-addon-api@8.9.2: {}
 
   node-domexception@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,8 +203,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       '@earendil-works/pi-coding-agent':
-        specifier: 0.80.2
-        version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+        specifier: 0.84.1
+        version: 0.84.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@github/copilot-sdk':
         specifier: ^1.0.1
         version: 1.0.1(typescript@5.9.3)
@@ -4114,6 +4114,225 @@ packages:
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
+  '@aws-sdk/core@3.977.7':
+    resolution: {integrity: sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.68':
+    resolution: {integrity: sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.70':
+    resolution: {integrity: sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.13':
+    resolution: {integrity: sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.75':
+    resolution: {integrity: sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.79':
+    resolution: {integrity: sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.68':
+    resolution: {integrity: sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.12':
+    resolution: {integrity: sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.74':
+    resolution: {integrity: sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.32':
+    resolution: {integrity: sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.27':
+    resolution: {integrity: sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.50':
+    resolution: {integrity: sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.42':
+    resolution: {integrity: sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.44':
+    resolution: {integrity: sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1108.0':
+    resolution: {integrity: sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.3':
+    resolution: {integrity: sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.9':
+    resolution: {integrity: sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.38':
+    resolution: {integrity: sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@earendil-works/pi-agent-core@0.84.2':
+    resolution: {integrity: sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.84.2':
+    resolution: {integrity: sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-client@0.84.2':
+    resolution: {integrity: sha512-/RFSPhD/bZbpOp1oJj+UneSUFSgZhWxzcSENUY+8+8xhoBrWXMYI2t77XNx4Yf+c8YK2qTHquForhNcelYpXvg==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-coding-agent@0.84.1':
+    resolution: {integrity: sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-protocol@0.84.2':
+    resolution: {integrity: sha512-jbBh03fkeckWEroHpcZBr4w5/Ibat8WwdXFlXHivYQImrQNFtLpDeL0t1cku4hmK0q3pceIRQHkw4fwbM4YILQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-telemetry@0.84.2':
+    resolution: {integrity: sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.2':
+    resolution: {integrity: sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==}
+    engines: {node: '>=22.19.0'}
+
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@smithy/core@3.33.0':
+    resolution: {integrity: sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.0':
+    resolution: {integrity: sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.0':
+    resolution: {integrity: sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.0':
+    resolution: {integrity: sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.0':
+    resolution: {integrity: sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.0':
+    resolution: {integrity: sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  grok-mermaid@0.2.2:
+    resolution: {integrity: sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==}
+    engines: {node: '>=18'}
+
+  hono@4.13.2:
+    resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
+    engines: {node: '>=16.9.0'}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
+
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  openai@6.40.0:
+    resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -4194,15 +4413,15 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
-      '@aws-sdk/util-locate-window': 3.965.8
+      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/util-locate-window': 3.965.9
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.3
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -4211,7 +4430,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.3
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -4219,17 +4438,17 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/eventstream-handler-node': 3.972.22
-      '@aws-sdk/middleware-eventstream': 3.972.18
-      '@aws-sdk/middleware-websocket': 3.972.31
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/eventstream-handler-node': 3.972.32
+      '@aws-sdk/middleware-eventstream': 3.972.27
+      '@aws-sdk/middleware-websocket': 3.972.50
       '@aws-sdk/token-providers': 3.1048.0
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/fetch-http-handler': 5.7.0
       '@smithy/node-http-handler': 4.7.3
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@aws-sdk/core@3.974.23':
@@ -4373,11 +4592,11 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1048.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1074.0':
@@ -4943,9 +5162,9 @@ snapshots:
 
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
     dependencies:
-      google-auth-library: 10.9.0
+      google-auth-library: 10.9.1
       p-retry: 4.6.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       ws: 8.19.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
@@ -5271,18 +5490,18 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.28)
+      '@hono/node-server': 1.19.17(hono@4.13.2)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.28
-      jose: 6.2.3
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.2
+      jose: 6.2.8
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -5436,8 +5655,8 @@ snapshots:
 
   '@smithy/node-http-handler@4.7.3':
     dependencies:
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.8.2':
@@ -5747,7 +5966,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5826,7 +6045,7 @@ snapshots:
   body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 2.0.0
+      content-type: 2.1.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.3
@@ -6146,7 +6365,7 @@ snapshots:
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
 
   expand-template@2.0.3: {}
 
@@ -6267,7 +6486,7 @@ snapshots:
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.5
+      gaxios: 7.3.1
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -6394,7 +6613,7 @@ snapshots:
 
   hosted-git-info@9.0.3:
     dependencies:
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -6574,7 +6793,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
@@ -7068,7 +7287,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
@@ -7195,7 +7414,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
@@ -7809,8 +8028,8 @@ snapshots:
 
   type-is@2.1.0:
     dependencies:
-      content-type: 2.0.0
-      media-typer: 1.1.0
+      content-type: 2.1.0
+      media-typer: 1.1.1
       mime-types: 3.0.2
 
   typebox@1.1.38: {}
@@ -8043,3 +8262,367 @@ snapshots:
       react: 19.2.4
 
   zwitch@2.0.4: {}
+
+  '@aws-sdk/core@3.977.7':
+    dependencies:
+      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/xml-builder': 3.972.38
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.0
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.11.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.13':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-env': 3.972.68
+      '@aws-sdk/credential-provider-http': 3.972.70
+      '@aws-sdk/credential-provider-login': 3.972.75
+      '@aws-sdk/credential-provider-process': 3.972.68
+      '@aws-sdk/credential-provider-sso': 3.973.12
+      '@aws-sdk/credential-provider-web-identity': 3.972.74
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.79':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.68
+      '@aws-sdk/credential-provider-http': 3.972.70
+      '@aws-sdk/credential-provider-ini': 3.973.13
+      '@aws-sdk/credential-provider-process': 3.972.68
+      '@aws-sdk/credential-provider-sso': 3.973.12
+      '@aws-sdk/credential-provider-web-identity': 3.972.74
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.12':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/token-providers': 3.1108.0
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.74':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.32':
+    dependencies:
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.27':
+    dependencies:
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.42':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/signature-v4-multi-region': 3.996.44
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.11.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.44':
+    dependencies:
+      '@aws-sdk/types': 3.974.3
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1108.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/nested-clients': 3.997.42
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.3':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.9':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.38':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
+  '@earendil-works/pi-agent-core@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@earendil-works/pi-telemetry': 0.84.2
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.2
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.40.0(ws@8.19.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      typebox: 1.3.7
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-client@0.84.2':
+    dependencies:
+      '@earendil-works/pi-protocol': 0.84.2
+
+  '@earendil-works/pi-coding-agent@0.84.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@earendil-works/pi-client': 0.84.2
+      '@earendil-works/pi-protocol': 0.84.2
+      '@earendil-works/pi-tui': 0.84.2
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      grok-mermaid: 0.2.2
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.3.7
+      undici: 8.9.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-protocol@0.84.2':
+    dependencies:
+      typebox: 1.3.7
+
+  '@earendil-works/pi-telemetry@0.84.2': {}
+
+  '@earendil-works/pi-tui@0.84.2':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
+  '@hono/node-server@1.19.17(hono@4.13.2)':
+    dependencies:
+      hono: 4.13.2
+
+  '@protobufjs/utf8@1.1.2': {}
+
+  '@smithy/core@3.33.0':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.0':
+    dependencies:
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.0':
+    dependencies:
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.0':
+    dependencies:
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.0':
+    dependencies:
+      '@smithy/core': 3.33.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  content-type@2.1.0: {}
+
+  eventsource-parser@3.1.1: {}
+
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-uri@3.1.5: {}
+
+  gaxios@7.3.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  grok-mermaid@0.2.2: {}
+
+  hono@4.13.2: {}
+
+  ip-address@10.5.0: {}
+
+  jose@6.2.8: {}
+
+  lru-cache@11.5.2: {}
+
+  media-typer@1.1.1: {}
+
+  openai@6.40.0(ws@8.19.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.3.6
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.2.0
+      long: 5.3.2
+
+  typebox@1.3.7: {}
+
+  undici-types@8.3.0: {}
+
+  undici@8.9.0: {}


### PR DESCRIPTION
Reproduce and fix the Pi terminal lifecycle regression and stale input path.

- terminalize Pi on agent_settled, not low-level agent_end
- convert post-settlement steer into a fresh prompt
- add Claude post-result re-arm
- persist clientId input ledger and reject replay/conflicting reuse before spine append
- add privacy-safe lifecycle diagnostics and regression coverage

Focused tests: 279 passed. Full Tentacle suite: 884/885; the sole failure is the existing config.test.ts HOME-isolation mismatch.