### PR TITLE
fix(ios): keep large session navigation responsive

### DIFF
--- a/packages/arm/ios/Kraki/App/Mac/MacChatTestPages.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacChatTestPages.swift
@@ -1359,7 +1359,7 @@ private extension MacChatScenarioHarness {
             sparseID,
             category: "History & virtualization",
             title: "08 · History · Sparse protocol seqs",
-            summary: "Persistent rows contain off-spine seq gaps; top pagination must still advance without stalling.",
+            summary: "Replayed legacy spine rows retain historical off-spine seq gaps; top pagination must still advance without stalling.",
             phases: [phase(
                 "Sparse tail",
                 messages: sparseMessages,

--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -101,20 +101,8 @@ final class MessageRouter {
     /// 126_037 would race ahead of an idle seq of 12 and the badge
     /// would never light up).
     ///
-    /// Keep this set in sync with `RelayClient.PERSISTENT_TYPES` in
-    /// `packages/tentacle/src/relay-client.ts`.
-    private static let persistentTypes: Set<String> = [
-        "session_created",
-        "agent_message",
-        "interrupted_turn",
-        "turn_status",
-        "user_message",
-        "system_message",
-        "error",
-        "session_ended",
-        "idle",
-        "session_replay_batch",
-    ]
+    /// The exact type set is centralized in `SessionSpineContract`, shared with
+    /// MessageStore so routing and persistence cannot silently drift apart.
 
     // MARK: Init
 
@@ -353,7 +341,7 @@ final class MessageRouter {
         // session_list/session_read authority. A genuinely visible Chat may
         // acknowledge the live seq immediately through the shared auto-read gate.
         if let seq = dict["seq"] as? Int,
-           Self.persistentTypes.contains(type) {
+           SessionSpineContract.contains(type: type, seq: seq) {
             appState.messageProvider?.observeLiveMessageSeq(sessionId, seq: seq, kind: type)
             // Keep the card/read projection in step with the persisted live
             // head. SQLite alone is not observable to the Session Card.
@@ -463,10 +451,11 @@ final class MessageRouter {
             // else lands in the live card action slot verbatim.
             appState.messageStore.applyCardAction(sessionId, Self.decodeCardAction(payload))
 
-        // ── Tool events (off-spine trace) ────────────────────────────────
-        // No longer persisted or seq'd — the live tool surfaces via the card
-        // action slot. We keep only the session-list activity chip + attachment
-        // pre-registration so an expanded tool's args/result show a spinner.
+        // ── Legacy raw tool events (off-spine trace) ─────────────────────
+        // Current Tentacle projects live tools only through `card_action` and
+        // returns raw tool records through `turn_trace_batch`. Keep these cases
+        // as compatibility handling for older Tentacles; never persist or use
+        // their global envelope seq as a Session spine cursor.
 
         case "tool_start":
             appState.messageStore.clearRuntimeStatusIfCompacting(sessionId)

--- a/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
@@ -159,6 +159,39 @@ struct SessionSummary: Codable, Identifiable, Sendable {
     var messageCount: Int
 }
 
+// MARK: - Session spine contract
+
+/// The durable per-Session sequence owned by Tentacle.
+///
+/// There are three distinct ordering domains in the protocol:
+/// - transport/Pulse ordering, which is connection-scoped;
+/// - the global envelope `seq` retained by transient live messages;
+/// - this dense per-Session spine `seq`, assigned only when Tentacle appends a
+///   `PERSISTENT_TYPE` to `messages.jsonl`.
+///
+/// Rendering is a projection of this set: lifecycle rows, `error`, and `idle`
+/// remain on the durable spine even when they do not produce their own cell.
+/// Historical pre-pure-spine logs can be sparse because retired transient rows
+/// consumed Session seq values; replay filters those rows without renumbering.
+/// Keep this set exactly aligned with `RelayClient.PERSISTENT_TYPES`.
+enum SessionSpineContract {
+    static let persistentTypes: Set<String> = [
+        "session_created",
+        "agent_message",
+        "interrupted_turn",
+        "turn_status",
+        "user_message",
+        "system_message",
+        "error",
+        "session_ended",
+        "idle",
+    ]
+
+    static func contains(type: String, seq: Int) -> Bool {
+        seq > 0 && persistentTypes.contains(type)
+    }
+}
+
 // MARK: - Chat Message (unified storage type)
 
 /// Flat message representation used for storage and UI rendering.

--- a/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
+++ b/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
@@ -298,26 +298,41 @@ final class KrakiVoiceInputController {
         self.context = context
         recordingStartedHandler = onRecordingStarted
         finalHandler = onFinal
-        state = .requestingPermission
-        KLog.d("🎙️ [voice] stage=permission session=\(sessionID.prefix(12)) warm=\(isConnectionWarm ? 1 : 0)")
 
-        let wasUndetermined = audioPolicy.permission == .undetermined
-        guard await audioPolicy.requestPermission() else {
-            if recordingGeneration == currentRecording {
-                failRecording(VoiceInputError.microphoneDenied, closeTransport: false)
-            }
+        switch audioPolicy.permission {
+        case .granted:
+            // The auth handshake already warmed the signed broker connection.
+            // Do not expose a synthetic permission phase when TCC access was
+            // granted previously; proceed directly to audio activation/start.
+            KLog.d("🎙️ [voice] stage=permission-ready session=\(sessionID.prefix(12)) warm=\(isConnectionWarm ? 1 : 0)")
+
+        case .denied:
+            failRecording(VoiceInputError.microphoneDenied, closeTransport: false)
             return
-        }
-        guard recordingGeneration == currentRecording else { return }
-        if wasUndetermined {
+
+        case .undetermined:
+            // Only a genuinely undecided OS permission belongs in the visible
+            // Requesting microphone state. Apple requires this prompt to remain
+            // user-initiated, so warm connection setup must not request it.
+            state = .requestingPermission
+            KLog.d("🎙️ [voice] stage=permission-request session=\(sessionID.prefix(12)) warm=\(isConnectionWarm ? 1 : 0)")
+            guard await audioPolicy.requestPermission() else {
+                if recordingGeneration == currentRecording {
+                    failRecording(VoiceInputError.microphoneDenied, closeTransport: false)
+                }
+                return
+            }
+            guard recordingGeneration == currentRecording else { return }
+            // The permission callback can win a short race with TCC's visible
+            // authorization state. Wait for the same policy used by capture.
             for _ in 0..<20 where audioPolicy.permission != .granted {
                 try? await Task.sleep(for: .milliseconds(50))
                 guard recordingGeneration == currentRecording else { return }
             }
-        }
-        guard audioPolicy.permission == .granted else {
-            failRecording(VoiceInputError.microphoneDenied, closeTransport: false)
-            return
+            guard audioPolicy.permission == .granted else {
+                failRecording(VoiceInputError.microphoneDenied, closeTransport: false)
+                return
+            }
         }
         guard audioPolicy.activate(), recordingGeneration == currentRecording else {
             if recordingGeneration == currentRecording {

--- a/packages/arm/ios/Kraki/Core/Storage/MessageDatabase.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageDatabase.swift
@@ -275,6 +275,50 @@ final class MessageDatabase {
         }
     }
 
+    /// The last `limit` rows strictly before `beforeSeq`, sorted ascending.
+    /// Unlike a numeric seq range, this remains a real page when legacy logs
+    /// contain holes from historical off-spine events.
+    func messagesBefore(_ sessionId: String, beforeSeq: Int, limit: Int) -> [ChatMessage] {
+        do {
+            return try dbPool.read { db in
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT payload FROM messages
+                        WHERE session_id = ? AND seq < ?
+                        ORDER BY seq DESC
+                        LIMIT ?
+                        """,
+                    arguments: [sessionId, beforeSeq, limit]
+                )
+                return Self.decode(rows).reversed()
+            }
+        } catch {
+            return []
+        }
+    }
+
+    /// The first `limit` rows strictly after `afterSeq`, sorted ascending.
+    func messagesAfter(_ sessionId: String, afterSeq: Int, limit: Int) -> [ChatMessage] {
+        do {
+            return try dbPool.read { db in
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT payload FROM messages
+                        WHERE session_id = ? AND seq > ?
+                        ORDER BY seq ASC
+                        LIMIT ?
+                        """,
+                    arguments: [sessionId, afterSeq, limit]
+                )
+                return Self.decode(rows)
+            }
+        } catch {
+            return []
+        }
+    }
+
     /// The last `limit` messages by seq, sorted ascending. Used to
     /// bootstrap a session's initial window and to feed preview
     /// recomputation without loading the whole session.

--- a/packages/arm/ios/Kraki/Core/Storage/MessageDatabase.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageDatabase.swift
@@ -7,8 +7,8 @@
 /// `ChatMessage` field evolution doesn't require schema migration —
 /// only stable identity columns sit in the table proper.
 ///
-/// Used as the persistence backend for `MessageStore`. Not accessed
-/// directly by any other layer.
+/// Used as the persistence backend for `MessageStore`; MessageProvider captures
+/// it only for off-main DB reads and leaves all window mutation to the store.
 ///
 /// WAL mode is enabled so reads never block writes; writes are
 /// serialised by GRDB's `DatabasePool`.
@@ -74,8 +74,9 @@ final class MessageDatabase {
     /// DB is fine; downgrading is not supported.
     private static let schemaVersion = "v1"
     /// Pure-spine migration: PR #154 moved tools/narration/permission/question
-    /// off the spine, so old rows + their (now-mismatched) seqs are garbage.
-    /// No back-compat — drop and recreate the table for a clean slate.
+    /// off the spine, so old *client-cached* rows are invalid. Drop and recreate
+    /// locally; authoritative Tentacle replay then repopulates only persistent
+    /// rows, preserving any legitimate legacy seq holes from its old log.
     private static let schemaVersionPureSpine = "v2_pure_spine"
 
     // MARK: - State
@@ -275,9 +276,9 @@ final class MessageDatabase {
         }
     }
 
-    /// The last `limit` rows strictly before `beforeSeq`, sorted ascending.
-    /// Unlike a numeric seq range, this remains a real page when legacy logs
-    /// contain holes from historical off-spine events.
+    /// The last `limit` persisted spine rows strictly before `beforeSeq`, sorted
+    /// ascending. Unlike a numeric seq range, this remains a real page when
+    /// replayed legacy logs contain arbitrarily large historical seq holes.
     func messagesBefore(_ sessionId: String, beforeSeq: Int, limit: Int) -> [ChatMessage] {
         do {
             return try dbPool.read { db in
@@ -298,7 +299,8 @@ final class MessageDatabase {
         }
     }
 
-    /// The first `limit` rows strictly after `afterSeq`, sorted ascending.
+    /// The first `limit` persisted spine rows strictly after `afterSeq`, sorted
+    /// ascending. Row count, rather than seq span, defines the page.
     func messagesAfter(_ sessionId: String, afterSeq: Int, limit: Int) -> [ChatMessage] {
         do {
             return try dbPool.read { db in

--- a/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
@@ -189,9 +189,10 @@ final class MessageProvider {
         }
     }
 
-    /// Live-message observer: called from `MessageRouter` every time
-    /// a persistent push message lands (user_message, agent_message,
-    /// tool_complete, etc.). Bumps `tentacleLastSeq` up to the new
+    /// Live-message observer: called from `MessageRouter` every time a durable
+    /// spine push lands (user_message, agent_message, idle, terminal status,
+    /// etc.). Off-spine tool/card/trace traffic never enters this path. Bumps
+    /// `tentacleLastSeq` up to the new
     /// seq so the `at-head` check in `requestLatest`/`ensureLoaded`
     /// reflects what we've actually received via push, not just what
     /// the last `session_list` reported. Without this, after a few
@@ -465,14 +466,10 @@ final class MessageProvider {
         requestFromTentacle(sessionId: sessionId, beforeSeq: beforeSeq, reason: reason)
     }
 
-    /// Number of persistent rows in each DB-first page. Page by row count,
-    /// not by a numeric seq interval: current sessions are dense, but legacy
-    /// logs may contain large seq holes from historical off-spine events.
+    /// Number of persistent spine rows in each DB-first page. Page by row count,
+    /// never by numeric seq distance: current Tentacle appends a dense spine,
+    /// while replay preserves arbitrarily large holes from legacy off-spine rows.
     private static let ensurePageRowLimit = 10
-    /// Do not jump across a genuinely missing local cache region. Legacy logs
-    /// can have modest off-spine seq gaps; larger boundaries fall back to Relay
-    /// so a partial SQLite cache cannot silently skip history.
-    private static let maxLegacyBoundaryGap = 100
 
     /// Load one page of older persistent rows, DB-first. A non-empty page is
     /// prepended in spine order; an empty page escalates to WS `requestBefore`.
@@ -489,14 +486,13 @@ final class MessageProvider {
             return false
         }
         let topSeq = state.topSeq
-        let page = appState.messageStore.db.messagesBefore(
+        let page = appState.messageStore.dbMessagesBefore(
             sessionId,
             beforeSeq: topSeq,
             limit: Self.ensurePageRowLimit
         )
 
-        if let nearest = page.last,
-           topSeq - nearest.seq <= Self.maxLegacyBoundaryGap {
+        if !page.isEmpty {
             appState.messageStore.prependOlderPage(sessionId, page)
             let newTop = appState.messageStore.windowState(sessionId)?.topSeq ?? topSeq
             KLog.diag("📥 [2/history←DB ensureOlderLoaded] session=\(sessionId.prefix(12)) topSeq=\(topSeq)→\(newTop) source=GRDB count=\(page.count)")
@@ -554,7 +550,8 @@ final class MessageProvider {
         #if os(macOS)
         KLog.chatEntry(
             "mac-fetch phase=start direction=older session=\(sessionId.prefix(12)) "
-                + "window=[\(state.topSeq),\(state.bottomSeq)] query=[\(from),\(to)]"
+                + "window=[\(state.topSeq),\(state.bottomSeq)] "
+                + "query=rows-before-\(topSeq) limit=\(Self.ensurePageRowLimit)"
         )
         #endif
 
@@ -597,11 +594,11 @@ final class MessageProvider {
             return false
         }
 
-        if let nearest = page.last,
-           topSeq - nearest.seq <= Self.maxLegacyBoundaryGap {
+        if !page.isEmpty {
             let tExp0 = CFAbsoluteTimeGetCurrent()
-            // Persistent spine rows are ordered but need not be integer-adjacent;
-            // off-spine events legitimately consume protocol seq values.
+            // Current spine rows are dense; replayed legacy rows remain ordered
+            // but need not be integer-adjacent because retired transient events
+            // consumed the omitted historical seq values.
             appState.messageStore.prependOlderPage(sessionId, page)
             let expMs = (CFAbsoluteTimeGetCurrent() - tExp0) * 1000
             let newTop = appState.messageStore.windowState(sessionId)?.topSeq ?? topSeq
@@ -650,14 +647,13 @@ final class MessageProvider {
         guard let last = tentacleLastSeq[sessionId], state.bottomSeq < last else {
             return false                          // already at head
         }
-        let page = appState.messageStore.db.messagesAfter(
+        let page = appState.messageStore.dbMessagesAfter(
             sessionId,
             afterSeq: state.bottomSeq,
             limit: Self.ensurePageRowLimit
         )
 
-        if let nearest = page.first,
-           nearest.seq - state.bottomSeq <= Self.maxLegacyBoundaryGap {
+        if !page.isEmpty {
             appState.messageStore.appendNewerPage(sessionId, page)
             let newBottom = appState.messageStore.windowState(sessionId)?.bottomSeq ?? state.bottomSeq
             if newBottom > state.bottomSeq {
@@ -729,7 +725,7 @@ final class MessageProvider {
         }
 
         // Identify the exact turn-aligned request answered by this batch.
-        // `messages` contains only persistent spine rows, while older session
+        // `messages` contains only persistent spine rows, while legacy session
         // logs may have filtered tool/narration seqs near the upper boundary;
         // therefore the final persistent seq can legitimately be several
         // integers below `beforeSeq - 1`.

--- a/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
@@ -465,16 +465,17 @@ final class MessageProvider {
         requestFromTentacle(sessionId: sessionId, beforeSeq: beforeSeq, reason: reason)
     }
 
-    /// Page size for ensure-older / ensure-newer DB-first reads. Keep both
-    /// platforms incremental so reaching a history edge does not inject a large
-    /// cold TextKit slab into one collection-view update.
-    private static let ensurePageSize = 10
+    /// Number of persistent rows in each DB-first page. Page by row count,
+    /// not by a numeric seq interval: current sessions are dense, but legacy
+    /// logs may contain large seq holes from historical off-spine events.
+    private static let ensurePageRowLimit = 10
+    /// Do not jump across a genuinely missing local cache region. Legacy logs
+    /// can have modest off-spine seq gaps; larger boundaries fall back to Relay
+    /// so a partial SQLite cache cannot silently skip history.
+    private static let maxLegacyBoundaryGap = 100
 
-    /// Load one page of older messages, DB-first. Reads the page
-    /// `[topSeq - PAGE..topSeq - 1]` from disk; if that page is
-    /// contiguous (last seq == topSeq - 1) it goes into the in-memory
-    /// window with no network. Otherwise we don't have it — escalate
-    /// to a WS `requestBefore`.
+    /// Load one page of older persistent rows, DB-first. A non-empty page is
+    /// prepended in spine order; an empty page escalates to WS `requestBefore`.
     ///
     /// Returns `true` when the window grew synchronously (DB hit).
     /// `false` means either we're already at history start, or a WS
@@ -488,18 +489,15 @@ final class MessageProvider {
             return false
         }
         let topSeq = state.topSeq
-        let from = max(1, topSeq - Self.ensurePageSize)
-        let to = topSeq - 1
+        let page = appState.messageStore.db.messagesBefore(
+            sessionId,
+            beforeSeq: topSeq,
+            limit: Self.ensurePageRowLimit
+        )
 
-        let page = appState.messageStore.dbMessages(sessionId, from: from, to: to)
-
-        // Contiguity check: the row immediately below the window
-        // (topSeq - 1) must be present. DB rows can have holes when a
-        // session was only partially backfilled, so an empty page or
-        // a page whose last seq < to means we don't truly have what
-        // sits between us and the next chunk.
-        if let last = page.last, last.seq == to {
-            appState.messageStore.expandWindow(sessionId, page)
+        if let nearest = page.last,
+           topSeq - nearest.seq <= Self.maxLegacyBoundaryGap {
+            appState.messageStore.prependOlderPage(sessionId, page)
             let newTop = appState.messageStore.windowState(sessionId)?.topSeq ?? topSeq
             KLog.diag("📥 [2/history←DB ensureOlderLoaded] session=\(sessionId.prefix(12)) topSeq=\(topSeq)→\(newTop) source=GRDB count=\(page.count)")
             return true
@@ -550,8 +548,6 @@ final class MessageProvider {
         guard !loadingOlderDB.contains(sessionId) else { return false }
 
         let topSeq = state.topSeq
-        let from = max(1, topSeq - Self.ensurePageSize)
-        let to = topSeq - 1
 
         loadingOlderDB.insert(sessionId)
         defer { loadingOlderDB.remove(sessionId) }
@@ -582,7 +578,7 @@ final class MessageProvider {
         let db = appState.messageStore.db
         let tRead0 = CFAbsoluteTimeGetCurrent()
         let page = await Task.detached(priority: .userInitiated) {
-            db.messages(sessionId, from: from, to: to)
+            db.messagesBefore(sessionId, beforeSeq: topSeq, limit: Self.ensurePageRowLimit)
         }.value
         let readMs = (CFAbsoluteTimeGetCurrent() - tRead0) * 1000
 
@@ -601,7 +597,8 @@ final class MessageProvider {
             return false
         }
 
-        if !page.isEmpty {
+        if let nearest = page.last,
+           topSeq - nearest.seq <= Self.maxLegacyBoundaryGap {
             let tExp0 = CFAbsoluteTimeGetCurrent()
             // Persistent spine rows are ordered but need not be integer-adjacent;
             // off-spine events legitimately consume protocol seq values.
@@ -653,12 +650,14 @@ final class MessageProvider {
         guard let last = tentacleLastSeq[sessionId], state.bottomSeq < last else {
             return false                          // already at head
         }
-        let from = state.bottomSeq + 1
-        let to = state.bottomSeq + Self.ensurePageSize
+        let page = appState.messageStore.db.messagesAfter(
+            sessionId,
+            afterSeq: state.bottomSeq,
+            limit: Self.ensurePageRowLimit
+        )
 
-        let page = appState.messageStore.dbMessages(sessionId, from: from, to: to)
-
-        if !page.isEmpty {
+        if let nearest = page.first,
+           nearest.seq - state.bottomSeq <= Self.maxLegacyBoundaryGap {
             appState.messageStore.appendNewerPage(sessionId, page)
             let newBottom = appState.messageStore.windowState(sessionId)?.bottomSeq ?? state.bottomSeq
             if newBottom > state.bottomSeq {

--- a/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
@@ -465,14 +465,10 @@ final class MessageProvider {
         requestFromTentacle(sessionId: sessionId, beforeSeq: beforeSeq, reason: reason)
     }
 
-    /// Page size for ensure-older / ensure-newer DB-first reads. macOS uses a
-    /// smaller incremental page so reaching the history edge does not replace a
-    /// compact scrollbar with another 200-row slab in one update.
-    #if os(macOS)
+    /// Page size for ensure-older / ensure-newer DB-first reads. Keep both
+    /// platforms incremental so reaching a history edge does not inject a large
+    /// cold TextKit slab into one collection-view update.
     private static let ensurePageSize = 10
-    #else
-    private static let ensurePageSize = 200
-    #endif
 
     /// Load one page of older messages, DB-first. Reads the page
     /// `[topSeq - PAGE..topSeq - 1]` from disk; if that page is

--- a/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
@@ -1,9 +1,11 @@
 /// MessageStore — Per-session message window plus the disk-backed
 /// truth in `MessageDatabase`.
 ///
-/// **Design model.** Each session has a contiguous in-memory window
-/// (`messages[sessionId]`) that is a *subset* of what's actually
-/// persisted in SQLite. The window's range is tracked in
+/// **Design model.** Each session has a contiguous-in-spine-order in-memory
+/// window (`messages[sessionId]`) that is a *subset* of what's actually
+/// persisted in SQLite. Current Tentacle rows are integer-dense; replayed
+/// legacy rows may have seq holes where retired transient events once lived.
+/// The window's range is tracked in
 /// `windows[sessionId]`. Callers that need the full truth (e.g.
 /// `MessageProvider` deciding "do I need to fetch from tentacle?")
 /// go through the DB-only query methods below; callers that render
@@ -53,8 +55,9 @@ final class MessageStore {
     // MARK: - Per-session window
 
     /// Window of messages currently held in memory, per session.
-    /// Always a contiguous `[topSeq..bottomSeq]` slice of the DB,
-    /// or empty if the session has never been opened in this
+    /// Always a consecutive slice of persisted spine rows bounded by
+    /// `[topSeq...bottomSeq]`, not necessarily every integer in that range for
+    /// legacy logs. Empty if the session has never been opened in this
     /// process. Mutations are always single dict re-assignments so
     /// `@Observable` fires exactly once per logical update.
     var messages: [String: [ChatMessage]] = [:]
@@ -78,20 +81,10 @@ final class MessageStore {
     /// etc.) and lives only in memory. Optimistic pending input
     /// placeholders never reach this store — they live in
     /// `CommandSender.outbox` and are appended at render time.
-    static let persistentTypes: Set<String> = [
-        "session_created",
-        "agent_message",
-        "interrupted_turn",
-        "turn_status",
-        "user_message",
-        "system_message",
-        "error",
-        "session_ended",
-        "idle",
-    ]
+    static let persistentTypes = SessionSpineContract.persistentTypes
 
     static func isPersistent(_ msg: ChatMessage) -> Bool {
-        msg.seq > 0 && persistentTypes.contains(msg.type)
+        SessionSpineContract.contains(type: msg.type, seq: msg.seq)
     }
 
     /// Start from a compact tail and lazy-load the rest as the user reaches the
@@ -284,10 +277,10 @@ final class MessageStore {
         try? db.insert(sessionId, batch)
     }
 
-    /// Prepend a page selected by persistent-spine order. Unlike live-tail
-    /// ingestion, history paging must not require `seq == topSeq - 1`: protocol
-    /// seq values also belong to off-spine tools/narration that are deliberately
-    /// absent from this table and render window.
+    /// Prepend a page selected by persistent-spine row order. Unlike the live
+    /// tail emitted by current Tentacle, replayed legacy history must not require
+    /// `seq == topSeq - 1`: retired off-spine events may have consumed the
+    /// missing historical seq values before replay filtered them out.
     func prependOlderPage(_ sessionId: String, _ rawPage: [ChatMessage]) {
         let page = rawPage.filter(Self.isPersistent)
         guard !page.isEmpty,
@@ -343,9 +336,9 @@ final class MessageStore {
         #endif
     }
 
-    /// Append a DB-selected newer page by persistent-spine order. Protocol
-    /// seq values can have off-spine gaps, so this path must not require the
-    /// first row to equal `bottomSeq + 1`.
+    /// Append a DB-selected newer page by persistent-spine row order. Legacy
+    /// replay can contain historical seq gaps, so this path must not require
+    /// the first row to equal `bottomSeq + 1`.
     func appendNewerPage(_ sessionId: String, _ rawPage: [ChatMessage]) {
         let page = rawPage.filter(Self.isPersistent)
         guard !page.isEmpty,
@@ -550,7 +543,7 @@ final class MessageStore {
     // MARK: - Memory window control
 
     /// Trim an already-loaded tail window after rendered heights have warmed.
-    /// `expandWindow` enforces the px cap while paging, but the initial 200-row
+    /// `expandWindow` enforces the px cap while paging, but the initial compact
     /// bootstrap predates the height oracle and otherwise remains arbitrarily
     /// tall. This keeps the newest tail, removes only the oldest in-memory rows,
     /// and leaves SQLite untouched so scrolling to the top can page them back.
@@ -657,8 +650,8 @@ final class MessageStore {
 
     // MARK: - Memory queries (synchronous)
 
-    /// Returns the current window contents. Always a contiguous
-    /// `[topSeq..bottomSeq]` slice of server-confirmed messages.
+    /// Returns the current window contents. Always a consecutive slice of
+    /// server-confirmed persistent spine rows; legacy seq integers may be sparse.
     /// Optimistic pending input placeholders are NOT included —
     /// callers that want to render those merge `CommandSender.outbox`
     /// at their own layer.
@@ -700,6 +693,16 @@ final class MessageStore {
     /// escalation is needed.
     func dbMessages(_ sessionId: String, from: Int, to: Int) -> [ChatMessage] {
         db.messages(sessionId, from: from, to: to)
+    }
+
+    /// Persistent-spine row page immediately before a raw window boundary.
+    func dbMessagesBefore(_ sessionId: String, beforeSeq: Int, limit: Int) -> [ChatMessage] {
+        db.messagesBefore(sessionId, beforeSeq: beforeSeq, limit: limit)
+    }
+
+    /// Persistent-spine row page immediately after a raw window boundary.
+    func dbMessagesAfter(_ sessionId: String, afterSeq: Int, limit: Int) -> [ChatMessage] {
+        db.messagesAfter(sessionId, afterSeq: afterSeq, limit: limit)
     }
 
     /// Decide whether the seq range `(afterSeq, +∞)` contains any

--- a/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
@@ -94,15 +94,14 @@ final class MessageStore {
         msg.seq > 0 && persistentTypes.contains(msg.type)
     }
 
-    /// iOS keeps the production 200-row bootstrap. The Mac viewport is much
-    /// wider and has edge-triggered DB pagination, so opening 200 raw rows only
-    /// creates an unnecessarily long scrollbar and extra height warm-up. Start
-    /// with a compact tail and lazy-load the rest as the user reaches the top.
+    /// Start from a compact tail and lazy-load the rest as the user reaches the
+    /// top. iOS previously materialized 200 rows at entry, which made one rich
+    /// history window repeatedly rebuild hundreds of offscreen geometries.
     #if os(macOS)
     private static let initialWindowSize = 15
     private static let defaultMinimumPixelManagedWindowCount = 15
     #else
-    private static let initialWindowSize = 200
+    private static let initialWindowSize = 30
     private static let defaultMinimumPixelManagedWindowCount = 1
     #endif
     /// Maximum count of in-memory window before `expandWindow` trims

--- a/packages/arm/ios/Kraki/Core/Storage/PendingTailBuffer.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/PendingTailBuffer.swift
@@ -1,8 +1,9 @@
 /// PendingTailBuffer — pure data structure backing
 /// MessageProvider's push-gap recovery.
 ///
-/// **Problem.** Pushes from tentacle land with strictly ascending
-/// `seq`. Network reorder, brief WebSocket flap, or app-suspend
+/// **Problem.** Current Tentacle assigns a dense, strictly ascending Session
+/// spine `seq` only to persistent rows. Network reorder, brief WebSocket flap,
+/// or app-suspend
 /// races can cause us to receive `seq=205` while we last persisted
 /// `seq=200` (gap [201..204]). Today MessageStore silently drops
 /// such pushes from the in-memory window — they hit DB but the UI
@@ -19,13 +20,12 @@
 /// drain loop runs again, advancing as far as it can, and repeats
 /// until the buffer is empty.
 ///
-/// **Tombstones.** Tentacle filters non-persistent types out of the
-/// range response, so seqs that were live on the wire (e.g. an
-/// `active` heartbeat at seq=203 inside our [201..204] request)
-/// won't come back. The drain loop must still advance past them or
-/// it would stall forever. `tombstones` records seqs the server has
-/// explicitly told us are missing; drain treats them as virtual
-/// committed entries.
+/// **Tombstones.** Current pure-spine ranges are dense. Tombstones exist for
+/// replayed legacy logs, where tool/narration/state records once consumed a
+/// Session seq and are now filtered from range responses without renumbering.
+/// The drain loop must advance past those confirmed historical holes or it
+/// would stall forever. Global transport seqs on current transient messages are
+/// a different ordering domain and never participate here.
 ///
 /// **Why a separate pure struct?** The algorithm has enough corner
 /// cases (truncation, dedupe, multi-hole convergence, tombstone GC)
@@ -42,8 +42,8 @@ struct PendingTailBuffer {
     /// Sorted ascending by `seq`. Unique on `seq` (dedupe on insert).
     private(set) var messages: [ChatMessage] = []
 
-    /// Seqs that tentacle has confirmed are not persistent (filtered
-    /// from a `range_batch` response). Drain steps past these as if
+    /// Legacy Session seqs that Tentacle has confirmed are not persistent
+    /// (filtered from a `range_batch` response). Drain steps past these as if
     /// they were committed. GC'd to `seq >= cursor` after each drain.
     private(set) var tombstones: Set<Int> = []
 

--- a/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
@@ -607,8 +607,9 @@ final class SessionStore {
     }
 
     /// Apply a live state transition without persisting the metadata snapshot.
-    /// `active`, `idle`, and `compacting` envelopes carry a global transport seq
-    /// and are reconciled authoritatively by session_list after reconnect.
+    /// `active`/`compacting` carry only global envelope ordering; `idle` is also
+    /// a durable spine row, but session_list remains the reconnect authority for
+    /// the Session's state and cursor pair.
     func setTransientState(_ id: String, _ state: SessionState) {
         applyState(id, state)
     }
@@ -625,7 +626,8 @@ final class SessionStore {
         }
     }
 
-    /// Record the tool whose `tool_start` event just arrived. The icon
+    /// Compatibility projection for a raw `tool_start` from an older Tentacle.
+    /// Current Tentacles put the live action in `card_action`. The icon
     /// (and headline) is later cleared by either the matching
     /// `tool_complete` (handled in `clearCurrentTool`) or an `idle`
     /// transition. Also bumps the activity snapshot to `.toolRunning`.

--- a/packages/arm/ios/Kraki/Features/Chat/ChatLoadingState.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatLoadingState.swift
@@ -15,6 +15,26 @@ enum ChatEntryLoading {
         !hasMaterializedLatest && providerWaitingForLatest
     }
 
+    /// A cold launch restores every cached device as offline until the first
+    /// authenticated Relay snapshot arrives. Keep Chat's first frame behind the
+    /// existing entry gate during that short handshake so it does not lay out
+    /// once without the composer and jump again when the device becomes online.
+    /// A genuine connection failure releases the gate and keeps offline history
+    /// available.
+    static func isInitialConnectionGateActive(
+        hasStoredCredentials: Bool,
+        hasCompletedInitialConnect: Bool,
+        connectionStatus: ConnectionStatus
+    ) -> Bool {
+        guard hasStoredCredentials, !hasCompletedInitialConnect else { return false }
+        switch connectionStatus {
+        case .awaitingLogin, .connecting, .authenticating:
+            return true
+        case .connected, .disconnected, .error:
+            return false
+        }
+    }
+
     static func isWaitingForLatest(
         expectedLastSeq: Int,
         windowBottomSeq: Int,

--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -1246,7 +1246,18 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     }
 
     private func flushPendingApply() {
-        guard let work = pendingApply else { return }
+        guard !collectionView.isDragging,
+              !collectionView.isDecelerating,
+              !scrollingToTop,
+              let work = pendingApply else { return }
+        // A Relay history response can extend the buffered edge after this
+        // apply was first deferred. Never let that larger, colder buffer slip
+        // through the old barrier and synchronously self-size in applyEdges.
+        if measuringOlderPage || measuringNewerPage
+            || bufferedOlderNeedsMeasurement() || bufferedNewerNeedsMeasurement() {
+            resumeBufferedPageMeasurements()
+            return
+        }
         pendingApply = nil
         work()
     }
@@ -1580,6 +1591,17 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             return
         }
         refreshSpineSnapshot()
+        // A network `.before` response may advance the raw window after the
+        // initiating DB-first task has already returned. Treat that external
+        // front growth as the same buffered pagination transaction rather than
+        // reloading cold rows directly from this observation callback.
+        if !items.isEmpty,
+           let edge = reconcileEdges(old: items, new: ids),
+           edge.insertFront > 0 {
+            paginationSnapshotDeferred = true
+            resumeBufferedPageMeasurements()
+            return
+        }
         // Tail append (including the important empty → first-message
         // transition): reconcile items → ids and reload. Head metadata can
         // also change without changing ids; refresh the footer/jump state so
@@ -1928,27 +1950,65 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// look-ahead), `apply` runs on the next tick with nothing to measure —
     /// so this adds no latency when warm and bounded latency when cold,
     /// instead of a synchronous self-size storm inside `applyEdges`.
+    private func bufferedOlderNeedsMeasurement() -> Bool {
+        let count = bufferedOlderCount()
+        guard count > 0 else { return false }
+        return messages.prefix(count).contains { sizer.cached($0.id) == nil }
+    }
+
+    private func bufferedNewerNeedsMeasurement() -> Bool {
+        let count = bufferedNewerCount()
+        guard count > 0 else { return false }
+        return messages.suffix(count).contains { sizer.cached($0.id) == nil }
+    }
+
+    private func finishOlderPageMeasurement(reason: String) {
+        measuringOlderPage = false
+        // The store can grow again while the pager is budget-slicing the first
+        // response. Re-run the barrier over the current buffer before applying.
+        if bufferedOlderNeedsMeasurement() {
+            resumeBufferedPageMeasurements()
+            return
+        }
+        if pendingApply != nil {
+            flushPendingApply()
+            return
+        }
+        maybeFlushOlder(reason: reason)
+        prefetchOlderIfNeeded()
+    }
+
+    private func finishNewerPageMeasurement(reason: String) {
+        measuringNewerPage = false
+        if bufferedNewerNeedsMeasurement() {
+            resumeBufferedPageMeasurements()
+            return
+        }
+        if pendingApply != nil {
+            flushPendingApply()
+            return
+        }
+        maybeFlushNewer(reason: reason)
+        prefetchNewerIfNeeded()
+    }
+
     private func resumeBufferedPageMeasurements() {
         let older = bufferedOlderCount()
-        if older > 0 {
+        if older > 0, !measuringOlderPage {
             paginationSnapshotDeferred = true
             measuringOlderPage = true
             measurePage(messages.prefix(older)) { [weak self] in
                 guard let self else { return }
-                self.measuringOlderPage = false
-                self.maybeFlushOlder(reason: self.atOldest ? "atOldest" : "resume")
-                self.prefetchOlderIfNeeded()
+                self.finishOlderPageMeasurement(reason: self.atOldest ? "atOldest" : "resume")
             }
         }
         let newer = bufferedNewerCount()
-        if newer > 0 {
+        if newer > 0, !measuringNewerPage {
             paginationSnapshotDeferred = true
             measuringNewerPage = true
             measurePage(messages.suffix(newer)) { [weak self] in
                 guard let self else { return }
-                self.measuringNewerPage = false
-                self.maybeFlushNewer(reason: self.atNewest ? "atNewest" : "resume")
-                self.prefetchNewerIfNeeded()
+                self.finishNewerPageMeasurement(reason: self.atNewest ? "atNewest" : "resume")
             }
         }
         if older == 0, newer == 0, items == ids {
@@ -2066,9 +2126,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             chatPerfLog.log("[txn \(txn.id)] group buf=\(n) dt=\(self.f1(txn.lap()))")
             self.measuringNewerPage = true
             self.measurePage(self.messages.suffix(n)) {
-                self.measuringNewerPage = false
-                self.maybeFlushNewer(reason: self.atNewest ? "atNewest" : "fetched")
-                self.prefetchNewerIfNeeded()
+                self.finishNewerPageMeasurement(reason: self.atNewest ? "atNewest" : "fetched")
             }
         }
     }
@@ -2223,9 +2281,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             // known, so flush/prefetch decisions read a hot cache.
             self.measuringOlderPage = true
             self.measurePage(self.messages.prefix(n)) {
-                self.measuringOlderPage = false
-                self.maybeFlushOlder(reason: self.atOldest ? "atOldest" : "fetched")
-                self.prefetchOlderIfNeeded()
+                self.finishOlderPageMeasurement(reason: self.atOldest ? "atOldest" : "fetched")
             }
         }
     }

--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -549,6 +549,14 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// time). Separate from the now-persistent edge spinners.
     private var fetchingOlder = false
     private var fetchingNewer = false
+    /// A fetched page is still queued for exact measurement. Keep this state
+    /// separate from the DB read so live synchronization cannot reveal cold
+    /// rows in the gap between fetch completion and the pager barrier.
+    private var measuringOlderPage = false
+    private var measuringNewerPage = false
+    /// The model snapshot has advanced past `items`, but those edge rows are
+    /// intentionally buffered until measurement and a stable anchored apply.
+    private var paginationSnapshotDeferred = false
     private var didInitialScroll = false
 
     /// Bumped on every re-anchor (jump-to-latest) so a fetch that was already
@@ -659,6 +667,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         warmKickWork = nil
         cancelPendingWarm()
         pager.cancelAll()
+        measuringOlderPage = false
+        measuringNewerPage = false
         chatPerfLog.log("[lifecycle] willDisappear movingFromParent=\(isMovingFromParent ? 1 : 0)")
         super.viewWillDisappear(animated)
     }
@@ -1288,6 +1298,10 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     private var lastWarmWidth: CGFloat = 0
     private var pendingHeightRefreshIDs = Set<String>()
     private var heightRefreshScheduled = false
+    /// Keep one compact screen of nearby rows hot after entry/settling. The
+    /// initial window is only 30 persistent messages, so eight neighbors cover
+    /// typical real Sessions without restoring the old whole-history warm storm.
+    private static let warmRadius = 8
 
     private func scheduleWarmKick() {
         warmKickWork?.cancel()
@@ -1377,10 +1391,19 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         sizer.prepare(width: width)
 
         let visible = collectionView.indexPathsForVisibleItems.map(\.item).sorted()
-        let candidates = visible.isEmpty ? [items.count - 1] : visible
+        var candidates = visible.isEmpty ? [items.count - 1] : visible
+        if let first = visible.first, let last = visible.last {
+            for distance in 1...Self.warmRadius {
+                let before = first - distance
+                let after = last + distance
+                if before >= 0 { candidates.append(before) }
+                if after < items.count { candidates.append(after) }
+            }
+        }
 
+        var seen = Set<Int>()
         var jobs: [() -> Void] = []
-        for index in candidates {
+        for index in candidates where seen.insert(index).inserted {
             guard index >= 0, index < items.count,
                   let message = message(items[index]) else { continue }
             if sizer.cached(message.id) != nil {
@@ -1521,6 +1544,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         // page settles; `cardChanged` (streaming tail) still reconfigures the
         // single live-card cell cheaply so the tail keeps updating live.
         let pagingInFlight = fetchingOlder || fetchingNewer
+            || measuringOlderPage || measuringNewerPage
+            || paginationSnapshotDeferred || pendingApply != nil
         if pagingInFlight {
             refreshSpineSnapshot()
             if cardChanged, let idx = items.firstIndex(of: Self.liveCardID) {
@@ -1598,6 +1623,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
                 loadingOlder = hasLoadedWindow && !atOldest
                 loadingNewer = hasLoadedWindow && hasAuthoritativeHead && !atNewest
                 items = newIds
+                paginationSnapshotDeferred = false
                 collectionView.reloadData()
                 collectionView.layoutIfNeeded()
             }
@@ -1651,6 +1677,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         }
 
         items = newIds
+        paginationSnapshotDeferred = false
         let newCount = items.count
 
         UIView.performWithoutAnimation {
@@ -1879,19 +1906,28 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     private func resumeBufferedPageMeasurements() {
         let older = bufferedOlderCount()
         if older > 0 {
+            paginationSnapshotDeferred = true
+            measuringOlderPage = true
             measurePage(messages.prefix(older)) { [weak self] in
                 guard let self else { return }
+                self.measuringOlderPage = false
                 self.maybeFlushOlder(reason: self.atOldest ? "atOldest" : "resume")
                 self.prefetchOlderIfNeeded()
             }
         }
         let newer = bufferedNewerCount()
         if newer > 0 {
+            paginationSnapshotDeferred = true
+            measuringNewerPage = true
             measurePage(messages.suffix(newer)) { [weak self] in
                 guard let self else { return }
+                self.measuringNewerPage = false
                 self.maybeFlushNewer(reason: self.atNewest ? "atNewest" : "resume")
                 self.prefetchNewerIfNeeded()
             }
+        }
+        if older == 0, newer == 0, items == ids {
+            paginationSnapshotDeferred = false
         }
     }
 
@@ -1959,9 +1995,9 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         let n = bufferedNewerCount()
         guard n > 0 else { return 0 }
         let w = collectionView.bounds.width
-        var hgt: CGFloat = 0
-        for message in messages.suffix(n) { hgt += sizer.height(for: message, width: w) }
-        return hgt
+        return messages.suffix(n).reduce(0) { total, message in
+            total + (sizer.cached(message.id) ?? sizer.estimatedHeight(for: message, width: w))
+        }
     }
     /// Distance from the viewport to the bottom of loaded content (px).
     private func distanceToBottom() -> CGFloat {
@@ -1973,7 +2009,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// refreshes the snapshot, measures the buffered page off-frame, then re-evaluates flush +
     /// prefetch. Mirror of `fetchOlder`.
     private func fetchNewer() {
-        guard !fetchingNewer, !atNewest, !scrollingToTop else { return }
+        guard !fetchingNewer, !measuringNewerPage, !atNewest, !scrollingToTop else { return }
         fetchingNewer = true
         KLog.chat("📤 [page] fetch-newer session=\(sessionId.prefix(12)) win=[\(vm.windowTopSeq),\(vm.windowBottomSeq)] head=\(vm.sessionLastSeq) distBottom=\(Int(distanceToBottom()))")
         let gen = pagingGeneration
@@ -1998,10 +2034,14 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
                 chatPerfLog.log("[txn \(txn.id)] END noop moved=false total=\(self.f1(txn.total()))")
                 return
             }
+            self.paginationSnapshotDeferred = true
             self.refreshSpineSnapshot()
             let n = self.bufferedNewerCount()
+            if self.items == self.ids { self.paginationSnapshotDeferred = false }
             chatPerfLog.log("[txn \(txn.id)] group buf=\(n) dt=\(self.f1(txn.lap()))")
+            self.measuringNewerPage = true
             self.measurePage(self.messages.suffix(n)) {
+                self.measuringNewerPage = false
                 self.maybeFlushNewer(reason: self.atNewest ? "atNewest" : "fetched")
                 self.prefetchNewerIfNeeded()
             }
@@ -2012,7 +2052,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// the band. Mirror of `prefetchOlderIfNeeded`.
     private func prefetchNewerIfNeeded() {
         guard !suppressPagingForBottom else { return }
-        guard !atNewest, !fetchingNewer, !scrollingToTop else { return }
+        guard pendingApply == nil else { return }
+        guard !atNewest, !fetchingNewer, !measuringNewerPage, !scrollingToTop else { return }
         guard distanceToBottom() < olderPrefetchStart() else { return }
         guard bufferedNewerHeight() < olderBufferTargetHeight else { return }
         fetchNewer()
@@ -2022,6 +2063,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// `maybeFlushOlder` (near the BOTTOM instead of the top).
     private func maybeFlushNewer(reason: String) {
         guard !suppressPagingForBottom else { return }
+        guard pendingApply == nil, !measuringNewerPage else { return }
         let n = bufferedNewerCount()
         guard n > 0, !scrollingToTop else { return }
         let atRest = !collectionView.isDragging && !collectionView.isDecelerating
@@ -2045,6 +2087,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             chatPerfLog.log("[flush \(reason)] NO-COMMON reload old=\(old.count) new=\(new.count)")
             loadingNewer = !atNewest
             items = new
+            paginationSnapshotDeferred = false
             collectionView.reloadData()
             warmWindow()
             return
@@ -2057,6 +2100,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             chatPerfLog.log("[flush \(reason)] midInvalid mismatch=\(mm.idx) → reload")
             loadingNewer = !atNewest
             items = new
+            paginationSnapshotDeferred = false
             collectionView.reloadData()
             warmWindow()
             return
@@ -2096,9 +2140,9 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         let n = bufferedOlderCount()
         guard n > 0 else { return 0 }
         let w = collectionView.bounds.width
-        var hgt: CGFloat = 0
-        for message in messages.prefix(n) { hgt += sizer.height(for: message, width: w) }
-        return hgt
+        return messages.prefix(n).reduce(0) { total, message in
+            total + (sizer.cached(message.id) ?? sizer.estimatedHeight(for: message, width: w))
+        }
     }
     /// Keep filling the buffer until it can cover this much content above the
     /// viewport — enough to clear the trigger band in one reveal (+ margin).
@@ -2113,7 +2157,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// (advances the model), measures the buffered page off-frame, then
     /// re-evaluates flush + prefetch.
     private func fetchOlder() {
-        guard !fetchingOlder, !atOldest, !scrollingToTop else { return }
+        guard !fetchingOlder, !measuringOlderPage, !atOldest, !scrollingToTop else { return }
         fetchingOlder = true
         KLog.chat("📤 [page] fetch-older session=\(sessionId.prefix(12)) win=[\(vm.windowTopSeq),\(vm.windowBottomSeq)] head=\(vm.sessionLastSeq) off=\(Int(collectionView.contentOffset.y))")
         let gen = pagingGeneration
@@ -2144,12 +2188,16 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             // Advance the grouped model — the buffer grows. (The test page's
             // `provider.loadOlder()` is the analog; snapshot refresh is the cost the mock
             // window doesn't have, kept here off the REVEAL.)
+            self.paginationSnapshotDeferred = true
             self.refreshSpineSnapshot()
             let n = self.bufferedOlderCount()
+            if self.items == self.ids { self.paginationSnapshotDeferred = false }
             chatPerfLog.log("[txn \(txn.id)] group buf=\(n) dt=\(self.f1(txn.lap()))")
             // Warm the buffered turns off-frame; only THEN are their heights
             // known, so flush/prefetch decisions read a hot cache.
+            self.measuringOlderPage = true
             self.measurePage(self.messages.prefix(n)) {
+                self.measuringOlderPage = false
                 self.maybeFlushOlder(reason: self.atOldest ? "atOldest" : "fetched")
                 self.prefetchOlderIfNeeded()
             }
@@ -2159,7 +2207,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// Top up the buffer while approaching the top, until it can clear the band.
     private func prefetchOlderIfNeeded() {
         guard !suppressPagingForBottom else { return }
-        guard !atOldest, !fetchingOlder, !scrollingToTop else { return }
+        guard pendingApply == nil else { return }
+        guard !atOldest, !fetchingOlder, !measuringOlderPage, !scrollingToTop else { return }
         let y = collectionView.contentOffset.y
         guard y < olderPrefetchStart() else { return }
         // Buffer already deep enough to clear the band → hold (don't over-fetch).
@@ -2175,6 +2224,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// older rows to arrive instead of washboarding one tiny page per frame.
     private func maybeFlushOlder(reason: String) {
         guard !suppressPagingForBottom else { return }
+        guard pendingApply == nil, !measuringOlderPage else { return }
         let n = bufferedOlderCount()
         guard n > 0, !scrollingToTop else { return }
         let y = collectionView.contentOffset.y
@@ -2201,6 +2251,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             chatPerfLog.log("[flush \(reason)] NO-COMMON reload old=\(old.count) new=\(new.count)")
             loadingOlder = !atOldest
             items = new
+            paginationSnapshotDeferred = false
             collectionView.reloadData()
             warmWindow()
             return
@@ -2213,6 +2264,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             chatPerfLog.log("[flush \(reason)] midInvalid mismatch=\(mm.idx) → reload")
             loadingOlder = !atOldest
             items = new
+            paginationSnapshotDeferred = false
             collectionView.reloadData()
             warmWindow()
             return

--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -260,13 +260,13 @@ private final class RealCellSizer {
     /// Warm path: measure + cache off the critical frame (called by the
     /// scheduler). Cheap no-op if already cached. No sync-miss log — this is
     /// the intended, budget-sliced measurement.
-    func prime(_ t: ChatMessage, width: CGFloat) {
+    func prime(_ t: ChatMessage, width: CGFloat, notify: Bool = true) {
         guard width > 0 else { return }
         resetIfWidthChanged(width)
         if cache[t.id] != nil { return }
         let t0 = CFAbsoluteTimeGetCurrent()
         cache[t.id] = measure(t, width: width)
-        onHeightReady?(t.id)
+        if notify { onHeightReady?(t.id) }
         let ms = (CFAbsoluteTimeGetCurrent() - t0) * 1000
         if ms > 8 {
             chatPerfLog.log("[prime] slow id=\(t.id) ms=\(String(format: "%.1f", ms))")
@@ -652,15 +652,22 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        isLeavingView = false
+        settleInitialVisibleGeometryBeforePresentation()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         isLeavingView = false
         pager.resume()
         resumeBufferedPageMeasurements()
         logEntryState("viewDidAppear")
-        // Upgrade only what is already on screen on the first display-link tick.
-        // This keeps entry non-blocking while preventing a visibly clipped
-        // estimate from surviving until the delayed look-ahead warm pass.
+        // Catch rows that materialized after viewWillAppear (for example an
+        // empty DB window filled by the provider), then start the delayed
+        // look-ahead pass. Ordinary loaded entry rows were already settled
+        // before the navigation transition was presented.
         warmWindow(radius: 0)
         scheduleWarmKick()
     }
@@ -1302,6 +1309,73 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         updateJumpButtonVisibility()
     }
 
+    /// Resolve the bottom viewport before UIKit presents the navigation
+    /// transition. The list can cheaply estimate every loaded row, but exposing
+    /// those estimates makes the final bubble (or the rows immediately above a
+    /// live card) appear clipped until the async warmer expands them. Measuring
+    /// only the already-visible tail here keeps entry bounded while ensuring
+    /// the first composited frame uses the same exact geometry as the cells.
+    private func settleInitialVisibleGeometryBeforePresentation() {
+        guard !initialVisibleGeometrySettled,
+              !isSettlingInitialVisibleGeometry,
+              collectionView != nil,
+              !items.isEmpty else { return }
+        let width = collectionView.bounds.width
+        guard width > 0 else { return }
+
+        isSettlingInitialVisibleGeometry = true
+        defer { isSettlingInitialVisibleGeometry = false }
+        let started = CFAbsoluteTimeGetCurrent()
+        let oldContentHeight = collectionView.contentSize.height
+        sizer.prepare(width: width)
+        lastWarmWidth = width
+        collectionView.layoutIfNeeded()
+
+        var measuredIDs = Set<String>()
+        // A height correction can slightly change which older row intersects
+        // the top edge. Iterate a small bounded number of times so every row in
+        // the final first viewport is exact without warming the whole window.
+        for _ in 0..<3 {
+            let cold = collectionView.indexPathsForVisibleItems
+                .sorted()
+                .compactMap { indexPath -> ChatMessage? in
+                    guard indexPath.item < items.count,
+                          let message = message(items[indexPath.item]),
+                          sizer.cached(message.id) == nil else { return nil }
+                    return message
+                }
+            guard !cold.isEmpty else { break }
+            for message in cold {
+                sizer.prime(message, width: width, notify: false)
+                measuredIDs.insert(message.id)
+            }
+            let context = UICollectionViewFlowLayoutInvalidationContext()
+            context.invalidateFlowLayoutDelegateMetrics = true
+            context.invalidateFlowLayoutAttributes = true
+            collectionView.collectionViewLayout.invalidateLayout(with: context)
+            collectionView.layoutIfNeeded()
+            if followingBottom {
+                pinToBottom(reason: "entry-exact")
+            }
+        }
+
+        let hasColdVisibleMessage = collectionView.indexPathsForVisibleItems.contains { indexPath in
+            guard indexPath.item < items.count,
+                  let message = message(items[indexPath.item]) else { return false }
+            return sizer.cached(message.id) == nil
+        }
+        guard !hasColdVisibleMessage else { return }
+        appliedHeightIDs.formUnion(measuredIDs)
+        initialVisibleGeometrySettled = true
+        let elapsed = (CFAbsoluteTimeGetCurrent() - started) * 1_000
+        chatPerfLog.log(
+            "[entry] exact-visible n=\(measuredIDs.count) "
+                + "content=\(String(format: "%.1f", oldContentHeight))"
+                + "→\(String(format: "%.1f", collectionView.contentSize.height)) "
+                + "ms=\(String(format: "%.1f", elapsed)) live=\(hasLiveCardItem ? 1 : 0)"
+        )
+    }
+
     /// Pre-measure heights OFF the scroll critical path. Warm the loaded
     /// window's turns during idle so on-screen scrolling never pays a
     /// synchronous self-size. Unlike the old preload-everything provider we
@@ -1311,6 +1385,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     private var warmEnqueued = Set<String>()
     private var appliedHeightIDs = Set<String>()
     private var lastWarmWidth: CGFloat = 0
+    private var initialVisibleGeometrySettled = false
+    private var isSettlingInitialVisibleGeometry = false
     private var pendingHeightRefreshIDs = Set<String>()
     private var heightRefreshScheduled = false
     /// Keep one compact screen of nearby rows hot after entry/settling. The
@@ -1375,6 +1451,19 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             let oldHeights = Dictionary(uniqueKeysWithValues: paths.map { path in
                 (path, self.collectionView.layoutAttributesForItem(at: path)?.frame.height ?? -1)
             })
+            let contentHeightDelta = paths.reduce(CGFloat.zero) { total, path in
+                let old = oldHeights[path] ?? 0
+                guard path.item < self.items.count,
+                      let new = self.sizer.cached(self.items[path.item]), old >= 0 else { return total }
+                return total + new - old
+            }
+            if self.followingBottom, abs(contentHeightDelta) > 0.5 {
+                // Rebase the scroll offset inside the same FlowLayout
+                // invalidation transaction that changes content height. Laying
+                // out first and pinning second briefly exposes an earlier,
+                // clipped viewport when nearby rows warm after entry.
+                context.contentOffsetAdjustment = CGPoint(x: 0, y: contentHeightDelta)
+            }
             // `sizeForItemAt` is a FlowLayout delegate metric. Invalidating only
             // item attributes can leave the old estimated height cached until a
             // user scroll starts another layout cycle, producing the observed
@@ -1386,7 +1475,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             self.collectionView.layoutIfNeeded()
 
             if self.followingBottom {
-                self.pinToBottom(reason: "height-warm")
+                self.lastPinnedViewportSize = self.collectionView.bounds.size
+                self.lastPinnedAdjustedInsets = self.collectionView.adjustedContentInset
             } else if let anchor,
                       let newFrame = self.collectionView.layoutAttributesForItem(at: anchor.0)?.frame {
                 self.collectionView.contentOffset.y += newFrame.minY - anchor.1
@@ -1403,6 +1493,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
                     "[height] apply n=\(paths.count) changed=\(changed) "
                         + "content=\(String(format: "%.1f", oldContentHeight))"
                         + "→\(String(format: "%.1f", self.collectionView.contentSize.height)) "
+                        + "off=\(String(format: "%.1f", self.collectionView.contentOffset.y)) "
+                        + "distBottom=\(String(format: "%.1f", self.distanceToBottom())) "
                         + "ms=\(String(format: "%.1f", layoutMs))"
                 )
             }
@@ -1616,6 +1708,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         if idsChanged || edgeStateChanged {
             // Full reload only when the spine item set or edge spinners moved.
             let wasAtBottom = followingBottom || distanceToBottom() <= Self.bottomFollowTolerance
+            let isFirstMaterialization = items.isEmpty && !newIds.isEmpty
             items = newIds
             lastLiveCardSignature = cardSig
             collectionView.reloadData()
@@ -1623,6 +1716,13 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             if !items.isEmpty, !didInitialScroll || wasAtBottom {
                 followingBottom = true
                 pinToBottom(reason: "live-update", animated: didInitialScroll && !wasAtBottom)
+            }
+            // If the controller was created while its DB window was still
+            // empty, this observation is its real first frame. Settle that tail
+            // synchronously in the same run-loop turn before it can be shown.
+            if isFirstMaterialization {
+                initialVisibleGeometrySettled = false
+                settleInitialVisibleGeometryBeforePresentation()
             }
         } else if cardChanged {
             // Only the streaming tail cell's content changed (same item set).

--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -132,6 +132,7 @@ private final class SpinnerReusableView: UICollectionReusableView {
 /// (Dynamic Type, interface style) resolve identically to the live list.
 private final class RealCellSizer {
     private var cache: [String: CGFloat] = [:]
+    private var estimateCache: [String: CGFloat] = [:]
     private var measuredWidth: CGFloat = 0
 
     /// Real session id / agent so the offscreen measure renders the SAME
@@ -178,6 +179,7 @@ private final class RealCellSizer {
     private func resetIfWidthChanged(_ width: CGFloat) {
         if width != measuredWidth {
             cache.removeAll(keepingCapacity: true)
+            estimateCache.removeAll(keepingCapacity: true)
             measuredWidth = width
         }
     }
@@ -195,6 +197,9 @@ private final class RealCellSizer {
     /// during the initial layout.
     func estimatedHeight(for t: ChatMessage, width: CGFloat) -> CGFloat {
         guard width > 0 else { return 44 }
+        resetIfWidthChanged(width)
+        if let cached = estimateCache[t.id] { return cached }
+
         let isUser = t.type == "user_message" || t.type == "send_input" || t.type == "pending_input"
         let usable = max(120, width - 24)
         let bubbleWidth = isUser
@@ -202,22 +207,21 @@ private final class RealCellSizer {
             : usable - width * 0.05
         let bodyWidth = max(80, bubbleWidth - 28)
         let text = t.content ?? t.result ?? t.interruptedDraft ?? ""
-        // Bound the estimator itself for unusually large historical replies;
-        // the exact scheduler will measure the complete text after entry.
-        let sample = String(text.prefix(8_000))
         let bodyHeight: CGFloat
-        if sample.isEmpty || sample == "[image]" {
+        if text.isEmpty || text == "[image]" {
             bodyHeight = 0
         } else {
+            // Entry layout asks for every row. Never run CoreText/NSString
+            // boundingRect here: one long history window otherwise turns every
+            // layout invalidation into an O(messages × text length) main-thread
+            // stall. A cached glyph-density estimate is sufficient until the
+            // small visible warm band upgrades the row to exact TextKit geometry.
             let font = UIFont.preferredFont(forTextStyle: .subheadline)
-            let rect = (sample as NSString).boundingRect(
-                with: CGSize(width: bodyWidth, height: .greatestFiniteMagnitude),
-                options: [.usesLineFragmentOrigin, .usesFontLeading],
-                attributes: [.font: font],
-                context: nil
-            )
-            let codeBlocks = sample.components(separatedBy: "```").count / 2
-            bodyHeight = ceil(rect.height) + CGFloat(codeBlocks) * 16
+            let glyphUnits = min(text.utf8.count, 8_000)
+            let averageGlyphWidth = max(5, font.pointSize * 0.52)
+            let unitsPerLine = max(12, Int(bodyWidth / averageGlyphWidth))
+            let wrappedLines = max(1, Int(ceil(Double(glyphUnits) / Double(unitsPerLine))))
+            bodyHeight = CGFloat(wrappedLines) * ceil(font.lineHeight)
         }
 
         var height = bodyHeight > 0 ? bodyHeight + 32 : 1
@@ -233,7 +237,9 @@ private final class RealCellSizer {
         if t.type == "turn_status" || t.type == "interrupted_turn" {
             height += 44
         }
-        return min(max(ceil(height), 1), 1_600)
+        let result = min(max(ceil(height), 1), 1_600)
+        estimateCache[t.id] = result
+        return result
     }
 
     /// Cache-or-measure. A miss measures SYNCHRONOUSLY on the calling
@@ -309,11 +315,10 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
 
     private let sizer = RealCellSizer()
 
-    /// Pre-warms the height cache off the critical frame, ≤budget ms per
-    /// frame, so a scroll into fresh markdown cells hits the cache instead
-    /// of paying the self-size on the scroll frame. The real app's exact
-    /// scheduler — reused verbatim. PAUSED during active gestures/momentum
-    /// (it's only opportunistic look-ahead, must never fight a scroll frame).
+    /// Upgrades only the currently visible height cache after entry or scroll
+    /// settling, ≤budget ms per frame. Pending jobs are discarded as soon as a
+    /// gesture or navigation transition begins so exact measurement never owns
+    /// an interaction frame.
     private let warmer = HeightMeasurementScheduler(budgetMs: 4.0)
 
     /// Dedicated scheduler for the ONE page a pending paginate is about to
@@ -593,6 +598,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
 
     // Frame-time monitor.
     private var displayLink: CADisplayLink?
+    private var warmKickWork: DispatchWorkItem?
+    private var isLeavingView = false
     private var lastFrameTs: CFTimeInterval = 0
     private var hitchCount = 0
     private var worstFrameMs: Double = 0
@@ -630,6 +637,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
 
     deinit {
         displayLink?.invalidate()
+        warmKickWork?.cancel()
         codeHighlightSettleWork?.cancel()
         if let codeHighlightObserver {
             NotificationCenter.default.removeObserver(codeHighlightObserver)
@@ -638,7 +646,21 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        isLeavingView = false
+        pager.resume()
+        resumeBufferedPageMeasurements()
         logEntryState("viewDidAppear")
+        scheduleWarmKick()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        isLeavingView = true
+        warmKickWork?.cancel()
+        warmKickWork = nil
+        cancelPendingWarm()
+        pager.cancelAll()
+        chatPerfLog.log("[lifecycle] willDisappear movingFromParent=\(isMovingFromParent ? 1 : 0)")
+        super.viewWillDisappear(animated)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -913,8 +935,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         sizer.prepare(width: w)
         // Cold rows use a cheap estimate. Exact TextKit geometry is upgraded
         // by warmWindow() in display-link budget slices and invalidated in a
-        // coalesced layout pass, so initial reloadData never measures all 200
-        // rows synchronously on the main thread.
+        // coalesced layout pass, so initial reloadData never measures the whole
+        // loaded window synchronously on the main thread.
         let height = sizer.cached(message.id)
             ?? sizer.estimatedHeight(for: message, width: w)
         return CGSize(width: w, height: height)
@@ -1088,7 +1110,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// PREFER sliding the already-loaded tail UP to the head (`pageNewerRaw`
     /// extends the bottom while the px-cap trims the top): this keeps the warm,
     /// already-measured ~14-screen window, so the jump glides over real content
-    /// with no cold-cell refill. `jumpToHead` (nuke + reload the last 200 msgs)
+    /// with no cold-cell refill. `jumpToHead` (nuke + reload the compact tail)
     /// collapses the window to a 1-2 turn stub, and the paging engine then
     /// storms ~13 screens of cold older-refill (~20 × 30ms hitches) — so it's
     /// used only when there's no window yet or the gap is too big to bridge.
@@ -1232,16 +1254,26 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         loadingOlder = hasLoadedWindow && !atOldest
         loadingNewer = hasLoadedWindow && hasAuthoritativeHead && !atNewest
         collectionView.reloadData()
+        if !items.isEmpty {
+            // Position the first layout at the tail. Laying out at offset zero
+            // first creates the oldest visible rich cells only to discard them
+            // when pinToBottom runs, adding hundreds of milliseconds to entry.
+            collectionView.scrollToItem(
+                at: IndexPath(item: items.count - 1, section: 0),
+                at: .bottom,
+                animated: false
+            )
+        }
         collectionView.layoutIfNeeded()
         didInitialScroll = true
         followingBottom = true
         pinToBottom(reason: "initial")
         lastReason = "initial"
         let ms = (CFAbsoluteTimeGetCurrent() - t0) * 1000
+        chatPerfLog.log("[entry] applyInitial ms=\(String(format: "%.1f", ms)) items=\(items.count)")
         KLog.chat("📥 [chat-entry] applyInitial session=\(sessionId.prefix(12)) items=\(items.count) win=[\(vm.windowTopSeq),\(vm.windowBottomSeq)] head=\(vm.sessionLastSeq) atNewest=\(atNewest) ms=\(String(format: "%.1f", ms))")
         logEntryState("applyInitial")
         updateOverlay()
-        warmWindow()
         updateJumpButtonVisibility()
     }
 
@@ -1252,9 +1284,29 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// measured by `pager` behind the spinner after `loadOlder`/`loadNewer`
     /// brings them in. Paused while the finger or momentum is moving.
     private var warmEnqueued = Set<String>()
+    private var appliedHeightIDs = Set<String>()
     private var lastWarmWidth: CGFloat = 0
     private var pendingHeightRefreshIDs = Set<String>()
     private var heightRefreshScheduled = false
+
+    private func scheduleWarmKick() {
+        warmKickWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.viewIfLoaded?.window != nil else { return }
+            self.warmKickWork = nil
+            self.warmWindow()
+        }
+        warmKickWork = work
+        // Let the navigation transition and the first back/tap opportunity
+        // settle before any atomic TextKit measurement reaches the main actor.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: work)
+    }
+
+    private func cancelPendingWarm() {
+        warmer.cancelAll()
+        warmEnqueued = Set(warmEnqueued.filter { sizer.cached($0) != nil })
+        pendingHeightRefreshIDs.removeAll(keepingCapacity: true)
+    }
 
     /// Coalesce exact-height upgrades into one layout pass. When the user is
     /// following the newest tail, repin after the pass; otherwise preserve the
@@ -1269,7 +1321,10 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             self.heightRefreshScheduled = false
             let ids = self.pendingHeightRefreshIDs
             self.pendingHeightRefreshIDs.removeAll(keepingCapacity: true)
-            guard !ids.isEmpty, self.collectionView != nil else { return }
+            guard !ids.isEmpty,
+                  !self.isLeavingView,
+                  self.collectionView != nil,
+                  self.viewIfLoaded?.window != nil else { return }
 
             let top = self.collectionView.contentOffset.y + self.collectionView.adjustedContentInset.top
             let anchor = self.collectionView.indexPathsForVisibleItems
@@ -1281,9 +1336,12 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
                 }
                 .first
             let context = UICollectionViewFlowLayoutInvalidationContext()
-            let paths = ids.compactMap { id in
+            let applicableIDs = ids.filter { self.items.contains($0) }
+            let paths = applicableIDs.compactMap { id in
                 self.items.firstIndex(of: id).map { IndexPath(item: $0, section: 0) }
             }
+            guard !paths.isEmpty else { return }
+            let layoutStarted = CFAbsoluteTimeGetCurrent()
             context.invalidateItems(at: paths)
             self.collectionView.collectionViewLayout.invalidateLayout(with: context)
             self.collectionView.layoutIfNeeded()
@@ -1294,30 +1352,49 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
                       let newFrame = self.collectionView.layoutAttributesForItem(at: anchor.0)?.frame {
                 self.collectionView.contentOffset.y += newFrame.minY - anchor.1
             }
+            self.appliedHeightIDs.formUnion(applicableIDs)
+            let layoutMs = (CFAbsoluteTimeGetCurrent() - layoutStarted) * 1_000
+            if layoutMs > 4 {
+                chatPerfLog.log("[height] apply n=\(paths.count) ms=\(String(format: "%.1f", layoutMs))")
+            }
         }
     }
 
     private func warmWindow() {
         let width = collectionView.bounds.width
-        guard width > 0 else { return }
+        guard width > 0,
+              !items.isEmpty,
+              !isLeavingView,
+              viewIfLoaded?.window != nil else { return }
         // Width changed (rotation / split): cancel jobs measured for the old
         // geometry before clearing the cache and restarting the warm pass.
         if width != lastWarmWidth {
             lastWarmWidth = width
-            warmer.cancelAll()
+            cancelPendingWarm()
             warmEnqueued.removeAll(keepingCapacity: true)
+            appliedHeightIDs.removeAll(keepingCapacity: true)
         }
         sizer.prepare(width: width)
+
+        let visible = collectionView.indexPathsForVisibleItems.map(\.item).sorted()
+        let candidates = visible.isEmpty ? [items.count - 1] : visible
+
         var jobs: [() -> Void] = []
-        func enqueueIfCold(_ t: ChatMessage) {
-            guard sizer.cached(t.id) == nil, !warmEnqueued.contains(t.id) else { return }
-            warmEnqueued.insert(t.id)
-            jobs.append { [weak self] in self?.sizer.prime(t, width: width) }
+        for index in candidates {
+            guard index >= 0, index < items.count,
+                  let message = message(items[index]) else { continue }
+            if sizer.cached(message.id) != nil {
+                if !appliedHeightIDs.contains(message.id) {
+                    scheduleHeightRefresh(for: message.id)
+                }
+                continue
+            }
+            guard !warmEnqueued.contains(message.id) else { continue }
+            warmEnqueued.insert(message.id)
+            jobs.append { [weak self] in self?.sizer.prime(message, width: width) }
         }
-        // The loaded window — what the user sees and scrolls through now.
-        for message in messages { enqueueIfCold(message) }
         guard !jobs.isEmpty else { return }
-        chatPerfLog.log("[warm] enqueue n=\(jobs.count)")
+        chatPerfLog.log("[warm] enqueue n=\(jobs.count) visible=\(visible.first ?? -1)-\(visible.last ?? -1)")
         warmer.enqueue(jobs)
     }
 
@@ -1713,7 +1790,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         // markdown self-size for a pending page runs here behind the spinner
         // — never on a scroll frame. The apply (barrier) fires once every
         // height is measured, so the page is fully rendered before it lands.
-        warmer.resume()
+        warmWindow()
         pager.resume()
         setVisibleBodiesInteractive(true)
         settleEdges()
@@ -1726,7 +1803,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         if !decelerate {
             scheduleCodeHighlightRefreshIfNeeded()
             flushPendingApply()
-            warmer.resume()
+            warmWindow()
             pager.resume()
             setVisibleBodiesInteractive(true)
             settleEdges()
@@ -1761,8 +1838,10 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         followingBottom = distanceToBottom() <= Self.bottomFollowTolerance
         // Stand down warming AND page measurement for the duration of the
         // gesture/fling so no expensive self-size competes with scroll frames.
-        // The spinner stays up; the page measures + applies once motion stops.
-        warmer.pause()
+        // Discard stale visible-height jobs from the old viewport; the new visible
+        // band is enqueued when motion settles. Page work is preserved because
+        // its barrier owns a pending pagination apply.
+        cancelPendingWarm()
         pager.pause()
         setVisibleBodiesInteractive(false)
     }
@@ -1797,7 +1876,27 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// look-ahead), `apply` runs on the next tick with nothing to measure —
     /// so this adds no latency when warm and bounded latency when cold,
     /// instead of a synchronous self-size storm inside `applyEdges`.
+    private func resumeBufferedPageMeasurements() {
+        let older = bufferedOlderCount()
+        if older > 0 {
+            measurePage(messages.prefix(older)) { [weak self] in
+                guard let self else { return }
+                self.maybeFlushOlder(reason: self.atOldest ? "atOldest" : "resume")
+                self.prefetchOlderIfNeeded()
+            }
+        }
+        let newer = bufferedNewerCount()
+        if newer > 0 {
+            measurePage(messages.suffix(newer)) { [weak self] in
+                guard let self else { return }
+                self.maybeFlushNewer(reason: self.atNewest ? "atNewest" : "resume")
+                self.prefetchNewerIfNeeded()
+            }
+        }
+    }
+
     private func measurePage(_ page: ArraySlice<ChatMessage>, then apply: @escaping () -> Void) {
+        guard !isLeavingView, viewIfLoaded?.window != nil else { return }
         let width = collectionView.bounds.width
         guard width > 0 else { apply(); return }
         var jobs: [() -> Void] = []
@@ -1982,12 +2081,11 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     // `reconcileEdges(old: items, new: ids)` (the oldest applied turn may merge
     // into a new id when older history arrives), NOT raw seq arithmetic.
     //
-    // Why this cannot run away (the 370-fetch/3-apply bug): one production DB
-    // page is `ensurePageSize`=200 raw msgs → many turns → far TALLER than the
-    // viewport, so a SINGLE fetched page already exceeds `olderBufferTargetHeight`.
-    // `prefetchOlderIfNeeded` then HOLDS (no more fetches) until a flush drains
-    // the buffer. So a fling does ~one fetch+snapshot refresh per revealed page, not one
-    // per frame.
+    // Why this cannot run away (the 370-fetch/3-apply bug): DB fetches are
+    // serialized, and each 10-row page extends one shared buffer. Short rows may
+    // require a few compact pages, but prefetch stops as soon as buffered height
+    // reaches `olderBufferTargetHeight`; a reveal then drains the whole buffer in
+    // one apply instead of fetching once per scroll frame.
 
     /// Older turns grouped into the model but not yet revealed in `items`.
     private func bufferedOlderCount() -> Int {

--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -124,8 +124,9 @@ private final class SpinnerReusableView: UICollectionReusableView {
 /// is the whole point of phase 2: we pay the real cost, then hide it behind
 /// measure-ahead (the scheduler pre-warms the cache off the critical frame).
 /// Because the flow layout uses `estimatedItemSize = .zero`, the height we
-/// return is the cell's DEFINITIVE height — the layout and the anchor offset
-/// correction both read this one source of truth.
+/// return is definitive once the row is warm. Cold rows use a lightweight
+/// estimate during entry, then the same cache is upgraded by the scheduler;
+/// layout and anchor correction read that single source of truth thereafter.
 ///
 /// `container` must be installed in the view hierarchy by the VC so traits
 /// (Dynamic Type, interface style) resolve identically to the live list.
@@ -137,6 +138,9 @@ private final class RealCellSizer {
     /// TextKit config the live cell uses. Set by the VC right after init.
     var sessionId: String = "perf"
     var agent: String = "claude"
+    /// Builds the same geometry description used by a visible cell.
+    var contentBuilder: ((ChatMessage) -> TKBubbleContent)?
+    var onHeightReady: ((String) -> Void)?
 
     /// Container whose safe-area insets are forced to zero — a real list
     /// cell self-sizes with none, but an offscreen view pinned into the VC
@@ -180,6 +184,58 @@ private final class RealCellSizer {
 
     func cached(_ id: String) -> CGFloat? { cache[id] }
 
+    func prepare(width: CGFloat) {
+        guard width > 0 else { return }
+        resetIfWidthChanged(width)
+    }
+
+    /// Cheap first-pass geometry for rows that have not been measured yet.
+    /// This path must stay free of Markdown, TextKit, image decoding, and
+    /// SwiftUI host measurement because UICollectionView asks for every row
+    /// during the initial layout.
+    func estimatedHeight(for t: ChatMessage, width: CGFloat) -> CGFloat {
+        guard width > 0 else { return 44 }
+        let isUser = t.type == "user_message" || t.type == "send_input" || t.type == "pending_input"
+        let usable = max(120, width - 24)
+        let bubbleWidth = isUser
+            ? usable - width * 0.18
+            : usable - width * 0.05
+        let bodyWidth = max(80, bubbleWidth - 28)
+        let text = t.content ?? t.result ?? t.interruptedDraft ?? ""
+        // Bound the estimator itself for unusually large historical replies;
+        // the exact scheduler will measure the complete text after entry.
+        let sample = String(text.prefix(8_000))
+        let bodyHeight: CGFloat
+        if sample.isEmpty || sample == "[image]" {
+            bodyHeight = 0
+        } else {
+            let font = UIFont.preferredFont(forTextStyle: .subheadline)
+            let rect = (sample as NSString).boundingRect(
+                with: CGSize(width: bodyWidth, height: .greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin, .usesFontLeading],
+                attributes: [.font: font],
+                context: nil
+            )
+            let codeBlocks = sample.components(separatedBy: "```").count / 2
+            bodyHeight = ceil(rect.height) + CGFloat(codeBlocks) * 16
+        }
+
+        var height = bodyHeight > 0 ? bodyHeight + 32 : 1
+        let attachmentCount = t.contentRefAttachments.count
+            + (t.attachments?.filter { $0.type == "image" }.count ?? 0)
+        if attachmentCount > 0 {
+            let imageWidth = max(80, min(bodyWidth, 280))
+            let imageHeight = min(240, imageWidth * 0.66)
+            height += bodyHeight > 0 ? 6 : 16
+            height += imageHeight * CGFloat(min(attachmentCount, 3))
+            height += CGFloat(max(0, min(attachmentCount, 3) - 1)) * 6
+        }
+        if t.type == "turn_status" || t.type == "interrupted_turn" {
+            height += 44
+        }
+        return min(max(ceil(height), 1), 1_600)
+    }
+
     /// Cache-or-measure. A miss measures SYNCHRONOUSLY on the calling
     /// thread — when that caller is `sizeForItemAt` during a scroll, the
     /// cost lands on the scroll frame, so we log it as the key jank signal.
@@ -204,6 +260,7 @@ private final class RealCellSizer {
         if cache[t.id] != nil { return }
         let t0 = CFAbsoluteTimeGetCurrent()
         cache[t.id] = measure(t, width: width)
+        onHeightReady?(t.id)
         let ms = (CFAbsoluteTimeGetCurrent() - t0) * 1000
         if ms > 8 {
             chatPerfLog.log("[prime] slow id=\(t.id) ms=\(String(format: "%.1f", ms))")
@@ -213,7 +270,7 @@ private final class RealCellSizer {
     /// The real self-size: configure the offscreen cell exactly like the
     /// live one and ask UIKit for its fitting height.
     private func measure(_ t: ChatMessage, width: CGFloat) -> CGFloat {
-        TKBubbleContent.make(message: t, sessionId: sessionId, agent: agent)
+        (contentBuilder?(t) ?? TKBubbleContent.make(message: t, sessionId: sessionId, agent: agent))
             .cellHeight(cellWidth: width)
     }
 }
@@ -332,6 +389,15 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         super.init(nibName: nil, bundle: nil)
         sizer.sessionId = sessionId
         sizer.agent = agent
+        sizer.contentBuilder = { [weak self] message in
+            guard let self else {
+                return TKBubbleContent.make(message: message, sessionId: sessionId, agent: agent)
+            }
+            return self.bubbleContent(for: message)
+        }
+        sizer.onHeightReady = { [weak self] id in
+            self?.scheduleHeightRefresh(for: id)
+        }
         // PX window cap: feed the store the rendered height of each turn (keyed
         // by end seq) so `expandWindow` trims the far edge by SCREEN HEIGHT, not
         // message count. Reads the live sizer cache via `seqToTurnId` (built in
@@ -688,6 +754,23 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         return MessageStore.SessionCard(text: text, action: action)
     }
 
+    /// Build the same content description used by a visible cell and by the
+    /// offscreen warm sizer. Frozen terminal messages use the live-card path.
+    private func bubbleContent(for message: ChatMessage) -> TKBubbleContent {
+        if message.type == "turn_status" || message.type == "interrupted_turn" {
+            return TKBubbleContent.live(
+                card: frozenCard(from: message),
+                agent: agentName,
+                sessionId: sessionId,
+                steps: message.steps ?? 0,
+                isFrozen: true,
+                frozenTimestamp: message.finishedAt ?? message.timestamp,
+                attachments: message.contentRefAttachments
+            )
+        }
+        return TKBubbleContent.make(message: message, sessionId: sessionId, agent: agentName)
+    }
+
     /// Toggle body text selection/links on visible TextKit cells. Off during
     /// scroll (the UITextInteraction is the only per-cell fling cost), on at rest.
     private func setVisibleBodiesInteractive(_ on: Bool) {
@@ -824,18 +907,17 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
                                                 sessionId: sessionId, steps: vm.lastUserStepsHint)
             return CGSize(width: w, height: content.cellHeight(cellWidth: w))
         }
-        if let message = frozenCardMessage(indexPath.item) {
-            let content = TKBubbleContent.live(card: frozenCard(from: message), agent: agentName,
-                                                sessionId: sessionId, steps: message.steps ?? 0,
-                                                isFrozen: true,
-                                                frozenTimestamp: message.finishedAt ?? message.timestamp,
-                                                attachments: message.contentRefAttachments)
-            return CGSize(width: w, height: content.cellHeight(cellWidth: w))
-        }
         guard indexPath.item < items.count, let message = message(items[indexPath.item]) else {
             return CGSize(width: w, height: 44)
         }
-        return CGSize(width: w, height: sizer.height(for: message, width: w))
+        sizer.prepare(width: w)
+        // Cold rows use a cheap estimate. Exact TextKit geometry is upgraded
+        // by warmWindow() in display-link budget slices and invalidated in a
+        // coalesced layout pass, so initial reloadData never measures all 200
+        // rows synchronously on the main thread.
+        let height = sizer.cached(message.id)
+            ?? sizer.estimatedHeight(for: message, width: w)
+        return CGSize(width: w, height: height)
     }
 
     private func presentLiveSteps() {
@@ -1171,16 +1253,61 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// brings them in. Paused while the finger or momentum is moving.
     private var warmEnqueued = Set<String>()
     private var lastWarmWidth: CGFloat = 0
+    private var pendingHeightRefreshIDs = Set<String>()
+    private var heightRefreshScheduled = false
+
+    /// Coalesce exact-height upgrades into one layout pass. When the user is
+    /// following the newest tail, repin after the pass; otherwise preserve the
+    /// first visible item's screen position while rows above it change height.
+    private func scheduleHeightRefresh(for id: String) {
+        guard collectionView != nil else { return }
+        pendingHeightRefreshIDs.insert(id)
+        guard !heightRefreshScheduled else { return }
+        heightRefreshScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.heightRefreshScheduled = false
+            let ids = self.pendingHeightRefreshIDs
+            self.pendingHeightRefreshIDs.removeAll(keepingCapacity: true)
+            guard !ids.isEmpty, self.collectionView != nil else { return }
+
+            let top = self.collectionView.contentOffset.y + self.collectionView.adjustedContentInset.top
+            let anchor = self.collectionView.indexPathsForVisibleItems
+                .sorted()
+                .compactMap { indexPath -> (IndexPath, CGFloat)? in
+                    guard let frame = self.collectionView.layoutAttributesForItem(at: indexPath)?.frame,
+                          frame.maxY > top + 1 else { return nil }
+                    return (indexPath, frame.minY)
+                }
+                .first
+            let context = UICollectionViewFlowLayoutInvalidationContext()
+            let paths = ids.compactMap { id in
+                self.items.firstIndex(of: id).map { IndexPath(item: $0, section: 0) }
+            }
+            context.invalidateItems(at: paths)
+            self.collectionView.collectionViewLayout.invalidateLayout(with: context)
+            self.collectionView.layoutIfNeeded()
+
+            if self.followingBottom {
+                self.pinToBottom(reason: "height-warm")
+            } else if let anchor,
+                      let newFrame = self.collectionView.layoutAttributesForItem(at: anchor.0)?.frame {
+                self.collectionView.contentOffset.y += newFrame.minY - anchor.1
+            }
+        }
+    }
 
     private func warmWindow() {
         let width = collectionView.bounds.width
         guard width > 0 else { return }
-        // Width changed (rotation / split): the sizer dropped its cache, so the
-        // "already enqueued" set is stale — clear it and re-warm from scratch.
+        // Width changed (rotation / split): cancel jobs measured for the old
+        // geometry before clearing the cache and restarting the warm pass.
         if width != lastWarmWidth {
             lastWarmWidth = width
+            warmer.cancelAll()
             warmEnqueued.removeAll(keepingCapacity: true)
         }
+        sizer.prepare(width: width)
         var jobs: [() -> Void] = []
         func enqueueIfCold(_ t: ChatMessage) {
             guard sizer.cached(t.id) == nil, !warmEnqueued.contains(t.id) else { return }

--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -658,6 +658,10 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         pager.resume()
         resumeBufferedPageMeasurements()
         logEntryState("viewDidAppear")
+        // Upgrade only what is already on screen on the first display-link tick.
+        // This keeps entry non-blocking while preventing a visibly clipped
+        // estimate from surviving until the delayed look-ahead warm pass.
+        warmWindow(radius: 0)
         scheduleWarmKick()
     }
 
@@ -1356,7 +1360,17 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             }
             guard !paths.isEmpty else { return }
             let layoutStarted = CFAbsoluteTimeGetCurrent()
-            context.invalidateItems(at: paths)
+            let oldContentHeight = self.collectionView.contentSize.height
+            let oldHeights = Dictionary(uniqueKeysWithValues: paths.map { path in
+                (path, self.collectionView.layoutAttributesForItem(at: path)?.frame.height ?? -1)
+            })
+            // `sizeForItemAt` is a FlowLayout delegate metric. Invalidating only
+            // item attributes can leave the old estimated height cached until a
+            // user scroll starts another layout cycle, producing the observed
+            // "broken on entry, fixed after one swipe" state. Force FlowLayout
+            // to re-read the now-exact sizer cache in this same settled pass.
+            context.invalidateFlowLayoutDelegateMetrics = true
+            context.invalidateFlowLayoutAttributes = true
             self.collectionView.collectionViewLayout.invalidateLayout(with: context)
             self.collectionView.layoutIfNeeded()
 
@@ -1368,13 +1382,23 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             }
             self.appliedHeightIDs.formUnion(applicableIDs)
             let layoutMs = (CFAbsoluteTimeGetCurrent() - layoutStarted) * 1_000
-            if layoutMs > 4 {
-                chatPerfLog.log("[height] apply n=\(paths.count) ms=\(String(format: "%.1f", layoutMs))")
+            let changed = paths.reduce(into: 0) { count, path in
+                let old = oldHeights[path] ?? -1
+                let new = self.collectionView.layoutAttributesForItem(at: path)?.frame.height ?? -1
+                if abs(new - old) > 0.5 { count += 1 }
+            }
+            if layoutMs > 4 || changed > 0 {
+                chatPerfLog.log(
+                    "[height] apply n=\(paths.count) changed=\(changed) "
+                        + "content=\(String(format: "%.1f", oldContentHeight))"
+                        + "→\(String(format: "%.1f", self.collectionView.contentSize.height)) "
+                        + "ms=\(String(format: "%.1f", layoutMs))"
+                )
             }
         }
     }
 
-    private func warmWindow() {
+    private func warmWindow(radius requestedRadius: Int? = nil) {
         let width = collectionView.bounds.width
         guard width > 0,
               !items.isEmpty,
@@ -1392,8 +1416,9 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
 
         let visible = collectionView.indexPathsForVisibleItems.map(\.item).sorted()
         var candidates = visible.isEmpty ? [items.count - 1] : visible
-        if let first = visible.first, let last = visible.last {
-            for distance in 1...Self.warmRadius {
+        let radius = requestedRadius ?? Self.warmRadius
+        if radius > 0, let first = visible.first, let last = visible.last {
+            for distance in 1...radius {
                 let before = first - distance
                 let after = last + distance
                 if before >= 0 { candidates.append(before) }
@@ -2157,7 +2182,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// (advances the model), measures the buffered page off-frame, then
     /// re-evaluates flush + prefetch.
     private func fetchOlder() {
-        guard !fetchingOlder, !measuringOlderPage, !atOldest, !scrollingToTop else { return }
+        guard !fetchingOlder, !measuringOlderPage, !vm.isLoadingOlder,
+              !atOldest, !scrollingToTop else { return }
         fetchingOlder = true
         KLog.chat("📤 [page] fetch-older session=\(sessionId.prefix(12)) win=[\(vm.windowTopSeq),\(vm.windowBottomSeq)] head=\(vm.sessionLastSeq) off=\(Int(collectionView.contentOffset.y))")
         let gen = pagingGeneration
@@ -2208,7 +2234,8 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     private func prefetchOlderIfNeeded() {
         guard !suppressPagingForBottom else { return }
         guard pendingApply == nil else { return }
-        guard !atOldest, !fetchingOlder, !measuringOlderPage, !scrollingToTop else { return }
+        guard !atOldest, !fetchingOlder, !measuringOlderPage,
+              !vm.isLoadingOlder, !scrollingToTop else { return }
         let y = collectionView.contentOffset.y
         guard y < olderPrefetchStart() else { return }
         // Buffer already deep enough to clear the band → hold (don't over-fetch).

--- a/packages/arm/ios/Kraki/Features/Chat/ChatView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatView.swift
@@ -68,14 +68,22 @@ struct ChatView: View {
         let _ = viewModel?.runtimeStatus
         let providerWaitingForLatest = viewModel == nil
             || viewModel?.isWaitingForLatestBubble == true
+        let waitingForInitialConnection = ChatEntryLoading.isInitialConnectionGateActive(
+            hasStoredCredentials: appState.hasStoredCredentials,
+            hasCompletedInitialConnect: appState.hasCompletedInitialConnect,
+            connectionStatus: appState.connectionStatus
+        )
+        let entrySourceWaiting = providerWaitingForLatest || waitingForInitialConnection
         let waitingForLatest = ChatEntryLoading.isEntryGateActive(
-            providerWaitingForLatest: providerWaitingForLatest,
+            providerWaitingForLatest: entrySourceWaiting,
             hasMaterializedLatest: hasMaterializedLatest
         )
         let entryDiagnosticSignature = [
             "session=\(sessionId)",
             "vm=\(viewModel == nil ? 0 : 1)",
             "gate=\(waitingForLatest ? 1 : 0)",
+            "connectionGate=\(waitingForInitialConnection ? 1 : 0)",
+            "connection=\(String(describing: appState.connectionStatus))",
             "metaHead=\(session?.lastSeq ?? 0)",
             "providerHead=\(viewModel?.sessionLastSeq ?? 0)",
             "window=\(viewModel?.windowTopSeq ?? 0)-\(viewModel?.windowBottomSeq ?? 0)",
@@ -167,7 +175,7 @@ struct ChatView: View {
         .onChange(of: entryDiagnosticSignature, initial: true) { _, state in
             KLog.chatEntry("surface \(state)")
         }
-        .onChange(of: providerWaitingForLatest, initial: true) { _, isWaiting in
+        .onChange(of: entrySourceWaiting, initial: true) { _, isWaiting in
             if !isWaiting { hasMaterializedLatest = true }
         }
         .task(id: sessionId) {

--- a/packages/arm/ios/Kraki/Features/Chat/ChatViewModel.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatViewModel.swift
@@ -160,10 +160,10 @@ final class ChatViewModel {
     }
 
     /// Keep stale cached history off-screen only while a real head request is
-    /// still in flight. `SessionInfo.lastSeq` covers the complete protocol
-    /// stream, while the render window contains only persistent spine rows; a
-    /// terminal idle/status event can therefore make the two seqs differ by one
-    /// even though every visible message is already authoritative.
+    /// still in flight. `SessionInfo.lastSeq` and the raw window boundaries are
+    /// both persistent-spine seqs; `cachedMessages` is merely the renderable
+    /// projection, so nonvisual idle/error/lifecycle rows do not affect whether
+    /// the raw cache has reached the authoritative Tentacle head.
     var isWaitingForLatestBubble: Bool {
         guard isDeviceOnline else { return false }
         let sessionLoading = appState?.sessionStore.loadingSessions.contains(sessionId) ?? false

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
@@ -1000,7 +1000,7 @@ final class MacChatDocumentView: NSView {
         let key = cacheKey(item)
         // Estimated height is already projection-aware and attributed only to
         // the bubble's terminal seq. Returning it before idle warming lets the
-        // initial 200-row bootstrap be px-trimmed before first presentation;
+        // compact initial tail be px-trimmed before first presentation;
         // exact heights replace it as cells/warm jobs finish.
         return heightCache[key] ?? pendingHeights[key] ?? item.estimatedHeight
     }

--- a/packages/arm/ios/Kraki/Features/Chat/TextKit/TextKitBubble.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/TextKit/TextKitBubble.swift
@@ -939,6 +939,7 @@ final class TKBubbleContent {
     let frozenTimestamp: String?
 
     private var heightCache: [CGFloat: CGFloat] = [:]
+    private var bubbleWidthCache: [CGFloat: CGFloat] = [:]
     private var bodyTextHeightCache: [CGFloat: CGFloat] = [:]
 
     init(message: ChatMessage, kind: Kind, hueSeed: String,
@@ -1010,20 +1011,38 @@ final class TKBubbleContent {
     }
 
     func bubbleWidth(cellWidth: CGFloat) -> CGFloat {
+        if let cached = bubbleWidthCache[cellWidth] { return cached }
         let maximum = maximumBubbleWidth(cellWidth: cellWidth)
+        let width: CGFloat
         switch kind {
         case .agent, .user:
             // Match Web's max-width flex bubble: short body/action content hugs
             // its natural width while long content wraps at the established
-            // maximum. Attachments remain an independent sibling.
-            guard htmlArtifacts.isEmpty else { return maximum }
-            let bodyNatural = body.map(TKMeasure.naturalWidth) ?? 0
-            let natural = max(bodyNatural, naturalActionWidth())
-            let fitted = ceil(natural) + TKMetrics.msgPadH * 2
-            return min(maximum, max(fitted, TKMetrics.msgPadH * 2 + 1))
+            // maximum. Attachments remain an independent sibling. Natural width
+            // is expensive CoreText work, so cache it for every immutable content
+            // object instead of repeating it from each layoutSubviews pass.
+            if htmlArtifacts.isEmpty {
+                // Once a body is this long it will fill the bubble in ordinary
+                // prose/code/table history. Avoid shaping the entire attributed
+                // string at infinite width just to rediscover that it exceeds
+                // the cap; short messages still keep the exact hug-content look.
+                let bodyNatural: CGFloat
+                if let body, body.length > 160 {
+                    bodyNatural = maximum
+                } else {
+                    bodyNatural = body.map(TKMeasure.naturalWidth) ?? 0
+                }
+                let natural = max(bodyNatural, naturalActionWidth())
+                let fitted = ceil(natural) + TKMetrics.msgPadH * 2
+                width = min(maximum, max(fitted, TKMetrics.msgPadH * 2 + 1))
+            } else {
+                width = maximum
+            }
         case .error, .system:
-            return maximum
+            width = maximum
         }
+        bubbleWidthCache[cellWidth] = width
+        return width
     }
 
     func attachmentWidth(cellWidth: CGFloat) -> CGFloat {

--- a/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
+++ b/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
@@ -234,6 +234,26 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertEqual(factory.sessions[0].starts.count, 1)
     }
 
+    func testDeniedPermissionFailsWithoutRequestingItAgain() async {
+        let host = FakeVoiceHost()
+        let factory = FakeVoiceFactory()
+        let audio = FakeVoiceAudioPolicy()
+        audio.permission = .denied
+        let controller = KrakiVoiceInputController(
+            host: host,
+            sessionFactory: factory,
+            audioPolicy: audio
+        )
+
+        await controller.begin(sessionID: "session-1", context: context()) { _ in }
+
+        XCTAssertEqual(controller.state, .failed(VoiceInputError.microphoneDenied.localizedDescription))
+        XCTAssertEqual(audio.permissionRequestCount, 0)
+        XCTAssertEqual(audio.activationCount, 0)
+        XCTAssertTrue(host.requestedResources.isEmpty)
+        XCTAssertTrue(factory.sessions.isEmpty)
+    }
+
     func testCancelWhilePermissionPromptIsOpenDoesNotResumeRecordingSetup() async {
         let host = FakeVoiceHost()
         let factory = FakeVoiceFactory()
@@ -307,6 +327,7 @@ final class KrakiVoiceInputTests: XCTestCase {
         )
         await controller.begin(sessionID: "session-1", context: context()) { _ in }
         XCTAssertEqual(controller.state, .obtainingLease)
+        XCTAssertEqual(audio.permissionRequestCount, 0)
         XCTAssertEqual(host.requestedResources, ["voice/doubao"])
 
         controller.receiveLease(lease())
@@ -480,13 +501,14 @@ final class KrakiVoiceInputTests: XCTestCase {
         )
     }
 
-    func testForegroundWarmConnectionIsReusedAcrossRecordings() async {
+    func testForegroundWarmConnectionSkipsGrantedPermissionUIAndIsReusedAcrossRecordings() async {
         let host = FakeVoiceHost()
         let factory = FakeVoiceFactory()
+        let audio = FakeVoiceAudioPolicy()
         let controller = KrakiVoiceInputController(
             host: host,
             sessionFactory: factory,
-            audioPolicy: FakeVoiceAudioPolicy()
+            audioPolicy: audio
         )
         controller.prepare()
         XCTAssertEqual(host.requestedResources, ["voice/doubao"])
@@ -499,6 +521,8 @@ final class KrakiVoiceInputTests: XCTestCase {
 
         var finals: [String] = []
         await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
+        XCTAssertEqual(audio.permissionRequestCount, 0)
+        XCTAssertEqual(controller.state, .recording)
         XCTAssertEqual(factory.sessions[0].starts.count, 1)
         factory.sessions[0].emit(.final("first", rawText: nil))
         await Task.yield()
@@ -507,6 +531,7 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertEqual(factory.sessions[0].closeCount, 0)
 
         await controller.begin(sessionID: "session-2", context: context()) { finals.append($0) }
+        XCTAssertEqual(audio.permissionRequestCount, 0)
         XCTAssertEqual(factory.sessions.count, 1)
         XCTAssertEqual(factory.sessions[0].starts.count, 2)
         factory.sessions[0].emit(.final("second", rawText: nil))

--- a/packages/arm/ios/KrakiTests/MessageStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/MessageStoreTests.swift
@@ -4,19 +4,44 @@ import XCTest
 @MainActor
 final class MessageStoreTests: XCTestCase {
 
+    private var database: MessageDatabase!
     private var store: MessageStore!
 
     override func setUp() async throws {
         try await super.setUp()
-        let db = try MessageDatabase()
-        store = MessageStore(db: db)
+        database = try MessageDatabase()
+        store = MessageStore(db: database)
         store.clearCard("sess-1")
     }
 
     override func tearDown() async throws {
         store?.clearCard("sess-1")
         store = nil
+        database = nil
         try await super.tearDown()
+    }
+
+    func testInitialWindowLoadsThirtyNewestMessages() throws {
+        let sessionId = "initial-window"
+        let messages = (1...80).map { seq in
+            ChatMessage(
+                type: seq.isMultiple(of: 2) ? "agent_message" : "user_message",
+                seq: seq,
+                sessionId: sessionId,
+                deviceId: "device",
+                timestamp: "2026-08-16T00:00:00Z",
+                payload: ["content": AnyCodable("message-\(seq)")]
+            )
+        }
+        try database.insert(sessionId, messages)
+
+        let loaded = store.loadInitialWindow(sessionId)
+
+        XCTAssertEqual(loaded.count, 30)
+        XCTAssertEqual(loaded.first?.seq, 51)
+        XCTAssertEqual(loaded.last?.seq, 80)
+        XCTAssertEqual(store.windowState(sessionId)?.topSeq, 51)
+        XCTAssertEqual(store.windowState(sessionId)?.bottomSeq, 80)
     }
 
     // MARK: - Card draft (keep-last)

--- a/packages/arm/ios/KrakiTests/MessagesTests.swift
+++ b/packages/arm/ios/KrakiTests/MessagesTests.swift
@@ -225,6 +225,61 @@ final class MessageProviderHeadTests: XCTestCase {
         XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 41)
     }
 
+    func testEnsureOlderLoadedPagesByPersistentRowsAcrossLegacySeqGaps() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-message-provider-sparse-older-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = try MessageDatabase(databaseURL: root.appendingPathComponent("messages.sqlite"))
+        let sessionId = "sess-sparse-older"
+        let messages = (1...80).map { index in
+            let seq = index * 7
+            return ChatMessage(
+                type: index.isMultiple(of: 2) ? "agent_message" : "user_message",
+                seq: seq,
+                sessionId: sessionId,
+                deviceId: "dev-1",
+                timestamp: "2026-08-17T00:00:00Z",
+                payload: ["content": AnyCodable("message-\(seq)")]
+            )
+        }
+        try database.insert(sessionId, messages)
+
+        let app = AppState(testDatabase: database)
+        _ = app.messageStore.loadInitialWindow(sessionId)
+        XCTAssertEqual(app.messageStore.currentWindow(sessionId).map(\.seq), stride(from: 357, through: 560, by: 7).map { $0 })
+
+        XCTAssertTrue(app.messageProvider?.ensureOlderLoaded(sessionId: sessionId) == true)
+        XCTAssertEqual(app.messageStore.currentWindow(sessionId).prefix(10).map(\.seq), stride(from: 287, through: 350, by: 7).map { $0 })
+        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 287)
+    }
+
+    func testEnsureOlderLoadedDoesNotSkipLargeLocalCacheHole() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-message-provider-hole-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = try MessageDatabase(databaseURL: root.appendingPathComponent("messages.sqlite"))
+        let sessionId = "sess-local-hole"
+        let seqs = Array(1...10) + Array(1_000...1_029)
+        let messages = seqs.map { seq in
+            ChatMessage(
+                type: seq.isMultiple(of: 2) ? "agent_message" : "user_message",
+                seq: seq,
+                sessionId: sessionId,
+                deviceId: "dev-1",
+                timestamp: "2026-08-17T00:00:00Z",
+                payload: ["content": AnyCodable("message-\(seq)")]
+            )
+        }
+        try database.insert(sessionId, messages)
+
+        let app = AppState(testDatabase: database)
+        _ = app.messageStore.loadInitialWindow(sessionId)
+        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 1_000)
+
+        XCTAssertFalse(app.messageProvider?.ensureOlderLoaded(sessionId: sessionId) == true)
+        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 1_000)
+    }
+
     func testEnsureNewerLoadedAdvancesAcrossOffSpineSeqGaps() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("kraki-message-provider-newer-test-\(UUID().uuidString)", isDirectory: true)

--- a/packages/arm/ios/KrakiTests/MessagesTests.swift
+++ b/packages/arm/ios/KrakiTests/MessagesTests.swift
@@ -198,6 +198,33 @@ final class ChatMessageTests: XCTestCase {
 
 @MainActor
 final class MessageProviderHeadTests: XCTestCase {
+    func testEnsureOlderLoadedAddsTenRowsToCompactIOSWindow() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-message-provider-older-page-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = try MessageDatabase(databaseURL: root.appendingPathComponent("messages.sqlite"))
+        let sessionId = "sess-older-page"
+        let messages = (1...80).map { seq in
+            ChatMessage(
+                type: seq.isMultiple(of: 2) ? "agent_message" : "user_message",
+                seq: seq,
+                sessionId: sessionId,
+                deviceId: "dev-1",
+                timestamp: "2026-08-16T00:00:00Z",
+                payload: ["content": AnyCodable("message-\(seq)")]
+            )
+        }
+        try database.insert(sessionId, messages)
+
+        let app = AppState(testDatabase: database)
+        _ = app.messageStore.loadInitialWindow(sessionId)
+        XCTAssertEqual(app.messageStore.currentWindow(sessionId).map(\.seq), Array(51...80))
+
+        XCTAssertTrue(app.messageProvider?.ensureOlderLoaded(sessionId: sessionId) == true)
+        XCTAssertEqual(app.messageStore.currentWindow(sessionId).map(\.seq), Array(41...80))
+        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 41)
+    }
+
     func testEnsureNewerLoadedAdvancesAcrossOffSpineSeqGaps() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("kraki-message-provider-newer-test-\(UUID().uuidString)", isDirectory: true)

--- a/packages/arm/ios/KrakiTests/MessagesTests.swift
+++ b/packages/arm/ios/KrakiTests/MessagesTests.swift
@@ -198,6 +198,24 @@ final class ChatMessageTests: XCTestCase {
 
 @MainActor
 final class MessageProviderHeadTests: XCTestCase {
+    func testSessionSpineContractMatchesTentaclePersistentTypes() {
+        XCTAssertEqual(SessionSpineContract.persistentTypes, Set([
+            "session_created",
+            "agent_message",
+            "interrupted_turn",
+            "turn_status",
+            "user_message",
+            "system_message",
+            "error",
+            "session_ended",
+            "idle",
+        ]))
+        for transient in ["active", "compacting", "agent_message_delta", "card_action",
+                          "tool_start", "tool_complete", "agent_narration", "permission", "question"] {
+            XCTAssertFalse(SessionSpineContract.contains(type: transient, seq: 99), transient)
+        }
+    }
+
     func testEnsureOlderLoadedAddsTenRowsToCompactIOSWindow() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("kraki-message-provider-older-page-test-\(UUID().uuidString)", isDirectory: true)
@@ -253,16 +271,16 @@ final class MessageProviderHeadTests: XCTestCase {
         XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 287)
     }
 
-    func testEnsureOlderLoadedDoesNotSkipLargeLocalCacheHole() throws {
+    func testEnsureOlderLoadedPagesAcrossLargeLegacySeqGaps() throws {
         let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("kraki-message-provider-hole-test-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("kraki-message-provider-large-legacy-gap-test-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
         let database = try MessageDatabase(databaseURL: root.appendingPathComponent("messages.sqlite"))
-        let sessionId = "sess-local-hole"
-        let seqs = Array(1...10) + Array(1_000...1_029)
-        let messages = seqs.map { seq in
-            ChatMessage(
-                type: seq.isMultiple(of: 2) ? "agent_message" : "user_message",
+        let sessionId = "sess-large-legacy-gap"
+        let messages = (1...80).map { index in
+            let seq = index * 496
+            return ChatMessage(
+                type: index.isMultiple(of: 2) ? "agent_message" : "user_message",
                 seq: seq,
                 sessionId: sessionId,
                 deviceId: "dev-1",
@@ -274,10 +292,12 @@ final class MessageProviderHeadTests: XCTestCase {
 
         let app = AppState(testDatabase: database)
         _ = app.messageStore.loadInitialWindow(sessionId)
-        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 1_000)
+        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 25_296)
 
-        XCTAssertFalse(app.messageProvider?.ensureOlderLoaded(sessionId: sessionId) == true)
-        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 1_000)
+        XCTAssertTrue(app.messageProvider?.ensureOlderLoaded(sessionId: sessionId) == true)
+        XCTAssertEqual(app.messageStore.currentWindow(sessionId).prefix(10).map(\.seq),
+                       stride(from: 20_336, through: 24_800, by: 496).map { $0 })
+        XCTAssertEqual(app.messageStore.windowState(sessionId)?.topSeq, 20_336)
     }
 
     func testEnsureNewerLoadedAdvancesAcrossOffSpineSeqGaps() throws {
@@ -302,8 +322,8 @@ final class MessageProviderHeadTests: XCTestCase {
         _ = app.messageStore.loadInitialWindow(sessionId)
         XCTAssertEqual(app.messageStore.windowState(sessionId)?.bottomSeq, 3)
 
-        // Newer persistent rows can be sparse because off-spine protocol
-        // events consume seq values without entering this SQLite table.
+        // Replayed legacy persistent rows can remain sparse because retired
+        // off-spine events consumed the historical seq values before filtering.
         try database.insert(sessionId, [makeMessage(5), makeMessage(7)])
         app.messageProvider?.setTentacleInfo(sessionId: sessionId, lastSeq: 7, deviceId: "dev-1")
 

--- a/packages/arm/ios/KrakiTests/TextKitPureSpineTests.swift
+++ b/packages/arm/ios/KrakiTests/TextKitPureSpineTests.swift
@@ -5,10 +5,58 @@ import SwiftUI
 
 @MainActor
 final class TextKitPureSpineTests: XCTestCase {
+    private final class FlowLayoutMetricProbe: NSObject, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+        var heights: [CGFloat] = [100, 100, 100]
+
+        func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+            heights.count
+        }
+
+        func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+            collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath)
+        }
+
+        func collectionView(_ collectionView: UICollectionView,
+                            layout collectionViewLayout: UICollectionViewLayout,
+                            sizeForItemAt indexPath: IndexPath) -> CGSize {
+            CGSize(width: collectionView.bounds.width, height: heights[indexPath.item])
+        }
+    }
+
     private func descendants<T: UIView>(of root: UIView, as type: T.Type = T.self) -> [T] {
         root.subviews.flatMap { subview in
             (subview as? T).map { [$0] } ?? descendants(of: subview, as: type)
         }
+    }
+
+    func testFlowLayoutMetricInvalidationReflowsFollowingRowsWithoutScroll() {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumLineSpacing = 0
+        layout.estimatedItemSize = .zero
+        let collection = UICollectionView(
+            frame: CGRect(x: 0, y: 0, width: 320, height: 600),
+            collectionViewLayout: layout
+        )
+        let probe = FlowLayoutMetricProbe()
+        collection.dataSource = probe
+        collection.delegate = probe
+        collection.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
+        collection.reloadData()
+        collection.layoutIfNeeded()
+
+        XCTAssertEqual(layout.layoutAttributesForItem(at: IndexPath(item: 1, section: 0))?.frame.minY, 100)
+        XCTAssertEqual(collection.contentSize.height, 300)
+
+        probe.heights[0] = 240
+        let context = UICollectionViewFlowLayoutInvalidationContext()
+        context.invalidateFlowLayoutDelegateMetrics = true
+        context.invalidateFlowLayoutAttributes = true
+        layout.invalidateLayout(with: context)
+        collection.layoutIfNeeded()
+
+        XCTAssertEqual(layout.layoutAttributesForItem(at: IndexPath(item: 0, section: 0))?.frame.height, 240)
+        XCTAssertEqual(layout.layoutAttributesForItem(at: IndexPath(item: 1, section: 0))?.frame.minY, 240)
+        XCTAssertEqual(collection.contentSize.height, 440)
     }
 
     private func message(_ type: String, seq: Int, content: String? = nil) -> ChatMessage {

--- a/packages/arm/ios/KrakiTests/TextKitPureSpineTests.swift
+++ b/packages/arm/ios/KrakiTests/TextKitPureSpineTests.swift
@@ -29,12 +29,12 @@ final class TextKitPureSpineTests: XCTestCase {
         }
     }
 
-    func testFlowLayoutMetricInvalidationReflowsFollowingRowsWithoutScroll() {
+    func testFlowLayoutMetricInvalidationReflowsRowsAndPreservesBottomOffsetWithoutScroll() {
         let layout = UICollectionViewFlowLayout()
         layout.minimumLineSpacing = 0
         layout.estimatedItemSize = .zero
         let collection = UICollectionView(
-            frame: CGRect(x: 0, y: 0, width: 320, height: 600),
+            frame: CGRect(x: 0, y: 0, width: 320, height: 200),
             collectionViewLayout: layout
         )
         let probe = FlowLayoutMetricProbe()
@@ -46,17 +46,20 @@ final class TextKitPureSpineTests: XCTestCase {
 
         XCTAssertEqual(layout.layoutAttributesForItem(at: IndexPath(item: 1, section: 0))?.frame.minY, 100)
         XCTAssertEqual(collection.contentSize.height, 300)
+        collection.contentOffset.y = 100
 
         probe.heights[0] = 240
         let context = UICollectionViewFlowLayoutInvalidationContext()
         context.invalidateFlowLayoutDelegateMetrics = true
         context.invalidateFlowLayoutAttributes = true
+        context.contentOffsetAdjustment = CGPoint(x: 0, y: 140)
         layout.invalidateLayout(with: context)
         collection.layoutIfNeeded()
 
         XCTAssertEqual(layout.layoutAttributesForItem(at: IndexPath(item: 0, section: 0))?.frame.height, 240)
         XCTAssertEqual(layout.layoutAttributesForItem(at: IndexPath(item: 1, section: 0))?.frame.minY, 240)
         XCTAssertEqual(collection.contentSize.height, 440)
+        XCTAssertEqual(collection.contentOffset.y, 240)
     }
 
     private func message(_ type: String, seq: Int, content: String? = nil) -> ChatMessage {
@@ -274,6 +277,31 @@ final class TextKitPureSpineTests: XCTestCase {
         XCTAssertFalse(ChatEntryLoading.isEntryGateActive(
             providerWaitingForLatest: false,
             hasMaterializedLatest: false
+        ))
+
+        for status in [ConnectionStatus.awaitingLogin, .connecting, .authenticating] {
+            XCTAssertTrue(ChatEntryLoading.isInitialConnectionGateActive(
+                hasStoredCredentials: true,
+                hasCompletedInitialConnect: false,
+                connectionStatus: status
+            ))
+        }
+        for status in [ConnectionStatus.connected, .disconnected, .error] {
+            XCTAssertFalse(ChatEntryLoading.isInitialConnectionGateActive(
+                hasStoredCredentials: true,
+                hasCompletedInitialConnect: false,
+                connectionStatus: status
+            ))
+        }
+        XCTAssertFalse(ChatEntryLoading.isInitialConnectionGateActive(
+            hasStoredCredentials: false,
+            hasCompletedInitialConnect: false,
+            connectionStatus: .connecting
+        ))
+        XCTAssertFalse(ChatEntryLoading.isInitialConnectionGateActive(
+            hasStoredCredentials: true,
+            hasCompletedInitialConnect: true,
+            connectionStatus: .connecting
         ))
     }
 

--- a/packages/arm/ios/MIGRATION-pure-spine.md
+++ b/packages/arm/ios/MIGRATION-pure-spine.md
@@ -6,11 +6,13 @@
 > **pass-through ephemeral**, never business-logic'd or stored.
 >
 > Confirmed facts:
-> - Tentacle (`main`) already assigns **dense per-session seq only to spine**
->   (`PERSISTENT_TYPES = {session_created, agent_message, user_message, error,
->   system_message, session_ended, idle}`), tools/narration → `trace.jsonl`
->   (no seq), permission/question → card action slot (no seq). So the client's
->   `seq == bottomSeq+1` contiguity contract holds natively.
+> - Tentacle (`main`) assigns **dense per-session seq only to newly appended spine rows**
+>   (`PERSISTENT_TYPES = {session_created, agent_message, interrupted_turn,
+>   turn_status, user_message, error, system_message, session_ended, idle}`),
+>   tools/narration → `trace.jsonl` (no Session seq), permission/question → card
+>   action slot (no Session seq). Replayed pre-pure-spine logs retain historical
+>   seq holes after retired transient rows are filtered, so history paging must
+>   use spine-row order rather than numeric seq span.
 > - No back-compat: **wipe the local DB** on migration.
 > - `ChatMessage` is dynamic (`type` + `payload[AnyCodable]`) → new types are
 >   cheap (type strings + accessors, no per-type Codable).
@@ -38,10 +40,11 @@ Phases are ordered so each is independently buildable/testable.
 - [ ] Add `requestTurnTrace(sessionId:, bubbleSeq:)` → `request_turn_trace`.
 - [ ] Add `requestCard(sessionId:)` → `request_card`.
 
-**persistentTypes — TWO places must match the tentacle exactly**
-- [ ] `MessageStore.persistentTypes` (L74) →
-      `{ session_created, user_message, agent_message, system_message, error, idle, session_ended }`.
-- [ ] `MessageRouter.persistentTypes` (L96) → same set.
+**persistentTypes — routing and storage must match Tentacle exactly**
+- [ ] `SessionSpineContract.persistentTypes` →
+      `{ session_created, user_message, agent_message, interrupted_turn, turn_status,
+      system_message, error, idle, session_ended }`.
+- [ ] `MessageStore` and `MessageRouter` → consume that one shared Swift set.
 - [ ] `MessageRouter.notifyWorthyTypes` → `{ idle, error }` (permission/question
       are no longer spine; they're the card).
 
@@ -183,4 +186,5 @@ Phases are ordered so each is independently buildable/testable.
 ## Open decisions (locked)
 1. DB: **wipe** (schema v2 drop-recreate). ✅
 2. permission/question: **card slot only** (not spine-persisted). ✅ (matches web)
-3. spine seq density: **already dense** on tentacle. ✅ (verified in relay-client.ts)
+3. spine seq density: **dense for newly appended Tentacle rows**. ✅
+   Legacy replay remains ordered but may be integer-sparse. (verified in relay-client.ts)

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -286,14 +286,14 @@ export interface QuestionRequest extends BaseEnvelope {
 }
 
 /**
- * Live tool-lifecycle broadcast. Under the three-axis model these are no
- * longer persisted to messages.jsonl nor assigned a per-session (spine)
- * seq — they are removed from PERSISTENT_TYPES and instead mirrored to
- * `trace.jsonl`. They REMAIN the live wire event for a streaming turn's
- * steps: clients render them immediately and merge `tool_start` →
- * `tool_complete` by `toolCallId`. History / on-idle refresh is pulled via
- * {@link TurnTraceBatchMessage}, keyed by the concluding bubble's seq (no
- * separate turn id — a turn is already identified by its spine bubble).
+ * Tool-lifecycle trace record. Under the three-axis model these are neither
+ * persisted to messages.jsonl nor assigned a per-session (spine) seq. Current
+ * Tentacle mirrors them to `trace.jsonl` and projects live state through the
+ * server-owned `card_action` slot; it does not broadcast raw standalone tool
+ * messages. Arms may still decode this shape for pulled trace history and
+ * legacy Tentacle compatibility, merging `tool_start` → `tool_complete` by
+ * `toolCallId`. History is pulled via {@link TurnTraceBatchMessage}, keyed by
+ * the concluding bubble's seq.
  */
 export interface ToolStartMessage extends BaseEnvelope {
   type: 'tool_start';

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -1350,7 +1350,7 @@ describe('SessionManager', () => {
       const { sessionId } = sm.createSession('copilot');
       const u1 = sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: { content: 'a' } }));
       expect(sm.getMeta(sessionId)!.currentTurnStartSeq).toBe(u1);
-      // A mid-turn permission (also persistent) must NOT move the turn start.
+      // Simulate a legacy on-spine permission; it must NOT move the turn start.
       sm.appendMessage(sessionId, 'permission', JSON.stringify({ type: 'permission', payload: { id: 'p1' } }));
       expect(sm.getMeta(sessionId)!.currentTurnStartSeq).toBe(u1);
       // Next normal user_message starts a new turn.
@@ -1432,7 +1432,7 @@ describe('SessionManager', () => {
       const { sessionId } = sm.createSession('copilot');
       sm.appendMessage(sessionId, 'user_message', JSON.stringify({ type: 'user_message', payload: {} }));
       tool(sm, sessionId, 'before', 'read_file');
-      // Permission is a spine message mid-turn; it must not split the trace turn.
+      // Simulate a legacy on-spine permission; it must not split the trace turn.
       sm.appendMessage(sessionId, 'permission', JSON.stringify({ type: 'permission', payload: { id: 'p1' } }));
       sm.appendMessage(sessionId, 'permission_resolved', JSON.stringify({ type: 'permission_resolved', payload: { permissionId: 'p1' } }));
       tool(sm, sessionId, 'after', 'edit');

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -87,8 +87,9 @@ export interface LoggedMessage {
 }
 
 /**
- * One line in a session's `trace.jsonl` — a tool_start/tool_complete broadcast
- * mirrored off the spine. Tagged with the turn's start seq (the user_message
+ * One line in a session's `trace.jsonl` — a tool/action trace record mirrored
+ * off the spine and projected live through `card_action`. Tagged with the
+ * turn's start seq (the user_message
  * that began the turn) so a turn's steps can be pulled by its bubble seq.
  * `payload` is the full enriched wire message (same JSON that was broadcast).
  */
@@ -1072,7 +1073,7 @@ export class SessionManager {
   // ── Turn trace (TRACE axis) ─────────────────────────────
 
   /**
-   * Mirror a tool_start/tool_complete broadcast to the session's `trace.jsonl`.
+   * Mirror an off-spine tool/action record to the session's `trace.jsonl`.
    * These are NOT on the spine (no per-session seq); they are tagged with the
    * current turn's start seq so {@link readTurnTrace} can slice them per turn.
    */
@@ -1328,9 +1329,10 @@ export class SessionManager {
    * and are layered on top separately by `enrichSessionList` (the attention
    * override), so they must never come from this file scan.
    *
-   * Scans complete JSONL rows backwards in bounded chunks: the spine is now
-   * sparse (`tool_start`/`tool_complete` live in `trace.jsonl`), but older
-   * sessions still carry them, and an inline-image row can be much larger than
+   * Scans complete JSONL rows backwards in bounded chunks. The current spine
+   * has fewer durable row types while retaining dense Session seqs; older logs
+   * may still carry tool rows and therefore replay as a sparse filtered spine.
+   * An inline-image row can also be much larger than
    * one read chunk.
    */
   private getSessionPreview(sessionId: string): import('@kraki/protocol').SessionPreviewDigest | undefined {


### PR DESCRIPTION
## Summary

Fixes severe iOS Session-entry and navigation jank for long, production-shaped histories.

This PR includes the earlier cold-height scheduling change that was validated in TestFlight build `0.1.0 (7)`, plus the follow-up fix for the remaining repeated layout storm found with a 200-message Markdown/code/table stress Session.

## Root cause

- Initial collection layout synchronously sized the full 200-message window.
- The cold estimator still called `boundingRect` over long bodies for every row and every invalidation.
- Exact-height warming queued the entire window; each completed measurement invalidated layout and repeated expensive estimates.
- Pending warm/page work could continue while leaving the Session, delaying Back navigation.

In the stress fixture this produced an approximately 9.2s initial `applyInitial`, followed by repeated 8–9s layout passes.

## Changes

- Use cached, lightweight cold height estimates; no TextKit/CoreText/Markdown work in the cold `sizeForItemAt` path.
- Warm exact TextKit heights only for visible rows after the navigation transition settles.
- Coalesce exact-height invalidations while preserving bottom following or the historical visible anchor.
- Cancel stale warm and pagination measurement work when scrolling or leaving the view; resume buffered pagination safely on re-entry.
- Start initial layout at the tail instead of materializing top cells before scrolling to bottom.
- Reduce the iOS initial persistent window from 200 rows to 30.
- Reduce iOS DB-first older/newer pages from 200 rows to 10; macOS remains at its existing 10-row page size and 15-row initial window.
- Add regression coverage for the 30-row initial window and 10-row older page.

## Validation

On iPhone 17 Pro simulator, iOS 26.5:

- 200-message long Markdown/code/table stress Session:
  - before: `applyInitial` ~9.2s
  - after: `applyInitial` ~225–250ms
- normal four-message production renderer fixture: `applyInitial` ~35.9ms
- page measurement: ~1.33s for 30 rows -> ~0.45s for 10 rows
- Back during pending page measurement returned to the Session list in ~0.39s
- repeated entry and buffered paging resumed without synchronous sizing misses
- no `[size] sync-miss` in the final renderer validation

Local checks after rebasing onto latest `origin/main`:

- iOS full suite: 292 tests, 2 existing skips, 0 failures
- macOS GUI Debug build: passed
- `git diff --check`: passed

## Release plan

Do not merge automatically. After PR review and required checks pass, upload this branch to TestFlight for device validation.
