### PR TITLE
fix(mac): stabilize history pagination and trace viewport health

### DIFF
--- a/docs/native-macos-automation.md
+++ b/docs/native-macos-automation.md
@@ -126,7 +126,8 @@ Supported methods:
 - `pageNewer`
 - `scrollToBubble`
 - `scrollChat`
-- `simulateMissingLiveScrollEnd` — Debug-only scroll-settle watchdog regression hook
+- `simulateMissingLiveScrollEnd` — Debug-only scroll-settle watchdog regression hook;
+  pass `overlapScrollerKnob=true` to cover a concurrent scrollbar drag
 - `createSession`
 - `selectSession`
 - `sendInput`
@@ -182,7 +183,8 @@ Mac history records use four prefixes:
 - `mac-window`: initial window selection and older/newer px-managed trimming;
 - `mac-fetch`: DB/Relay pagination start, apply, stale-result, and fallback;
 - `mac-page`: the window projected into the AppKit list, including seq ranges,
-  visible real/placeholder seqs, cache counts, warm state, offset, and edge state;
+  visible real/placeholder/unmaterialized seqs, cache counts, warm state, offset,
+  and edge state;
 - `mac-watchdog`: a missing AppKit live-scroll-end callback was recovered.
 
 After a reproduction, preserve the approximate time and Session ID/title, then
@@ -196,7 +198,14 @@ log show --last 30m --style compact \
   --predicate 'subsystem == "chat.kraki.ios" AND eventMessage CONTAINS "mac-"'
 ```
 
-A healthy page converges to `placeholders=[]`, `warm=0`, and
-`pendingHeight=0`. `reason=placeholder-stuck`, repeated page transitions with
-no new user input, or a window shrinking below the Mac 15-row floor identifies
-the failing layer without exposing message content.
+The CLI exposes both watchdog paths without native input:
+
+```bash
+scripts/kraki-native.py simulate-missing-scroll-end
+scripts/kraki-native.py simulate-missing-scroll-end --overlap-scroller-knob
+```
+
+A healthy page converges to `placeholders=[]`, `missing=[]`, `warm=0`, and
+`pendingHeight=0`. `reason=viewport-stuck`, repeated page transitions with no
+new user input, or a window shrinking below the Mac 15-row floor identifies the
+failing layer without exposing message content.

--- a/docs/native-macos-automation.md
+++ b/docs/native-macos-automation.md
@@ -120,6 +120,13 @@ Supported methods:
 
 - `ping`
 - `snapshot`
+- `chatState`
+- `chatLayout`
+- `pageOlder`
+- `pageNewer`
+- `scrollToBubble`
+- `scrollChat`
+- `simulateMissingLiveScrollEnd` — Debug-only scroll-settle watchdog regression hook
 - `createSession`
 - `selectSession`
 - `sendInput`
@@ -162,3 +169,34 @@ Semantic automation verifies the real application state and rendering path. A
 test that specifically requires physical native mouse/key events must run in a
 dedicated macOS VM or test Mac, because macOS does not provide headless native
 window-event isolation comparable to browser contexts.
+
+## Production Mac history diagnostics
+
+The production Mac app writes a bounded, low-frequency Chat presentation trace
+to `~/Documents/chat-entry.log` and mirrors the same records to Unified Log.
+The file rotates at 512 KiB. It never records message text, attachment data,
+credentials, tokens, or tool arguments/results.
+
+Mac history records use four prefixes:
+
+- `mac-window`: initial window selection and older/newer px-managed trimming;
+- `mac-fetch`: DB/Relay pagination start, apply, stale-result, and fallback;
+- `mac-page`: the window projected into the AppKit list, including seq ranges,
+  visible real/placeholder seqs, cache counts, warm state, offset, and edge state;
+- `mac-watchdog`: a missing AppKit live-scroll-end callback was recovered.
+
+After a reproduction, preserve the approximate time and Session ID/title, then
+inspect only the relevant metadata lines:
+
+```bash
+tail -300 ~/Documents/chat-entry.log \
+  | grep -E 'mac-(window|fetch|page|watchdog)'
+
+log show --last 30m --style compact \
+  --predicate 'subsystem == "chat.kraki.ios" AND eventMessage CONTAINS "mac-"'
+```
+
+A healthy page converges to `placeholders=[]`, `warm=0`, and
+`pendingHeight=0`. `reason=placeholder-stuck`, repeated page transitions with
+no new user input, or a window shrinking below the Mac 15-row floor identifies
+the failing layer without exposing message content.

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.14;
+				MARKETING_VERSION = 0.2.15;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.14;
+				MARKETING_VERSION = 0.2.15;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
@@ -261,8 +261,14 @@ final class MacAutomationDriver {
             guard let scrollView = findChatScrollView() else {
                 send(error: "invalid_state", message: "No production MacChatScrollView is mounted", id: id, on: connection); return
             }
-            scrollView.automationSimulateMissingLiveScrollEnd()
-            send(result: ["requested": true], id: id, on: connection)
+            let overlapScrollerKnob = params["overlapScrollerKnob"] as? Bool ?? false
+            scrollView.automationSimulateMissingLiveScrollEnd(
+                overlapScrollerKnob: overlapScrollerKnob
+            )
+            send(result: [
+                "requested": true,
+                "overlapScrollerKnob": overlapScrollerKnob,
+            ], id: id, on: connection)
         case "captureHTMLArtifactCard":
             guard let scrollView = findChatScrollView() else {
                 send(error: "invalid_state", message: "No production MacChatScrollView is mounted", id: id, on: connection); return

--- a/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
@@ -257,6 +257,12 @@ final class MacAutomationDriver {
                 "afterY": Double(result.after),
                 "moved": abs(result.after - result.before) > 0.5,
             ], id: id, on: connection)
+        case "simulateMissingLiveScrollEnd":
+            guard let scrollView = findChatScrollView() else {
+                send(error: "invalid_state", message: "No production MacChatScrollView is mounted", id: id, on: connection); return
+            }
+            scrollView.automationSimulateMissingLiveScrollEnd()
+            send(result: ["requested": true], id: id, on: connection)
         case "captureHTMLArtifactCard":
             guard let scrollView = findChatScrollView() else {
                 send(error: "invalid_state", message: "No production MacChatScrollView is mounted", id: id, on: connection); return

--- a/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageProvider.swift
@@ -559,6 +559,12 @@ final class MessageProvider {
 
         loadingOlderDB.insert(sessionId)
         defer { loadingOlderDB.remove(sessionId) }
+        #if os(macOS)
+        KLog.chatEntry(
+            "mac-fetch phase=start direction=older session=\(sessionId.prefix(12)) "
+                + "window=[\(state.topSeq),\(state.bottomSeq)] query=[\(from),\(to)]"
+        )
+        #endif
 
         #if DEBUG
         // Isolated Chat performance runs can inject a realistic round-trip so
@@ -590,6 +596,12 @@ final class MessageProvider {
         // the new top.
         guard let nowState = appState.messageStore.windowState(sessionId),
               nowState.topSeq == topSeq else {
+            #if os(macOS)
+            KLog.chatEntry(
+                "mac-fetch phase=stale direction=older session=\(sessionId.prefix(12)) "
+                    + "requestedTop=\(topSeq) currentTop=\(appState.messageStore.windowState(sessionId)?.topSeq ?? 0)"
+            )
+            #endif
             return false
         }
 
@@ -602,6 +614,14 @@ final class MessageProvider {
             let newTop = appState.messageStore.windowState(sessionId)?.topSeq ?? topSeq
             if newTop < topSeq {
                 KLog.diag("📥 [2/history←DB ensureOlderLoadedAsync] session=\(sessionId.prefix(12)) topSeq=\(topSeq)→\(newTop) count=\(page.count) ⏱️read=\(Int(readMs))ms prepend=\(String(format: "%.1f", expMs))ms")
+                #if os(macOS)
+                let current = appState.messageStore.windowState(sessionId)
+                KLog.chatEntry(
+                    "mac-fetch phase=applied direction=older session=\(sessionId.prefix(12)) "
+                        + "beforeTop=\(topSeq) after=[\(current?.topSeq ?? 0),\(current?.bottomSeq ?? 0)] "
+                        + "rows=\(page.count) readMs=\(Int(readMs))"
+                )
+                #endif
                 return true
             }
         }
@@ -615,6 +635,11 @@ final class MessageProvider {
             return false
         }
         KLog.diag("📤 [2/history→WS ensureOlderLoadedAsync] session=\(sessionId.prefix(12)) topSeq=\(topSeq) — DB exhausted, request older")
+        #if os(macOS)
+        KLog.chatEntry(
+            "mac-fetch phase=ws-fallback direction=older session=\(sessionId.prefix(12)) top=\(topSeq)"
+        )
+        #endif
         requestBefore(sessionId: sessionId, beforeSeq: topSeq, reason: "olderPage")
         return false
     }

--- a/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
@@ -100,8 +100,10 @@ final class MessageStore {
     /// with a compact tail and lazy-load the rest as the user reaches the top.
     #if os(macOS)
     private static let initialWindowSize = 15
+    private static let defaultMinimumPixelManagedWindowCount = 15
     #else
     private static let initialWindowSize = 200
+    private static let defaultMinimumPixelManagedWindowCount = 1
     #endif
     /// Maximum count of in-memory window before `expandWindow` trims
     /// the opposite end. DB still has everything; trimmed rows can
@@ -128,6 +130,10 @@ final class MessageStore {
     /// `heightForSeq` is set. ~14 screens; keeps both paging edges far apart so
     /// applies stay incremental. `.infinity` (default) disables the px cap.
     var maxWindowPx: CGFloat = .infinity
+    /// Minimum row overlap retained whenever the px cap trims a window. macOS
+    /// keeps its compact 15-row initial tail; iOS preserves the existing
+    /// one-row sliding behavior. Tests can override this policy explicitly.
+    var minimumPixelManagedWindowCount: Int = MessageStore.defaultMinimumPixelManagedWindowCount
 
 
     // MARK: - Live write
@@ -291,6 +297,7 @@ final class MessageStore {
         guard !older.isEmpty else { return }
 
         var window = messages[sessionId] ?? []
+        let beforeCount = window.count
         let existing = Set(window.map(\.seq))
         let prepend = older.filter { !existing.contains($0.seq) }
         guard !prepend.isEmpty else { return }
@@ -299,8 +306,15 @@ final class MessageStore {
         updated.topSeq = prepend.first!.seq
 
         if let h = heightForSeq, maxWindowPx.isFinite {
-            let oldCount = window.count - prepend.count
-            let maxRemove = min(prepend.count, max(0, oldCount - 1))
+            // Never let a px-managed window collapse below the compact initial
+            // tail. A handful of very tall bubbles can exceed maxWindowPx by
+            // themselves; keeping the 15-row floor is still memory-bounded and
+            // prevents older pagination from trimming away the user's visible
+            // anchor before the prepend is presented.
+            let maxRemove = min(
+                prepend.count,
+                max(0, beforeCount - minimumPixelManagedWindowCount)
+            )
             var removed = 0
             func windowPx() -> CGFloat { window.reduce(0) { $0 + h(sessionId, $1.seq) } }
             while removed < maxRemove, window.count > 1, windowPx() > maxWindowPx {
@@ -320,6 +334,14 @@ final class MessageStore {
         }
         messages[sessionId] = window
         windows[sessionId] = updated
+        #if os(macOS)
+        let trimmed = max(0, beforeCount + prepend.count - window.count)
+        KLog.chatEntry(
+            "mac-window reason=prepend session=\(sessionId.prefix(12)) "
+                + "before=[\(state.topSeq),\(state.bottomSeq)] after=[\(updated.topSeq),\(updated.bottomSeq)] "
+                + "added=\(prepend.count) trimmedNewer=\(trimmed) retained=\(window.count)"
+        )
+        #endif
     }
 
     /// Append a DB-selected newer page by persistent-spine order. Protocol
@@ -335,14 +357,17 @@ final class MessageStore {
         guard !append.isEmpty else { return }
 
         var window = messages[sessionId] ?? []
+        let beforeCount = window.count
         window.append(contentsOf: append)
         var updated = state
         updated.bottomSeq = append.last!.seq
 
         if let h = heightForSeq, maxWindowPx.isFinite {
             func windowPx() -> CGFloat { window.reduce(0) { $0 + h(sessionId, $1.seq) } }
-            let oldCount = window.count - append.count
-            let maxRemove = min(append.count, max(0, oldCount - 1))
+            let maxRemove = min(
+                append.count,
+                max(0, beforeCount - minimumPixelManagedWindowCount)
+            )
             var removed = 0
             while removed < maxRemove, window.count > 1, windowPx() > maxWindowPx {
                 window.removeFirst()
@@ -360,6 +385,14 @@ final class MessageStore {
 
         messages[sessionId] = window
         windows[sessionId] = updated
+        #if os(macOS)
+        let trimmed = max(0, beforeCount + append.count - window.count)
+        KLog.chatEntry(
+            "mac-window reason=append session=\(sessionId.prefix(12)) "
+                + "before=[\(state.topSeq),\(state.bottomSeq)] after=[\(updated.topSeq),\(updated.bottomSeq)] "
+                + "added=\(append.count) trimmedOlder=\(trimmed) retained=\(window.count)"
+        )
+        #endif
     }
 
     /// Extend the in-memory window with rows from `batch` that
@@ -395,6 +428,7 @@ final class MessageStore {
         let extendsBotSlice = batch[botIdx...]
 
         var window = messages[sessionId] ?? []
+        let originalWindowCount = window.count
         var updated = state
         var didPrepend = false
         var didAppend = false
@@ -460,15 +494,17 @@ final class MessageStore {
         // for tall turns could be < a screen → the two paging edges co-fire =
         // the ping-pong/crash). The trim mirrors the validated ScrollPerfTest
         // engine: SLIDE not leap — remove at most the page we just added (so the
-        // window slides rather than collapses) and keep ≥1 of the pre-call rows
-        // as overlap, so a single update never swaps the whole window.
+        // window slides rather than collapses) and never fall below the compact
+        // initial-tail count, so tall rows cannot reduce the overlap to one row.
         if let h = heightForSeq, maxWindowPx.isFinite {
             func windowPx() -> CGFloat { window.reduce(0) { $0 + h(sessionId, $1.seq) } }
             if didAppend {
                 // Extended the bottom → trim the TOP (older rows, off-screen
-                // above). Keep ≥1 old row; remove ≤ the page we just appended.
-                let oldCount = window.count - appendedCount
-                let maxRemove = min(appendedCount, max(0, oldCount - 1))
+                // above). Keep the initial-tail floor; remove ≤ the appended page.
+                let maxRemove = min(
+                    appendedCount,
+                    max(0, originalWindowCount - minimumPixelManagedWindowCount)
+                )
                 var removed = 0
                 while removed < maxRemove, window.count > 1, windowPx() > maxWindowPx {
                     window.removeFirst()
@@ -477,9 +513,11 @@ final class MessageStore {
                 }
             } else if didPrepend {
                 // Extended the top → trim the BOTTOM (newer rows, off-screen
-                // below). Keep ≥1 old row; remove ≤ the page we just prepended.
-                let oldCount = window.count - prependedCount
-                let maxRemove = min(prependedCount, max(0, oldCount - 1))
+                // below). Keep the initial-tail floor; remove ≤ the prepended page.
+                let maxRemove = min(
+                    prependedCount,
+                    max(0, originalWindowCount - minimumPixelManagedWindowCount)
+                )
                 var removed = 0
                 while removed < maxRemove, window.count > 1, windowPx() > maxWindowPx {
                     window.removeLast()
@@ -531,16 +569,28 @@ final class MessageStore {
         guard renderedHeight > maxWindowPx else { return false }
 
         var removeCount = 0
-        while removeCount < window.count - 1, renderedHeight > maxWindowPx {
+        let maxRemove = max(0, window.count - minimumPixelManagedWindowCount)
+        while removeCount < maxRemove, renderedHeight > maxWindowPx {
             renderedHeight -= heightForSeq(sessionId, window[removeCount].seq)
             removeCount += 1
         }
         guard removeCount > 0 else { return false }
 
+        let oldTop = state.topSeq
+        let oldBottom = state.bottomSeq
+        let oldCount = window.count
         window.removeFirst(removeCount)
         state.topSeq = window.first!.seq
         messages[sessionId] = window
         windows[sessionId] = state
+        #if os(macOS)
+        KLog.chatEntry(
+            "mac-window reason=tail-trim session=\(sessionId.prefix(12)) "
+                + "before=[\(oldTop),\(oldBottom)] after=[\(state.topSeq),\(state.bottomSeq)] "
+                + "removed=\(removeCount) retained=\(window.count) oldCount=\(oldCount) "
+                + "renderedPx=\(Int(renderedHeight)) capPx=\(Int(maxWindowPx))"
+        )
+        #endif
         return true
     }
 
@@ -590,6 +640,12 @@ final class MessageStore {
             topSeq: first.seq,
             bottomSeq: last.seq
         )
+        #if os(macOS)
+        KLog.chatEntry(
+            "mac-window reason=initial session=\(sessionId.prefix(12)) "
+                + "window=[\(first.seq),\(last.seq)] rows=\(recent.count)"
+        )
+        #endif
         return recent
     }
 

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
@@ -4,6 +4,18 @@ import QuartzCore
 import SwiftUI
 import os.log
 
+fileprivate struct MacChatPresentationHealth {
+    let itemCount: Int
+    let intersectingSeqs: [Int]
+    let realSeqs: [Int]
+    let placeholderSeqs: [Int]
+    let preparedContentCount: Int
+    let exactHeightCount: Int
+    let pendingHeightCount: Int
+    let warmActive: Bool
+    let viewportFillScheduled: Bool
+}
+
 private enum MacChatPerf {
     private static let logger = OSLog(subsystem: "chat.kraki.ios", category: "mac-chat-perf")
     static let enabled: Bool = {
@@ -1188,6 +1200,41 @@ final class MacChatDocumentView: NSView {
         return true
     }
 
+    fileprivate func presentationHealth(in viewport: NSRect) -> MacChatPresentationHealth {
+        let indexes = desiredIndexes(for: viewport, runway: 0).filter {
+            $0 < contents.count && $0 < itemFrames.count && itemFrames[$0].intersects(viewport)
+        }
+        let visible = indexes.compactMap { index -> (Int, MacChatBubbleCell)? in
+            guard let cell = visibleCells[index], !cell.isHidden else { return nil }
+            return (index, cell)
+        }
+        return MacChatPresentationHealth(
+            itemCount: contents.count,
+            intersectingSeqs: indexes.map { contents[$0].seq },
+            realSeqs: visible.compactMap { index, cell in
+                cell.isPlaceholderFlag ? nil : contents[index].seq
+            }.sorted(),
+            placeholderSeqs: visible.compactMap { index, cell in
+                cell.isPlaceholderFlag ? contents[index].seq : nil
+            }.sorted(),
+            preparedContentCount: contentCache.count,
+            exactHeightCount: heightCache.count,
+            pendingHeightCount: pendingHeights.count,
+            warmActive: warmBatchActive,
+            viewportFillScheduled: viewportFillScheduled
+        )
+    }
+
+    func intersectingPlaceholderSeqs(in viewport: NSRect) -> [Int] {
+        visibleCells.compactMap { index, cell in
+            guard index < contents.count,
+                  !cell.isHidden,
+                  cell.isPlaceholderFlag,
+                  cell.frame.intersects(viewport) else { return nil }
+            return contents[index].seq
+        }.sorted()
+    }
+
     func layoutDiagnostics(viewport: NSRect) -> [String: Any] {
         let indexedCells = visibleCells.compactMap { index, cell -> (Int, MacChatBubbleCell)? in
             guard index < contents.count else { return nil }
@@ -1802,6 +1849,8 @@ final class MacChatScrollView: MacSmoothScrollView {
     private var discreteWheelActive = false
     private var scrollSettlePending = false
     private var scrollSettleWorkItem: DispatchWorkItem?
+    private var scrollInteractionWatchdogWorkItem: DispatchWorkItem?
+    private var scrollActivityGeneration = 0
     private var deferredEdgePaging = false
     private var thumbViewportUpdateScheduled = false
     private var thumbViewportGeneration = 0
@@ -1811,6 +1860,15 @@ final class MacChatScrollView: MacSmoothScrollView {
     private(set) var hasUserScrolled = false
     private var initialTailTrimRequested = false
     private(set) var representedSessionId: String?
+    private var presentationEpoch = 0
+    private var diagnosticWindowTop = 0
+    private var diagnosticWindowBottom = 0
+    private var diagnosticRawCount = 0
+    private var diagnosticBubbleCount = 0
+    private var diagnosticAtOldest = false
+    private var diagnosticAtNewest = false
+    private var lastPresentationLogSignature = ""
+    private var presentationHealthWorkItem: DispatchWorkItem?
     private var geometryAnchorLock: (key: String, delta: CGFloat)?
     private var bubbleActionMouseMonitor: Any?
     private var pendingBubbleActionClick: (
@@ -1851,6 +1909,7 @@ final class MacChatScrollView: MacSmoothScrollView {
             if tracking {
                 self?.entryBottomLocked = false
                 self?.allowsEdgePaging = true
+                self?.olderEdgeArmed = true
                 self?.beginScrollInteraction(scrollerKnob: true)
             } else {
                 self?.endScrollInteraction(scrollerKnob: true)
@@ -1941,6 +2000,8 @@ final class MacChatScrollView: MacSmoothScrollView {
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     deinit {
+        scrollInteractionWatchdogWorkItem?.cancel()
+        presentationHealthWorkItem?.cancel()
         chatDocumentView.tearDown()
         if let bubbleActionMouseMonitor {
             NSEvent.removeMonitor(bubbleActionMouseMonitor)
@@ -2054,9 +2115,25 @@ final class MacChatScrollView: MacSmoothScrollView {
     func prepareForSession(_ sessionId: String) {
         guard representedSessionId != sessionId else { return }
         representedSessionId = sessionId
+        presentationEpoch += 1
+        diagnosticWindowTop = 0
+        diagnosticWindowBottom = 0
+        diagnosticRawCount = 0
+        diagnosticBubbleCount = 0
+        diagnosticAtOldest = false
+        diagnosticAtNewest = false
+        lastPresentationLogSignature = ""
+        presentationHealthWorkItem?.cancel()
+        presentationHealthWorkItem = nil
+        KLog.chatEntry(
+            "mac-page reason=prepare session=\(sessionId.prefix(12)) epoch=\(presentationEpoch)"
+        )
         resetSmoothWheelAnimation()
         scrollSettleWorkItem?.cancel()
         scrollSettleWorkItem = nil
+        scrollInteractionWatchdogWorkItem?.cancel()
+        scrollInteractionWatchdogWorkItem = nil
+        scrollActivityGeneration += 1
         scrollSettlePending = false
         liveScrollActive = false
         knobScrollActive = false
@@ -2146,8 +2223,34 @@ final class MacChatScrollView: MacSmoothScrollView {
             knobScrollActive = false
         } else {
             liveScrollActive = false
+            scrollInteractionWatchdogWorkItem?.cancel()
+            scrollInteractionWatchdogWorkItem = nil
+            scrollActivityGeneration += 1
         }
         scheduleScrollSettleIfIdle()
+    }
+
+    private func notePreciseScrollActivity() {
+        scrollActivityGeneration += 1
+        let generation = scrollActivityGeneration
+        scrollInteractionWatchdogWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self,
+                  generation == self.scrollActivityGeneration,
+                  self.liveScrollActive,
+                  !self.knobScrollActive else { return }
+            self.scrollInteractionWatchdogWorkItem = nil
+            self.liveScrollActive = false
+            let sessionPrefix = self.representedSessionId.map { String($0.prefix(12)) } ?? "none"
+            KLog.chatEntry(
+                "mac-watchdog session=\(sessionPrefix) "
+                    + "reason=missing-live-scroll-end placeholders="
+                    + "\(self.chatDocumentView.intersectingPlaceholderSeqs(in: self.contentView.bounds).count)"
+            )
+            self.scheduleScrollSettleIfIdle()
+        }
+        scrollInteractionWatchdogWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45, execute: work)
     }
 
     private func scheduleScrollSettleIfIdle() {
@@ -2185,6 +2288,11 @@ final class MacChatScrollView: MacSmoothScrollView {
         // stall the first settled frame for hundreds of milliseconds.
         _ = chatDocumentView.updateVisibleCells(in: contentView.bounds, runwayOverride: 0)
         adoptStableGeometryAnchorIfNeeded()
+        let settledHealth = chatDocumentView.presentationHealth(in: contentView.bounds)
+        if !settledHealth.placeholderSeqs.isEmpty {
+            emitPresentationLog(reason: "settled-placeholder", force: true)
+            schedulePresentationHealthCheck()
+        }
         if deferredEdgePaging {
             deferredEdgePaging = false
             driveEdgePagingIfNeeded(in: contentView)
@@ -2327,14 +2435,96 @@ final class MacChatScrollView: MacSmoothScrollView {
         updateJumpButtonVisibility(animated: false)
     }
 
+    func noteFirstUsableLayout() {
+        emitPresentationLog(reason: "initial-ready", force: true)
+    }
+
+    func notePresentationSnapshot(
+        windowTop: Int,
+        windowBottom: Int,
+        rawCount: Int,
+        bubbleCount: Int,
+        atOldest: Bool,
+        atNewest: Bool
+    ) {
+        presentationHealthWorkItem?.cancel()
+        presentationHealthWorkItem = nil
+        diagnosticWindowTop = windowTop
+        diagnosticWindowBottom = windowBottom
+        diagnosticRawCount = rawCount
+        diagnosticBubbleCount = bubbleCount
+        diagnosticAtOldest = atOldest
+        diagnosticAtNewest = atNewest
+        emitPresentationLog(reason: "apply", force: false)
+        if !chatDocumentView.intersectingPlaceholderSeqs(in: contentView.bounds).isEmpty {
+            schedulePresentationHealthCheck()
+        }
+    }
+
+    private func schedulePresentationHealthCheck() {
+        presentationHealthWorkItem?.cancel()
+        let epoch = presentationEpoch
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, epoch == self.presentationEpoch else { return }
+            self.presentationHealthWorkItem = nil
+            let health = self.chatDocumentView.presentationHealth(in: self.contentView.bounds)
+            if !self.isScrollInteractionActive, !health.placeholderSeqs.isEmpty {
+                _ = self.chatDocumentView.updateVisibleCells(
+                    in: self.contentView.bounds,
+                    runwayOverride: 0
+                )
+            }
+            let refreshed = self.chatDocumentView.presentationHealth(in: self.contentView.bounds)
+            self.emitPresentationLog(
+                reason: refreshed.placeholderSeqs.isEmpty
+                    ? "placeholder-resolved"
+                    : "placeholder-stuck",
+                force: true
+            )
+        }
+        presentationHealthWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: work)
+    }
+
+    private func emitPresentationLog(reason: String, force: Bool) {
+        guard let representedSessionId else { return }
+        let health = chatDocumentView.presentationHealth(in: contentView.bounds)
+        let signature = "\(diagnosticWindowTop):\(diagnosticWindowBottom):\(health.itemCount):"
+            + "\(health.realSeqs):\(health.placeholderSeqs):\(health.preparedContentCount):"
+            + "\(health.exactHeightCount):\(health.pendingHeightCount):\(health.warmActive):"
+            + "\(loadingOlder):\(loadingNewer):\(diagnosticAtOldest):\(diagnosticAtNewest)"
+        guard force || signature != lastPresentationLogSignature else { return }
+        lastPresentationLogSignature = signature
+        KLog.chatEntry(
+            "mac-page reason=\(reason) session=\(representedSessionId.prefix(12)) "
+                + "epoch=\(presentationEpoch) window=[\(diagnosticWindowTop),\(diagnosticWindowBottom)] "
+                + "raw=\(diagnosticRawCount) bubbles=\(diagnosticBubbleCount) "
+                + "viewport=\(health.intersectingSeqs) real=\(health.realSeqs) "
+                + "placeholders=\(health.placeholderSeqs) prepared=\(health.preparedContentCount) "
+                + "exact=\(health.exactHeightCount) pendingHeight=\(health.pendingHeightCount) "
+                + "warm=\(health.warmActive ? 1 : 0) fill=\(health.viewportFillScheduled ? 1 : 0) "
+                + "offset=\(Int(contentView.bounds.minY)) distanceBottom=\(Int(distanceToBottom)) "
+                + "atOldest=\(diagnosticAtOldest ? 1 : 0) atNewest=\(diagnosticAtNewest ? 1 : 0) "
+                + "fetchOlder=\(loadingOlder ? 1 : 0) fetchNewer=\(loadingNewer ? 1 : 0)"
+        )
+    }
+
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 116 || event.keyCode == 115 || event.keyCode == 126 {
             geometryAnchorLock = nil
             entryBottomLocked = false
             allowsEdgePaging = true
+            olderEdgeArmed = true
         }
         super.keyDown(with: event)
     }
+
+    #if DEBUG
+    func automationSimulateMissingLiveScrollEnd() {
+        beginScrollInteraction(scrollerKnob: false)
+        notePreciseScrollActivity()
+    }
+    #endif
 
     @discardableResult
     func automationScrollToBubble(seq: Int, screenY: CGFloat = 96) -> Bool {
@@ -2356,6 +2546,7 @@ final class MacChatScrollView: MacSmoothScrollView {
     func automationScroll(direction: String, ticks: Int) -> (before: CGFloat, after: CGFloat) {
         geometryAnchorLock = nil
         hasUserScrolled = true
+        if direction == "up" { olderEdgeArmed = true }
         if direction == "down" { suppressNewerPagingAfterOlder = false }
         resetSmoothWheelAnimation()
         entryBottomLocked = false
@@ -2381,12 +2572,19 @@ final class MacChatScrollView: MacSmoothScrollView {
     override func scrollWheel(with event: NSEvent) {
         geometryAnchorLock = nil
         hasUserScrolled = true
-        if event.scrollingDeltaY < -0.01 {
+        if event.scrollingDeltaY > 0.01 {
+            olderEdgeArmed = true
+        } else if event.scrollingDeltaY < -0.01 {
             suppressNewerPagingAfterOlder = false
         }
         entryBottomLocked = false
         followingBottom = false
         allowsEdgePaging = true
+        if event.hasPreciseScrollingDeltas,
+           abs(event.scrollingDeltaY) > 0.01 || abs(event.scrollingDeltaX) > 0.01 {
+            if !liveScrollActive { beginScrollInteraction(scrollerKnob: false) }
+            notePreciseScrollActivity()
+        }
         super.scrollWheel(with: event)
     }
 
@@ -2461,9 +2659,6 @@ final class MacChatScrollView: MacSmoothScrollView {
     }
 
     private func prefetchOlderIfNeeded(proposedY: CGFloat) {
-        if proposedY > 640 {
-            olderEdgeArmed = true
-        }
         if allowsEdgePaging,
            olderEdgeArmed,
            !suppressPagingForBottom,
@@ -2502,6 +2697,8 @@ final class MacChatScrollView: MacSmoothScrollView {
             "hasUserScrolled": hasUserScrolled,
             "discreteWheelActive": discreteWheelActive,
             "liveScrollActive": liveScrollActive,
+            "scrollSettlePending": scrollSettlePending,
+            "scrollWatchdogPending": scrollInteractionWatchdogWorkItem != nil,
         ]
         if let geometryAnchorLock,
            let frame = chatDocumentView.frame(forKey: geometryAnchorLock.key) {
@@ -2788,6 +2985,15 @@ struct MacChatListRepresentable: NSViewRepresentable {
                 scrollView.contentView.bounds.origin.y = target
             }
         }
+        let windowState = messageStore.windowState(sessionId)
+        scrollView.notePresentationSnapshot(
+            windowTop: windowState?.topSeq ?? 0,
+            windowBottom: windowState?.bottomSeq ?? 0,
+            rawCount: messageStore.currentWindow(sessionId).count,
+            bubbleCount: builtItems.count,
+            atOldest: atOldest,
+            atNewest: atNewest
+        )
         let totalMs = (CACurrentMediaTime() - totalStarted) * 1_000
         if totalMs >= 16 {
             MacChatPerf.slow(
@@ -2832,6 +3038,7 @@ struct MacChatListRepresentable: NSViewRepresentable {
             initialColdEstablishmentCompleted = true
             scrollView.alphaValue = 1
             scrollView.onFirstUsableLayout = nil
+            scrollView.noteFirstUsableLayout()
         }
     }
 

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
@@ -9,11 +9,16 @@ fileprivate struct MacChatPresentationHealth {
     let intersectingSeqs: [Int]
     let realSeqs: [Int]
     let placeholderSeqs: [Int]
+    let unmaterializedSeqs: [Int]
     let preparedContentCount: Int
     let exactHeightCount: Int
     let pendingHeightCount: Int
     let warmActive: Bool
     let viewportFillScheduled: Bool
+
+    var unresolvedSeqs: [Int] {
+        Array(Set(placeholderSeqs + unmaterializedSeqs)).sorted()
+    }
 }
 
 private enum MacChatPerf {
@@ -1205,9 +1210,12 @@ final class MacChatDocumentView: NSView {
             $0 < contents.count && $0 < itemFrames.count && itemFrames[$0].intersects(viewport)
         }
         let visible = indexes.compactMap { index -> (Int, MacChatBubbleCell)? in
-            guard let cell = visibleCells[index], !cell.isHidden else { return nil }
+            guard let cell = visibleCells[index], !cell.isHidden, cell.alphaValue > 0.01 else {
+                return nil
+            }
             return (index, cell)
         }
+        let visibleIndexes = Set(visible.map { $0.0 })
         return MacChatPresentationHealth(
             itemCount: contents.count,
             intersectingSeqs: indexes.map { contents[$0].seq },
@@ -1217,22 +1225,15 @@ final class MacChatDocumentView: NSView {
             placeholderSeqs: visible.compactMap { index, cell in
                 cell.isPlaceholderFlag ? contents[index].seq : nil
             }.sorted(),
+            unmaterializedSeqs: indexes.compactMap { index in
+                visibleIndexes.contains(index) ? nil : contents[index].seq
+            }.sorted(),
             preparedContentCount: contentCache.count,
             exactHeightCount: heightCache.count,
             pendingHeightCount: pendingHeights.count,
             warmActive: warmBatchActive,
             viewportFillScheduled: viewportFillScheduled
         )
-    }
-
-    func intersectingPlaceholderSeqs(in viewport: NSRect) -> [Int] {
-        visibleCells.compactMap { index, cell in
-            guard index < contents.count,
-                  !cell.isHidden,
-                  cell.isPlaceholderFlag,
-                  cell.frame.intersects(viewport) else { return nil }
-            return contents[index].seq
-        }.sorted()
     }
 
     func layoutDiagnostics(viewport: NSRect) -> [String: Any] {
@@ -1856,7 +1857,7 @@ final class MacChatScrollView: MacSmoothScrollView {
     private var thumbViewportGeneration = 0
     private var snapshotApplyActive = false
     private var suppressRunwayForNextReflect = false
-    private var olderEdgeArmed = true
+    private var olderEdgeArmed = false
     private(set) var hasUserScrolled = false
     private var initialTailTrimRequested = false
     private(set) var representedSessionId: String?
@@ -2144,7 +2145,7 @@ final class MacChatScrollView: MacSmoothScrollView {
         pendingBubbleActionClick = nil
         snapshotApplyActive = false
         suppressRunwayForNextReflect = false
-        olderEdgeArmed = true
+        olderEdgeArmed = false
         hasUserScrolled = false
         initialTailTrimRequested = false
         allowsEdgePaging = false
@@ -2221,6 +2222,11 @@ final class MacChatScrollView: MacSmoothScrollView {
     private func endScrollInteraction(scrollerKnob: Bool) {
         if scrollerKnob {
             knobScrollActive = false
+            // A missing live-scroll-end may have overlapped a scrollbar drag.
+            // The watchdog deliberately yields while the knob owns geometry;
+            // re-arm it once knob tracking finishes so the live state cannot
+            // remain fenced forever.
+            if liveScrollActive { notePreciseScrollActivity() }
         } else {
             liveScrollActive = false
             scrollInteractionWatchdogWorkItem?.cancel()
@@ -2236,16 +2242,16 @@ final class MacChatScrollView: MacSmoothScrollView {
         scrollInteractionWatchdogWorkItem?.cancel()
         let work = DispatchWorkItem { [weak self] in
             guard let self,
-                  generation == self.scrollActivityGeneration,
-                  self.liveScrollActive,
-                  !self.knobScrollActive else { return }
+                  generation == self.scrollActivityGeneration else { return }
             self.scrollInteractionWatchdogWorkItem = nil
+            guard self.liveScrollActive, !self.knobScrollActive else { return }
             self.liveScrollActive = false
             let sessionPrefix = self.representedSessionId.map { String($0.prefix(12)) } ?? "none"
+            let health = self.chatDocumentView.presentationHealth(in: self.contentView.bounds)
             KLog.chatEntry(
                 "mac-watchdog session=\(sessionPrefix) "
-                    + "reason=missing-live-scroll-end placeholders="
-                    + "\(self.chatDocumentView.intersectingPlaceholderSeqs(in: self.contentView.bounds).count)"
+                    + "reason=missing-live-scroll-end placeholders=\(health.placeholderSeqs.count) "
+                    + "unmaterialized=\(health.unmaterializedSeqs.count)"
             )
             self.scheduleScrollSettleIfIdle()
         }
@@ -2289,8 +2295,8 @@ final class MacChatScrollView: MacSmoothScrollView {
         _ = chatDocumentView.updateVisibleCells(in: contentView.bounds, runwayOverride: 0)
         adoptStableGeometryAnchorIfNeeded()
         let settledHealth = chatDocumentView.presentationHealth(in: contentView.bounds)
-        if !settledHealth.placeholderSeqs.isEmpty {
-            emitPresentationLog(reason: "settled-placeholder", force: true)
+        if !settledHealth.unresolvedSeqs.isEmpty {
+            emitPresentationLog(reason: "settled-unresolved", force: true)
             schedulePresentationHealthCheck()
         }
         if deferredEdgePaging {
@@ -2436,7 +2442,14 @@ final class MacChatScrollView: MacSmoothScrollView {
     }
 
     func noteFirstUsableLayout() {
-        emitPresentationLog(reason: "initial-ready", force: true)
+        let epoch = presentationEpoch
+        DispatchQueue.main.async { [weak self] in
+            guard let self, epoch == self.presentationEpoch else { return }
+            // `notePresentationSnapshot` runs after the atomic AppKit apply.
+            // Deferring one turn ensures initial-ready carries that window's
+            // actual range/counts instead of the prepare-time zero values.
+            self.emitPresentationLog(reason: "initial-ready", force: true)
+        }
     }
 
     func notePresentationSnapshot(
@@ -2447,8 +2460,6 @@ final class MacChatScrollView: MacSmoothScrollView {
         atOldest: Bool,
         atNewest: Bool
     ) {
-        presentationHealthWorkItem?.cancel()
-        presentationHealthWorkItem = nil
         diagnosticWindowTop = windowTop
         diagnosticWindowBottom = windowBottom
         diagnosticRawCount = rawCount
@@ -2456,19 +2467,22 @@ final class MacChatScrollView: MacSmoothScrollView {
         diagnosticAtOldest = atOldest
         diagnosticAtNewest = atNewest
         emitPresentationLog(reason: "apply", force: false)
-        if !chatDocumentView.intersectingPlaceholderSeqs(in: contentView.bounds).isEmpty {
+        if !chatDocumentView.presentationHealth(in: contentView.bounds).unresolvedSeqs.isEmpty {
             schedulePresentationHealthCheck()
         }
     }
 
     private func schedulePresentationHealthCheck() {
-        presentationHealthWorkItem?.cancel()
+        // Streaming snapshots may arrive 10–20 times per second. Keep the first
+        // deadline for this epoch instead of perpetually postponing diagnosis;
+        // the work item reads the latest window metadata when it fires.
+        guard presentationHealthWorkItem == nil else { return }
         let epoch = presentationEpoch
         let work = DispatchWorkItem { [weak self] in
             guard let self, epoch == self.presentationEpoch else { return }
             self.presentationHealthWorkItem = nil
             let health = self.chatDocumentView.presentationHealth(in: self.contentView.bounds)
-            if !self.isScrollInteractionActive, !health.placeholderSeqs.isEmpty {
+            if !self.isScrollInteractionActive, !health.unresolvedSeqs.isEmpty {
                 _ = self.chatDocumentView.updateVisibleCells(
                     in: self.contentView.bounds,
                     runwayOverride: 0
@@ -2476,9 +2490,9 @@ final class MacChatScrollView: MacSmoothScrollView {
             }
             let refreshed = self.chatDocumentView.presentationHealth(in: self.contentView.bounds)
             self.emitPresentationLog(
-                reason: refreshed.placeholderSeqs.isEmpty
-                    ? "placeholder-resolved"
-                    : "placeholder-stuck",
+                reason: refreshed.unresolvedSeqs.isEmpty
+                    ? "viewport-resolved"
+                    : "viewport-stuck",
                 force: true
             )
         }
@@ -2490,8 +2504,9 @@ final class MacChatScrollView: MacSmoothScrollView {
         guard let representedSessionId else { return }
         let health = chatDocumentView.presentationHealth(in: contentView.bounds)
         let signature = "\(diagnosticWindowTop):\(diagnosticWindowBottom):\(health.itemCount):"
-            + "\(health.realSeqs):\(health.placeholderSeqs):\(health.preparedContentCount):"
-            + "\(health.exactHeightCount):\(health.pendingHeightCount):\(health.warmActive):"
+            + "\(health.realSeqs):\(health.placeholderSeqs):\(health.unmaterializedSeqs):"
+            + "\(health.preparedContentCount):\(health.exactHeightCount):"
+            + "\(health.pendingHeightCount):\(health.warmActive):"
             + "\(loadingOlder):\(loadingNewer):\(diagnosticAtOldest):\(diagnosticAtNewest)"
         guard force || signature != lastPresentationLogSignature else { return }
         lastPresentationLogSignature = signature
@@ -2500,7 +2515,8 @@ final class MacChatScrollView: MacSmoothScrollView {
                 + "epoch=\(presentationEpoch) window=[\(diagnosticWindowTop),\(diagnosticWindowBottom)] "
                 + "raw=\(diagnosticRawCount) bubbles=\(diagnosticBubbleCount) "
                 + "viewport=\(health.intersectingSeqs) real=\(health.realSeqs) "
-                + "placeholders=\(health.placeholderSeqs) prepared=\(health.preparedContentCount) "
+                + "placeholders=\(health.placeholderSeqs) missing=\(health.unmaterializedSeqs) "
+                + "prepared=\(health.preparedContentCount) "
                 + "exact=\(health.exactHeightCount) pendingHeight=\(health.pendingHeightCount) "
                 + "warm=\(health.warmActive ? 1 : 0) fill=\(health.viewportFillScheduled ? 1 : 0) "
                 + "offset=\(Int(contentView.bounds.minY)) distanceBottom=\(Int(distanceToBottom)) "
@@ -2520,9 +2536,14 @@ final class MacChatScrollView: MacSmoothScrollView {
     }
 
     #if DEBUG
-    func automationSimulateMissingLiveScrollEnd() {
+    func automationSimulateMissingLiveScrollEnd(overlapScrollerKnob: Bool = false) {
         beginScrollInteraction(scrollerKnob: false)
         notePreciseScrollActivity()
+        guard overlapScrollerKnob else { return }
+        beginScrollInteraction(scrollerKnob: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.55) { [weak self] in
+            self?.endScrollInteraction(scrollerKnob: true)
+        }
     }
     #endif
 

--- a/packages/arm/ios/KrakiTests/MessageStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/MessageStoreTests.swift
@@ -268,6 +268,19 @@ final class MessageStoreTests: XCTestCase {
         XCTAssertEqual(localStore.currentWindow(sessionId).count, 25)
         XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(1...25))
         XCTAssertEqual(localStore.windowState(sessionId), .init(topSeq: 1, bottomSeq: 25))
+
+        // The contiguous replay/live-ingest path uses expandWindow rather than
+        // the sparse-page helpers. It must retain the same pre-call overlap.
+        localStore.messages[sessionId] = (11...25).map(message)
+        localStore.windows[sessionId] = .init(topSeq: 11, bottomSeq: 25)
+        localStore.expandWindow(sessionId, (1...10).map(message))
+        XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(1...25))
+        XCTAssertEqual(localStore.windowState(sessionId), .init(topSeq: 1, bottomSeq: 25))
+
+        localStore.expandWindow(sessionId, (26...35).map(message))
+        XCTAssertEqual(localStore.currentWindow(sessionId).count, 25)
+        XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(11...35))
+        XCTAssertEqual(localStore.windowState(sessionId), .init(topSeq: 11, bottomSeq: 35))
     }
 
     // MARK: - Reset

--- a/packages/arm/ios/KrakiTests/MessageStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/MessageStoreTests.swift
@@ -220,6 +220,56 @@ final class MessageStoreTests: XCTestCase {
         XCTAssertNil(store.turnSteps("sess-1", bubbleSeq: 99))
     }
 
+    // MARK: - Pixel-managed history window
+
+    func testPixelManagedWindowRetainsInitialTailFloorAcrossPaging() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-window-floor-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = try MessageDatabase(databaseURL: root.appendingPathComponent("messages.sqlite"))
+        let localStore = MessageStore(db: database)
+        let sessionId = "window-floor"
+        func message(_ seq: Int) -> ChatMessage {
+            ChatMessage(
+                type: seq.isMultiple(of: 2) ? "agent_message" : "user_message",
+                seq: seq,
+                sessionId: sessionId,
+                deviceId: "dev-1",
+                timestamp: nil,
+                payload: ["content": AnyCodable("message-\(seq)")]
+            )
+        }
+
+        localStore.minimumPixelManagedWindowCount = 15
+        localStore.maxWindowPx = 4_800
+        localStore.heightForSeq = { _, _ in 1_000 }
+        localStore.messages[sessionId] = (11...25).map(message)
+        localStore.windows[sessionId] = .init(topSeq: 11, bottomSeq: 25)
+
+        XCTAssertFalse(localStore.trimTailWindowToRenderedHeight(sessionId))
+        XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(11...25))
+
+        localStore.prependOlderPage(sessionId, (1...10).map(message))
+        XCTAssertEqual(localStore.currentWindow(sessionId).count, 25)
+        XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(1...25))
+        XCTAssertEqual(localStore.windowState(sessionId), .init(topSeq: 1, bottomSeq: 25))
+
+        localStore.messages[sessionId] = (1...15).map(message)
+        localStore.windows[sessionId] = .init(topSeq: 1, bottomSeq: 15)
+        localStore.appendNewerPage(sessionId, (16...25).map(message))
+        XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(1...25))
+
+        localStore.appendNewerPage(sessionId, (26...35).map(message))
+        XCTAssertEqual(localStore.currentWindow(sessionId).count, 25)
+        XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(11...35))
+        XCTAssertEqual(localStore.windowState(sessionId), .init(topSeq: 11, bottomSeq: 35))
+
+        localStore.prependOlderPage(sessionId, (1...10).map(message))
+        XCTAssertEqual(localStore.currentWindow(sessionId).count, 25)
+        XCTAssertEqual(localStore.currentWindow(sessionId).map(\.seq), Array(1...25))
+        XCTAssertEqual(localStore.windowState(sessionId), .init(topSeq: 1, bottomSeq: 25))
+    }
+
     // MARK: - Reset
 
     func testResetClearsCardsTracesAndRuntimeStatus() {

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.14"
-        CURRENT_PROJECT_VERSION: 16
+        MARKETING_VERSION: "0.2.15"
+        CURRENT_PROJECT_VERSION: 17
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic

--- a/scripts/kraki-native.py
+++ b/scripts/kraki-native.py
@@ -76,6 +76,7 @@ def parser() -> argparse.ArgumentParser:
     scroll_chat = sub.add_parser("scroll-chat")
     scroll_chat.add_argument("direction", choices=["up", "down"])
     scroll_chat.add_argument("--ticks", type=int, default=1)
+    sub.add_parser("simulate-missing-scroll-end")
 
     create = sub.add_parser("create-session")
     create.add_argument("--device", required=True)
@@ -158,6 +159,8 @@ def main() -> None:
         method, params = "scrollToBubble", {"seq": args.seq, "screenY": args.screen_y}
     elif command == "scroll-chat":
         method, params = "scrollChat", {"direction": args.direction, "ticks": args.ticks}
+    elif command == "simulate-missing-scroll-end":
+        method, params = "simulateMissingLiveScrollEnd", {}
     elif command == "create-session":
         method = "createSession"
         params = compact({

--- a/scripts/kraki-native.py
+++ b/scripts/kraki-native.py
@@ -76,7 +76,8 @@ def parser() -> argparse.ArgumentParser:
     scroll_chat = sub.add_parser("scroll-chat")
     scroll_chat.add_argument("direction", choices=["up", "down"])
     scroll_chat.add_argument("--ticks", type=int, default=1)
-    sub.add_parser("simulate-missing-scroll-end")
+    missing_scroll_end = sub.add_parser("simulate-missing-scroll-end")
+    missing_scroll_end.add_argument("--overlap-scroller-knob", action="store_true")
 
     create = sub.add_parser("create-session")
     create.add_argument("--device", required=True)
@@ -160,7 +161,9 @@ def main() -> None:
     elif command == "scroll-chat":
         method, params = "scrollChat", {"direction": args.direction, "ticks": args.ticks}
     elif command == "simulate-missing-scroll-end":
-        method, params = "simulateMissingLiveScrollEnd", {}
+        method, params = "simulateMissingLiveScrollEnd", {
+            "overlapScrollerKnob": args.overlap_scroller_knob,
+        }
     elif command == "create-session":
         method = "createSession"
         params = compact({


### PR DESCRIPTION
## Summary
- keep at least the Mac's 15-row pre-pagination tail as overlap when px-based history trimming runs
- prevent programmatic anchor/layout changes from re-arming older pagination without a new user upward-scroll action
- recover from a missing AppKit `didEndLiveScroll` callback after scroll inactivity so prepared placeholders cannot remain fenced indefinitely
- add bounded privacy-safe `mac-window`, `mac-fetch`, `mac-page`, and `mac-watchdog` diagnostics to `~/Documents/chat-entry.log` and Unified Log
- add Debug automation for the missing-scroll-end regression

## Reproduced failure shape
Using a transactionally consistent, network-isolated snapshot of the production SQLite/session metadata:

- DB/session head: `654`
- initial 15-row tail was px-trimmed to `648…654`
- projection collapsed to 4 bubbles, with only the latest 2 intersecting the viewport
- one upward action could advance `648…654 → 628…646`, removing the original visible anchor and loading two pages without a second user action

No message content was printed or logged.

## Fixed behavior on the same snapshot

- initial window remains `640…654`: 15 persistent rows / 10 bubbles
- first older page moves to `630…654`: 25 rows, preserving the complete prior tail
- visible seq `644` stays visible across the prepend
- no automatic second page after the first request settles
- pagination remains bounded: subsequent pages retain 15 pre-existing rows plus one 10-row page
- 48 rapid switches across 6 production-shaped sessions: 0 represented-session mismatches, 0 final placeholders
- missing-live-scroll-end regression: watchdog armed, then recovered with all interaction flags false

## Validation
- focused `MessageStoreTests`: 17/17 passed
- full iOS `KrakiTests`: 293 executed, 2 skipped, 0 failures
- `KrakiMac` Debug build: passed
- CoreText scroll benchmark: 240/240 moves, max scroll 1.190ms, max/final placeholders 0, TextKit cells 0, allocations 3
- production-snapshot pagination/switch stress: passed
- `git diff --check`: passed
- Python automation client compile: passed

The production app and production database were not restarted, replaced, or modified.


## Independent release review repairs

A second lifecycle/diagnostics review found and repaired additional edge cases before release:

- older paging now starts disarmed, so horizontal/downward input cannot unlock an older fetch on a short top-aligned page
- the missing-live-scroll-end watchdog re-arms after an overlapping scrollbar-knob drag instead of leaving `liveScrollActive` fenced
- `initial-ready` is emitted after the atomic snapshot metadata is staged, so it cannot report a prepare-time `[0,0]` window
- viewport health distinguishes placeholder cells from completely unmaterialized intersecting rows and retries either state
- streaming snapshots no longer postpone the 750ms health deadline indefinitely
- the 15-row overlap regression now covers `expandWindow` as well as sparse older/newer page helpers

Review validation:

- downward input at latest: no older fetch
- first upward input: exactly one page, `[640,654] → [630,654]`
- no further input: no second page
- ordinary missing-scroll-end watchdog: settled
- missing-scroll-end overlapping scrollbar knob: settled
- 48 rapid switches across 6 production-shaped Sessions: 0 represented-session mismatches, 0 final placeholder failures, 0 initial-arm failures
- full iOS suite: 293 executed, 2 skipped, 0 failures
- macOS Debug and universal Release builds: passed
- CoreText benchmark: 240/240 moves, max 1.371ms, max/final placeholders 0, TextKit cells 0, allocations 3

This PR prepares macOS GUI `0.2.15 (17)`. iOS and Tentacle versions are unchanged.
