### PR TITLE
fix(mac): resize voice composer with transcript

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.12;
+				MARKETING_VERSION = 0.2.13;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.12;
+				MARKETING_VERSION = 0.2.13;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAppDelegate.swift
@@ -701,6 +701,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
                     pieces: transcriptPieces(samples[0]),
                     revision: "0"
                 )
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(width: 560)
             )
         )
@@ -713,11 +714,42 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         window.contentView = host
         host.frame = window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 600, height: 180)
 
+        let layoutProbe = MacComposerVoiceTranscriptView(frame: NSRect(x: 0, y: 0, width: 560, height: 18))
+        _ = layoutProbe.update(pieces: transcriptPieces(samples[0]), width: 560)
+        _ = layoutProbe.update(pieces: transcriptPieces(samples[3]), width: 560)
+        let dynamicLongHeight = layoutProbe.intrinsicContentSize.height
+        let surfaceHost = NSHostingView(
+            rootView: AnyView(
+                HStack(spacing: 12) {
+                    MacComposerVoiceTranscript(
+                        pieces: transcriptPieces(samples[3]),
+                        revision: "surface-long"
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    Color.clear.frame(width: 38, height: 32)
+                }
+                .padding(.leading, 18)
+                .padding(.trailing, 12)
+                .padding(.vertical, 4)
+                .frame(width: 500, alignment: .leading)
+            )
+        )
+        let surfaceWindow = NSWindow(
+            contentRect: NSRect(x: -20_000, y: -20_000, width: 500, height: 220),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        surfaceWindow.contentView = surfaceHost
+        surfaceHost.frame = surfaceWindow.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 500, height: 220)
+        surfaceHost.layoutSubtreeIfNeeded()
         let started = CACurrentMediaTime()
         for round in 0..<200 {
             let index = round % samples.count
             host.rootView = AnyView(
                 MacComposerVoiceTranscript(pieces: transcriptPieces(samples[index]), revision: "\(round)")
+                    .fixedSize(horizontal: false, vertical: true)
                     .frame(width: 560)
             )
             host.layoutSubtreeIfNeeded()
@@ -748,6 +780,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             let streamed = String(chineseStream.prefix(count))
             host.rootView = AnyView(
                 MacComposerVoiceTranscript(pieces: voiceOnlyPieces(streamed), revision: "cjk-\(count)")
+                    .fixedSize(horizontal: false, vertical: true)
                     .frame(width: 560)
             )
             host.layoutSubtreeIfNeeded()
@@ -803,7 +836,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         ) as? NSColor
         let lookaheadOpacityOK = abs((lookaheadAlpha?.alphaComponent ?? 0) - 0.30) < 0.01
         NSLog(
-            "[voice-transcript-regression] rounds=200 ms=%.3f pureCoreText=%d scrollViews=%d prefixOK=%d font=%.1f adaptiveColor=%d lookaheadOpacity=%d lightBrightness=%.3f darkBrightness=%.3f height=%.1f",
+            "[voice-transcript-regression] rounds=200 ms=%.3f pureCoreText=%d scrollViews=%d prefixOK=%d font=%.1f adaptiveColor=%d lookaheadOpacity=%d lightBrightness=%.3f darkBrightness=%.3f dynamicHeight=%.1f dynamicHeightOK=%d surfaceHeight=%.1f surfaceHeightOK=%d height=%.1f",
             elapsed,
             transcriptView == nil ? 0 : 1,
             scrollViewCount,
@@ -813,6 +846,10 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             lookaheadOpacityOK ? 1 : 0,
             lightBrightness,
             darkBrightness,
+            dynamicLongHeight,
+            dynamicLongHeight >= 140 ? 1 : 0,
+            surfaceHost.fittingSize.height,
+            surfaceHost.fittingSize.height >= 140 ? 1 : 0,
             transcriptView?.bounds.height ?? 0
         )
         NSLog(

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
@@ -1173,9 +1173,19 @@ private struct MacComposerVoiceSurface: View {
 final class MacComposerVoiceTranscriptView: NSView {
     typealias Piece = (text: String, opacity: Double)
 
+    private static let font = NSFont.systemFont(ofSize: 15)
+    static let lineHeight = ceil(NSLayoutManager().defaultLineHeight(for: font))
+    static let maxVisibleLines: CGFloat = 8
+
     private var pieces: [Piece] = []
     private var value = NSAttributedString(string: "")
     private var framesetter: CTFramesetter?
+    private var measuredWidth: CGFloat = 0
+    private var measuredHeight: CGFloat = lineHeight
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: measuredHeight)
+    }
 
     override var isFlipped: Bool { true }
     override var isOpaque: Bool { false }
@@ -1187,9 +1197,16 @@ final class MacComposerVoiceTranscriptView: NSView {
         setAccessibilityRole(.staticText)
         setAccessibilityLabel("Voice transcript")
         setAccessibilityValue(value.string)
-        let height = Self.measure(value, width: width)
+        if width > 1 {
+            measuredWidth = width
+            measuredHeight = min(Self.measure(value, width: width), Self.lineHeight * Self.maxVisibleLines)
+        } else {
+            measuredWidth = 0
+            measuredHeight = Self.lineHeight
+        }
+        invalidateIntrinsicContentSize()
         needsDisplay = true
-        return height
+        return measuredHeight
     }
 
     static func measure(_ pieces: [Piece], width: CGFloat) -> CGFloat {
@@ -1233,7 +1250,7 @@ final class MacComposerVoiceTranscriptView: NSView {
     }
 
     private static func measure(_ text: NSAttributedString, width: CGFloat) -> CGFloat {
-        guard text.length > 0 else { return 18 }
+        guard text.length > 0 else { return lineHeight }
         let framesetter = CTFramesetterCreateWithAttributedString(text)
         let suggested = CTFramesetterSuggestFrameSizeWithConstraints(
             framesetter,
@@ -1242,7 +1259,19 @@ final class MacComposerVoiceTranscriptView: NSView {
             CGSize(width: max(1, width), height: .greatestFiniteMagnitude),
             nil
         )
-        return max(18, ceil(suggested.height + 1))
+        return max(lineHeight, ceil(suggested.height + 1))
+    }
+
+    override func layout() {
+        super.layout()
+        guard bounds.width > 1,
+              abs(bounds.width - measuredWidth) > 0.5 else { return }
+        measuredWidth = bounds.width
+        let height = min(Self.measure(value, width: bounds.width), Self.lineHeight * Self.maxVisibleLines)
+        guard abs(height - measuredHeight) > 0.5 else { return }
+        measuredHeight = height
+        invalidateIntrinsicContentSize()
+        needsDisplay = true
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -1343,8 +1372,10 @@ struct MacComposerVoiceTranscript: NSViewRepresentable {
         guard let proposedWidth = proposal.width, proposedWidth > 1 else { return nil }
         let width = proposedWidth
         let contentHeight = MacComposerVoiceTranscriptView.measure(pieces, width: width)
-        let lineHeight = ceil(NSLayoutManager().defaultLineHeight(for: .systemFont(ofSize: 15)))
-        return CGSize(width: width, height: min(contentHeight, lineHeight * 8))
+        return CGSize(
+            width: width,
+            height: min(contentHeight, MacComposerVoiceTranscriptView.lineHeight * MacComposerVoiceTranscriptView.maxVisibleLines)
+        )
     }
 }
 

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.12"
-        CURRENT_PROJECT_VERSION: 14
+        MARKETING_VERSION: "0.2.13"
+        CURRENT_PROJECT_VERSION: 15
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- give the native macOS voice transcript a dynamic intrinsic height
- remeasure when transcript content or available width changes
- extend the voice composer regression to cover short-to-long updates and the full composer surface
- prepare macOS 0.2.13 (build 15)

## Validation
- macOS Debug build
- macOS Release build with code signing disabled; bundle reports 0.2.13 (15)
- voice transcript benchmark: dynamicHeight=144, surfaceHeight=152, all checks pass
- full KrakiTests suite: 290 tests, 2 existing skips, 0 failures
- git diff --check