### PR TITLE
fix(mac): refine composer and session action feedback

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1481,7 +1481,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1491,7 +1491,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.23;
+				MARKETING_VERSION = 0.2.24;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1561,7 +1561,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1571,7 +1571,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.23;
+				MARKETING_VERSION = 0.2.24;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacAutomationDriver.swift
@@ -603,7 +603,7 @@ final class MacAutomationDriver {
     }
 
     private func compactingGlyphAnimationRegression(id: Any?, connection: Int32) {
-        let host = NSHostingView(rootView: CompactingStatusGlyph())
+        let host = NSHostingView(rootView: MacCompactingStatusGlyph())
         host.frame = NSRect(x: 0, y: 0, width: 16, height: 16)
         let window = NSWindow(
             contentRect: host.frame,

--- a/packages/arm/ios/Kraki/App/Mac/MacChatTestPages.swift
+++ b/packages/arm/ios/Kraki/App/Mac/MacChatTestPages.swift
@@ -2238,7 +2238,7 @@ private extension MacChatScenarioHarness {
             sidebarDraftID,
             category: "Sidebar projection",
             title: "46 · Sidebar · Unsent draft",
-            summary: "Draft text remains stored, [draft] is absent, and only the human icon turns red.",
+            summary: "Draft text remains stored, [draft] is absent, and the draft text plus keyboard icon use a muted red reminder.",
             phases: [phase(
                 "Draft retained",
                 messages: basicConversation(sidebarDraftID, user: "Previous prompt", agent: "Previous response"),

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacBubbleActionSlot.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacBubbleActionSlot.swift
@@ -212,21 +212,22 @@ struct MacBubbleActionSlot: View {
         fill: Color,
         border: Color
     ) -> some View {
-        Button {
-            guard let permissionId = message.permissionId else { return }
-            onResolvePermission(permissionId, message.toolName, decision)
-        } label: {
+        MacChatActionButton(
+            action: {
+                guard let permissionId = message.permissionId else { return }
+                onResolvePermission(permissionId, message.toolName, decision)
+            },
+            foreground: foreground,
+            fill: fill,
+            border: border,
+            accent: decision == "deny" ? .red : (decision == "execute" ? .orange : .green)
+        ) {
             Text(label)
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(foreground)
                 .lineLimit(1)
                 .minimumScaleFactor(0.82)
                 .frame(maxWidth: .infinity, minHeight: 32)
-                .background(fill, in: RoundedRectangle(cornerRadius: 8))
-                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(border, lineWidth: 1))
-                .contentShape(RoundedRectangle(cornerRadius: 8))
         }
-        .buttonStyle(.plain)
         .frame(maxWidth: .infinity)
         .accessibilityLabel("\(label) permission")
         .background {
@@ -291,22 +292,24 @@ struct MacBubbleActionSlot: View {
             } else if let choices = message.choices, !choices.isEmpty {
                 VStack(spacing: 6) {
                     ForEach(choices, id: \.self) { choice in
-                        Button {
-                            guard let questionId = message.questionId else { return }
-                            onAnswerQuestion(questionId, choice)
-                        } label: {
+                        MacChatActionButton(
+                            action: {
+                                guard let questionId = message.questionId else { return }
+                                onAnswerQuestion(questionId, choice)
+                            },
+                            foreground: Color.textPrimary,
+                            fill: Color.surfacePrimary.opacity(0.6),
+                            border: Color.borderPrimary,
+                            accent: .purple
+                        ) {
                             Text(MacLiveMarkdown.attributed(choice))
                                 .font(.system(size: 13))
-                                .foregroundStyle(Color.textPrimary)
                                 .multilineTextAlignment(.leading)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 9)
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(Color.surfacePrimary.opacity(0.6), in: RoundedRectangle(cornerRadius: 8))
-                                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.borderPrimary))
                         }
-                        .buttonStyle(.plain)
                         .accessibilityLabel("Answer: \(choice)")
                         .background {
                             GeometryReader { proxy in
@@ -330,6 +333,88 @@ struct MacBubbleActionSlot: View {
     static func switchesToExecute(mode: SessionMode, toolName: String?) -> Bool {
         guard mode == .discuss, let toolName else { return false }
         return ["write", "write_file", "create", "create_file", "edit", "edit_file"].contains(toolName)
+    }
+}
+
+/// Native-feeling action surface for buttons embedded in a Mac chat bubble.
+/// SwiftUI's plain button style removes the platform's visual feedback, so we
+/// provide explicit hover, pressed, and border layers while keeping the
+/// existing AppKit action-frame hit routing untouched.
+private struct MacChatActionButton<Label: View>: View {
+    let action: () -> Void
+    let foreground: Color
+    let fill: Color
+    let border: Color
+    let accent: Color
+    let label: () -> Label
+    @State private var isHovered = false
+
+    init(
+        action: @escaping () -> Void,
+        foreground: Color,
+        fill: Color,
+        border: Color,
+        accent: Color,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.action = action
+        self.foreground = foreground
+        self.fill = fill
+        self.border = border
+        self.accent = accent
+        self.label = label
+    }
+
+    var body: some View {
+        Button(action: action) {
+            label()
+        }
+        .buttonStyle(MacChatActionButtonStyle(
+            foreground: foreground,
+            fill: fill,
+            border: border,
+            accent: accent,
+            isHovered: isHovered
+        ))
+        .onHover { isHovered = $0 }
+    }
+}
+
+private struct MacChatActionButtonStyle: ButtonStyle {
+    let foreground: Color
+    let fill: Color
+    let border: Color
+    let accent: Color
+    let isHovered: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(foreground)
+            .background {
+                let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
+                shape.fill(fill)
+                    .overlay(
+                        shape.fill(Color.white.opacity(isHovered ? 0.07 : 0))
+                    )
+                    .overlay(
+                        shape.fill(Color.black.opacity(configuration.isPressed ? 0.13 : 0))
+                    )
+                    .overlay(
+                        shape.strokeBorder(
+                            isHovered ? accent.opacity(0.68) : border,
+                            lineWidth: isHovered ? 1.2 : 1
+                        )
+                    )
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .shadow(
+                color: isHovered ? accent.opacity(0.18) : .clear,
+                radius: isHovered ? 5 : 0,
+                y: isHovered ? 1 : 0
+            )
+            .animation(.easeOut(duration: 0.12), value: isHovered)
+            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
     }
 }
 

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatComposer.swift
@@ -243,6 +243,9 @@ struct MacChatComposer: View {
     private var inputRow: some View {
         HStack(spacing: 8) {
             imageAttachButton
+            if canShowVoice && !voiceOwnsComposer {
+                inlineVoiceButton
+            }
             inputBox
             if canShowAbort { abortButton }
         }
@@ -259,7 +262,6 @@ struct MacChatComposer: View {
             } else {
                 HStack(alignment: .center, spacing: 0) {
                     textFieldForMode
-                    if canShowVoice { inlineVoiceButton }
                     sendIconButton
                 }
             }

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
@@ -626,12 +626,14 @@ struct MacCompactingStatusGlyph: View {
         // The 3D glyph remains vertically legible at the 16pt sidebar slot.
         // Compression closes the gaps without scaling the symbol or flashing
         // its color, matching the approved design preview.
-        let layerSpacing = 4.8 - 1.8 * compression
+        // Each layer nearly fills the 16pt leading slot horizontally. The
+        // earlier 7.2pt face was too narrow beside the other status glyphs.
+        let layerSpacing = 4.2 - 1.6 * compression
         return ZStack {
             ForEach(0..<3, id: \.self) { index in
                 MacCompacting3DSquare()
                     .stroke(Color(hex: 0x0891B2), style: StrokeStyle(lineWidth: 0.9, lineCap: .round, lineJoin: .round))
-                    .frame(width: 7.2, height: 5.0)
+                    .frame(width: 14.4, height: 7.2)
                     .offset(y: CGFloat(index - 1) * layerSpacing)
             }
         }

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
@@ -600,40 +600,74 @@ private struct MacSidebarSessionRow: View {
     }
 }
 
-/// Compacting is a physical compression gesture rather than a color pulse:
-/// three cyan squares stand vertically, squeeze together, then expand again.
-/// The fill stays constant so the state reads through geometry, not flashing.
+/// Compacting keeps the original 3D square-stack language rather than
+/// introducing a new filled-block icon. Each mark is an isometric square
+/// drawn as a cyan wireframe; the three marks share a vertical axis and only
+/// their vertical separation changes during the compression cycle.
 struct MacCompactingStatusGlyph: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    private let cycleDuration: TimeInterval = 1.6
+    private let cycleDuration: TimeInterval = 1.8
 
     var body: some View {
         if reduceMotion {
-            squares(compression: 0)
+            layers(compression: 0)
         } else {
             TimelineView(.animation(minimumInterval: 1.0 / 18.0)) { context in
                 let phase = context.date.timeIntervalSinceReferenceDate
                     .truncatingRemainder(dividingBy: cycleDuration)
                 let normalized = phase / cycleDuration
                 let compression = 0.5 - 0.5 * cos(normalized * 2 * .pi)
-                squares(compression: compression)
+                layers(compression: compression)
             }
         }
     }
 
-    private func squares(compression: Double) -> some View {
-        let spacing = 1.2 - 0.95 * compression
-        let scaleY = 1 - 0.28 * compression
-        return VStack(spacing: spacing) {
-            ForEach(0..<3, id: \.self) { _ in
-                RoundedRectangle(cornerRadius: 1.2, style: .continuous)
-                    .fill(Color(hex: 0x0891B2))
-                    .frame(width: 4.8, height: 4.8)
-                    .scaleEffect(x: 1 - 0.06 * compression, y: scaleY)
+    private func layers(compression: Double) -> some View {
+        // The 3D glyph remains vertically legible at the 16pt sidebar slot.
+        // Compression closes the gaps without scaling the symbol or flashing
+        // its color, matching the approved design preview.
+        let layerSpacing = 4.8 - 1.8 * compression
+        return ZStack {
+            ForEach(0..<3, id: \.self) { index in
+                MacCompacting3DSquare()
+                    .stroke(Color(hex: 0x0891B2), style: StrokeStyle(lineWidth: 0.9, lineCap: .round, lineJoin: .round))
+                    .frame(width: 7.2, height: 5.0)
+                    .offset(y: CGFloat(index - 1) * layerSpacing)
             }
         }
         .frame(width: 16, height: 16)
         .accessibilityHidden(true)
+    }
+}
+
+private struct MacCompacting3DSquare: Shape {
+    func path(in rect: CGRect) -> Path {
+        // Isometric square face plus its short lower extrusion. At this size
+        // the resulting outline reads as the same 3D/rhombus-like symbol as
+        // square.stack.3d.down.right, while allowing vertical gap animation.
+        let width = rect.width
+        let faceHeight = rect.height * 0.77
+        let left = rect.minX + width * 0.02
+        let right = rect.maxX - width * 0.02
+        let centerX = rect.midX
+        let top = rect.minY
+        let faceMidY = top + faceHeight * 0.5
+        let faceBottom = top + faceHeight
+        let extrusion = rect.height * 0.23
+
+        var path = Path()
+        path.move(to: CGPoint(x: centerX, y: top))
+        path.addLine(to: CGPoint(x: right, y: faceMidY))
+        path.addLine(to: CGPoint(x: centerX, y: faceBottom))
+        path.addLine(to: CGPoint(x: left, y: faceMidY))
+        path.closeSubpath()
+
+        path.move(to: CGPoint(x: left, y: faceMidY))
+        path.addLine(to: CGPoint(x: left, y: faceMidY + extrusion))
+        path.addLine(to: CGPoint(x: centerX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: right, y: faceMidY + extrusion))
+        path.addLine(to: CGPoint(x: right, y: faceMidY))
+        return path
     }
 }
 

--- a/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
+++ b/packages/arm/ios/Kraki/Features/Sessions/SessionsSidebarView+macOS.swift
@@ -448,6 +448,10 @@ struct SessionsSidebarView: View {
 // digest-authoritative preview. The leading preview slot is reserved for
 // coarse state only; it never exposes a transient tool or narration.
 
+/// Muted enough for a dark sidebar, but clearly distinct from a sent human
+/// message. Draft text and its keyboard glyph share this reminder color.
+private let macDraftAccent = Color(hex: 0xC65D5D)
+
 private struct MacSidebarSessionRow: View {
     @Environment(AppState.self) private var appState
     let session: SessionInfo
@@ -581,7 +585,7 @@ private struct MacSidebarSessionRow: View {
             if let previewText = projection.previewText {
                 Text(previewText)
                     .font(.system(size: 11))
-                    .foregroundStyle(Color.textSecondary)
+                    .foregroundStyle(projection.isDraft ? macDraftAccent : Color.textSecondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
             } else {
@@ -593,6 +597,43 @@ private struct MacSidebarSessionRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Compacting is a physical compression gesture rather than a color pulse:
+/// three cyan squares stand vertically, squeeze together, then expand again.
+/// The fill stays constant so the state reads through geometry, not flashing.
+struct MacCompactingStatusGlyph: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private let cycleDuration: TimeInterval = 1.6
+
+    var body: some View {
+        if reduceMotion {
+            squares(compression: 0)
+        } else {
+            TimelineView(.animation(minimumInterval: 1.0 / 18.0)) { context in
+                let phase = context.date.timeIntervalSinceReferenceDate
+                    .truncatingRemainder(dividingBy: cycleDuration)
+                let normalized = phase / cycleDuration
+                let compression = 0.5 - 0.5 * cos(normalized * 2 * .pi)
+                squares(compression: compression)
+            }
+        }
+    }
+
+    private func squares(compression: Double) -> some View {
+        let spacing = 1.2 - 0.95 * compression
+        let scaleY = 1 - 0.28 * compression
+        return VStack(spacing: spacing) {
+            ForEach(0..<3, id: \.self) { _ in
+                RoundedRectangle(cornerRadius: 1.2, style: .continuous)
+                    .fill(Color(hex: 0x0891B2))
+                    .frame(width: 4.8, height: 4.8)
+                    .scaleEffect(x: 1 - 0.06 * compression, y: scaleY)
+            }
+        }
+        .frame(width: 16, height: 16)
+        .accessibilityHidden(true)
     }
 }
 
@@ -611,7 +652,7 @@ private struct MacSessionStatusGlyph: View {
             case .active:
                 activityDots
             case .compacting:
-                CompactingStatusGlyph()
+                MacCompactingStatusGlyph()
             case .waiting:
                 LucideIcon(.messageCircleQuestion,
                            size: 14,
@@ -641,7 +682,7 @@ private struct MacSessionStatusGlyph: View {
                     LucideIcon(.keyboard,
                                size: 14,
                                strokeWidth: 2,
-                               color: Color(hex: 0x4F8C86))
+                               color: macDraftAccent)
                 } else {
                     LucideIcon(.circleUser,
                                size: 13,

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.23"
-        CURRENT_PROJECT_VERSION: 25
+        MARKETING_VERSION: "0.2.24"
+        CURRENT_PROJECT_VERSION: 26
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- move the macOS voice microphone to the leading side of the Input Box
- add explicit hover and pressed feedback to Question and Permission action buttons
- use a muted red for unsent Draft preview text and its keyboard glyph
- replace the macOS Compacting preview symbol with three fixed-color vertical squares that compress and expand geometrically
- point the Compacting regression at the macOS glyph and update the Scenario description

## Validation
- macOS KrakiMac Debug build passed
- iOS Kraki tests: 307 executed, 2 skipped, 0 failures
- compactingGlyphAnimationRegression: passed=true, changed=true
- isolated Question, Permission, Composer, Draft, and Compacting Scenario captures verified
- git diff --check passed

No production app was installed, replaced, or restarted.
