### PR TITLE
fix(mac): keep session activity animation alive and refine status icons

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.16;
+				MARKETING_VERSION = 0.2.17;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.16;
+				MARKETING_VERSION = 0.2.17;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
@@ -545,6 +545,10 @@ final class MacAutomationDriver {
             transientScrollerRegression(id: id, connection: connection)
         case "sessionListScrollerRegression":
             sessionListScrollerRegression(id: id, connection: connection)
+        case "sessionActivityDotsRegression":
+            MacSessionActivityDotsRegression.run { [weak self] result in
+                self?.send(result: result, id: id, on: connection)
+            }
         case "composerPasteFocusRegression":
             MacComposerPasteFocusRegression.run { [weak self] result in
                 self?.send(result: result, id: id, on: connection)

--- a/packages/arm/ios/Kraki/Core/Protocol/SessionCardPresentation.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/SessionCardPresentation.swift
@@ -114,13 +114,22 @@ struct SessionCardProjection: Equatable {
 struct SessionCardStatusGlyph: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let status: SessionCardStatus
+    var hasDraft: Bool = false
 
     var body: some View {
         Group {
             switch status {
-            case .active, .compacting:
-                IOSSessionActivityDots(color: status == .compacting ? Color(hex: 0x0891B2) : .krakiPrimary,
-                                       reduceMotion: reduceMotion)
+            case .active:
+                IOSSessionActivityDots(color: .krakiPrimary, reduceMotion: reduceMotion)
+            case .compacting:
+                Image(systemName: "square.stack.3d.down.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color(hex: 0x0891B2))
+                    .symbolEffect(
+                        .variableColor.iterative.reversing.dimInactiveLayers,
+                        options: .repeat(.continuous).speed(0.72),
+                        isActive: !reduceMotion
+                    )
             case .waiting:
                 LucideIcon(.messageCircleQuestion, size: 14, strokeWidth: 2.2, color: Color(hex: 0xD97706))
             case .approval:
@@ -134,7 +143,14 @@ struct SessionCardStatusGlyph: View {
             case .agentMessage:
                 LucideIcon(.botMessageSquare, size: 13, strokeWidth: 1.9, color: .krakiPrimary)
             case .humanMessage:
-                LucideIcon(.circleUser, size: 13, strokeWidth: 1.9, color: .secondary)
+                if hasDraft {
+                    LucideIcon(.keyboard,
+                               size: 14,
+                               strokeWidth: 2,
+                               color: Color(hex: 0x4F8C86))
+                } else {
+                    LucideIcon(.circleUser, size: 13, strokeWidth: 1.9, color: .secondary)
+                }
             case .idle:
                 Color.clear
             }

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionCardView.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionCardView.swift
@@ -150,7 +150,10 @@ private struct SessionCardBody: View {
 
     private var previewRow: some View {
         HStack(spacing: 5) {
-            SessionCardStatusGlyph(status: projection.status)
+            SessionCardStatusGlyph(
+                status: projection.status,
+                hasDraft: projection.isDraft
+            )
                 .accessibilityLabel(projection.status.accessibilityLabel ?? "")
 
             if let previewText = projection.previewText {

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
@@ -608,8 +608,17 @@ private struct MacSessionStatusGlyph: View {
     var body: some View {
         Group {
             switch status {
-            case .active, .compacting:
+            case .active:
                 activityDots
+            case .compacting:
+                Image(systemName: "square.stack.3d.down.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color(hex: 0x0891B2))
+                    .symbolEffect(
+                        .variableColor.iterative.reversing.dimInactiveLayers,
+                        options: .repeat(.continuous).speed(0.72),
+                        isActive: !reduceMotion
+                    )
             case .waiting:
                 LucideIcon(.messageCircleQuestion,
                            size: 14,
@@ -635,10 +644,17 @@ private struct MacSessionStatusGlyph: View {
                            strokeWidth: 1.9,
                            color: Color.krakiPrimary)
             case .humanMessage:
-                LucideIcon(.circleUser,
-                           size: 13,
-                           strokeWidth: 1.9,
-                           color: hasDraft ? Color.red : Color.textSecondary)
+                if hasDraft {
+                    LucideIcon(.keyboard,
+                               size: 14,
+                               strokeWidth: 2,
+                               color: Color(hex: 0x4F8C86))
+                } else {
+                    LucideIcon(.circleUser,
+                               size: 13,
+                               strokeWidth: 1.9,
+                               color: Color.textSecondary)
+                }
             case .idle:
                 Color.clear
             }
@@ -647,13 +663,9 @@ private struct MacSessionStatusGlyph: View {
         .accessibilityHidden(true)
     }
 
-    private var activityColor: Color {
-        status == .compacting ? Color(hex: 0x0891B2) : Color.krakiPrimary
-    }
-
     private var activityDots: some View {
         MacSessionActivityDots(
-            color: NSColor(activityColor),
+            color: NSColor(Color.krakiPrimary),
             reduceMotion: reduceMotion
         )
         .frame(width: 14, height: 14)

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
@@ -375,7 +375,12 @@ struct SessionsSidebarView: View {
         let preview = appState.sessionStore.sessionPreviews[session.id]
         let hasDraft = appState.sessionStore.drafts[session.id]?.isEmpty == false
         let status = SessionCardStatus.resolve(
-            sessionState: session.state,
+            sessionState: {
+                if case .compacting = appState.messageStore.runtimeStatus(session.id) {
+                    return .compacting
+                }
+                return session.state
+            }(),
             previewType: preview?.type,
             deviceOnline: appState.deviceStore.devices[session.deviceId]?.online,
             hasDraft: hasDraft
@@ -461,7 +466,11 @@ private struct MacSidebarSessionRow: View {
             session: session,
             device: device,
             preview: preview,
-            draft: appState.sessionStore.drafts[session.id]
+            draft: appState.sessionStore.drafts[session.id],
+            isCompacting: {
+                if case .compacting = appState.messageStore.runtimeStatus(session.id) { return true }
+                return false
+            }()
         )
     }
 
@@ -669,6 +678,10 @@ private struct MacSessionActivityDots: NSViewRepresentable {
 private final class MacSessionActivityDotsView: NSView {
     private let dotLayers: [CALayer] = (0..<3).map { _ in CALayer() }
     private var reduceMotion = false
+    private weak var observedClipView: NSClipView?
+    private var clipBoundsObserver: NSObjectProtocol?
+    private var visibilityTimer: Timer?
+    private var wasVisibleInClip = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -684,7 +697,24 @@ private final class MacSessionActivityDotsView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        if let clipBoundsObserver {
+            NotificationCenter.default.removeObserver(clipBoundsObserver)
+        }
+        visibilityTimer?.invalidate()
+    }
+
     override var intrinsicContentSize: NSSize { NSSize(width: 14, height: 14) }
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        refreshClipObservation()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        refreshClipObservation()
+    }
 
     override func layout() {
         super.layout()
@@ -704,10 +734,63 @@ private final class MacSessionActivityDotsView: NSView {
         }
         CATransaction.commit()
 
-        guard self.reduceMotion != reduceMotion || dotLayers[0].animation(forKey: "thinking") == nil else {
+        let reduceMotionChanged = self.reduceMotion != reduceMotion
+        self.reduceMotion = reduceMotion
+        refreshClipObservation()
+        guard reduceMotionChanged || dotLayers[0].animation(forKey: "thinking") == nil else {
             return
         }
-        self.reduceMotion = reduceMotion
+        installAnimations()
+    }
+
+    private func refreshClipObservation() {
+        let clipView = enclosingScrollView?.contentView
+        if clipView !== observedClipView {
+            if let clipBoundsObserver {
+                NotificationCenter.default.removeObserver(clipBoundsObserver)
+            }
+            clipBoundsObserver = nil
+            observedClipView = clipView
+            wasVisibleInClip = false
+
+            if let clipView {
+                clipView.postsBoundsChangedNotifications = true
+                clipBoundsObserver = NotificationCenter.default.addObserver(
+                    forName: NSView.boundsDidChangeNotification,
+                    object: clipView,
+                    queue: .main
+                ) { [weak self] _ in
+                    self?.updateViewportVisibility()
+                }
+            }
+        }
+        updateVisibilityTimer()
+        updateViewportVisibility()
+    }
+
+    private func updateVisibilityTimer() {
+        guard window != nil, observedClipView != nil else {
+            visibilityTimer?.invalidate()
+            visibilityTimer = nil
+            return
+        }
+        guard visibilityTimer == nil else { return }
+        let timer = Timer(timeInterval: 0.20, repeats: true) { [weak self] _ in
+            self?.updateViewportVisibility()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        visibilityTimer = timer
+    }
+
+    private func updateViewportVisibility() {
+        let isVisible = window != nil && observedClipView != nil && !visibleRect.isEmpty
+        defer { wasVisibleInClip = isVisible }
+        guard isVisible, !wasVisibleInClip else { return }
+        // SwiftUI keeps lazy sidebar rows alive while they are off-screen.
+        // AppKit/Core Animation may stop or evict a detached presentation
+        // timeline without causing `updateNSView` to run when the row returns.
+        // Reinstall on the actual viewport transition even if the model layer
+        // still reports the old animation key.
         installAnimations()
     }
 
@@ -733,20 +816,154 @@ private final class MacSessionActivityDotsView: NSView {
             group.animations = [opacity, scale]
             group.duration = 1.2
             group.repeatCount = .infinity
-            group.beginTime = CACurrentMediaTime() + Double(index) * 0.16
+            group.beginTime = dot.convertTime(CACurrentMediaTime(), from: nil) + Double(index) * 0.16
             group.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             dot.add(group, forKey: "thinking")
         }
     }
+
+    #if DEBUG
+    var debugHasAnimations: Bool {
+        dotLayers.allSatisfy { $0.animation(forKey: "thinking") != nil }
+    }
+
+    var debugVisibilityState: [String: Any] {
+        [
+            "hasClip": observedClipView != nil,
+            "wasVisible": wasVisibleInClip,
+            "visibleRectEmpty": visibleRect.isEmpty,
+        ]
+    }
+
+    var debugPresentationOpacities: [Float] {
+        dotLayers.map { $0.presentation()?.opacity ?? $0.opacity }
+    }
+
+    func debugEvictAnimations() {
+        dotLayers.forEach { $0.removeAnimation(forKey: "thinking") }
+    }
+    #endif
 }
 
 #if DEBUG
+@MainActor
+enum MacSessionActivityDotsRegression {
+    private struct ListView: View {
+        var body: some View {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(0..<80, id: \.self) { index in
+                        HStack(spacing: 8) {
+                            if index == 0 {
+                                MacSessionActivityDots(color: .systemBlue, reduceMotion: false)
+                                    .frame(width: 14, height: 14)
+                            } else {
+                                Color.clear.frame(width: 14, height: 14)
+                            }
+                            Text("Session \(index)")
+                            Spacer(minLength: 0)
+                        }
+                        .frame(height: 48)
+                        .padding(.horizontal, 8)
+                    }
+                }
+            }
+            .frame(width: 260, height: 180)
+        }
+    }
+
+    static func run(completion: @escaping ([String: Any]) -> Void) {
+        Task { @MainActor in
+            completion(await result())
+        }
+    }
+
+    private static func result() async -> [String: Any] {
+        let size = NSSize(width: 260, height: 180)
+        let host = NSHostingView(rootView: ListView())
+        host.frame = NSRect(origin: .zero, size: size)
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = host
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        window.orderFrontRegardless()
+        defer { window.close() }
+        host.layoutSubtreeIfNeeded()
+        host.display()
+
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        guard let scrollView = firstView(NSScrollView.self, in: host),
+              let initialDots = firstView(MacSessionActivityDotsView.self, in: host),
+              let documentView = scrollView.documentView else {
+            return ["passed": false, "error": "missing scroll view or activity dots"]
+        }
+
+        let initialBefore = initialDots.debugPresentationOpacities
+        try? await Task.sleep(nanoseconds: 180_000_000)
+        let initialAfter = initialDots.debugPresentationOpacities
+        let initialMoving = moved(initialBefore, initialAfter)
+        let maximumY = max(0, documentView.frame.height - scrollView.contentView.bounds.height)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: maximumY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        try? await Task.sleep(nanoseconds: 180_000_000)
+        let offscreen = initialDots.visibleRect.isEmpty
+        initialDots.debugEvictAnimations()
+        let evicted = !initialDots.debugHasAnimations
+        scrollView.contentView.scroll(to: .zero)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        guard let returnedDots = firstView(MacSessionActivityDotsView.self, in: host) else {
+            return ["passed": false, "error": "activity dots did not return"]
+        }
+        let returnedBefore = returnedDots.debugPresentationOpacities
+        try? await Task.sleep(nanoseconds: 180_000_000)
+        let returnedAfter = returnedDots.debugPresentationOpacities
+        let returnedMoving = moved(returnedBefore, returnedAfter)
+        let restoredAnimations = returnedDots.debugHasAnimations
+        let reusedView = returnedDots === initialDots
+        return [
+            "passed": initialMoving && offscreen && evicted && restoredAnimations && returnedMoving,
+            "initialMoving": initialMoving,
+            "offscreen": offscreen,
+            "evicted": evicted,
+            "reusedView": reusedView,
+            "restoredAnimations": restoredAnimations,
+            "returnedMoving": returnedMoving,
+            "visibility": returnedDots.debugVisibilityState,
+            "initialBefore": initialBefore.map(Double.init),
+            "initialAfter": initialAfter.map(Double.init),
+            "returnedBefore": returnedBefore.map(Double.init),
+            "returnedAfter": returnedAfter.map(Double.init),
+        ]
+    }
+
+    private static func firstView<T: NSView>(_ type: T.Type, in root: NSView) -> T? {
+        if let match = root as? T { return match }
+        for child in root.subviews {
+            if let match = firstView(type, in: child) { return match }
+        }
+        return nil
+    }
+
+    private static func moved(_ before: [Float], _ after: [Float]) -> Bool {
+        zip(before, after).contains { abs($0 - $1) > 0.02 }
+    }
+}
+
 struct MacSessionSpeakerGlyphRegressionView: View {
     private let rows: [(String, SessionState, String?, Bool?, Bool)] = [
         ("Human · user_message", .idle, "user_message", true, false),
         ("Agent · agent_message", .idle, "agent_message", true, false),
         ("Human · draft", .idle, "agent_message", true, true),
         ("Active", .active, "agent_message", true, false),
+        ("Compacting", .compacting, "agent_message", true, false),
         ("Question", .idle, "question", true, false),
         ("Permission", .idle, "permission", true, false),
         ("Error", .idle, "error", true, false),

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.16"
-        CURRENT_PROJECT_VERSION: 18
+        MARKETING_VERSION: "0.2.17"
+        CURRENT_PROJECT_VERSION: 19
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- resume Active session activity dots when a LazyVStack row returns from off-screen
- use the selected status icon mapping on macOS and iOS: muted teal keyboard for drafts, existing blue dots for Active, and animated cyan stacked-context for Compacting
- preserve runtime Compacting projection on macOS and prepare GUI `0.2.17 (19)`

## Validation
- macOS Universal Release build (`arm64` + `x86_64`)
- iOS test suite: 295 executed, 2 skipped, 0 failures
- activity-dot lifecycle regression: 10/10
- status precedence regression: passed
- `git diff --check`
