### PR TITLE
fix(mac): keep launch gate visibly active while loading

### DIFF
--- a/docs/ios-launch-flow.md
+++ b/docs/ios-launch-flow.md
@@ -7,7 +7,7 @@ Kraki iOS uses two launch surfaces:
 
 ## Returning authenticated user
 
-1. `RootView` starts in `IOSLaunchCoordinator.Phase.launching` and paints a minimal entry gate containing only the current theme background and centered Kraki logo.
+1. `RootView` starts in `IOSLaunchCoordinator.Phase.launching` and paints a minimal entry gate containing only the current theme background and centered Kraki logo. iOS intentionally has no runtime Loading indicator: the system launch snapshot and this in-app continuation are meant to read as one calm Splash Screen.
 2. The initial Relay connection starts behind the gate. Network readiness does not control whether cached UI can eventually open.
 3. `MainTabView` mounts underneath the gate with notification/deep-link navigation disabled.
 4. `IOSLaunchPresentationReadyProbe` waits until the UIKit hierarchy is attached to a real `UIWindow`, forces its first layout pass, and reports on the following main-run-loop turn.
@@ -16,7 +16,7 @@ Kraki iOS uses two launch surfaces:
 
 ## Signed-out user
 
-The launch gate remains visible for the short visual floor, then routes to the existing iOS `LoginView`. The first WebSocket connection still starts behind the gate so `auth_info` can make GitHub sign-in available.
+The launch gate remains visible for the short visual floor, then routes to the existing iOS `LoginView`. The first WebSocket connection still starts behind the gate so `auth_info` can make GitHub sign-in available. The iOS cold-launch gate remains intentionally Logo-only; animated activity feedback is a macOS-only affordance.
 
 A successful login stages `MainTabView` through the same presentation boundary. Explicit logout returns directly to `LoginView` and does not replay the cold-launch animation.
 

--- a/docs/mac-launch-flow.md
+++ b/docs/mac-launch-flow.md
@@ -8,15 +8,16 @@ The production main scene is a single `Window(id: "main")`, not a `WindowGroup`.
 
 ### Cold process launch
 
-1. Show the minimal Kraki launch gate immediately: the current theme background with only a centered Kraki logo.
-2. Resolve local CLI/stored credential availability behind the gate.
-3. For an authenticated launch, mount `MainWindowView` underneath the gate with no Session selected.
-4. Keep Session/deep-link navigation queued while an AppKit probe completes the shell's first window-backed layout pass.
-5. Keep the gate visible for at least 350 ms, then fade it after that presentation probe reports ready. A 2-second presentation watchdog is a bounded fallback if AppKit does not deliver the expected attach callback.
-6. Route to one of:
+1. Show the Kraki launch gate immediately: the current theme background, a centered Kraki logo, and a thin indeterminate activity bar below the logo.
+2. Commit the activity bar's AppKit `CALayer` animation to the render server before starting work that may synchronously use the main thread.
+3. Resolve local CLI/stored credential availability behind the gate.
+4. For an authenticated launch, mount `MainWindowView` underneath the gate with no Session selected.
+5. Keep Session/deep-link navigation queued while an AppKit probe completes the shell's first window-backed layout pass.
+6. Keep the gate visible for at least 350 ms, then fade it after that presentation probe reports ready. A 2-second presentation watchdog is a bounded fallback if AppKit does not deliver the expected attach callback.
+7. Route to one of:
    - the already-settled authenticated shell, landing on Welcome with no Session selected;
    - the signed-out entry gate, with `kraki connect` instructions.
-7. Relay authentication and Tentacle status may continue after the authenticated shell appears. Network readiness never blocks the full-window gate indefinitely.
+8. Relay authentication and Tentacle status may continue after the authenticated shell appears. Network readiness never blocks the full-window gate indefinitely.
 
 ### Warm window reopen
 
@@ -24,14 +25,14 @@ When the process is still running in the menu bar, reopening the main window res
 
 ### Signed out
 
-Launch and Signed Out share the same theme surface but intentionally have different content. Launch contains only the centered logo; Signed Out adds:
+Launch and Signed Out share the same theme surface but intentionally have different content. Launch contains the centered logo and the activity bar; Signed Out adds:
 
 - the `kraki connect` command and a native Copy action;
 - a `Check Again` action;
 - automatic credential discovery when the user returns to Kraki from Terminal;
 - in-place checking/failure status.
 
-Signed Out never mounts the authenticated shell. Authenticated cold launch stages only the Sidebar/Welcome shell under the launch gate so its synchronous first layout is hidden; Session navigation stays queued, therefore Chat, Composer, CoreText cells, image preview, and HTML artifact state are not mounted behind the gate.
+Signed Out never mounts the authenticated shell. Authenticated cold launch stages only the Sidebar/Welcome shell under the launch gate so its synchronous first layout is hidden; Session navigation stays queued, therefore Chat, Composer, CoreText cells, image preview, and HTML artifact state are not mounted behind the gate. The activity bar is AppKit/Core Animation-backed rather than a SwiftUI timer, so it continues to provide feedback during a normal first-layout burst after its first transaction has been committed.
 
 A reconnecting `session_list` is reconciled as one SessionStore transaction and schedules one persistence snapshot. It must not invalidate the Sidebar and rebuild the full snapshot several times per Session.
 

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1481,7 +1481,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1491,7 +1491,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.22;
+				MARKETING_VERSION = 0.2.23;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1561,7 +1561,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1571,7 +1571,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.22;
+				MARKETING_VERSION = 0.2.23;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		7072CE0B000723DAD5D771C6 /* TentaclePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A34822755FED065BFDA075 /* TentaclePane.swift */; };
 		71AB0F5DFBF3366EAC49D05D /* ChatLoadingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63003A2D28B352ABAB064761 /* ChatLoadingState.swift */; };
 		759AE50B2E38D95776D64D57 /* LoginView+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877AB77036AB504E9C76156D /* LoginView+macOS.swift */; };
+		945558DB880907D741553F0E /* MacLaunchActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D80A4B531EA5EBD081A0626 /* MacLaunchActivityIndicator.swift */; };
 		7673EB233CA3945C12E9C318 /* MacChatTestPages.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C3EAC80F5625784F50037 /* MacChatTestPages.swift */; };
 		770252CC17F7BF25C1A114C1 /* MacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE814884FDD9A0A46CCCCB69 /* MacApp.swift */; };
 		7999D41402AD34E2D934AA0E /* AccountPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E5D28B402A345F0D22B851 /* AccountPane.swift */; };
@@ -221,6 +222,7 @@
 		E584D9C40B57680AF34DE750 /* FlatBubbleTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DA5D4B10C2EF6EA184D1E3 /* FlatBubbleTestView.swift */; };
 		E74ACB62F0337BF8D7E95E3B /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57D3E8B020B76BCD75B0243 /* ChatViewModel.swift */; };
 		E7E8B3D8B17CDFA130977730 /* SessionSubscriptionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23E728794AEA9E7A803A564 /* SessionSubscriptionController.swift */; };
+		E99066BB398A92ECC653535A /* MacLaunchActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D80A4B531EA5EBD081A0626 /* MacLaunchActivityIndicator.swift */; };
 		EBB7E4C62FE6047767653940 /* NewSessionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD29591F2C7F6E0D0AFAE855 /* NewSessionSheet.swift */; };
 		ED69BD9687C030C318D9EF49 /* SessionSubscriptionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23E728794AEA9E7A803A564 /* SessionSubscriptionController.swift */; };
 		EF182DDCEE43C64585164D92 /* VoiceInputCore in Frameworks */ = {isa = PBXBuildFile; productRef = C18741B12304BDBDCC5AF55E /* VoiceInputCore */; };
@@ -336,6 +338,7 @@
 		69B9A691EAC2476B0D3210AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6AD698C5DD0F8DDB4A3D6CFE /* KrakiApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KrakiApp.swift; sourceTree = "<group>"; };
 		6B52AA4B3D7FFBB698F94CE9 /* TurnSpineProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnSpineProjection.swift; sourceTree = "<group>"; };
+		6D80A4B531EA5EBD081A0626 /* MacLaunchActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacLaunchActivityIndicator.swift; sourceTree = "<group>"; };
 		6DF461DDEA102ED1927719DE /* SessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreTests.swift; sourceTree = "<group>"; };
 		6EDC494E5B0CBA712CCA550C /* ChatPerfListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPerfListView.swift; sourceTree = "<group>"; };
 		6FC184CE4CAFDEF1914453D4 /* TabBarHider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarHider.swift; sourceTree = "<group>"; };
@@ -463,6 +466,7 @@
 				28D15C4DAE8AB0534C9C6226 /* MacBubbleTestView.swift */,
 				92398F20B425BB1B9F83DB93 /* MacChatMockSnapshot.swift */,
 				B66C3EAC80F5625784F50037 /* MacChatTestPages.swift */,
+				6D80A4B531EA5EBD081A0626 /* MacLaunchActivityIndicator.swift */,
 				63302839C21EFDE37CC56C13 /* MacMockData.swift */,
 				C024AE6690757FB0A6916CEE /* MacNotifications.swift */,
 				CD6C23118C2C309C39C2A515 /* MacUpdateController.swift */,
@@ -1082,6 +1086,7 @@
 				DFA7C9DEE69AE83C1C88F2AE /* MacChatMockSnapshot.swift in Sources */,
 				1F1F3DC51446612B13699140 /* MacChatTestPages.swift in Sources */,
 				AC00BC8720774E96C977047D /* MacChatScrollView.swift in Sources */,
+				E99066BB398A92ECC653535A /* MacLaunchActivityIndicator.swift in Sources */,
 				2D511A9C6FB61ADC2DA98C62 /* MacChatView.swift in Sources */,
 				A69E09D819C14CBA937D83D4 /* MacHTMLArtifactPanel.swift in Sources */,
 				858780C909D555E4389D53F9 /* MacMockData.swift in Sources */,
@@ -1191,6 +1196,7 @@
 				C6BB0C7305CBF9BC6A9C8A4E /* MacChatMockSnapshot.swift in Sources */,
 				7673EB233CA3945C12E9C318 /* MacChatTestPages.swift in Sources */,
 				1070A66DCB67C1EBF3CE79DB /* MacChatScrollView.swift in Sources */,
+				945558DB880907D741553F0E /* MacLaunchActivityIndicator.swift in Sources */,
 				C6C8EC4BB9D1B7EC88565DD8 /* MacChatView.swift in Sources */,
 				08F85030BFB022147598ABAE /* MacHTMLArtifactPanel.swift in Sources */,
 				6F7C13F76FDD7E9103905674 /* MacMockData.swift in Sources */,

--- a/packages/arm/ios/Kraki/App/Mac/MacApp.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacApp.swift
@@ -48,6 +48,7 @@ final class MacLaunchCoordinator {
     @ObservationIgnored private var hasStarted = false
     @ObservationIgnored private var servicesStarted = false
     @ObservationIgnored private var launchStartedAt: Date?
+    @ObservationIgnored private var hasCommittedLaunchActivity = false
     @ObservationIgnored private var isFinishingAuthenticatedSurface = false
     @ObservationIgnored private var presentationWatchdogTask: Task<Void, Never>?
 
@@ -69,6 +70,17 @@ final class MacLaunchCoordinator {
         let startedAt = Date()
         launchStartedAt = startedAt
         KLog.diag("[MacLaunch] gate presented")
+
+        // The launch gate must get one render-server-owned activity frame
+        // before authenticated shell construction can synchronously consume
+        // the main thread. The bounded fallback keeps a missing AppKit callback
+        // from turning this handshake into a new startup deadlock.
+        await waitForLaunchActivityCommit()
+        guard !Task.isCancelled else {
+            hasStarted = false
+            return
+        }
+
         if !servicesStarted {
             servicesStarted = true
             Task { @MainActor in
@@ -124,6 +136,26 @@ final class MacLaunchCoordinator {
             }
             phase = .signedOut
             logDestination("signedOut")
+        }
+    }
+
+    /// Called after the AppKit launch indicator has installed its repeating
+    /// CALayer animation and flushed the first transaction to the render
+    /// server. This is intentionally synchronous and process-scoped: a warm
+    /// window reopen must not wait on a stale view instance.
+    func launchActivityDidCommit() {
+        hasCommittedLaunchActivity = true
+    }
+
+    private func waitForLaunchActivityCommit() async {
+        guard !hasCommittedLaunchActivity else { return }
+        let deadline = Date().addingTimeInterval(0.35)
+        while !hasCommittedLaunchActivity, Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(8))
+            if Task.isCancelled { return }
+        }
+        if !hasCommittedLaunchActivity {
+            KLog.diag("[MacLaunch] activity commit watchdog fired")
         }
     }
 
@@ -499,7 +531,12 @@ struct MacApp: App {
                 }
 
                 if launchCoordinator.isLaunchGateVisible {
-                    MacEntryGateView(mode: .launching)
+                    MacEntryGateView(
+                        mode: .launching,
+                        onLaunchActivityCommitted: {
+                            launchCoordinator.launchActivityDidCommit()
+                        }
+                    )
                         .transition(.opacity)
                         .zIndex(10)
                 }

--- a/packages/arm/ios/Kraki/App/Mac/MacLaunchActivityIndicator.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacLaunchActivityIndicator.swift
@@ -1,0 +1,180 @@
+#if os(macOS)
+import AppKit
+import QuartzCore
+import SwiftUI
+
+/// A tiny indeterminate launch indicator backed by a render-server animation.
+///
+/// The animation is committed before the authenticated shell is mounted. Once
+/// Core Animation owns the repeating motion, a synchronous first-layout burst
+/// on the main thread does not turn the launch gate into a frozen-looking
+/// surface. The view intentionally owns no launch-routing state.
+struct MacLaunchActivityIndicator: NSViewRepresentable {
+    let reduceMotion: Bool
+    let onAnimationCommitted: () -> Void
+
+    func makeNSView(context: Context) -> LaunchActivityIndicatorView {
+        let view = LaunchActivityIndicatorView()
+        view.reduceMotion = reduceMotion
+        view.onAnimationCommitted = onAnimationCommitted
+        return view
+    }
+
+    func updateNSView(_ nsView: LaunchActivityIndicatorView, context: Context) {
+        nsView.onAnimationCommitted = onAnimationCommitted
+        nsView.setReduceMotion(reduceMotion)
+    }
+
+    final class LaunchActivityIndicatorView: NSView {
+        private static let trackHeight: CGFloat = 2
+        private static let indicatorWidth: CGFloat = 58
+        private static let animationDuration: CFTimeInterval = 1.25
+        private static let animationKey = "kraki.launch.activity"
+
+        var onAnimationCommitted: (() -> Void)?
+        var reduceMotion = false
+
+        private var didCommitAnimation = false
+        private var trackLayer: CALayer?
+        private var indicatorLayer: CAGradientLayer?
+
+        override var isFlipped: Bool { true }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard window != nil else { return }
+            installLayersIfNeeded()
+            startOrUpdateAnimation()
+        }
+
+        override func layout() {
+            super.layout()
+            installLayersIfNeeded()
+            updateLayerFrames()
+        }
+
+        override func viewDidChangeEffectiveAppearance() {
+            super.viewDidChangeEffectiveAppearance()
+            updateColors()
+        }
+
+        func setReduceMotion(_ value: Bool) {
+            guard reduceMotion != value else { return }
+            reduceMotion = value
+            startOrUpdateAnimation()
+        }
+
+        private func installLayersIfNeeded() {
+            guard trackLayer == nil else { return }
+
+            wantsLayer = true
+            let root = layer ?? CALayer()
+            layer = root
+            root.masksToBounds = true
+
+            let track = CALayer()
+            root.addSublayer(track)
+            trackLayer = track
+
+            let indicator = CAGradientLayer()
+            indicator.startPoint = CGPoint(x: 0, y: 0.5)
+            indicator.endPoint = CGPoint(x: 1, y: 0.5)
+            root.addSublayer(indicator)
+            indicatorLayer = indicator
+
+            updateLayerFrames()
+            updateColors()
+        }
+
+        private func updateLayerFrames() {
+            guard let trackLayer, let indicatorLayer else { return }
+            let bounds = self.bounds
+            trackLayer.frame = CGRect(
+                x: 0,
+                y: max(0, (bounds.height - Self.trackHeight) / 2),
+                width: bounds.width,
+                height: Self.trackHeight
+            )
+            indicatorLayer.frame = CGRect(
+                x: -Self.indicatorWidth,
+                y: max(0, (bounds.height - Self.trackHeight) / 2),
+                width: Self.indicatorWidth,
+                height: Self.trackHeight
+            )
+        }
+
+        private func updateColors() {
+            guard let trackLayer, let indicatorLayer else { return }
+            let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            let primary = NSColor(
+                calibratedRed: dark ? 0x5E / 255 : 0x0B / 255,
+                green: dark ? 0xA0 / 255 : 0x5B / 255,
+                blue: dark ? 0xD7 / 255 : 0x9C / 255,
+                alpha: 1
+            )
+            let cyan = NSColor(
+                calibratedRed: dark ? 0x22 / 255 : 0x08 / 255,
+                green: dark ? 0xD3 / 255 : 0x91 / 255,
+                blue: dark ? 0xEE / 255 : 0xB2 / 255,
+                alpha: 1
+            )
+            trackLayer.backgroundColor = primary.withAlphaComponent(dark ? 0.16 : 0.11).cgColor
+            indicatorLayer.colors = [
+                NSColor.clear.cgColor,
+                primary.withAlphaComponent(0.74).cgColor,
+                cyan.withAlphaComponent(0.96).cgColor,
+                primary.withAlphaComponent(0.74).cgColor,
+                NSColor.clear.cgColor,
+            ]
+        }
+
+        private func startOrUpdateAnimation() {
+            guard window != nil else { return }
+            installLayersIfNeeded()
+            guard let indicatorLayer else { return }
+
+            indicatorLayer.removeAnimation(forKey: Self.animationKey)
+            updateLayerFrames()
+
+            if reduceMotion {
+                // Reduce Motion keeps a visible, non-moving center segment so
+                // the gate still communicates activity without spatial motion.
+                indicatorLayer.position.x = bounds.midX
+                indicatorLayer.opacity = 0.8
+                didCommitAnimationIfNeeded()
+                return
+            }
+
+            indicatorLayer.opacity = 1
+            let startX = -Self.indicatorWidth / 2
+            let endX = bounds.width + Self.indicatorWidth / 2
+            indicatorLayer.position.x = startX
+
+            let animation = CABasicAnimation(keyPath: "position.x")
+            animation.fromValue = startX
+            animation.toValue = endX
+            animation.duration = Self.animationDuration
+            animation.repeatCount = .infinity
+            animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            // Use the layer's local clock so the first motion starts from the
+            // same committed frame even when the view is inside a retained
+            // SwiftUI/AppKit hierarchy.
+            animation.beginTime = indicatorLayer.convertTime(CACurrentMediaTime(), from: nil)
+            indicatorLayer.add(animation, forKey: Self.animationKey)
+            didCommitAnimationIfNeeded()
+        }
+
+        private func didCommitAnimationIfNeeded() {
+            guard !didCommitAnimation else { return }
+            didCommitAnimation = true
+            // Flush this transaction before releasing launch bootstrap. The
+            // callback is deferred one turn so the render server receives the
+            // layer tree before MainWindowView can synchronously materialize.
+            CATransaction.flush()
+            DispatchQueue.main.async { [weak self] in
+                self?.onAnimationCommitted?()
+            }
+        }
+    }
+}
+#endif

--- a/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Auth/LoginView+macOS.swift
@@ -23,6 +23,7 @@ struct MacEntryGateView: View {
     var isCheckingCredentials: Bool = false
     var loginCheckFailed: Bool = false
     var onRetry: () -> Void = {}
+    var onLaunchActivityCommitted: () -> Void = {}
 
     @State private var appeared = false
 
@@ -33,6 +34,17 @@ struct MacEntryGateView: View {
                 ZStack {
                     Color.surfacePrimary
                     launchLogo
+
+                    // Keep the Logo physically centered. The indicator is
+                    // positioned independently below it and does not change
+                    // the Logo's center or the launch-gate layout contract.
+                    MacLaunchActivityIndicator(
+                        reduceMotion: reduceMotion,
+                        onAnimationCommitted: onLaunchActivityCommitted
+                    )
+                    .frame(width: 128, height: 2)
+                    .offset(y: 119)
+                    .accessibilityLabel("Opening Kraki")
                 }
                 .ignoresSafeArea()
             case .signedOut:

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.22"
-        CURRENT_PROJECT_VERSION: 24
+        MARKETING_VERSION: "0.2.23"
+        CURRENT_PROJECT_VERSION: 25
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- add an AppKit/Core Animation indeterminate activity bar to the macOS authenticated launch gate
- commit the animation before authenticated shell construction so normal first-layout work does not look frozen
- keep iOS system and in-app launch surfaces Logo-only
- document the platform-specific launch behavior

## Validation
- macOS KrakiMac Debug build passed
- iOS Kraki tests: 307 executed, 2 skipped, 0 failures
- AppKit indicator probe observed render-server movement across samples
- isolated macOS launch fixture capture preserved the physical Logo center
- git diff --check passed

No production app was installed, replaced, or restarted.
