### PR TITLE
fix(mac): expose session thinking controls

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.21;
+				MARKETING_VERSION = 0.2.22;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1555,7 +1555,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.21;
+				MARKETING_VERSION = 0.2.22;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
+++ b/packages/arm/ios/Kraki/Core/Networking/MessageRouter.swift
@@ -62,6 +62,8 @@ extension SessionDigest {
             id: id,
             agent: json["agent"] as? String ?? "",
             model: json["model"] as? String,
+            reasoningEffort: (json["reasoningEffort"] as? String)
+                .flatMap(ReasoningEffort.init(rawValue:)),
             title: json["title"] as? String,
             autoTitle: json["autoTitle"] as? String,
             state: SessionState(rawValue: json["state"] as? String ?? "idle") ?? .idle,
@@ -545,7 +547,13 @@ final class MessageRouter {
 
         case "session_model_set":
             if let model = payload?["model"] as? String {
-                appState.sessionStore.setSessionModel(sessionId, model: model)
+                let effort = (payload?["reasoningEffort"] as? String)
+                    .flatMap(ReasoningEffort.init(rawValue:))
+                appState.sessionStore.setSessionModel(
+                    sessionId,
+                    model: model,
+                    reasoningEffort: effort
+                )
             }
 
         case "session_title_updated":
@@ -766,6 +774,8 @@ final class MessageRouter {
             deviceName: device?.name ?? deviceId,
             agent: payload?["agent"] as? String ?? "",
             model: payload?["model"] as? String,
+            reasoningEffort: (payload?["reasoningEffort"] as? String)
+                .flatMap(ReasoningEffort.init(rawValue:)),
             title: nil,
             autoTitle: nil,
             state: .active,

--- a/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/Messages.swift
@@ -392,6 +392,7 @@ enum EnvelopeCodingKeys: String, CodingKey {
 struct SessionCreatedPayload: Codable, Sendable {
     let agent: String
     var model: String?
+    var reasoningEffort: ReasoningEffort?
     var requestId: String?
     var lastSeq: Int?
 }

--- a/packages/arm/ios/Kraki/Core/Protocol/ProtocolTypes.swift
+++ b/packages/arm/ios/Kraki/Core/Protocol/ProtocolTypes.swift
@@ -189,6 +189,7 @@ enum ReasoningEffort: String, Codable, Sendable {
     case medium
     case high
     case xhigh
+    case max
 }
 
 // MARK: - Session Types
@@ -217,6 +218,7 @@ struct SessionDigest: Codable, Identifiable, Sendable {
     let id: String
     let agent: String
     var model: String? = nil
+    var reasoningEffort: ReasoningEffort? = nil
     var title: String? = nil
     var autoTitle: String? = nil
     var state: SessionState

--- a/packages/arm/ios/Kraki/Core/Storage/CommandSender.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/CommandSender.swift
@@ -324,7 +324,11 @@ final class CommandSender {
         send(["type": "set_session_model", "payload": payload], sessionId: sessionId)
 
         // Optimistic update
-        appState.sessionStore.setModel(sessionId, model)
+        appState.sessionStore.setModel(
+            sessionId,
+            model,
+            reasoningEffort: reasoningEffort
+        )
     }
 
     // MARK: - Session Lifecycle

--- a/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
+++ b/packages/arm/ios/Kraki/Core/Storage/SessionStore.swift
@@ -14,6 +14,7 @@ struct SessionInfo: Identifiable, Equatable, Codable {
     var deviceName: String
     var agent: String
     var model: String?
+    var reasoningEffort: ReasoningEffort?
     var title: String?
     var autoTitle: String?
     var state: SessionState
@@ -48,7 +49,7 @@ struct SessionInfo: Identifiable, Equatable, Codable {
     // stream.
 
     private enum CodingKeys: String, CodingKey {
-        case id, deviceId, deviceName, agent, model, title, autoTitle
+        case id, deviceId, deviceName, agent, model, reasoningEffort, title, autoTitle
         case state, mode, lastSeq, readSeq
         case messageCount, createdAt, usage, pinned
     }
@@ -59,6 +60,7 @@ struct SessionInfo: Identifiable, Equatable, Codable {
         deviceName: String,
         agent: String,
         model: String? = nil,
+        reasoningEffort: ReasoningEffort? = nil,
         title: String? = nil,
         autoTitle: String? = nil,
         state: SessionState,
@@ -78,6 +80,7 @@ struct SessionInfo: Identifiable, Equatable, Codable {
         self.deviceName = deviceName
         self.agent = agent
         self.model = model
+        self.reasoningEffort = reasoningEffort
         self.title = title
         self.autoTitle = autoTitle
         self.state = state
@@ -100,6 +103,7 @@ struct SessionInfo: Identifiable, Equatable, Codable {
         self.deviceName = try c.decode(String.self, forKey: .deviceName)
         self.agent = try c.decode(String.self, forKey: .agent)
         self.model = try c.decodeIfPresent(String.self, forKey: .model)
+        self.reasoningEffort = try c.decodeIfPresent(ReasoningEffort.self, forKey: .reasoningEffort)
         self.title = try c.decodeIfPresent(String.self, forKey: .title)
         self.autoTitle = try c.decodeIfPresent(String.self, forKey: .autoTitle)
         self.state = try c.decode(SessionState.self, forKey: .state)
@@ -123,6 +127,7 @@ struct SessionInfo: Identifiable, Equatable, Codable {
         try c.encode(deviceName, forKey: .deviceName)
         try c.encode(agent, forKey: .agent)
         try c.encodeIfPresent(model, forKey: .model)
+        try c.encodeIfPresent(reasoningEffort, forKey: .reasoningEffort)
         try c.encodeIfPresent(title, forKey: .title)
         try c.encodeIfPresent(autoTitle, forKey: .autoTitle)
         try c.encode(state, forKey: .state)
@@ -519,6 +524,7 @@ final class SessionStore {
             existing.deviceName = deviceName
             existing.agent = digest.agent
             existing.model = digest.model
+            existing.reasoningEffort = digest.reasoningEffort
             existing.title = digest.title
             existing.autoTitle = digest.autoTitle
             existing.state = digest.state
@@ -543,6 +549,7 @@ final class SessionStore {
                 deviceName: deviceName,
                 agent: digest.agent,
                 model: digest.model,
+                reasoningEffort: digest.reasoningEffort,
                 title: digest.title,
                 autoTitle: digest.autoTitle,
                 state: digest.state,
@@ -634,6 +641,7 @@ final class SessionStore {
                 existing.deviceName = deviceName
                 existing.agent = digest.agent
                 existing.model = digest.model
+                existing.reasoningEffort = digest.reasoningEffort
                 existing.title = digest.title
                 existing.autoTitle = digest.autoTitle
                 existing.state = digest.state
@@ -657,6 +665,7 @@ final class SessionStore {
                     deviceName: deviceName,
                     agent: digest.agent,
                     model: digest.model,
+                    reasoningEffort: digest.reasoningEffort,
                     title: digest.title,
                     autoTitle: digest.autoTitle,
                     state: digest.state,
@@ -718,8 +727,13 @@ final class SessionStore {
         scheduleSave()
     }
 
-    func setModel(_ id: String, _ model: String) {
+    func setModel(
+        _ id: String,
+        _ model: String,
+        reasoningEffort: ReasoningEffort? = nil
+    ) {
         sessions[id]?.model = model
+        sessions[id]?.reasoningEffort = reasoningEffort
         scheduleSave()
     }
 
@@ -973,8 +987,12 @@ final class SessionStore {
     }
 
     /// Set session model (alias).
-    func setSessionModel(_ id: String, model: String) {
-        setModel(id, model)
+    func setSessionModel(
+        _ id: String,
+        model: String,
+        reasoningEffort: ReasoningEffort? = nil
+    ) {
+        setModel(id, model, reasoningEffort: reasoningEffort)
     }
 
     /// Set session pinned state (alias).

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatView.swift
@@ -599,8 +599,19 @@ private struct MacSessionInfoSheet: View {
     @State private var showDeleteConfirmation = false
     @State private var sessionIDCopied = false
     @State private var sessionIDCopyFeedbackTask: Task<Void, Never>?
+    @State private var selectedModel: String
+    @State private var reasoningEffort: ReasoningEffort?
     @FocusState private var titleFocused: Bool
 
+    init(session: SessionInfo) {
+        self.session = session
+        _selectedModel = State(initialValue: session.model ?? "")
+        _reasoningEffort = State(initialValue: session.reasoningEffort)
+    }
+
+    private var liveSession: SessionInfo {
+        appState.sessionStore.sessions[session.id] ?? session
+    }
     private var currentMode: SessionMode {
         appState.sessionStore.sessionModes[session.id] ?? session.mode
     }
@@ -616,11 +627,17 @@ private struct MacSessionInfoSheet: View {
     private var availableModels: [String] {
         appState.deviceStore.models(for: session.deviceId, agentId: session.agent)
     }
+    private var modelDetails: [ModelDetail] {
+        appState.deviceStore.modelDetails(for: session.deviceId, agentId: session.agent)
+    }
+    private var supportedEfforts: [ReasoningEffort] {
+        guard let detail = modelDetails.first(where: { $0.id == selectedModel }),
+              detail.supportsReasoningEffort else { return [] }
+        return detail.supportedReasoningEfforts ?? []
+    }
     private var contextWindow: Int? {
-        guard let model = session.model else { return nil }
-        return appState.deviceStore
-            .modelDetails(for: session.deviceId, agentId: session.agent)
-            .first(where: { $0.id == model })?.contextWindow
+        guard let model = liveSession.model else { return nil }
+        return modelDetails.first(where: { $0.id == model })?.contextWindow
     }
 
     var body: some View {
@@ -649,6 +666,9 @@ private struct MacSessionInfoSheet: View {
         }
         .frame(width: 440, height: 580)
         .background(Color.surfacePrimary)
+        .onAppear { syncModelConfiguration() }
+        .onChange(of: liveSession.model) { _, _ in syncModelConfiguration() }
+        .onChange(of: liveSession.reasoningEffort) { _, _ in syncModelConfiguration() }
         .onDisappear {
             sessionIDCopyFeedbackTask?.cancel()
             sessionIDCopyFeedbackTask = nil
@@ -714,11 +734,11 @@ private struct MacSessionInfoSheet: View {
             infoRow("Agent", session.agent)
             infoRow(label: "Model") {
                 if availableModels.isEmpty {
-                    Text(session.model ?? "—")
+                    Text(liveSession.model ?? "—")
                 } else {
                     Picker("", selection: Binding(
-                        get: { session.model ?? availableModels.first ?? "" },
-                        set: { appState.commandSender?.setSessionModel(sessionId: session.id, model: $0) }
+                        get: { selectedModel },
+                        set: { applyModel($0) }
                     )) {
                         ForEach(availableModels, id: \.self) { Text($0).tag($0) }
                     }
@@ -726,7 +746,76 @@ private struct MacSessionInfoSheet: View {
                     .frame(maxWidth: 250, alignment: .trailing)
                 }
             }
+            if !supportedEfforts.isEmpty {
+                infoRow(label: "Thinking") {
+                    Picker("", selection: Binding(
+                        get: { reasoningEffort ?? supportedEfforts[0] },
+                        set: { applyReasoningEffort($0) }
+                    )) {
+                        ForEach(supportedEfforts, id: \.rawValue) { effort in
+                            Text(effortLabel(effort)).tag(effort)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 250, alignment: .trailing)
+                }
+            }
             infoRow("Created", session.createdAt.formatted(date: .abbreviated, time: .shortened))
+        }
+    }
+
+    private func syncModelConfiguration() {
+        selectedModel = liveSession.model ?? availableModels.first ?? ""
+        reasoningEffort = normalizedEffort(
+            for: selectedModel,
+            preferred: liveSession.reasoningEffort
+        )
+    }
+
+    private func normalizedEffort(
+        for model: String,
+        preferred: ReasoningEffort?
+    ) -> ReasoningEffort? {
+        guard let detail = modelDetails.first(where: { $0.id == model }),
+              detail.supportsReasoningEffort,
+              let efforts = detail.supportedReasoningEfforts,
+              !efforts.isEmpty else { return nil }
+        if let preferred, efforts.contains(preferred) { return preferred }
+        if let defaultEffort = detail.defaultReasoningEffort,
+           efforts.contains(defaultEffort) {
+            return defaultEffort
+        }
+        return efforts.first
+    }
+
+    private func applyModel(_ model: String) {
+        selectedModel = model
+        let effort = normalizedEffort(for: model, preferred: nil)
+        reasoningEffort = effort
+        appState.commandSender?.setSessionModel(
+            sessionId: session.id,
+            model: model,
+            reasoningEffort: effort
+        )
+    }
+
+    private func applyReasoningEffort(_ effort: ReasoningEffort) {
+        reasoningEffort = effort
+        appState.commandSender?.setSessionModel(
+            sessionId: session.id,
+            model: selectedModel,
+            reasoningEffort: effort
+        )
+    }
+
+    private func effortLabel(_ effort: ReasoningEffort) -> String {
+        switch effort {
+        case .low: return "Low"
+        case .medium: return "Medium"
+        case .high: return "High"
+        case .xhigh: return "XHigh"
+        case .max: return "Max"
         }
     }
 

--- a/packages/arm/ios/Kraki/Features/Sessions/NewSessionSheet+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/NewSessionSheet+macOS.swift
@@ -256,7 +256,8 @@ struct NewSessionSheet: View {
         case .low: return "Low"
         case .medium: return "Medium"
         case .high: return "High"
-        case .xhigh: return "Max"
+        case .xhigh: return "XHigh"
+        case .max: return "Max"
         }
     }
 }

--- a/packages/arm/ios/Kraki/Features/Sessions/NewSessionSheet.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/NewSessionSheet.swift
@@ -503,7 +503,8 @@ struct NewSessionSheet: View {
         case .low:    return "Low"
         case .medium: return "Medium"
         case .high:   return "High"
-        case .xhigh:  return "Max"
+        case .xhigh:  return "XHigh"
+        case .max:    return "Max"
         }
     }
 }
@@ -534,7 +535,8 @@ struct ModelPickerCard: View {
         case .low:    return "Low"
         case .medium: return "Medium"
         case .high:   return "High"
-        case .xhigh:  return "Max"
+        case .xhigh:  return "XHigh"
+        case .max:    return "Max"
         }
     }
 

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionInfoSheet.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionInfoSheet.swift
@@ -426,7 +426,8 @@ private struct ModelPickerScreen: View {
         self.session = session
         _selectedModel = State(initialValue: session.model ?? "")
         _reasoningEffort = State(
-            initialValue: session.model.flatMap { SessionPrefs.lastEffort(model: $0) }
+            initialValue: session.reasoningEffort
+                ?? session.model.flatMap { SessionPrefs.lastEffort(model: $0) }
         )
     }
 

--- a/packages/arm/ios/KrakiTests/ProtocolTypesTests.swift
+++ b/packages/arm/ios/KrakiTests/ProtocolTypesTests.swift
@@ -238,6 +238,7 @@ final class ProtocolEnumTests: XCTestCase {
         XCTAssertEqual(ReasoningEffort.medium.rawValue, "medium")
         XCTAssertEqual(ReasoningEffort.high.rawValue, "high")
         XCTAssertEqual(ReasoningEffort.xhigh.rawValue, "xhigh")
+        XCTAssertEqual(ReasoningEffort.max.rawValue, "max")
     }
 }
 
@@ -273,6 +274,7 @@ final class ProtocolStructTests: XCTestCase {
             id: "sess-1",
             agent: "claude",
             model: "claude-3",
+            reasoningEffort: .high,
             title: "My Session",
             autoTitle: "Auto Title",
             state: .active,
@@ -290,6 +292,7 @@ final class ProtocolStructTests: XCTestCase {
         XCTAssertEqual(decoded.id, "sess-1")
         XCTAssertEqual(decoded.agent, "claude")
         XCTAssertEqual(decoded.model, "claude-3")
+        XCTAssertEqual(decoded.reasoningEffort, .high)
         XCTAssertEqual(decoded.title, "My Session")
         XCTAssertEqual(decoded.autoTitle, "Auto Title")
         XCTAssertEqual(decoded.state, .active)

--- a/packages/arm/ios/KrakiTests/SessionStoreTests.swift
+++ b/packages/arm/ios/KrakiTests/SessionStoreTests.swift
@@ -25,6 +25,7 @@ final class SessionStoreTests: XCTestCase {
         id: String = "sess-1",
         agent: String = "claude",
         model: String? = "claude-3",
+        reasoningEffort: ReasoningEffort? = nil,
         title: String? = nil,
         autoTitle: String? = nil,
         state: SessionState = .active,
@@ -35,7 +36,8 @@ final class SessionStoreTests: XCTestCase {
         pinned: Bool? = nil
     ) -> SessionDigest {
         SessionDigest(
-            id: id, agent: agent, model: model, title: title,
+            id: id, agent: agent, model: model,
+            reasoningEffort: reasoningEffort, title: title,
             autoTitle: autoTitle, state: state, mode: mode,
             lastSeq: lastSeq, readSeq: readSeq,
             messageCount: messageCount,
@@ -46,7 +48,7 @@ final class SessionStoreTests: XCTestCase {
     // MARK: - Upsert
 
     func testUpsertSession() {
-        let digest = makeDigest()
+        let digest = makeDigest(reasoningEffort: .high)
         store.upsertSession(digest, deviceId: "dev-1", deviceName: "MacBook")
 
         let session = store.sessions["sess-1"]
@@ -54,6 +56,7 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(session?.id, "sess-1")
         XCTAssertEqual(session?.agent, "claude")
         XCTAssertEqual(session?.model, "claude-3")
+        XCTAssertEqual(session?.reasoningEffort, .high)
         XCTAssertEqual(session?.state, .active)
         XCTAssertEqual(session?.mode, .execute)
         XCTAssertEqual(session?.deviceId, "dev-1")
@@ -185,8 +188,9 @@ final class SessionStoreTests: XCTestCase {
 
     func testSetModel() {
         store.upsertSession(makeDigest(), deviceId: "d", deviceName: "n")
-        store.setModel("sess-1", "gpt-4")
+        store.setModel("sess-1", "gpt-4", reasoningEffort: .max)
         XCTAssertEqual(store.sessions["sess-1"]?.model, "gpt-4")
+        XCTAssertEqual(store.sessions["sess-1"]?.reasoningEffort, .max)
     }
 
     func testSetTitle() {

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.21"
-        CURRENT_PROJECT_VERSION: 23
+        MARKETING_VERSION: "0.2.22"
+        CURRENT_PROJECT_VERSION: 24
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/protocol",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Shared TypeScript types and message definitions for the Kraki protocol",
   "repository": {
     "type": "git",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -179,6 +179,7 @@ export interface SessionCreatedMessage extends BaseEnvelope {
   payload: {
     agent: string;
     model?: string;
+    reasoningEffort?: import('./devices.js').ReasoningEffort;
     /** Echoed from create_session for request tracking */
     requestId?: string;
     /** Current last message seq (0 for new sessions, >0 for forks) */

--- a/packages/protocol/src/sessions.ts
+++ b/packages/protocol/src/sessions.ts
@@ -25,6 +25,8 @@ export interface SessionSummary {
   deviceName: string;
   agent: import('./devices.js').AgentId;
   model?: string;
+  /** Active reasoning effort for the current model. */
+  reasoningEffort?: import('./devices.js').ReasoningEffort;
   title?: string;
   autoTitle?: string;
   state: SessionState;
@@ -53,6 +55,8 @@ export interface SessionDigest {
   id: string;
   agent: import('./devices.js').AgentId;
   model?: string;
+  /** Active reasoning effort for the current model. */
+  reasoningEffort?: import('./devices.js').ReasoningEffort;
   title?: string;
   autoTitle?: string;
   state: SessionState;

--- a/packages/tentacle/package.json
+++ b/packages/tentacle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraki/tentacle",
-  "version": "0.31.18",
+  "version": "0.31.19",
   "description": "Kraki agent bridge \u2014 the arm that connects your coding agent to the head",
   "repository": {
     "type": "git",

--- a/packages/tentacle/src/__tests__/relay-client.test.ts
+++ b/packages/tentacle/src/__tests__/relay-client.test.ts
@@ -680,7 +680,7 @@ describe('RelayClient set_session_model', () => {
     })));
 
     // sessionManager.setModel is called synchronously (persist + ack first)
-    expect(sm.setModel).toHaveBeenCalledWith('sess_1', 'claude-opus-4');
+    expect(sm.setModel).toHaveBeenCalledWith('sess_1', 'claude-opus-4', undefined);
     // adapter.setSessionModel is chained behind ensureSessionResumed (which
     // resolves synchronously here because getMeta returns a non-disconnected
     // session, so the .then fires after a microtask).
@@ -689,7 +689,7 @@ describe('RelayClient set_session_model', () => {
   });
 
   it('broadcasts session_model_set only after the adapter confirms the change', async () => {
-    buildConnectedClient();
+    const { sm } = buildConnectedClient();
     const ws = sockets[0];
     ws.sent.length = 0;
 
@@ -704,6 +704,7 @@ describe('RelayClient set_session_model', () => {
 
     await vi.runAllTimersAsync();
 
+    expect(sm.setModel).toHaveBeenCalledWith('sess_1', 'gpt-5', 'high');
     // Find the session_model_set broadcast in sent messages
     const sent = decodePulseSends(ws.sent);
     const modelSet = sent.find(m => m.type === 'session_model_set');
@@ -715,6 +716,11 @@ describe('RelayClient set_session_model', () => {
 
   it('does not acknowledge a failed model change and rolls persisted metadata back', async () => {
     const { adapter, sm } = buildConnectedClient();
+    sm.getMeta.mockReturnValue({
+      id: 'sess_1',
+      model: 'old-model',
+      reasoningEffort: 'low',
+    });
     adapter.setSessionModel.mockRejectedValueOnce(new Error('unknown provider'));
     const ws = sockets[0];
     ws.sent.length = 0;
@@ -729,8 +735,8 @@ describe('RelayClient set_session_model', () => {
     })));
     await vi.runAllTimersAsync();
 
-    expect(sm.setModel).toHaveBeenNthCalledWith(1, 'sess_1', 'missing/model');
-    expect(sm.setModel).toHaveBeenNthCalledWith(2, 'sess_1', 'old-model');
+    expect(sm.setModel).toHaveBeenNthCalledWith(1, 'sess_1', 'missing/model', undefined);
+    expect(sm.setModel).toHaveBeenNthCalledWith(2, 'sess_1', 'old-model', 'low');
     const sent = decodePulseSends(ws.sent);
     expect(sent.find(m => m.type === 'session_model_set')).toBeUndefined();
     expect(sent.find(m => m.type === 'error')?.payload.message).toContain('unknown provider');
@@ -829,7 +835,7 @@ describe('RelayClient set_session_model', () => {
     })));
 
     // Persist + ack are synchronous.
-    expect(sm.setModel).toHaveBeenCalledWith('sess_d', 'claude-opus-4');
+    expect(sm.setModel).toHaveBeenCalledWith('sess_d', 'claude-opus-4', undefined);
     // The adapter call is chained behind ensureSessionResumed.
     await vi.runAllTimersAsync();
     expect(adapter.resumeSession).toHaveBeenCalledWith('sess_d', expect.anything());

--- a/packages/tentacle/src/__tests__/session-manager.test.ts
+++ b/packages/tentacle/src/__tests__/session-manager.test.ts
@@ -238,8 +238,8 @@ describe('SessionManager', () => {
       expect(entry?.autoTitle).toBe('Working on tests');
     });
 
-    it('should copy autoTitle when forking', () => {
-      const { sessionId } = sm.createSession('copilot');
+    it('should copy autoTitle and reasoning effort when forking', () => {
+      const { sessionId } = sm.createSession('copilot', 'gpt-5', undefined, 'high');
       sm.setAutoTitle(sessionId, 'Original auto title');
       sm.setTitle(sessionId, 'Manual title');
 
@@ -247,18 +247,27 @@ describe('SessionManager', () => {
       const forkedMeta = sm.getMeta(forked.sessionId)!;
       expect(forkedMeta.autoTitle).toBe('Original auto title');
       expect(forkedMeta.title).toBe('Fork of Manual title');
+      expect(forkedMeta.reasoningEffort).toBe('high');
     });
   });
 
   // ── Model ──────────────────────────────────────────────
 
   describe('session model', () => {
-    it('should set and persist model', () => {
-      const { sessionId } = sm.createSession('copilot', 'claude-sonnet-4');
+    it('should set and persist model and reasoning effort', () => {
+      const { sessionId } = sm.createSession(
+        'copilot',
+        'claude-sonnet-4',
+        undefined,
+        'medium',
+      );
       expect(sm.getMeta(sessionId)!.model).toBe('claude-sonnet-4');
+      expect(sm.getMeta(sessionId)!.reasoningEffort).toBe('medium');
 
-      sm.setModel(sessionId, 'claude-opus-4');
+      sm.setModel(sessionId, 'claude-opus-4', 'xhigh');
       expect(sm.getMeta(sessionId)!.model).toBe('claude-opus-4');
+      expect(sm.getMeta(sessionId)!.reasoningEffort).toBe('xhigh');
+      expect(sm.getSessionList().find(s => s.id === sessionId)?.reasoningEffort).toBe('xhigh');
     });
 
     it('should no-op for non-existent session', () => {

--- a/packages/tentacle/src/adapters/base.ts
+++ b/packages/tentacle/src/adapters/base.ts
@@ -17,6 +17,7 @@ export interface SessionCreatedEvent {
   sessionId: string;
   agent: string;
   model?: string;
+  reasoningEffort?: import('@kraki/protocol').ReasoningEffort;
 }
 
 export interface TurnLifecycleEvent {
@@ -97,7 +98,7 @@ export interface CreateSessionConfig {
   /** Agent-specific model identifier (e.g. "claude-opus-4.6-1m") */
   model?: string;
   /** Reasoning effort level (for models that support it) */
-  reasoningEffort?: string;
+  reasoningEffort?: import('@kraki/protocol').ReasoningEffort;
   /** Context tier (for models that support long_context) */
   contextTier?: string;
   /** Working directory for the session */

--- a/packages/tentacle/src/adapters/claude.ts
+++ b/packages/tentacle/src/adapters/claude.ts
@@ -673,6 +673,7 @@ export class ClaudeAdapter extends AgentAdapter {
       sessionId,
       agent: 'claude',
       model: config.model,
+      reasoningEffort: config.reasoningEffort,
     });
 
     return { sessionId };

--- a/packages/tentacle/src/adapters/copilot.ts
+++ b/packages/tentacle/src/adapters/copilot.ts
@@ -1023,6 +1023,7 @@ export class CopilotAdapter extends AgentAdapter {
       sessionId: sid,
       agent: 'copilot',
       model: config.model,
+      reasoningEffort: effort,
     });
 
     return { sessionId: sid };

--- a/packages/tentacle/src/adapters/pi.ts
+++ b/packages/tentacle/src/adapters/pi.ts
@@ -1462,7 +1462,12 @@ export class PiAdapter extends AgentAdapter {
     mkdirSync(this.storeDir(sessionId), { recursive: true });
     const sess = this.spawn(sessionId, config.cwd ?? process.cwd(), model, MUTATING_DEFAULT_MODE, transcript, thinking);
     this.persistMeta(sessionId, sess);
-    this.onSessionCreated?.({ sessionId, agent: 'pi', model });
+    this.onSessionCreated?.({
+      sessionId,
+      agent: 'pi',
+      model,
+      reasoningEffort: config.reasoningEffort,
+    });
     return { sessionId };
   }
 

--- a/packages/tentacle/src/relay-client.ts
+++ b/packages/tentacle/src/relay-client.ts
@@ -1617,12 +1617,14 @@ export class RelayClient {
         }
         case 'set_session_model': {
           const { model, reasoningEffort, contextTier } = msg.payload;
-          const previousModel = this.sessionManager.getMeta(sessionId)?.model;
+          const previousMeta = this.sessionManager.getMeta(sessionId);
+          const previousModel = previousMeta?.model;
+          const previousReasoningEffort = previousMeta?.reasoningEffort;
           // Persist the intent before adapter resume so adapters that rebuild a
-          // disconnected SDK session can restore the requested model. Roll it
-          // back if the adapter rejects the change; never acknowledge a model
-          // switch that did not reach the agent runtime.
-          this.sessionManager.setModel(sessionId, model);
+          // disconnected SDK session can restore the requested model and effort.
+          // Roll both back if the adapter rejects the change; never acknowledge
+          // configuration that did not reach the agent runtime.
+          this.sessionManager.setModel(sessionId, model, reasoningEffort);
           // Pi must see the explicit model before generic lazy resume: a retired
           // provider in pi.jsonl can otherwise make pi exit before set_model.
           // Other agents retain the established resume-then-set ordering.
@@ -1640,7 +1642,9 @@ export class RelayClient {
               });
             })
             .catch((err) => {
-              if (previousModel) this.sessionManager.setModel(sessionId, previousModel);
+              if (previousModel) {
+                this.sessionManager.setModel(sessionId, previousModel, previousReasoningEffort);
+              }
               logger.error({ err, sessionId }, 'setSessionModel failed');
               this.send({ type: 'error', sessionId, payload: { message: `Failed to change model: ${(err as Error).message}` } });
             });
@@ -1983,7 +1987,12 @@ export class RelayClient {
     this.adapter.onSessionCreated = (event) => {
       // Track in SessionManager if not already tracked (from resume)
       if (!this.sessionManager.getMeta(event.sessionId)) {
-        this.sessionManager.createSession(event.agent, event.model, event.sessionId);
+        this.sessionManager.createSession(
+          event.agent,
+          event.model,
+          event.sessionId,
+          event.reasoningEffort,
+        );
       }
       // Look up requestId by sessionId (set in handleCreateSession before adapter call)
       const requestId = this.pendingRequestIds.get(event.sessionId);
@@ -1999,7 +2008,13 @@ export class RelayClient {
       this.send({
         type: 'session_created',
         sessionId: event.sessionId,
-        payload: { agent: event.agent, model: event.model ?? meta?.model, requestId, lastSeq: meta?.lastSeq ?? 0 },
+        payload: {
+          agent: event.agent,
+          model: event.model ?? meta?.model,
+          reasoningEffort: event.reasoningEffort ?? meta?.reasoningEffort,
+          requestId,
+          lastSeq: meta?.lastSeq ?? 0,
+        },
       });
     };
 

--- a/packages/tentacle/src/session-manager.ts
+++ b/packages/tentacle/src/session-manager.ts
@@ -116,6 +116,7 @@ export interface SessionMeta {
   id: string;
   agent: string;
   model?: string;
+  reasoningEffort?: import('@kraki/protocol').ReasoningEffort;
   title?: string;
   autoTitle?: string;
   state: 'active' | 'idle' | 'ended' | 'disconnected';
@@ -398,7 +399,12 @@ export class SessionManager {
   /**
    * Create a new session. Returns the session ID.
    */
-  createSession(agent: string, model?: string, sessionId?: string): { sessionId: string; runId: string } {
+  createSession(
+    agent: string,
+    model?: string,
+    sessionId?: string,
+    reasoningEffort?: import('@kraki/protocol').ReasoningEffort,
+  ): { sessionId: string; runId: string } {
     const id = sessionId ?? `sess_${randomUUID().slice(0, 12)}`;
     const runId = 'run_001';
     const sessionDir = this.sessionDir(id);
@@ -408,6 +414,7 @@ export class SessionManager {
       id,
       agent,
       model,
+      reasoningEffort,
       state: 'active',
       mode: 'discuss',
       currentRunId: runId,
@@ -553,6 +560,7 @@ export class SessionManager {
       id: newId,
       agent: sourceMeta.agent,
       model: sourceMeta.model,
+      reasoningEffort: sourceMeta.reasoningEffort,
       title: sourceMeta.title ? `Fork of ${sourceMeta.title}` : undefined,
       autoTitle: sourceMeta.autoTitle,
       state: 'active',
@@ -666,10 +674,15 @@ export class SessionManager {
   /**
    * Set session model.
    */
-  setModel(sessionId: string, model: string): void {
+  setModel(
+    sessionId: string,
+    model: string,
+    reasoningEffort?: import('@kraki/protocol').ReasoningEffort,
+  ): void {
     const meta = this.readMeta(sessionId);
     if (!meta) return;
     meta.model = model;
+    meta.reasoningEffort = reasoningEffort;
     meta.updatedAt = new Date().toISOString();
     this.writeMeta(sessionId, meta);
   }
@@ -1259,6 +1272,7 @@ export class SessionManager {
     id: string;
     agent: string;
     model?: string;
+    reasoningEffort?: import('@kraki/protocol').ReasoningEffort;
     title?: string;
     autoTitle?: string;
     state: 'active' | 'idle';
@@ -1286,6 +1300,7 @@ export class SessionManager {
         id: meta.id,
         agent: meta.agent,
         model: meta.model ? toWellFormedText(meta.model) : undefined,
+        reasoningEffort: meta.reasoningEffort,
         title: meta.title ? toWellFormedText(meta.title) : undefined,
         autoTitle: meta.autoTitle ? toWellFormedText(meta.autoTitle) : undefined,
         state,


### PR DESCRIPTION
## Summary
- add a Thinking selector when changing a running Session model in the Mac app
- persist and synchronize the active reasoning effort through Tentacle session metadata
- expose the `max` reasoning rung distinctly from `xhigh`
- bump Tentacle to 0.31.19, protocol to 0.21.2, and Mac GUI to 0.2.22

## Validation
- `pnpm validate`
- 226 targeted Tentacle tests
- iOS test suite: 307 passed, 2 skipped
- KrakiMac Debug build
