### PR TITLE
fix(mac): restore pending question cards after reconnect

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.15;
+				MARKETING_VERSION = 0.2.16;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.15;
+				MARKETING_VERSION = 0.2.16;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/MessageStore.swift
@@ -899,8 +899,11 @@ final class MessageStore {
     /// ACK. Unlike incremental delta/action handlers this is an authoritative
     /// reconnect/page-entry snapshot, so it may reopen the card gate when the
     /// digest says a turn is live and the snapshot actually carries draft or
-    /// action state. Empty idle/ended snapshots keep the concluded-turn gate
-    /// closed and can never resurrect a stale bubble.
+    /// action state. A durable pending question is the exception: Tentacle
+    /// intentionally rehydrates it after the agent has gone idle/disconnected,
+    /// and its authoritative question action must remain answerable. Empty
+    /// idle/ended snapshots still keep the concluded-turn gate closed and can
+    /// never resurrect a stale bubble.
     func replaceCardFromSubscription(
         _ sessionId: String,
         draft: String,
@@ -910,7 +913,13 @@ final class MessageStore {
         cards.removeValue(forKey: sessionId)
         let hasLiveCard = !draft.isEmpty || action != nil
         let liveState = state == .active || state == .compacting
-        guard liveState && hasLiveCard else {
+        // Pending questions are durable human-blocking state. They survive a
+        // Tentacle/Pi restart, whose session digest can legitimately be idle
+        // or disconnected while the question remains answerable. Do not apply
+        // this exception to ordinary drafts/tool cards: those still require a
+        // live digest so stale snapshots cannot resurrect a concluded turn.
+        let durableQuestion = action?.type == "question"
+        guard (liveState || durableQuestion) && hasLiveCard else {
             if !liveState { closedCardTurns.insert(sessionId) }
             return
         }

--- a/packages/arm/ios/KrakiTests/MessageStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/MessageStoreTests.swift
@@ -129,7 +129,11 @@ final class MessageStoreTests: XCTestCase {
         XCTAssertEqual(store.cards[sid]?.action?.type, "question")
         XCTAssertEqual(store.cards[sid]?.action?.question, "Deploy now?")
 
-        store.applyCardMessage(sid, "", reset: false)
+        store.applyCardMessage(sid, " Ready for approval.", reset: false)
+        XCTAssertEqual(
+            store.cards[sid]?.text,
+            "The deployment is ready. Ready for approval."
+        )
         XCTAssertEqual(store.cards[sid]?.action?.question, "Deploy now?")
     }
 

--- a/packages/arm/ios/KrakiTests/MessageStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/MessageStoreTests.swift
@@ -111,6 +111,39 @@ final class MessageStoreTests: XCTestCase {
         XCTAssertNil(store.cards[sid])
     }
 
+    func testIdleSubscriptionSnapshotRestoresDurableQuestionCard() {
+        let sid = "idle-question-subscription-card"
+        let question = ChatMessage(
+            type: "question", seq: 0, sessionId: sid, deviceId: nil, timestamp: nil,
+            payload: [
+                "id": AnyCodable("q-rehydrated"),
+                "question": AnyCodable("Deploy now?"),
+                "choices": AnyCodable(["Yes", "No"]),
+            ])
+
+        store.endCardTurn(sid)
+        store.replaceCardFromSubscription(
+            sid, draft: "The deployment is ready.", action: question, state: .idle)
+
+        XCTAssertEqual(store.cards[sid]?.text, "The deployment is ready.")
+        XCTAssertEqual(store.cards[sid]?.action?.type, "question")
+        XCTAssertEqual(store.cards[sid]?.action?.question, "Deploy now?")
+
+        store.applyCardMessage(sid, "", reset: false)
+        XCTAssertEqual(store.cards[sid]?.action?.question, "Deploy now?")
+    }
+
+    func testIdleSubscriptionSnapshotDoesNotRestoreOrdinaryToolCard() {
+        let sid = "idle-tool-subscription-card"
+        let tool = ChatMessage(
+            type: "tool_start", seq: 0, sessionId: sid, deviceId: nil, timestamp: nil,
+            payload: ["toolName": AnyCodable("shell")])
+
+        store.replaceCardFromSubscription(sid, draft: "stale", action: tool, state: .idle)
+
+        XCTAssertNil(store.cards[sid])
+    }
+
     func testActiveSubscriptionSnapshotCanAuthoritativelyReopenClosedGate() {
         let sid = "active-subscription-card"
         store.endCardTurn(sid)

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.15"
-        CURRENT_PROJECT_VERSION: 17
+        MARKETING_VERSION: "0.2.16"
+        CURRENT_PROJECT_VERSION: 18
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

- restore an authoritative pending `question` card from a session subscription snapshot even when the persisted session digest is idle/disconnected
- keep the existing stale-card fence for ordinary drafts and tool cards
- add regressions covering both the durable-question exception and the idle tool-card rejection

## Root cause

Tentacle persists an unresolved `ask_user` question outside the durable message spine so it remains answerable after the agent process or daemon is reconstructed. On reconnect it correctly restores the question into the subscription snapshot's `card.action`, while the session digest can legitimately remain idle/disconnected until the answer resumes the agent.

The native client previously accepted subscription cards only when `digest.state` was active or compacting. That made the sidebar preview show the question from `session_list.preview`, but the opened conversation discarded the corresponding authoritative question card.

## Safety

The exception is intentionally narrow: only `action.type == "question"` can reopen an idle subscription card. Empty idle snapshots and ordinary draft/tool actions still close the card gate, so a stale completed turn cannot be resurrected.

## Validation

- `MessageStoreTests`: 19/19 passed
- full iOS suite: 295 tests, 2 existing skips, 0 failures
- macOS GUI Debug build passed
- `git diff --check` passed
