### PR TITLE
fix(native): simplify launch screen branding

### DIFF
--- a/docs/ios-launch-flow.md
+++ b/docs/ios-launch-flow.md
@@ -7,7 +7,7 @@ Kraki iOS uses two launch surfaces:
 
 ## Returning authenticated user
 
-1. `RootView` starts in `IOSLaunchCoordinator.Phase.launching` and paints the branded entry gate.
+1. `RootView` starts in `IOSLaunchCoordinator.Phase.launching` and paints a minimal entry gate containing only the current theme background and centered Kraki logo.
 2. The initial Relay connection starts behind the gate. Network readiness does not control whether cached UI can eventually open.
 3. `MainTabView` mounts underneath the gate with notification/deep-link navigation disabled.
 4. `IOSLaunchPresentationReadyProbe` waits until the UIKit hierarchy is attached to a real `UIWindow`, forces its first layout pass, and reports on the following main-run-loop turn.

--- a/docs/mac-launch-flow.md
+++ b/docs/mac-launch-flow.md
@@ -8,7 +8,7 @@ The production main scene is a single `Window(id: "main")`, not a `WindowGroup`.
 
 ### Cold process launch
 
-1. Show the Kraki launch gate immediately.
+1. Show the minimal Kraki launch gate immediately: the current theme background with only a centered Kraki logo.
 2. Resolve local CLI/stored credential availability behind the gate.
 3. For an authenticated launch, mount `MainWindowView` underneath the gate with no Session selected.
 4. Keep Session/deep-link navigation queued while an AppKit probe completes the shell's first window-backed layout pass.
@@ -24,7 +24,7 @@ When the process is still running in the menu bar, reopening the main window res
 
 ### Signed out
 
-Launch and Signed Out use the same brand shell. Signed Out replaces the launch status with:
+Launch and Signed Out share the same theme surface but intentionally have different content. Launch contains only the centered logo; Signed Out adds:
 
 - the `kraki connect` command and a native Copy action;
 - a `Check Again` action;

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.19;
+				MARKETING_VERSION = 0.2.20;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.19;
+				MARKETING_VERSION = 0.2.20;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/RootView.swift
+++ b/packages/arm/ios/Kraki/App/RootView.swift
@@ -224,102 +224,22 @@ struct RootView: View {
     }
 }
 
-/// In-app continuation of the system launch screen. It intentionally matches
-/// the Mac brand shell while adapting spacing and scale for an iPhone viewport.
+/// Minimal in-app continuation of the system launch screen: the current
+/// theme surface with only the centered Kraki logo.
 struct IOSEntryGateView: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var appeared = false
-    @State private var showDelayedLaunchStatus = false
-
     var body: some View {
         ZStack {
             Color.surfacePrimary
-                .ignoresSafeArea()
 
-            ZStack {
-                Circle()
-                    .fill(Color.krakiPrimary.opacity(0.10))
-                    .frame(width: 360, height: 360)
-                    .blur(radius: 68)
-                    .offset(x: 150, y: -240)
-
-                Circle()
-                    .fill(Color.cyan.opacity(0.06))
-                    .frame(width: 320, height: 320)
-                    .blur(radius: 76)
-                    .offset(x: -170, y: 260)
-            }
-            .allowsHitTesting(false)
-            .accessibilityHidden(true)
-
-            VStack(spacing: 0) {
-                Spacer(minLength: 72)
-
-                VStack(spacing: 16) {
-                    Image("KrakiLogo")
-                        .resizable()
-                        .interpolation(.high)
-                        .frame(width: 108, height: 108)
-                        .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
-                        .shadow(color: Color.black.opacity(0.22), radius: 24, y: 12)
-                        .scaleEffect(appeared ? 1 : 0.97)
-                        .opacity(appeared ? 1 : 0)
-
-                    VStack(spacing: 6) {
-                        Text("KRAKI")
-                            .font(.system(size: 23, weight: .heavy, design: .monospaced))
-                            .tracking(4.0)
-                            .foregroundStyle(Color.textTitle)
-
-                        Text("Your coding sessions, ready when you are.")
-                            .font(.system(size: 12.5, weight: .medium))
-                            .foregroundStyle(Color.textSecondary)
-                            .multilineTextAlignment(.center)
-                    }
-                    .opacity(appeared ? 1 : 0)
-                    .offset(y: appeared ? 0 : 5)
-                }
-
-                Group {
-                    if showDelayedLaunchStatus {
-                        HStack(spacing: 9) {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text("Opening Kraki…")
-                                .font(.system(size: 11.5, weight: .medium))
-                                .foregroundStyle(Color.textMuted)
-                        }
-                        .transition(.opacity)
-                        .accessibilityLabel("Opening Kraki")
-                    } else {
-                        Color.clear
-                    }
-                }
-                .frame(height: 54)
-                .padding(.top, 20)
-
-                Spacer(minLength: 48)
-            }
-            .padding(.horizontal, 36)
+            Image("KrakiLogo")
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 108, height: 108)
+                .accessibilityLabel("Kraki")
         }
+        .ignoresSafeArea()
         .accessibilityIdentifier("ios.entry.launching")
         .accessibilityElement(children: .contain)
-        .task {
-            if reduceMotion {
-                appeared = true
-            } else {
-                withAnimation(.easeOut(duration: 0.24)) {
-                    appeared = true
-                }
-            }
-
-            showDelayedLaunchStatus = false
-            try? await Task.sleep(for: .milliseconds(550))
-            guard !Task.isCancelled else { return }
-            withAnimation(.easeIn(duration: 0.16)) {
-                showDelayedLaunchStatus = true
-            }
-        }
     }
 }
 

--- a/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
@@ -25,30 +25,59 @@ struct MacEntryGateView: View {
     var onRetry: () -> Void = {}
 
     @State private var appeared = false
-    @State private var showDelayedLaunchStatus = false
 
     var body: some View {
-        ZStack {
-            Color.surfacePrimary
+        Group {
+            switch mode {
+            case .launching:
+                ZStack {
+                    Color.surfacePrimary
+                    launchLogo
+                }
                 .ignoresSafeArea()
+            case .signedOut:
+                ZStack {
+                    Color.surfacePrimary
+                        .ignoresSafeArea()
+                    signedOutContent
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier(mode == .launching ? "mac.entry.launching" : "mac.entry.signedOut")
+        .accessibilityElement(children: .contain)
+        .task(id: mode) {
+            guard mode == .signedOut, !appeared else { return }
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(.easeOut(duration: 0.24)) {
+                    appeared = true
+                }
+            }
+        }
+    }
 
+    private var launchLogo: some View {
+        Image("KrakiLogo")
+            .resizable()
+            .interpolation(.high)
+            .frame(width: 112, height: 112)
+            .accessibilityLabel("Kraki")
+    }
+
+    private var signedOutContent: some View {
+        ZStack {
             entryBackdrop
 
             VStack(spacing: 0) {
                 Spacer(minLength: 48)
 
-                sharedBrand
+                signedOutBrand
 
-                Group {
-                    switch mode {
-                    case .launching:
-                        launchStatus
-                    case .signedOut:
-                        signedOutActions
-                    }
-                }
-                .frame(maxWidth: 420, minHeight: 210, alignment: .top)
-                .padding(.top, 24)
+                signedOutActions
+                    .frame(maxWidth: 420, minHeight: 210, alignment: .top)
+                    .padding(.top, 24)
 
                 Spacer(minLength: 36)
 
@@ -57,28 +86,6 @@ struct MacEntryGateView: View {
             }
             .padding(.horizontal, 48)
             .padding(.vertical, 34)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityIdentifier(mode == .launching ? "mac.entry.launching" : "mac.entry.signedOut")
-        .accessibilityElement(children: .contain)
-        .task(id: mode) {
-            if !appeared {
-                if reduceMotion {
-                    appeared = true
-                } else {
-                    withAnimation(.easeOut(duration: 0.24)) {
-                        appeared = true
-                    }
-                }
-            }
-
-            showDelayedLaunchStatus = false
-            guard mode == .launching else { return }
-            try? await Task.sleep(for: .milliseconds(550))
-            guard !Task.isCancelled else { return }
-            withAnimation(.easeIn(duration: 0.16)) {
-                showDelayedLaunchStatus = true
-            }
         }
     }
 
@@ -100,7 +107,7 @@ struct MacEntryGateView: View {
         .accessibilityHidden(true)
     }
 
-    private var sharedBrand: some View {
+    private var signedOutBrand: some View {
         VStack(spacing: 16) {
             Image("KrakiLogo")
                 .resizable()
@@ -117,33 +124,13 @@ struct MacEntryGateView: View {
                     .tracking(4.2)
                     .foregroundStyle(Color.textTitle)
 
-                Text(mode == .launching ? "Your coding sessions, ready when you are." : "Connect this Mac to your relay")
+                Text("Connect this Mac to your relay")
                     .font(.system(size: 12.5, weight: .medium))
                     .foregroundStyle(Color.textSecondary)
                     .multilineTextAlignment(.center)
             }
             .opacity(appeared ? 1 : 0)
             .offset(y: appeared ? 0 : 5)
-        }
-    }
-
-    @ViewBuilder
-    private var launchStatus: some View {
-        if showDelayedLaunchStatus {
-            HStack(spacing: 9) {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Opening Kraki…")
-                    .font(.system(size: 11.5, weight: .medium))
-                    .foregroundStyle(Color.textMuted)
-            }
-            .padding(.top, 18)
-            .transition(.opacity)
-            .accessibilityLabel("Opening Kraki")
-        } else {
-            Color.clear
-                .frame(height: 42)
-                .accessibilityHidden(true)
         }
     }
 

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.19"
-        CURRENT_PROJECT_VERSION: 21
+        MARKETING_VERSION: "0.2.20"
+        CURRENT_PROJECT_VERSION: 22
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- reduce the macOS and iOS authenticated cold-launch gate to the current theme background and centered Kraki logo
- remove launch-only glow, text, progress state, clipping, shadows, and logo entrance animation
- keep signed-out actions and all readiness/watchdog/navigation behavior unchanged
- prepare macOS 0.2.20 (22)

## Validation
- iOS: 307 tests executed, 2 skipped, 0 failures
- macOS Debug build succeeded
- macOS universal Release build succeeded (`x86_64 arm64`)
- isolated macOS and iOS fixture renders verified the logo center within 0.5 px of the full surface center
- `git diff --check`