### PR TITLE
fix(mac): make Compacting status glyph visibly animate

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.17;
+				MARKETING_VERSION = 0.2.18;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.17;
+				MARKETING_VERSION = 0.2.18;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
@@ -549,6 +549,8 @@ final class MacAutomationDriver {
             MacSessionActivityDotsRegression.run { [weak self] result in
                 self?.send(result: result, id: id, on: connection)
             }
+        case "compactingGlyphAnimationRegression":
+            compactingGlyphAnimationRegression(id: id, connection: connection)
         case "composerPasteFocusRegression":
             MacComposerPasteFocusRegression.run { [weak self] result in
                 self?.send(result: result, id: id, on: connection)
@@ -597,6 +599,52 @@ final class MacAutomationDriver {
             Task { @MainActor in self.stop() }
         default:
             send(error: "unknown_method", message: "Unknown method: \(method)", id: id, on: connection)
+        }
+    }
+
+    private func compactingGlyphAnimationRegression(id: Any?, connection: Int32) {
+        let host = NSHostingView(rootView: CompactingStatusGlyph())
+        host.frame = NSRect(x: 0, y: 0, width: 16, height: 16)
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = host
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        window.orderFrontRegardless()
+        host.layoutSubtreeIfNeeded()
+        host.display()
+
+        func renderedPNG() -> Data? {
+            guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else { return nil }
+            host.cacheDisplay(in: host.bounds, to: bitmap)
+            return bitmap.representation(using: .png, properties: [:])
+        }
+
+        guard let first = renderedPNG() else {
+            window.close()
+            send(error: "capture_failed", message: "Unable to render Compacting glyph", id: id, on: connection)
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 350_000_000)
+            let second = renderedPNG()
+            let changed = second.map { $0 != first } ?? false
+            self?.send(
+                result: [
+                    "passed": changed,
+                    "changed": changed,
+                    "firstBytes": first.count,
+                    "secondBytes": second?.count ?? 0,
+                ],
+                id: id,
+                on: connection
+            )
+            window.close()
         }
     }
 

--- a/packages/arm/ios/Kraki/Core/Protocol/SessionCardPresentation.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/SessionCardPresentation.swift
@@ -107,6 +107,38 @@ struct SessionCardProjection: Equatable {
     }
 }
 
+/// Shared Compacting glyph. Native variable-color layers provide the visual
+/// language; TimelineView periodically renews the view identity so a retained
+/// LazyVStack row cannot keep a stale symbol-effect presentation timeline.
+struct CompactingStatusGlyph: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private let cycleDuration: TimeInterval = 2.4
+
+    var body: some View {
+        if reduceMotion {
+            symbol
+        } else {
+            TimelineView(.animation(minimumInterval: 0.18)) { context in
+                let cycle = Int(context.date.timeIntervalSinceReferenceDate / cycleDuration)
+                symbol
+                    .id(cycle)
+                    .symbolEffect(
+                        .variableColor.iterative.reversing.hideInactiveLayers,
+                        options: .repeat(.continuous).speed(0.9),
+                        isActive: true
+                    )
+            }
+        }
+    }
+
+    private var symbol: some View {
+        Image(systemName: "square.stack.3d.down.right")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(Color(hex: 0x0891B2))
+            .frame(width: 16, height: 16)
+    }
+}
+
 #if os(iOS)
 /// iOS counterpart of the native macOS status slot. The slot remains fixed so
 /// changes between active work, a speaker glyph, and an empty preview do not
@@ -122,14 +154,7 @@ struct SessionCardStatusGlyph: View {
             case .active:
                 IOSSessionActivityDots(color: .krakiPrimary, reduceMotion: reduceMotion)
             case .compacting:
-                Image(systemName: "square.stack.3d.down.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Color(hex: 0x0891B2))
-                    .symbolEffect(
-                        .variableColor.iterative.reversing.dimInactiveLayers,
-                        options: .repeat(.continuous).speed(0.72),
-                        isActive: !reduceMotion
-                    )
+                CompactingStatusGlyph()
             case .waiting:
                 LucideIcon(.messageCircleQuestion, size: 14, strokeWidth: 2.2, color: Color(hex: 0xD97706))
             case .approval:

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
@@ -611,14 +611,7 @@ private struct MacSessionStatusGlyph: View {
             case .active:
                 activityDots
             case .compacting:
-                Image(systemName: "square.stack.3d.down.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Color(hex: 0x0891B2))
-                    .symbolEffect(
-                        .variableColor.iterative.reversing.dimInactiveLayers,
-                        options: .repeat(.continuous).speed(0.72),
-                        isActive: !reduceMotion
-                    )
+                CompactingStatusGlyph()
             case .waiting:
                 LucideIcon(.messageCircleQuestion,
                            size: 14,

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.17"
-        CURRENT_PROJECT_VERSION: 19
+        MARKETING_VERSION: "0.2.18"
+        CURRENT_PROJECT_VERSION: 20
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- make the cyan stacked-context Compacting glyph visibly animate at Sidebar size by hiding inactive layers during the iterative cycle
- use a shared macOS/iOS `CompactingStatusGlyph`
- periodically renew the SwiftUI view identity so retained LazyVStack rows cannot keep a stale symbol-effect presentation timeline
- add a Debug-only pixel-change regression endpoint
- prepare macOS GUI `0.2.18 (20)`

## Validation
- macOS Debug build
- macOS Universal Release build (`arm64` + `x86_64`)
- `compactingGlyphAnimationRegression`: passed, changed pixels detected across frames
- activity-dot lifecycle regression: passed
- status precedence regression: passed
- iOS suite: 295 executed, 2 skipped, 0 failures
- `git diff --check`
