### PR TITLE
fix(apps): keep cold-launch gates over first layout

### DIFF
--- a/docs/ios-launch-flow.md
+++ b/docs/ios-launch-flow.md
@@ -1,0 +1,41 @@
+# iOS Cold-Launch Flow
+
+Kraki iOS uses two launch surfaces:
+
+1. the system-generated static launch screen while iOS creates the process;
+2. an in-app `IOSEntryGateView` that remains in control while the real SwiftUI/UIKit application surface materializes.
+
+## Returning authenticated user
+
+1. `RootView` starts in `IOSLaunchCoordinator.Phase.launching` and paints the branded entry gate.
+2. The initial Relay connection starts behind the gate. Network readiness does not control whether cached UI can eventually open.
+3. `MainTabView` mounts underneath the gate with notification/deep-link navigation disabled.
+4. `IOSLaunchPresentationReadyProbe` waits until the UIKit hierarchy is attached to a real `UIWindow`, forces its first layout pass, and reports on the following main-run-loop turn.
+5. After both that presentation boundary and the 350 ms visual floor, the gate fades away. A 2-second presentation watchdog provides a bounded fallback if UIKit does not deliver the expected attach callback.
+6. Queued Session or Device navigation is then consumed. Chat is never mounted behind the cold-launch gate.
+
+## Signed-out user
+
+The launch gate remains visible for the short visual floor, then routes to the existing iOS `LoginView`. The first WebSocket connection still starts behind the gate so `auth_info` can make GitHub sign-in available.
+
+A successful login stages `MainTabView` through the same presentation boundary. Explicit logout returns directly to `LoginView` and does not replay the cold-launch animation.
+
+## Session-list reconciliation
+
+The initial and reconnecting `session_list` uses `SessionStore.reconcileSessionList`:
+
+- one device-scoped authoritative transaction;
+- stale Sessions for that Tentacle removed without touching other devices;
+- one observable metadata commit;
+- one persistence snapshot scheduled for the entire list.
+
+This avoids the former per-Session `upsert + mode + usage + pin` mutation pattern, which rebuilt the full snapshot hundreds of times and could stall both the iOS Session table and the macOS Sidebar after the main surface was already visible.
+
+## Debug fixture
+
+The iOS Simulator can render the in-app gate without Relay traffic:
+
+```bash
+SIMCTL_CHILD_KRAKI_IOS_ENTRY_GATE_PAGE=1 \
+  xcrun simctl launch --terminate-running-process <device-udid> chat.kraki.ios
+```

--- a/docs/mac-launch-flow.md
+++ b/docs/mac-launch-flow.md
@@ -10,11 +10,13 @@ The production main scene is a single `Window(id: "main")`, not a `WindowGroup`.
 
 1. Show the Kraki launch gate immediately.
 2. Resolve local CLI/stored credential availability behind the gate.
-3. Keep the gate visible for at least 350 ms to avoid a one-frame flash.
-4. Route to one of:
-   - authenticated `MainWindowView`, landing on Welcome with no Session selected;
+3. For an authenticated launch, mount `MainWindowView` underneath the gate with no Session selected.
+4. Keep Session/deep-link navigation queued while an AppKit probe completes the shell's first window-backed layout pass.
+5. Keep the gate visible for at least 350 ms, then fade it after that presentation probe reports ready. A 2-second presentation watchdog is a bounded fallback if AppKit does not deliver the expected attach callback.
+6. Route to one of:
+   - the already-settled authenticated shell, landing on Welcome with no Session selected;
    - the signed-out entry gate, with `kraki connect` instructions.
-5. Relay authentication and Tentacle status may continue after the authenticated shell appears. Network readiness never blocks the full-window gate indefinitely.
+7. Relay authentication and Tentacle status may continue after the authenticated shell appears. Network readiness never blocks the full-window gate indefinitely.
 
 ### Warm window reopen
 
@@ -29,7 +31,9 @@ Launch and Signed Out use the same brand shell. Signed Out replaces the launch s
 - automatic credential discovery when the user returns to Kraki from Terminal;
 - in-place checking/failure status.
 
-Neither entry mode mounts Sidebar, Chat, Composer, CoreText cells, image preview, or HTML artifact state behind the gate.
+Signed Out never mounts the authenticated shell. Authenticated cold launch stages only the Sidebar/Welcome shell under the launch gate so its synchronous first layout is hidden; Session navigation stays queued, therefore Chat, Composer, CoreText cells, image preview, and HTML artifact state are not mounted behind the gate.
+
+A reconnecting `session_list` is reconciled as one SessionStore transaction and schedules one persistence snapshot. It must not invalidate the Sidebar and rebuild the full snapshot several times per Session.
 
 ## Restore policy
 

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.18;
+				MARKETING_VERSION = 0.2.19;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.18;
+				MARKETING_VERSION = 0.2.19;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/KrakiApp.swift
+++ b/packages/arm/ios/Kraki/App/KrakiApp.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct KrakiApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @State private var appState: AppState
+    @State private var launchCoordinator = IOSLaunchCoordinator()
     @AppStorage("colorScheme") private var selectedScheme: AppColorScheme = .system
     @Environment(\.scenePhase) private var scenePhase
     private let alignmentPreviewEnabled: Bool
@@ -38,23 +39,14 @@ struct KrakiApp: App {
                 } else if clientAlignmentPreviewEnabled {
                     IOSClientAlignmentPreview()
                 } else {
-                    RootView()
+                    RootView(launchCoordinator: launchCoordinator)
                         .onAppear {
                             // Wire PushManager so AppDelegate (no SwiftUI env) can reach it.
                             AppDelegate.pushManager = appState.pushManager
                             Task { await appState.pushManager?.refreshPermissionStatus() }
-
-                            if appState.connectionStatus == .awaitingLogin {
-                                // Open the WS so we can request auth_info; the
-                                // server's response unlocks the GitHub OAuth
-                                // button on the login screen. No credentials
-                                // are sent here — `bootstrapAuth` decides what
-                                // to do once the socket is up. Debug builds get
-                                // the same prod-default; the "Dev Login
-                                // (localhost)" button on LoginView is the
-                                // explicit opt-in path to the local relay.
-                                appState.connect()
-                            }
+                            // RootView's process-scoped launch coordinator owns
+                            // the initial connect so network/auth work starts
+                            // behind the in-app launch gate exactly once.
                         }
                         .onChange(of: scenePhase) {
                             switch scenePhase {
@@ -79,11 +71,12 @@ struct KrakiApp: App {
                         }
                 }
                 #else
-                RootView()
+                RootView(launchCoordinator: launchCoordinator)
                     .onAppear {
                         AppDelegate.pushManager = appState.pushManager
                         Task { await appState.pushManager?.refreshPermissionStatus() }
-                        if appState.connectionStatus == .awaitingLogin { appState.connect() }
+                        // RootView starts the first connection behind the
+                        // process-scoped launch gate.
                     }
                     .onChange(of: scenePhase) {
                         switch scenePhase {

--- a/packages/arm/ios/Kraki/App/Mac/MacApp.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacApp.swift
@@ -18,15 +18,20 @@ import SwiftUI
 
 /// Process-scoped launch routing for the production Mac window.
 ///
-/// The coordinator deliberately lives above MainWindowView: neither Chat nor
-/// the signed-out page is mounted behind the launch surface. A cold process
-/// starts with no selected Session; closing and reopening the window while the
-/// menu-bar process remains alive reuses `lastSelectedSessionId` instead.
+/// The coordinator deliberately owns routing above MainWindowView. Once local
+/// credentials resolve, it stages the authenticated shell below the launch gate
+/// for one real AppKit layout pass, but keeps Session navigation queued so Chat
+/// is not mounted behind the launch surface. A cold process starts with no
+/// selected Session; closing and reopening the window while the menu-bar process
+/// remains alive reuses `lastSelectedSessionId` instead.
 @Observable
 @MainActor
 final class MacLaunchCoordinator {
     enum Phase: Equatable {
         case launching
+        /// Credentials are resolved and the authenticated shell is mounted,
+        /// but the launch gate remains above it until its first real layout.
+        case preparingAuthenticated
         case authenticated
         case signedOut
     }
@@ -36,8 +41,15 @@ final class MacLaunchCoordinator {
     private(set) var loginCheckFailed = false
     var lastSelectedSessionId: String?
 
+    var isLaunchGateVisible: Bool {
+        phase == .launching || phase == .preparingAuthenticated
+    }
+
     @ObservationIgnored private var hasStarted = false
     @ObservationIgnored private var servicesStarted = false
+    @ObservationIgnored private var launchStartedAt: Date?
+    @ObservationIgnored private var isFinishingAuthenticatedSurface = false
+    @ObservationIgnored private var presentationWatchdogTask: Task<Void, Never>?
 
     func bootstrap(
         appState: AppState,
@@ -55,6 +67,7 @@ final class MacLaunchCoordinator {
         }
 
         let startedAt = Date()
+        launchStartedAt = startedAt
         KLog.diag("[MacLaunch] gate presented")
         if !servicesStarted {
             servicesStarted = true
@@ -90,9 +103,76 @@ final class MacLaunchCoordinator {
             canEnterAuthenticatedRoot = usedCLILogin || appState.hasStoredCredentials
         }
 
-        // A very fast cache/auth path should still look intentional rather than
-        // flashing one frame of branding. This is a short visual floor, never a
-        // network wait: Relay authentication continues in the destination UI.
+        guard !Task.isCancelled else {
+            // Closing the only window can cancel its SwiftUI `.task` while the
+            // menu-bar process stays alive. Permit the warm reopen to bootstrap
+            // again instead of leaving the process permanently on Launch.
+            hasStarted = false
+            return
+        }
+
+        if canEnterAuthenticatedRoot {
+            // Do not remove the gate and only then construct the Sidebar. Mount
+            // the authenticated shell underneath it; a presentation probe will
+            // remove the gate after the first AppKit-backed layout has settled.
+            beginPreparingAuthenticatedSurface()
+        } else {
+            await waitForMinimumLaunchVisibility()
+            guard !Task.isCancelled else {
+                hasStarted = false
+                return
+            }
+            phase = .signedOut
+            logDestination("signedOut")
+        }
+    }
+
+    func authenticatedSurfaceDidPresent() async {
+        presentationWatchdogTask?.cancel()
+        presentationWatchdogTask = nil
+        await finishAuthenticatedSurface(source: "probe")
+    }
+
+    private func beginPreparingAuthenticatedSurface() {
+        phase = .preparingAuthenticated
+        presentationWatchdogTask?.cancel()
+        presentationWatchdogTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled, let self,
+                  self.phase == .preparingAuthenticated else { return }
+            self.presentationWatchdogTask = nil
+            KLog.diag("[MacLaunch] presentation watchdog fired")
+            await self.finishAuthenticatedSurface(source: "watchdog")
+        }
+    }
+
+    private func finishAuthenticatedSurface(source: String) async {
+        guard phase == .preparingAuthenticated,
+              !isFinishingAuthenticatedSurface else { return }
+        isFinishingAuthenticatedSurface = true
+        defer { isFinishingAuthenticatedSurface = false }
+
+        await waitForMinimumLaunchVisibility()
+        guard !Task.isCancelled, phase == .preparingAuthenticated else { return }
+        let queuedSelection = lastSelectedSessionId
+        phase = .authenticated
+        logDestination("authenticated source=\(source)")
+
+        // A deep link may have arrived while only the gate existed. Keep Chat
+        // unmounted during preparation, then deliver the queued navigation once
+        // the authenticated shell owns a stable first frame.
+        if let queuedSelection {
+            await Task.yield()
+            NotificationCenter.default.post(
+                name: .macSelectSession,
+                object: nil,
+                userInfo: ["sessionId": queuedSelection]
+            )
+        }
+    }
+
+    private func waitForMinimumLaunchVisibility() async {
+        let startedAt = launchStartedAt ?? Date()
         #if DEBUG
         let minimumVisibleSeconds = ProcessInfo.processInfo.environment["KRAKI_MAC_LAUNCH_MIN_MS"]
             .flatMap(Double.init)
@@ -103,19 +183,14 @@ final class MacLaunchCoordinator {
         #endif
         let remaining = minimumVisibleSeconds - Date().timeIntervalSince(startedAt)
         if remaining > 0 {
-            try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            try? await Task.sleep(for: .seconds(remaining))
         }
-        guard !Task.isCancelled else {
-            // Closing the only window can cancel its SwiftUI `.task` while the
-            // menu-bar process stays alive. Permit the warm reopen to bootstrap
-            // again instead of leaving the process permanently on Launch.
-            hasStarted = false
-            return
-        }
-        phase = canEnterAuthenticatedRoot ? .authenticated : .signedOut
-        let elapsedMs = Date().timeIntervalSince(startedAt) * 1_000
+    }
+
+    private func logDestination(_ destination: String) {
+        let elapsedMs = launchStartedAt.map { Date().timeIntervalSince($0) * 1_000 } ?? 0
         KLog.diag(
-            "[MacLaunch] destination=\(canEnterAuthenticatedRoot ? "authenticated" : "signedOut") "
+            "[MacLaunch] destination=\(destination) "
                 + String(format: "elapsedMs=%.1f", elapsedMs)
         )
     }
@@ -132,7 +207,8 @@ final class MacLaunchCoordinator {
             if !usedCLILogin, appState.connectionStatus == .awaitingLogin {
                 appState.connect()
             }
-            phase = .authenticated
+            launchStartedAt = Date()
+            beginPreparingAuthenticatedSurface()
         } else {
             loginCheckFailed = true
         }
@@ -145,10 +221,16 @@ final class MacLaunchCoordinator {
         guard phase != .launching else { return }
         if hasStoredCredentials {
             loginCheckFailed = false
-            phase = .authenticated
-        } else if connectionStatus == .awaitingLogin, phase == .authenticated {
+            if phase == .signedOut {
+                launchStartedAt = Date()
+                beginPreparingAuthenticatedSurface()
+            }
+        } else if connectionStatus == .awaitingLogin,
+                  phase == .authenticated || phase == .preparingAuthenticated {
             // Explicit logout or a failed first authentication returns to the
             // shared entry gate and drops process-local navigation state.
+            presentationWatchdogTask?.cancel()
+            presentationWatchdogTask = nil
             lastSelectedSessionId = nil
             phase = .signedOut
         }
@@ -268,7 +350,7 @@ struct MacApp: App {
                 // window, while the zoom divides the true window size.
                 .windowZoom()
                 .frame(minWidth: 800, idealWidth: 1100, minHeight: 600, idealHeight: 720)
-                .animation(.easeInOut(duration: 0.16), value: launchCoordinator.phase)
+                .animation(.easeInOut(duration: 0.16), value: launchCoordinator.isLaunchGateVisible)
                 .onReceive(NotificationCenter.default.publisher(for: .macSelectSession)) { note in
                     // Explicit user/deep-link navigation is allowed to cross the
                     // cold-launch gate. Scenario-window notifications are scoped
@@ -391,17 +473,37 @@ struct MacApp: App {
     @ViewBuilder
     private var productionRoot: some View {
         switch launchCoordinator.phase {
-        case .launching:
-            MacEntryGateView(mode: .launching)
-                .transition(.opacity)
-        case .authenticated:
-            MainWindowView(
-                initialSelectedSessionId: launchCoordinator.lastSelectedSessionId,
-                onSelectedSessionChanged: { sessionId in
-                    launchCoordinator.recordSelectedSession(sessionId)
+        case .launching, .preparingAuthenticated, .authenticated:
+            ZStack {
+                if launchCoordinator.phase != .launching {
+                    MainWindowView(
+                        // A cold-launch deep link remains queued until the shell's
+                        // first frame is ready, so Chat/Composer never mount behind
+                        // the launch gate. Warm reopen still restores immediately.
+                        initialSelectedSessionId: launchCoordinator.phase == .authenticated
+                            ? launchCoordinator.lastSelectedSessionId
+                            : nil,
+                        onSelectedSessionChanged: { sessionId in
+                            launchCoordinator.recordSelectedSession(sessionId)
+                        }
+                    )
+                    .allowsHitTesting(launchCoordinator.phase == .authenticated)
+                    .accessibilityHidden(launchCoordinator.phase != .authenticated)
+                    .background(
+                        MacLaunchPresentationReadyProbe {
+                            Task {
+                                await launchCoordinator.authenticatedSurfaceDidPresent()
+                            }
+                        }
+                    )
                 }
-            )
-            .transition(.opacity)
+
+                if launchCoordinator.isLaunchGateVisible {
+                    MacEntryGateView(mode: .launching)
+                        .transition(.opacity)
+                        .zIndex(10)
+                }
+            }
         case .signedOut:
             LoginView(
                 isCheckingCredentials: launchCoordinator.isCheckingCredentials,
@@ -413,6 +515,47 @@ struct MacApp: App {
                 }
             )
             .transition(.opacity)
+        }
+    }
+}
+
+/// Signals only after the authenticated AppKit surface is attached and has
+/// completed a real window layout pass. Keeping the launch gate above that work
+/// prevents the user from seeing a half-materialized Sidebar followed by a
+/// blocked frame.
+private struct MacLaunchPresentationReadyProbe: NSViewRepresentable {
+    let onReady: () -> Void
+
+    func makeNSView(context: Context) -> ProbeView {
+        let view = ProbeView()
+        view.onReady = onReady
+        return view
+    }
+
+    func updateNSView(_ nsView: ProbeView, context: Context) {
+        nsView.onReady = onReady
+        nsView.signalWhenReady()
+    }
+
+    final class ProbeView: NSView {
+        var onReady: (() -> Void)?
+        private var didSignal = false
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            signalWhenReady()
+        }
+
+        func signalWhenReady() {
+            guard window != nil, !didSignal else { return }
+            didSignal = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.window?.contentView?.layoutSubtreeIfNeeded()
+                DispatchQueue.main.async { [weak self] in
+                    self?.onReady?()
+                }
+            }
         }
     }
 }

--- a/packages/arm/ios/Kraki/App/RootView.swift
+++ b/packages/arm/ios/Kraki/App/RootView.swift
@@ -1,29 +1,155 @@
 #if os(iOS)
+import Observation
 import SwiftUI
+import UIKit
 
-/// Root coordinator: shows login or main tab bar depending on connection state.
+/// Process-scoped iOS launch routing. Returning users first mount the Sessions
+/// shell underneath a branded gate; the gate leaves only after UIKit has
+/// attached and laid out the real surface. Login/logout transitions remain
+/// immediate and do not replay the cold-launch screen.
+@Observable
+@MainActor
+final class IOSLaunchCoordinator {
+    enum Phase: Equatable {
+        case launching
+        case preparingAuthenticated
+        case authenticated
+        case signedOut
+    }
+
+    private(set) var phase: Phase = .launching
+
+    var isLaunchGateVisible: Bool {
+        phase == .launching || phase == .preparingAuthenticated
+    }
+
+    @ObservationIgnored private var hasStarted = false
+    @ObservationIgnored private var launchStartedAt: Date?
+    @ObservationIgnored private var isFinishingAuthenticatedSurface = false
+    @ObservationIgnored private var presentationWatchdogTask: Task<Void, Never>?
+    @ObservationIgnored private let minimumVisibleSecondsOverride: TimeInterval?
+    @ObservationIgnored private let presentationWatchdogSecondsOverride: TimeInterval?
+
+    init(
+        minimumVisibleSecondsOverride: TimeInterval? = nil,
+        presentationWatchdogSecondsOverride: TimeInterval? = nil
+    ) {
+        self.minimumVisibleSecondsOverride = minimumVisibleSecondsOverride
+        self.presentationWatchdogSecondsOverride = presentationWatchdogSecondsOverride
+    }
+
+    func bootstrap(appState: AppState) async {
+        guard !hasStarted else { return }
+        hasStarted = true
+        launchStartedAt = Date()
+        KLog.diag("[IOSLaunch] gate presented")
+
+        // Start auth/network work while the gate owns the screen. Stored
+        // credentials determine routing; network availability never blocks the
+        // gate because the authenticated shell can continue offline from cache.
+        if appState.connectionStatus == .awaitingLogin {
+            appState.connect()
+        }
+
+        if appState.hasStoredCredentials {
+            beginPreparingAuthenticatedSurface()
+        } else {
+            await waitForMinimumLaunchVisibility()
+            guard !Task.isCancelled else {
+                hasStarted = false
+                return
+            }
+            phase = .signedOut
+            logDestination("signedOut")
+        }
+    }
+
+    func authenticatedSurfaceDidPresent() async {
+        presentationWatchdogTask?.cancel()
+        presentationWatchdogTask = nil
+        await finishAuthenticatedSurface(source: "probe")
+    }
+
+    private func beginPreparingAuthenticatedSurface() {
+        phase = .preparingAuthenticated
+        presentationWatchdogTask?.cancel()
+        let watchdogSeconds = presentationWatchdogSecondsOverride ?? 2
+        presentationWatchdogTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(watchdogSeconds))
+            guard !Task.isCancelled, let self,
+                  self.phase == .preparingAuthenticated else { return }
+            self.presentationWatchdogTask = nil
+            KLog.diag("[IOSLaunch] presentation watchdog fired")
+            await self.finishAuthenticatedSurface(source: "watchdog")
+        }
+    }
+
+    private func finishAuthenticatedSurface(source: String) async {
+        guard phase == .preparingAuthenticated,
+              !isFinishingAuthenticatedSurface else { return }
+        isFinishingAuthenticatedSurface = true
+        defer { isFinishingAuthenticatedSurface = false }
+
+        await waitForMinimumLaunchVisibility()
+        guard !Task.isCancelled, phase == .preparingAuthenticated else { return }
+        phase = .authenticated
+        logDestination("authenticated source=\(source)")
+    }
+
+    func reconcileAuthentication(
+        hasStoredCredentials: Bool,
+        connectionStatus: ConnectionStatus
+    ) {
+        guard phase != .launching else { return }
+        if hasStoredCredentials {
+            if phase == .signedOut {
+                launchStartedAt = Date()
+                beginPreparingAuthenticatedSurface()
+            }
+        } else if connectionStatus == .awaitingLogin,
+                  phase == .authenticated || phase == .preparingAuthenticated {
+            presentationWatchdogTask?.cancel()
+            presentationWatchdogTask = nil
+            phase = .signedOut
+        }
+    }
+
+    private func waitForMinimumLaunchVisibility() async {
+        let startedAt = launchStartedAt ?? Date()
+        #if DEBUG
+        let minimumVisibleSeconds = minimumVisibleSecondsOverride
+            ?? ProcessInfo.processInfo.environment["KRAKI_IOS_LAUNCH_MIN_MS"]
+                .flatMap(Double.init)
+                .map { max(0, $0 / 1_000) }
+            ?? 0.35
+        #else
+        let minimumVisibleSeconds = minimumVisibleSecondsOverride ?? 0.35
+        #endif
+        let remaining = minimumVisibleSeconds - Date().timeIntervalSince(startedAt)
+        if remaining > 0 {
+            try? await Task.sleep(for: .seconds(remaining))
+        }
+    }
+
+    private func logDestination(_ destination: String) {
+        let elapsedMs = launchStartedAt.map { Date().timeIntervalSince($0) * 1_000 } ?? 0
+        KLog.diag(
+            "[IOSLaunch] destination=\(destination) "
+                + String(format: "elapsedMs=%.1f", elapsedMs)
+        )
+    }
+}
+
+/// Root coordinator: shows the cold-launch gate, login, or main tab bar.
 struct RootView: View {
     @Environment(AppState.self) private var appState
-    @Environment(\.colorScheme) private var colorScheme
+    let launchCoordinator: IOSLaunchCoordinator
 
     var body: some View {
         ZStack {
-            // Background matching web: white in light, slate-950 (#020617) in dark
             Color.surfacePrimary
                 .ignoresSafeArea()
 
-            // Show MainTabView when we have valid credentials —
-            // either loaded from disk at launch (returning user) or
-            // freshly written by AuthManager.handleAuthOk (post sign-
-            // in). `clearStoredCredentials()` flips this back to
-            // false on sign-out or credential rejection, re-routing
-            // to LoginView with no extra state to reconcile.
-            //
-            // `hasCompletedInitialConnect` is a separate concern (it
-            // gates the brand-header reconnect spinner inside
-            // MainTabView) and intentionally NOT part of this gate —
-            // mixing them would leave the user stuck on MainTabView
-            // after a credential rejection.
             #if DEBUG
             if ProcessInfo.processInfo.environment["KRAKI_AVATAR_TEST"] == "1" {
                 AvatarTestView()
@@ -32,23 +158,208 @@ struct RootView: View {
             } else if ProcessInfo.processInfo.environment["KRAKI_FLATBUBBLE"] == "1" {
                 FlatBubbleTestView()
             } else if ProcessInfo.processInfo.environment["KRAKI_LIVEBUBBLE"] == "1" {
-                // Debug shortcut: the pure-spine LIVE bubble (card) render demo,
-                // mock-driven so it validates on a simulator with WS locked.
                 NavigationStack { LiveBubbleTestView() }
-            } else if appState.hasStoredCredentials {
-                MainTabView()
+            } else if ProcessInfo.processInfo.environment["KRAKI_IOS_ENTRY_GATE_PAGE"] == "1" {
+                IOSEntryGateView()
             } else {
-                LoginView()
+                productionRoot
             }
             #else
-            if appState.hasStoredCredentials {
-                MainTabView()
-            } else {
-                LoginView()
-            }
+            productionRoot
             #endif
         }
-        .animation(.easeInOut(duration: 0.3), value: appState.hasStoredCredentials)
+        .animation(.easeInOut(duration: 0.16), value: launchCoordinator.isLaunchGateVisible)
+        .task {
+            #if DEBUG
+            if ProcessInfo.processInfo.environment["KRAKI_IOS_ENTRY_GATE_PAGE"] == "1" {
+                return
+            }
+            #endif
+            await launchCoordinator.bootstrap(appState: appState)
+        }
+        .onChange(of: appState.hasStoredCredentials) { _, hasStoredCredentials in
+            launchCoordinator.reconcileAuthentication(
+                hasStoredCredentials: hasStoredCredentials,
+                connectionStatus: appState.connectionStatus
+            )
+        }
+        .onChange(of: appState.connectionStatus) { _, connectionStatus in
+            launchCoordinator.reconcileAuthentication(
+                hasStoredCredentials: appState.hasStoredCredentials,
+                connectionStatus: connectionStatus
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var productionRoot: some View {
+        switch launchCoordinator.phase {
+        case .launching, .preparingAuthenticated, .authenticated:
+            ZStack {
+                if launchCoordinator.phase != .launching {
+                    MainTabView(
+                        allowsInitialNavigation: launchCoordinator.phase == .authenticated
+                    )
+                    .allowsHitTesting(launchCoordinator.phase == .authenticated)
+                    .accessibilityHidden(launchCoordinator.phase != .authenticated)
+                    .background(
+                        IOSLaunchPresentationReadyProbe {
+                            Task {
+                                await launchCoordinator.authenticatedSurfaceDidPresent()
+                            }
+                        }
+                    )
+                }
+
+                if launchCoordinator.isLaunchGateVisible {
+                    IOSEntryGateView()
+                        .transition(.opacity)
+                        .zIndex(10)
+                }
+            }
+        case .signedOut:
+            LoginView()
+                .transition(.opacity)
+        }
+    }
+}
+
+/// In-app continuation of the system launch screen. It intentionally matches
+/// the Mac brand shell while adapting spacing and scale for an iPhone viewport.
+struct IOSEntryGateView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+    @State private var showDelayedLaunchStatus = false
+
+    var body: some View {
+        ZStack {
+            Color.surfacePrimary
+                .ignoresSafeArea()
+
+            ZStack {
+                Circle()
+                    .fill(Color.krakiPrimary.opacity(0.10))
+                    .frame(width: 360, height: 360)
+                    .blur(radius: 68)
+                    .offset(x: 150, y: -240)
+
+                Circle()
+                    .fill(Color.cyan.opacity(0.06))
+                    .frame(width: 320, height: 320)
+                    .blur(radius: 76)
+                    .offset(x: -170, y: 260)
+            }
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 72)
+
+                VStack(spacing: 16) {
+                    Image("KrakiLogo")
+                        .resizable()
+                        .interpolation(.high)
+                        .frame(width: 108, height: 108)
+                        .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+                        .shadow(color: Color.black.opacity(0.22), radius: 24, y: 12)
+                        .scaleEffect(appeared ? 1 : 0.97)
+                        .opacity(appeared ? 1 : 0)
+
+                    VStack(spacing: 6) {
+                        Text("KRAKI")
+                            .font(.system(size: 23, weight: .heavy, design: .monospaced))
+                            .tracking(4.0)
+                            .foregroundStyle(Color.textTitle)
+
+                        Text("Your coding sessions, ready when you are.")
+                            .font(.system(size: 12.5, weight: .medium))
+                            .foregroundStyle(Color.textSecondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 5)
+                }
+
+                Group {
+                    if showDelayedLaunchStatus {
+                        HStack(spacing: 9) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Opening Kraki…")
+                                .font(.system(size: 11.5, weight: .medium))
+                                .foregroundStyle(Color.textMuted)
+                        }
+                        .transition(.opacity)
+                        .accessibilityLabel("Opening Kraki")
+                    } else {
+                        Color.clear
+                    }
+                }
+                .frame(height: 54)
+                .padding(.top, 20)
+
+                Spacer(minLength: 48)
+            }
+            .padding(.horizontal, 36)
+        }
+        .accessibilityIdentifier("ios.entry.launching")
+        .accessibilityElement(children: .contain)
+        .task {
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(.easeOut(duration: 0.24)) {
+                    appeared = true
+                }
+            }
+
+            showDelayedLaunchStatus = false
+            try? await Task.sleep(for: .milliseconds(550))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeIn(duration: 0.16)) {
+                showDelayedLaunchStatus = true
+            }
+        }
+    }
+}
+
+/// Reports readiness only after the real UIKit hierarchy is attached and has
+/// completed a window-backed layout pass. The launch overlay stays painted
+/// while that synchronous first materialization runs underneath it.
+private struct IOSLaunchPresentationReadyProbe: UIViewRepresentable {
+    let onReady: () -> Void
+
+    func makeUIView(context: Context) -> ProbeView {
+        let view = ProbeView()
+        view.onReady = onReady
+        return view
+    }
+
+    func updateUIView(_ uiView: ProbeView, context: Context) {
+        uiView.onReady = onReady
+        uiView.signalWhenReady()
+    }
+
+    final class ProbeView: UIView {
+        var onReady: (() -> Void)?
+        private var didSignal = false
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            signalWhenReady()
+        }
+
+        func signalWhenReady() {
+            guard window != nil, !didSignal else { return }
+            didSignal = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.window?.layoutIfNeeded()
+                DispatchQueue.main.async { [weak self] in
+                    self?.onReady?()
+                }
+            }
+        }
     }
 }
 

--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -625,19 +625,18 @@ final class MessageRouter {
             KLog.d("    [\(i)] \(pin) id=\(d.id) lastSeq=\(d.lastSeq) readSeq=\(d.readSeq) mode=\(d.mode.rawValue) agent=\(d.agent) model=\(d.model ?? "nil") state=\(d.state.rawValue) msgCount=\(d.messageCount) \(title) \(prev) \(usage)")
         }
 
-        // Remove sessions from this tentacle that are no longer in the list
-        let tentacleIds = Set(parsed.map(\.id))
-        for (sid, session) in appState.sessionStore.sessions {
-            if session.deviceId == tentacleDeviceId && !tentacleIds.contains(sid) {
-                appState.sessionStore.removeSession(sid)
-                appState.messageStore.clearRuntimeStatus(sid)
-                appState.messageStore.clearCard(sid)
-            }
+        let reconcileStartedAt = Date()
+        let removedSessionIDs = appState.sessionStore.reconcileSessionList(
+            parsed,
+            deviceId: tentacleDeviceId,
+            deviceName: deviceName
+        )
+        for sid in removedSessionIDs {
+            appState.messageStore.clearRuntimeStatus(sid)
+            appState.messageStore.clearCard(sid)
         }
 
         for digest in parsed {
-            appState.sessionStore.upsertSession(digest, deviceId: tentacleDeviceId, deviceName: deviceName)
-
             // Runtime status is ephemeral and the producer is authoritative.
             // Active live-card state is restored only by the current session's
             // subscription ACK; do not pull every active session via the legacy
@@ -660,19 +659,8 @@ final class MessageRouter {
                 appState.messageStore.endCardTurn(digest.id)
             }
 
-            // Sync mode
-            appState.sessionStore.setMode(digest.id, digest.mode)
-
-            // Sync usage
-            if let usage = digest.usage {
-                appState.sessionStore.setUsage(digest.id, usage)
-            }
-
-            // Sync pin
-            appState.sessionStore.setPinned(digest.id, digest.pinned ?? false)
-
-            // `upsertSession` has already applied Tentacle's authoritative
-            // last/read cursors. Local history never overrides them.
+            // `reconcileSessionList` already applied Tentacle's authoritative
+            // metadata and cursor pairs. Local history never overrides them.
 
             // Store tentacle info so any later replay request can be
             // routed to the right producer device.
@@ -682,6 +670,11 @@ final class MessageRouter {
                 deviceId: tentacleDeviceId
             )
         }
+        let reconcileMs = Date().timeIntervalSince(reconcileStartedAt) * 1_000
+        KLog.diag(
+            "[SessionList] reconciled count=\(parsed.count) removed=\(removedSessionIDs.count) "
+                + String(format: "elapsedMs=%.1f", reconcileMs)
+        )
 
         if let activeId = appState.sessionStore.activeSessionId,
            let active = appState.sessionStore.sessions[activeId] {

--- a/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
@@ -218,6 +218,11 @@ final class SessionStore {
     /// toggles, transient streaming state, etc. — see KLog dump in
     /// PID 52588: 3 flushes of identical 69550 bytes within 9s).
     private var lastFlushedHash: Int?
+    #if DEBUG
+    /// Regression hook: authoritative session-list reconciliation must schedule
+    /// exactly one snapshot, regardless of how many Sessions it contains.
+    private(set) var snapshotScheduleCountForTesting = 0
+    #endif
 
     private static let snapshotURL: URL = {
         KrakiDataPaths.persistentDirectory()
@@ -256,6 +261,9 @@ final class SessionStore {
     /// disk. Called after any mutation that changes a card-visible field.
     /// Safe to call frequently — the cache coalesces.
     fileprivate func scheduleSave() {
+        #if DEBUG
+        snapshotScheduleCountForTesting += 1
+        #endif
         guard persistenceEnabled else { return }
         // Compacting is runtime-only. Persist the underlying working fallback
         // so a cold launch cannot resurrect stale compaction before the next
@@ -569,6 +577,126 @@ final class SessionStore {
         }
         // Unread is projected from Tentacle's authoritative cursor pair.
         scheduleSave()
+    }
+
+    /// Apply one Tentacle's authoritative `session_list` as a single observable
+    /// transaction. The former router path called `upsertSession`, `setMode`,
+    /// `setUsage`, and `setPinned` for every digest. Each call rebuilt the full
+    /// persistence snapshot and invalidated Sidebar/List projections, turning a
+    /// 200-Session cold reconnect into hundreds of full-dictionary copies and
+    /// visible main-thread stalls.
+    ///
+    /// Sessions owned by other devices are preserved. The returned identities
+    /// are the stale Sessions removed for this Tentacle so the router can clear
+    /// their message-only runtime state after the metadata commit.
+    @discardableResult
+    func reconcileSessionList(
+        _ digests: [SessionDigest],
+        deviceId: String,
+        deviceName: String
+    ) -> Set<String> {
+        let authoritativeIDs = Set(digests.map(\.id))
+        let removedIDs = Set(sessions.values.compactMap { session in
+            session.deviceId == deviceId && !authoritativeIDs.contains(session.id)
+                ? session.id
+                : nil
+        })
+
+        var nextSessions = sessions
+        var nextPinned = pinnedSessions
+        var nextModes = sessionModes
+        var nextUsage = sessionUsage
+        var nextPreviews = sessionPreviews
+        var nextDrafts = drafts
+        var nextAutoReadSuppressed = autoReadSuppressedSessions
+
+        for id in removedIDs {
+            nextSessions.removeValue(forKey: id)
+            nextPinned.remove(id)
+            nextModes.removeValue(forKey: id)
+            nextUsage.removeValue(forKey: id)
+            nextPreviews.removeValue(forKey: id)
+            nextDrafts.removeValue(forKey: id)
+            nextAutoReadSuppressed.remove(id)
+        }
+
+        for digest in digests {
+            let date = ISO8601.parse(digest.createdAt) ?? Date()
+            // The router's previous upsert + setPinned sequence treated an
+            // omitted authoritative pin as false. Preserve that wire behavior.
+            let pinned = digest.pinned ?? false
+            let lastSeq = max(0, digest.lastSeq)
+            let readSeq = min(max(0, digest.readSeq), lastSeq)
+
+            if var existing = nextSessions[digest.id] {
+                let previousReadSeq = existing.readSeq
+                existing.deviceId = deviceId
+                existing.deviceName = deviceName
+                existing.agent = digest.agent
+                existing.model = digest.model
+                existing.title = digest.title
+                existing.autoTitle = digest.autoTitle
+                existing.state = digest.state
+                existing.mode = digest.mode
+                existing.lastSeq = lastSeq
+                existing.readSeq = readSeq
+                existing.messageCount = digest.messageCount
+                existing.usage = digest.usage
+                existing.pinned = pinned
+                nextSessions[digest.id] = existing
+
+                if readSeq < previousReadSeq && readSeq < lastSeq {
+                    nextAutoReadSuppressed.insert(digest.id)
+                } else if readSeq >= lastSeq {
+                    nextAutoReadSuppressed.remove(digest.id)
+                }
+            } else {
+                nextSessions[digest.id] = SessionInfo(
+                    id: digest.id,
+                    deviceId: deviceId,
+                    deviceName: deviceName,
+                    agent: digest.agent,
+                    model: digest.model,
+                    title: digest.title,
+                    autoTitle: digest.autoTitle,
+                    state: digest.state,
+                    mode: digest.mode,
+                    lastSeq: lastSeq,
+                    readSeq: readSeq,
+                    messageCount: digest.messageCount,
+                    createdAt: date,
+                    usage: digest.usage,
+                    pinned: pinned,
+                    currentToolName: nil,
+                    currentToolHeadline: nil
+                )
+            }
+
+            nextModes[digest.id] = digest.mode
+            if let usage = digest.usage {
+                nextUsage[digest.id] = usage
+            }
+            if let preview = digest.preview {
+                nextPreviews[digest.id] = preview
+            } else {
+                nextPreviews.removeValue(forKey: digest.id)
+            }
+            if pinned {
+                nextPinned.insert(digest.id)
+            } else {
+                nextPinned.remove(digest.id)
+            }
+        }
+
+        sessions = nextSessions
+        pinnedSessions = nextPinned
+        sessionModes = nextModes
+        sessionUsage = nextUsage
+        sessionPreviews = nextPreviews
+        drafts = nextDrafts
+        autoReadSuppressedSessions = nextAutoReadSuppressed
+        scheduleSave()
+        return removedIDs
     }
 
     func removeSession(_ id: String) {
@@ -903,8 +1031,6 @@ final class SessionStore {
 
     /// Sync sessions from a parsed session list.
     func syncSessions(_ summaries: [SessionDigest], deviceId: String = "", deviceName: String = "") {
-        for digest in summaries {
-            upsertSession(digest, deviceId: deviceId, deviceName: deviceName)
-        }
+        reconcileSessionList(summaries, deviceId: deviceId, deviceName: deviceName)
     }
 }

--- a/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
@@ -1,8 +1,10 @@
 /// Shared macOS entry gate for cold launch and signed-out states.
 ///
-/// Both modes own the full window surface and are selected above
-/// MainWindowView, so Sidebar, Chat, Composer, CoreText cells, and restored
-/// Session state are never mounted behind them.
+/// Signed Out owns the full window surface without mounting authenticated UI.
+/// During authenticated cold launch, the shell may be staged underneath this
+/// gate for one window-backed layout pass; Session navigation remains queued,
+/// so Chat, Composer, CoreText cells, and restored Session state do not mount
+/// before the gate leaves.
 
 #if os(macOS)
 import AppKit

--- a/packages/arm/ios/Kraki/Features/Auth/MainTabView.swift
+++ b/packages/arm/ios/Kraki/Features/Auth/MainTabView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Root tab bar — mirrors the web Sidebar's mobile navigation tabs.
 struct MainTabView: View {
     @Environment(AppState.self) private var appState
+    let allowsInitialNavigation: Bool
     @State private var sessionPath = NavigationPath()
     @State private var devicePath = NavigationPath()
     @State private var selectedTab: Int = 0
@@ -23,28 +24,28 @@ struct MainTabView: View {
                 .environment(appState)
         }
         .onChange(of: appState.sessionStore.navigateToSession) { _, _ in
+            guard allowsInitialNavigation else { return }
             consumePendingSessionNavigation()
         }
         .onAppear {
             // A notification can launch the process before MainTabView exists.
-            // Consume the already-populated route as well as later changes.
+            // Keep it queued while the launch overlay prepares the Sessions
+            // shell, then consume it only after the first stable frame.
+            guard allowsInitialNavigation else { return }
             consumePendingSessionNavigation()
+            consumePendingDeviceNavigation()
+        }
+        .onChange(of: allowsInitialNavigation) { _, allowed in
+            guard allowed else { return }
+            consumePendingSessionNavigation()
+            consumePendingDeviceNavigation()
         }
         .onChange(of: appState.sessionStore.unreadSessionIDs, initial: true) { _, ids in
             appState.pushManager?.syncApplicationBadge(unreadSessionIDs: ids)
         }
-        .onChange(of: appState.deviceStore.navigateToDeviceId) { _, target in
-            guard let target else { return }
-            // Switch to Devices tab and push the requested device detail.
-            // Also pop the session navigation stack so when the user
-            // taps back to the Sessions tab they land on the list, not
-            // on the chat they were viewing.
-            selectedTab = 1
-            sessionPath = NavigationPath()
-            devicePath = NavigationPath()
-            devicePath.append(DeviceNavID(id: target))
-            // Clear so it can fire again next time.
-            appState.deviceStore.navigateToDeviceId = nil
+        .onChange(of: appState.deviceStore.navigateToDeviceId) { _, _ in
+            guard allowsInitialNavigation else { return }
+            consumePendingDeviceNavigation()
         }
         .onChange(of: appState.sessionStore.popToSessionListSignal) { _, _ in
             // A session was deleted while the user was viewing it.
@@ -54,8 +55,9 @@ struct MainTabView: View {
             sessionPath = NavigationPath()
         }
         #if DEBUG
-        .task {
-            guard let target = ProcessInfo.processInfo.environment["KRAKI_OPEN_SESSION_ID"],
+        .task(id: allowsInitialNavigation) {
+            guard allowsInitialNavigation,
+                  let target = ProcessInfo.processInfo.environment["KRAKI_OPEN_SESSION_ID"],
                   !target.isEmpty else { return }
             // Pairing/auth and session_list are asynchronous. Wait until the
             // requested session exists, then drive the normal navigation path.
@@ -78,6 +80,18 @@ struct MainTabView: View {
         sessionPath = NavigationPath()
         sessionPath.append(SessionNavID(id: target))
         appState.sessionStore.navigateToSession = nil
+    }
+
+    private func consumePendingDeviceNavigation() {
+        guard let target = appState.deviceStore.navigateToDeviceId else { return }
+        // Switch to Devices and push only after launch preparation. This keeps
+        // a notification-created detail hierarchy from materializing behind the
+        // cold-launch gate.
+        selectedTab = 1
+        sessionPath = NavigationPath()
+        devicePath = NavigationPath()
+        devicePath.append(DeviceNavID(id: target))
+        appState.deviceStore.navigateToDeviceId = nil
     }
 
     // MARK: - Sub-views (shared)

--- a/packages/arm/ios/KrakiTests/SessionStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/SessionStoreTests.swift
@@ -74,6 +74,88 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions["sess-1"]?.lastSeq, 20)
     }
 
+    func testReconcileSessionListIsAtomicAndDeviceScoped() {
+        store.upsertSession(
+            makeDigest(id: "keep", lastSeq: 10, readSeq: 10, pinned: true),
+            deviceId: "dev-a",
+            deviceName: "Old Mac"
+        )
+        store.upsertSession(
+            makeDigest(id: "stale", pinned: true),
+            deviceId: "dev-a",
+            deviceName: "Old Mac"
+        )
+        store.upsertSession(
+            makeDigest(id: "other"),
+            deviceId: "dev-b",
+            deviceName: "Server"
+        )
+        store.setPreview("stale", text: "stale preview")
+        store.setDraft("stale", "unsent draft")
+
+        var keep = makeDigest(
+            id: "keep",
+            state: .idle,
+            mode: .safe,
+            lastSeq: 20,
+            readSeq: 9,
+            pinned: false
+        )
+        keep.preview = SessionPreview(
+            text: "authoritative preview",
+            type: "agent",
+            timestamp: "2024-01-02T00:00:00.000Z"
+        )
+        let added = makeDigest(
+            id: "added",
+            state: .active,
+            mode: .execute,
+            lastSeq: 3,
+            readSeq: 3,
+            pinned: nil
+        )
+        let schedulesBefore = store.snapshotScheduleCountForTesting
+
+        let removed = store.reconcileSessionList(
+            [keep, added],
+            deviceId: "dev-a",
+            deviceName: "MacBook Pro"
+        )
+
+        XCTAssertEqual(removed, Set(["stale"]))
+        XCTAssertNil(store.sessions["stale"])
+        XCTAssertNil(store.sessionPreviews["stale"])
+        XCTAssertNil(store.drafts["stale"])
+        XCTAssertNotNil(store.sessions["other"], "another device's Sessions must survive")
+        XCTAssertEqual(store.sessions["keep"]?.deviceName, "MacBook Pro")
+        XCTAssertEqual(store.sessions["keep"]?.mode, .safe)
+        XCTAssertEqual(store.sessions["keep"]?.lastSeq, 20)
+        XCTAssertEqual(store.sessions["keep"]?.readSeq, 9)
+        XCTAssertEqual(store.sessions["keep"]?.pinned, false)
+        XCTAssertTrue(store.isAutoReadSuppressed("keep"))
+        XCTAssertEqual(store.sessionPreviews["keep"]?.text, "authoritative preview")
+        XCTAssertEqual(store.sessions["added"]?.readSeq, 3)
+        XCTAssertFalse(store.pinnedSessions.contains("added"))
+        XCTAssertEqual(store.snapshotScheduleCountForTesting, schedulesBefore + 1)
+    }
+
+    func testLargeSessionListSchedulesOneSnapshot() {
+        let digests = (0..<500).map { index in
+            makeDigest(
+                id: "session-\(index)",
+                lastSeq: index,
+                readSeq: index,
+                pinned: index.isMultiple(of: 7)
+            )
+        }
+        let schedulesBefore = store.snapshotScheduleCountForTesting
+
+        store.reconcileSessionList(digests, deviceId: "dev-a", deviceName: "MacBook")
+
+        XCTAssertEqual(store.sessions.count, 500)
+        XCTAssertEqual(store.snapshotScheduleCountForTesting, schedulesBefore + 1)
+    }
+
     // MARK: - Remove
 
     func testRemoveSession() {
@@ -451,5 +533,70 @@ final class SessionStoreTests: XCTestCase {
         let digest = makeDigest(lastSeq: 10, readSeq: 5)
         store.upsertSession(digest, deviceId: "d", deviceName: "n")
         XCTAssertEqual(store.unreadCounts["sess-1"], 1)
+    }
+
+    // MARK: - iOS cold-launch gate
+
+    @MainActor
+    func testIOSLaunchGateWaitsForAuthenticatedSurfacePresentation() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-launch-gate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = try MessageDatabase(
+            databaseURL: root.appendingPathComponent("messages.sqlite")
+        )
+        let app = AppState(testDatabase: database)
+        let coordinator = IOSLaunchCoordinator(minimumVisibleSecondsOverride: 0)
+
+        await coordinator.bootstrap(appState: app)
+        XCTAssertEqual(coordinator.phase, .preparingAuthenticated)
+        XCTAssertTrue(coordinator.isLaunchGateVisible)
+
+        await coordinator.authenticatedSurfaceDidPresent()
+        XCTAssertEqual(coordinator.phase, .authenticated)
+        XCTAssertFalse(coordinator.isLaunchGateVisible)
+    }
+
+    @MainActor
+    func testIOSLaunchGateHasBoundedPresentationFallback() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-launch-watchdog-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = try MessageDatabase(
+            databaseURL: root.appendingPathComponent("messages.sqlite")
+        )
+        let app = AppState(testDatabase: database)
+        let coordinator = IOSLaunchCoordinator(
+            minimumVisibleSecondsOverride: 0,
+            presentationWatchdogSecondsOverride: 0.01
+        )
+
+        await coordinator.bootstrap(appState: app)
+        XCTAssertEqual(coordinator.phase, .preparingAuthenticated)
+        try await Task.sleep(for: .milliseconds(40))
+
+        XCTAssertEqual(coordinator.phase, .authenticated)
+        XCTAssertFalse(coordinator.isLaunchGateVisible)
+    }
+
+    @MainActor
+    func testIOSLaunchGateRoutesSignedOutWithoutMountingMainSurface() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-launch-signed-out-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = try MessageDatabase(
+            databaseURL: root.appendingPathComponent("messages.sqlite")
+        )
+        let app = AppState(testDatabase: database)
+        app.hasStoredCredentials = false
+        let coordinator = IOSLaunchCoordinator(minimumVisibleSecondsOverride: 0)
+
+        await coordinator.bootstrap(appState: app)
+
+        XCTAssertEqual(coordinator.phase, .signedOut)
+        XCTAssertFalse(coordinator.isLaunchGateVisible)
     }
 }

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.18"
-        CURRENT_PROJECT_VERSION: 20
+        MARKETING_VERSION: "0.2.19"
+        CURRENT_PROJECT_VERSION: 21
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- keep the macOS launch gate above the authenticated shell until a real AppKit window layout completes
- add the matching process-scoped in-app cold-launch gate to iOS and defer queued Session/Device navigation until the first UIKit frame is stable
- reconcile authoritative `session_list` metadata in one device-scoped SessionStore transaction and schedule one persistence snapshot instead of several full copies per Session
- add bounded 2-second presentation watchdogs, launch-flow docs, regression coverage, and prepare macOS `0.2.19 (21)`

## Validation
- iOS tests: 307 executed, 2 skipped, 0 failures
- macOS Debug build: passed
- macOS Universal Release build: passed (`x86_64 arm64`, `0.2.19 (21)`)
- isolated macOS launch probe: `source=probe`, gate exited after real layout with no activation/key window
- 500-Session regression: one snapshot schedule
- Biome lint: passed
- workspace build: passed
- arm-web tests: 436 passed
- `git diff --check`: passed

## Local environment note
Full local `pnpm validate` reaches the known environment-dependent Tentacle `config.test.ts` HOME-mock mismatch (`/Users/corelli/.kraki` vs its temporary HOME). Lint, workspace build, web tests, native builds, and iOS tests pass independently; GitHub CI is the authoritative clean-runner validation.
