### PR TITLE
fix(native): enlarge launch screen logo

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.20;
+				MARKETING_VERSION = 0.2.21;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.20;
+				MARKETING_VERSION = 0.2.21;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/RootView.swift
+++ b/packages/arm/ios/Kraki/App/RootView.swift
@@ -234,7 +234,7 @@ struct IOSEntryGateView: View {
             Image("KrakiLogo")
                 .resizable()
                 .interpolation(.high)
-                .frame(width: 108, height: 108)
+                .frame(width: 156, height: 156)
                 .accessibilityLabel("Kraki")
         }
         .ignoresSafeArea()

--- a/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
@@ -62,7 +62,7 @@ struct MacEntryGateView: View {
         Image("KrakiLogo")
             .resizable()
             .interpolation(.high)
-            .frame(width: 112, height: 112)
+            .frame(width: 176, height: 176)
             .accessibilityLabel("Kraki")
     }
 

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.20"
-        CURRENT_PROJECT_VERSION: 22
+        MARKETING_VERSION: "0.2.21"
+        CURRENT_PROJECT_VERSION: 23
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- enlarge the sole macOS cold-launch logo from 112pt to 176pt
- enlarge the sole iOS cold-launch logo from 108pt to 156pt
- preserve the exact physical-center alignment and minimal theme-background-only treatment
- prepare macOS 0.2.21 (23)

## Validation
- isolated macOS and iOS fixture renders verified center alignment within 0.5 px
- iOS: 307 tests executed, 2 skipped, 0 failures
- macOS Debug build succeeded
- macOS universal Release build succeeded (`x86_64 arm64`)
- `git diff --check`