### PR TITLE
fix(tentacle): prevent retry turn eviction deadlocks

### DIFF
--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.17",
+  "version": "0.31.18",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
+++ b/packages/tentacle/src/__tests__/pi-finalize-ask.test.ts
@@ -31,6 +31,7 @@ interface StubProc {
   send: ReturnType<typeof vi.fn>;
   sendRaw: ReturnType<typeof vi.fn>;
   request: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
 }
 
 function makeAdapter(promptWatchdog?: {
@@ -46,6 +47,7 @@ function makeAdapter(promptWatchdog?: {
     send: vi.fn(),
     sendRaw: vi.fn(),
     request: vi.fn().mockResolvedValue({}),
+    kill: vi.fn(),
   };
   const session = {
     proc,
@@ -82,6 +84,49 @@ function makeAdapter(promptWatchdog?: {
 }
 
 type Sess = ReturnType<typeof makeAdapter>['session'];
+
+describe('pi idle eviction lifecycle', () => {
+  it('does not evict a logical turn that is still retrying after agent_end', () => {
+    const { adapter, sid, proc, session, emit } = makeAdapter();
+    const onSessionEvicted = vi.fn();
+    adapter.onSessionEvicted = onSessionEvicted;
+
+    emit({ type: 'agent_end', willRetry: true });
+    session.lastActivity = Date.now() - 30 * 60_000 - 1;
+    (adapter as unknown as { sweepIdle: () => void }).sweepIdle();
+
+    expect(session.settledTurn).toBeUndefined();
+    expect(proc.kill).not.toHaveBeenCalled();
+    expect(onSessionEvicted).not.toHaveBeenCalledWith(sid);
+  });
+
+  it('does not evict settled sessions while native compaction is still active', () => {
+    const { adapter, proc, session, emit } = makeAdapter();
+    const onSessionEvicted = vi.fn();
+    adapter.onSessionEvicted = onSessionEvicted;
+    session.settledTurn = session.logicalTurn;
+    emit({ type: 'compaction_start', reason: 'threshold' });
+    session.lastActivity = Date.now() - 30 * 60_000 - 1;
+
+    (adapter as unknown as { sweepIdle: () => void }).sweepIdle();
+
+    expect(proc.kill).not.toHaveBeenCalled();
+    expect(onSessionEvicted).not.toHaveBeenCalled();
+  });
+
+  it('still evicts a genuinely settled, non-compacting session after the TTL', () => {
+    const { adapter, sid, proc, session } = makeAdapter();
+    const onSessionEvicted = vi.fn();
+    adapter.onSessionEvicted = onSessionEvicted;
+    session.settledTurn = session.logicalTurn;
+    session.lastActivity = Date.now() - 30 * 60_000 - 1;
+
+    (adapter as unknown as { sweepIdle: () => void }).sweepIdle();
+
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+    expect(onSessionEvicted).toHaveBeenCalledWith(sid);
+  });
+});
 
 describe('pi narration → draft + TRACE', () => {
   it('message_end prose → onNarration RECONCILE now, TRACE deferred (may still graduate)', () => {
@@ -161,7 +206,7 @@ describe('pi narration → draft + TRACE', () => {
 
 describe('pi abort', () => {
   it('waits for the pi abort acknowledgement before resolving', async () => {
-    const { adapter, sid, proc } = makeAdapter();
+    const { adapter, sid, proc, session } = makeAdapter();
     let acknowledge!: () => void;
     proc.request.mockReturnValueOnce(new Promise<void>((resolve) => { acknowledge = resolve; }));
 
@@ -175,6 +220,7 @@ describe('pi abort', () => {
     acknowledge();
     await aborting;
     expect(resolved).toBe(true);
+    expect(session.settledTurn).toBe(session.logicalTurn);
   });
 
   it('cancels pending question and permission UI requests before aborting', async () => {

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -2237,6 +2237,83 @@ describe('RelayClient pending-question digest', () => {
     expect(adapter.sendMessage).toHaveBeenNthCalledWith(2, 'sess_1', 'second', undefined);
   });
 
+  it('fails closed and releases the prompt queue when an active adapter session is evicted', async () => {
+    const { adapter, ws, sm } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+    let state = 'active';
+    smMock.getMeta.mockImplementation(() => ({
+      id: 'sess_1', agent: 'pi', state, lastSeq: 610, currentTurnStartSeq: 609,
+    }));
+    smMock.markActive.mockImplementation(() => { state = 'active'; });
+    smMock.markIdle.mockImplementation(() => { state = 'idle'; });
+    smMock.markDisconnected.mockImplementation(() => { state = 'disconnected'; });
+    smMock.resumeSession.mockImplementation(() => ({ context: {} }));
+
+    for (const [seq, text] of [[609, 'first'], [610, 'second']] as const) {
+      ws.emit('message', Buffer.from(JSON.stringify({
+        type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq,
+        timestamp: new Date().toISOString(), payload: { text },
+      })));
+    }
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+
+    (adapter.onSessionEvicted as (sid: string) => void)('sess_1');
+    (adapter.onSessionEvicted as (sid: string) => void)('sess_1');
+
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(2));
+    expect(adapter.resumeSession).toHaveBeenCalledWith('sess_1', {});
+    expect(adapter.sendMessage).toHaveBeenNthCalledWith(2, 'sess_1', 'second', undefined);
+    const statusCalls = smMock.appendMessage.mock.calls.filter((call) => call[1] === 'turn_status');
+    expect(statusCalls).toHaveLength(1);
+    expect(JSON.parse(statusCalls[0][2]).payload).toMatchObject({
+      action: {
+        type: 'failed',
+        payload: { source: 'process' },
+      },
+    });
+  });
+
+  it('terminalizes an active waiter-less steer when the adapter session is evicted', async () => {
+    const { adapter, ws, sm } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 609,
+      timestamp: new Date().toISOString(), payload: { text: 'change direction', delivery: 'steer' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+
+    (adapter.onSessionEvicted as (sid: string) => void)('sess_1');
+
+    const statusCalls = smMock.appendMessage.mock.calls.filter((call) => call[1] === 'turn_status');
+    expect(statusCalls).toHaveLength(1);
+    expect(JSON.parse(statusCalls[0][2]).payload).toMatchObject({
+      action: {
+        type: 'failed',
+        payload: { source: 'process' },
+      },
+    });
+    expect(smMock.markDisconnected).toHaveBeenCalledWith('sess_1');
+  });
+
+  it('keeps a sole open question recoverable across adapter eviction', async () => {
+    const { adapter, ws, sm, askQ } = buildClient();
+    const smMock = sm as Record<string, ReturnType<typeof vi.fn>>;
+
+    ws.emit('message', Buffer.from(JSON.stringify({
+      type: 'send_input', sessionId: 'sess_1', deviceId: 'app-x', seq: 609,
+      timestamp: new Date().toISOString(), payload: { text: 'ask me' },
+    })));
+    await vi.waitFor(() => expect(adapter.sendMessage).toHaveBeenCalledTimes(1));
+    askQ('q-recover');
+
+    (adapter.onSessionEvicted as (sid: string) => void)('sess_1');
+
+    const statusCalls = smMock.appendMessage.mock.calls.filter((call) => call[1] === 'turn_status');
+    expect(statusCalls).toHaveLength(0);
+    expect(smMock.markDisconnected).toHaveBeenCalledWith('sess_1');
+  });
+
   it('dispatches and persists active-turn steer immediately without waiting for idle', async () => {
     const { adapter, ws, sm } = buildClient();
     ws.emit('message', Buffer.from(JSON.stringify({

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -1631,6 +1631,10 @@ export class PiAdapter extends AgentAdapter {
       // active tool process group and waitForIdle() has completed. Relay-client
       // must not announce `idle` before that acknowledgement arrives.
       await s.proc.request('abort');
+      // RelayClient owns the visible aborted idle boundary, but the adapter must
+      // still record that this logical turn is terminal. Otherwise the stricter
+      // idle-eviction gate would retain an acknowledged-aborted Pi forever.
+      s.settledTurn = s.logicalTurn;
     } finally {
       s.aborting = false;
     }
@@ -1871,6 +1875,8 @@ export class PiAdapter extends AgentAdapter {
     for (const [id, s] of this.sessions) {
       if (
         s.proc.alive
+        && s.settledTurn === s.logicalTurn
+        && !this.compactingSessions.has(id)
         && s.pendingQuestions.size === 0
         && s.pendingPerms.size === 0
         && !s.aborting

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -2323,9 +2323,30 @@ export class RelayClient {
     // state by marking the session `disconnected` on eviction. No arm
     // broadcast — load-state is internal; the next user interaction goes
     // through ensureSessionResumed and lazy-loads transparently.
+    //
+    // Defensive fail-closed path: an adapter must never evict an active turn,
+    // but process lifecycle bugs can violate that contract (for example, a long
+    // retry backoff with no events being mistaken for idle). Terminalize every
+    // accepted unsettled turn before disconnecting; this also resolves a normal
+    // prompt waiter when present, but covers waiter-less steer/initial turns too.
+    // Keep a sole open question recoverable: Pi deliberately retains that card
+    // across process loss so its answer can become a lazy-resume recovery prompt.
     this.adapter.onSessionEvicted = (sessionId) => {
+      const turnId = this.activeInputTurnIds.get(sessionId);
+      const hasUnsettledAcceptedTurn = !!turnId
+        && this.settledAdapterTurnIds.get(sessionId) !== turnId;
+      const hasRecoverableQuestion = !!this.soleOpenQuestion(sessionId);
+      if (hasUnsettledAcceptedTurn && !hasRecoverableQuestion) {
+        this.pendingTerminalErrors.set(sessionId, {
+          message: 'Agent process was evicted before the active turn settled.',
+          code: 'process_lost',
+          source: 'process',
+          turnId,
+        });
+        this.settleAdapterIdle(sessionId, { turnId });
+      }
       this.sessionManager.markDisconnected(sessionId);
-      if (!this.soleOpenQuestion(sessionId)) this.card.delete(sessionId);
+      if (!hasRecoverableQuestion) this.card.delete(sessionId);
     };
 
     // SDK title fallback — use as fast placeholder while LLM generation runs


### PR DESCRIPTION
## Summary

Fix a Pi/Tentacle lifecycle deadlock where a logical turn in provider retry backoff could be mistaken for an idle process, evicted after the 30-minute TTL, and leave Relay's normal-input chain waiting forever for an idle boundary that would never arrive.

This also prepares `@kraki/tentacle` 0.31.18.

## Production incident correlation

For session `ms1nvx4p-92ff1650`, the final `agent_end(willRetry=true)` and the erroneous eviction were separated by exactly the idle TTL window:

- final retry event: `1786966241590`
- idle eviction: `1786968053544`
- delta: `1,811,954 ms`
- configured TTL: `1,800,000 ms`

The follow-up input had already been durably persisted, but remained behind the stale turn waiter/input chain after the Pi process disappeared.

## Root cause

1. `PiAdapter.sweepIdle()` checked elapsed activity but did not require the current logical turn to be terminal.
2. Native compaction was not part of eviction eligibility.
3. Relay assumed adapters only evicted sessions after idle, so an active eviction did not terminal-settle the turn or release its waiter.

## Fix

- only idle-evict Pi sessions whose current logical turn is settled
- keep native-compacting sessions ineligible for idle eviction
- mark abort-acknowledged turns settled so the stricter eviction fence cannot leak them
- fail closed when an adapter evicts an accepted, unsettled turn:
  - persist a `process_lost` terminal failure
  - settle the turn exactly once
  - release any normal prompt waiter/input chain
  - mark the runtime disconnected so queued input can lazy-resume
- preserve a sole open `ask_user` question across process loss for its existing recovery-prompt path

## Regression coverage

- retrying `agent_end(willRetry=true)` survives past the idle TTL
- native compaction survives past the idle TTL
- genuinely settled/non-compacting sessions remain evictable
- active eviction releases a queued follow-up and lazy-resumes exactly once
- duplicate eviction callbacks do not duplicate terminal settlement
- waiter-less active steer is terminalized
- sole open question remains recoverable
- abort acknowledgement updates adapter settlement state

## Validation

- `env -u KRAKI_HOME pnpm validate`
  - Biome: 152 files passed
  - Crypto: 36/36
  - Head: 261/261
  - Tentacle: 906/906
  - Integration: 44/44
  - Web: 436/436
- focused lifecycle tests: 187/187
- `tsc --noEmit`: passed
- `git diff --check`: passed
