### PR TITLE
fix(voice): roll over exhausted leases during dictation

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.13;
+				MARKETING_VERSION = 0.2.14;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.13;
+				MARKETING_VERSION = 0.2.14;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
+++ b/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
@@ -183,6 +183,9 @@ final class KrakiVoiceInputController {
     private var metricStart: ContinuousClock.Instant?
     private var reconnectAttempt = 0
     private var warmConnectionDesired = false
+    private var leaseRolloverAttempt = 0
+
+    private static let maxLeaseRolloverAttempts = 1
 
     init(
         host: KrakiVoiceInputHost? = nil,
@@ -288,6 +291,7 @@ final class KrakiVoiceInputController {
 
         let currentRecording = UUID()
         recordingGeneration = currentRecording
+        leaseRolloverAttempt = 0
         resetPresentation()
         activeSessionID = sessionID
         self.context = context
@@ -473,6 +477,8 @@ final class KrakiVoiceInputController {
     private func handleConnectionFailure(_ reason: String) {
         KLog.d("🎙️ [voice] stage=connection-failed reason=\(reason)")
         let quotaExhausted = reason.localizedCaseInsensitiveContains("quota_exhausted")
+        if quotaExhausted, recoverFromExhaustedLease() { return }
+
         let leaseDayChanged = reason.localizedCaseInsensitiveContains("wrong_day")
         let requiresFreshLease = quotaExhausted || leaseDayChanged
         closeConnection(keepLease: !requiresFreshLease)
@@ -482,6 +488,55 @@ final class KrakiVoiceInputController {
             state = .failed(message)
         }
         if warmConnectionDesired { scheduleReconnect(immediate: requiresFreshLease) }
+    }
+
+    /// Broker `quota_exhausted` means this signed lease's rolling allowance was
+    /// consumed. It is distinct from Head denying a replacement lease because
+    /// the account's daily quota is exhausted. Preserve the user's active
+    /// recording intent while a fresh lease and warm connection are acquired.
+    private func recoverFromExhaustedLease() -> Bool {
+        switch state {
+        case .recording, .obtainingLease:
+            guard leaseRolloverAttempt < Self.maxLeaseRolloverAttempts else { return false }
+            leaseRolloverAttempt += 1
+            checkpointCurrentRawSegment()
+            closeConnection(keepLease: false)
+            state = .obtainingLease
+            metricStart = .now
+            KLog.d("🎙️ [voice] stage=lease-rollover attempt=\(leaseRolloverAttempt)")
+            if warmConnectionDesired { scheduleReconnect(immediate: true) }
+            return true
+
+        case .finishing:
+            let recoveredText = rawText
+            let handler = finalHandler
+            closeConnection(keepLease: false)
+            recordingCleanup(clearHandlers: true)
+            state = .idle
+            if !recoveredText.isEmpty { handler?(recoveredText) }
+            if warmConnectionDesired { scheduleReconnect(immediate: true) }
+            return true
+
+        case .requestingPermission:
+            closeConnection(keepLease: false)
+            if warmConnectionDesired { scheduleReconnect(immediate: true) }
+            return true
+
+        case .idle, .failed:
+            closeConnection(keepLease: false)
+            if warmConnectionDesired { scheduleReconnect(immediate: true) }
+            return true
+        }
+    }
+
+    private func checkpointCurrentRawSegment() {
+        guard !currentRawSegment.isEmpty else { return }
+        stableRawPrefix = VoiceDraftMerger.merge(
+            existing: stableRawPrefix,
+            final: currentRawSegment
+        )
+        currentRawSegment = ""
+        rawText = stableRawPrefix
     }
 
     private func scheduleLeaseTimeout() {
@@ -681,6 +736,7 @@ final class KrakiVoiceInputController {
 
     private func recordingCleanup(clearHandlers: Bool) {
         recordingGeneration = UUID()
+        leaseRolloverAttempt = 0
         correctionDisplayTask?.cancel()
         correctionDisplayTask = nil
         pendingCorrectionText = nil

--- a/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
+++ b/packages/arm/ios/Kraki/Core/Speech/KrakiVoiceInputController.swift
@@ -184,6 +184,7 @@ final class KrakiVoiceInputController {
     private var reconnectAttempt = 0
     private var warmConnectionDesired = false
     private var leaseRolloverAttempt = 0
+    private var rolloverRawPrefix = ""
 
     private static let maxLeaseRolloverAttempts = 1
 
@@ -530,13 +531,17 @@ final class KrakiVoiceInputController {
     }
 
     private func checkpointCurrentRawSegment() {
-        guard !currentRawSegment.isEmpty else { return }
-        stableRawPrefix = VoiceDraftMerger.merge(
+        let currentConnectionText = VoiceDraftMerger.merge(
             existing: stableRawPrefix,
             final: currentRawSegment
         )
+        rolloverRawPrefix = VoiceDraftMerger.merge(
+            existing: rolloverRawPrefix,
+            final: currentConnectionText
+        )
+        stableRawPrefix = ""
         currentRawSegment = ""
-        rawText = stableRawPrefix
+        rawText = rolloverRawPrefix
     }
 
     private func scheduleLeaseTimeout() {
@@ -619,14 +624,29 @@ final class KrakiVoiceInputController {
     }
 
     private func resolvedFinalText(_ text: String, gatewayRawText: String?) -> String {
-        guard !stableRawPrefix.isEmpty else { return text }
-        let accumulatedLength = rawText.count
-        let gatewayRawLength = gatewayRawText?.count ?? 0
-        if text.count + 5 < accumulatedLength,
-           gatewayRawLength + 5 < accumulatedLength {
-            return VoiceDraftMerger.merge(existing: stableRawPrefix, final: text)
+        let currentConnectionText: String
+        if stableRawPrefix.isEmpty {
+            currentConnectionText = text
+        } else {
+            let accumulatedText = VoiceDraftMerger.merge(
+                existing: stableRawPrefix,
+                final: currentRawSegment
+            )
+            let gatewayRawLength = gatewayRawText?.count ?? 0
+            if text.count + 5 < accumulatedText.count,
+               gatewayRawLength + 5 < accumulatedText.count {
+                currentConnectionText = VoiceDraftMerger.merge(
+                    existing: stableRawPrefix,
+                    final: text
+                )
+            } else {
+                currentConnectionText = text
+            }
         }
-        return text
+        return VoiceDraftMerger.merge(
+            existing: rolloverRawPrefix,
+            final: currentConnectionText
+        )
     }
 
     #if DEBUG
@@ -656,7 +676,14 @@ final class KrakiVoiceInputController {
         } else {
             currentRawSegment = text
         }
-        rawText = VoiceDraftMerger.merge(existing: stableRawPrefix, final: currentRawSegment)
+        let currentConnectionText = VoiceDraftMerger.merge(
+            existing: stableRawPrefix,
+            final: currentRawSegment
+        )
+        rawText = VoiceDraftMerger.merge(
+            existing: rolloverRawPrefix,
+            final: currentConnectionText
+        )
     }
 
     private static func sharedPrefixLength(_ lhs: String, _ rhs: String) -> Int {
@@ -665,7 +692,10 @@ final class KrakiVoiceInputController {
 
     private func setCorrectionDelta(_ text: String) {
         guard state == .finishing, !text.isEmpty else { return }
-        pendingCorrectionText = text
+        pendingCorrectionText = VoiceDraftMerger.merge(
+            existing: rolloverRawPrefix,
+            final: text
+        )
         if correctionText.isEmpty {
             applyPendingCorrectionText()
             return
@@ -755,6 +785,7 @@ final class KrakiVoiceInputController {
         rawText = ""
         stableRawPrefix = ""
         currentRawSegment = ""
+        rolloverRawPrefix = ""
         correctionSource = ""
         correctionText = ""
         correctionSourceOffset = 0
@@ -765,7 +796,9 @@ final class KrakiVoiceInputController {
     private static func userFacingGatewayError(_ reason: String) -> String {
         let lower = reason.lowercased()
         if lower.contains("permission") { return VoiceInputError.microphoneDenied.localizedDescription }
-        if lower.contains("quota") { return "The voice-input quota was exhausted." }
+        if lower.contains("quota") {
+            return "The voice session couldn't be renewed. Please try again."
+        }
         if lower.contains("lease") || lower.contains("denied") || lower.contains("authorization") {
             return "The voice session authorization was rejected. Please try again."
         }

--- a/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
+++ b/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
@@ -556,7 +556,7 @@ final class KrakiVoiceInputTests: XCTestCase {
         var finals: [String] = []
         await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
         XCTAssertEqual(controller.state, .recording)
-        factory.sessions[0].emit(.partial("before quota rollover"))
+        factory.sessions[0].emit(.partial("hi"))
         await Task.yield()
         factory.sessions[0].emit(.failed("denied: quota_exhausted"))
         for _ in 0..<20 where host.requestedResources.count < 2 {
@@ -564,7 +564,7 @@ final class KrakiVoiceInputTests: XCTestCase {
         }
 
         XCTAssertEqual(controller.state, .obtainingLease)
-        XCTAssertEqual(controller.rawText, "before quota rollover")
+        XCTAssertEqual(controller.rawText, "hi")
         XCTAssertEqual(host.requestedResources, ["voice/doubao", "voice/doubao"])
         XCTAssertEqual(factory.sessions[0].closeCount, 1)
         XCTAssertTrue(finals.isEmpty)
@@ -576,13 +576,61 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertEqual(controller.state, .recording)
         XCTAssertEqual(factory.sessions[1].starts.count, 1)
 
-        factory.sessions[1].emit(.partial("after rollover"))
+        factory.sessions[1].emit(.partial("first segment after rollover"))
         await Task.yield()
-        XCTAssertEqual(controller.rawText, "before quota rollover after rollover")
-        factory.sessions[1].emit(.final("after rollover", rawText: "after rollover"))
+        factory.sessions[1].emit(.partial("next"))
         await Task.yield()
-        XCTAssertEqual(finals, ["before quota rollover after rollover"])
+        XCTAssertEqual(controller.rawText, "hi first segment after rollover next")
+        controller.finish()
+        factory.sessions[1].emit(.correctionDelta("corrected segment after rollover next"))
+        await Task.yield()
+        XCTAssertEqual(controller.displayText, "hi corrected segment after rollover next")
+        factory.sessions[1].emit(
+            .final(
+                "corrected segment after rollover next",
+                rawText: "first segment after rollover next"
+            )
+        )
+        await Task.yield()
+        XCTAssertEqual(finals, ["hi corrected segment after rollover next"])
         XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testRepeatedBrokerQuotaExhaustionUsesRenewalErrorNotDailyQuotaError() async {
+        let host = FakeVoiceHost()
+        let factory = FakeVoiceFactory()
+        let controller = KrakiVoiceInputController(
+            host: host,
+            sessionFactory: factory,
+            audioPolicy: FakeVoiceAudioPolicy()
+        )
+        controller.prepare()
+        controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+
+        var finals: [String] = []
+        await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
+        factory.sessions[0].emit(.failed("denied: quota_exhausted"))
+        for _ in 0..<20 where host.requestedResources.count < 2 {
+            await Task.yield()
+        }
+        controller.receiveLease(lease(jti: "lease-2"))
+        factory.sessions[1].emit(.connectionAuthorized)
+        await Task.yield()
+        XCTAssertEqual(controller.state, .recording)
+
+        factory.sessions[1].emit(.failed("denied: quota_exhausted"))
+        for _ in 0..<20 where host.requestedResources.count < 3 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(
+            controller.state,
+            .failed("The voice session couldn't be renewed. Please try again.")
+        )
+        XCTAssertEqual(host.requestedResources.count, 3)
+        XCTAssertTrue(finals.isEmpty)
     }
 
     func testQuotaExhaustedWhileFinishingCommitsRawDraftAndWarmsReplacement() async {

--- a/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
+++ b/packages/arm/ios/KrakiTests/KrakiVoiceInputTests.swift
@@ -540,7 +540,7 @@ final class KrakiVoiceInputTests: XCTestCase {
         XCTAssertEqual(factory.sessions.count, 1)
     }
 
-    func testQuotaExhaustedConnectionDiscardsLeaseAndRequestsReplacement() async {
+    func testQuotaExhaustedConnectionRollsLeaseAndContinuesRecording() async {
         let host = FakeVoiceHost()
         let factory = FakeVoiceFactory()
         let controller = KrakiVoiceInputController(
@@ -553,24 +553,67 @@ final class KrakiVoiceInputTests: XCTestCase {
         factory.sessions[0].emit(.connectionAuthorized)
         await Task.yield()
 
-        await controller.begin(sessionID: "session-1", context: context()) { _ in }
+        var finals: [String] = []
+        await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
         XCTAssertEqual(controller.state, .recording)
+        factory.sessions[0].emit(.partial("before quota rollover"))
+        await Task.yield()
         factory.sessions[0].emit(.failed("denied: quota_exhausted"))
         for _ in 0..<20 where host.requestedResources.count < 2 {
             await Task.yield()
         }
 
-        XCTAssertEqual(controller.state, .failed("The voice-input quota was exhausted."))
+        XCTAssertEqual(controller.state, .obtainingLease)
+        XCTAssertEqual(controller.rawText, "before quota rollover")
         XCTAssertEqual(host.requestedResources, ["voice/doubao", "voice/doubao"])
         XCTAssertEqual(factory.sessions[0].closeCount, 1)
-        guard factory.sessions.count == 1 else { return }
+        XCTAssertTrue(finals.isEmpty)
 
         controller.receiveLease(lease(jti: "lease-2"))
         XCTAssertEqual(factory.sessions.count, 2)
-        guard factory.sessions.count == 2 else { return }
         factory.sessions[1].emit(.connectionAuthorized)
         await Task.yield()
-        XCTAssertTrue(controller.isConnectionWarm)
+        XCTAssertEqual(controller.state, .recording)
+        XCTAssertEqual(factory.sessions[1].starts.count, 1)
+
+        factory.sessions[1].emit(.partial("after rollover"))
+        await Task.yield()
+        XCTAssertEqual(controller.rawText, "before quota rollover after rollover")
+        factory.sessions[1].emit(.final("after rollover", rawText: "after rollover"))
+        await Task.yield()
+        XCTAssertEqual(finals, ["before quota rollover after rollover"])
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testQuotaExhaustedWhileFinishingCommitsRawDraftAndWarmsReplacement() async {
+        let host = FakeVoiceHost()
+        let factory = FakeVoiceFactory()
+        let controller = KrakiVoiceInputController(
+            host: host,
+            sessionFactory: factory,
+            audioPolicy: FakeVoiceAudioPolicy()
+        )
+        controller.prepare()
+        controller.receiveLease(lease())
+        factory.sessions[0].emit(.connectionAuthorized)
+        await Task.yield()
+
+        var finals: [String] = []
+        await controller.begin(sessionID: "session-1", context: context()) { finals.append($0) }
+        factory.sessions[0].emit(.partial("recover this raw draft"))
+        await Task.yield()
+        controller.finish()
+        XCTAssertEqual(controller.state, .finishing)
+
+        factory.sessions[0].emit(.failed("denied: quota_exhausted"))
+        for _ in 0..<20 where host.requestedResources.count < 2 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(finals, ["recover this raw draft"])
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(host.requestedResources, ["voice/doubao", "voice/doubao"])
+        XCTAssertEqual(factory.sessions[0].closeCount, 1)
     }
 
     func testLeaseDenialsRemainDistinct() async {

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.13"
-        CURRENT_PROJECT_VERSION: 15
+        MARKETING_VERSION: "0.2.14"
+        CURRENT_PROJECT_VERSION: 16
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- treat broker `quota_exhausted` as exhaustion of the current rolling voice lease, not as an account-level daily quota denial
- preserve the active recording context, frozen pre-rollover transcript, partials, correction display, and final handler while acquiring a replacement lease
- resume capture automatically once the replacement connection is authorized
- preserve the raw draft if the lease expires while finishing
- keep Relay `voice_lease_denied(.quotaExhausted)` as the only true account/daily quota error
- bound automatic rollover to one attempt per recording and use a renewal error, not a quota error, if that safety limit is reached
- prepare macOS GUI `0.2.14` build `16`

## Production evidence
Three broker lease exhaustions occurred in the last 48 hours. A replacement lease was issued after 65.7ms, 51.6ms, and 92.6ms respectively, with zero Head lease denials. The existing client refreshed the warm connection but cleared the active recording intent and showed a misleading quota error, requiring another click.

## Review fixes
The release review found and fixed two transcript-boundary cases before merge:
- a short pre-rollover prefix could be lost by the existing final-text length heuristic
- conflating the frozen rollover prefix with new-connection ASR segmentation could duplicate text

The controller now keeps the frozen pre-rollover transcript separate from the replacement connection's own segment accumulator and carries it through partial, correction, final, and finishing paths.

## Validation
- focused `KrakiVoiceInputTests`: 20/20 passed
- full iOS `KrakiTests`: 292 executed, 2 skipped, 0 failures
- `KrakiMac` Debug build: passed
- `git diff --check`: passed

No production service or installed app was restarted or replaced.
