### PR TITLE
test(ios): add production scroll reliability gate

### DIFF
--- a/docs/ios-chat-scroll-production-gate.md
+++ b/docs/ios-chat-scroll-production-gate.md
@@ -1,0 +1,33 @@
+# iOS Chat scroll production gate
+
+The iOS Debug test `IOSChatScrollProductionTests.testProductionScrollGate` mounts the
+real `ChatPerfListVC`, `UICollectionView`, TextKit bubble cells, `MessageStore`, and
+DB-first `MessageProvider` against a temporary simulator database.
+
+It validates:
+
+- entry at the newest tail with valid content geometry;
+- first upward history pagination and exact prepend anchoring;
+- materialized visible cells while asynchronous page measurement settles;
+- repeated continuous upward packets without duplicate spine identities;
+- later upward approaches continuing to load older pages;
+- oldest-boundary clamping;
+- downward recovery of a px-trimmed newer page;
+- width/height reflow with valid offset bounds and visible cell materialization.
+
+Run the focused gate on an available iOS Simulator:
+
+```bash
+xcodebuild \
+  -project packages/arm/ios/Kraki.xcodeproj \
+  -scheme Kraki \
+  -destination 'platform=iOS Simulator,id=<SIMULATOR_UDID>' \
+  -derivedDataPath /tmp/kraki-ios-scroll-gate-derived \
+  CODE_SIGNING_ALLOWED=NO \
+  test -only-testing:KrakiTests/IOSChatScrollProductionTests/testProductionScrollGate
+```
+
+The fixture uses a temporary SQLite database and a test-only app graph. It does not
+open the production database, relay, credentials, or production Session. The small
+`#if DEBUG` follow-state probe avoids global/synthetic input while leaving pagination,
+measurement, UIKit batch updates, and anchor correction on their production paths.

--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		059644A88DFFBB489A036936 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 69B9A691EAC2476B0D3210AC /* Assets.xcassets */; };
 		063EA307ED63C7867624C342 /* NavigationIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9656866F24E385A14F14E699 /* NavigationIDs.swift */; };
 		06E56E8528A16D9D6D294135 /* MessageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9B1FD19F5052C3B8BD91E4 /* MessageStoreTests.swift */; };
+		0F1D9E8A3B4C5D6E7F8091A2 /* IOSChatScrollProductionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B4C5 /* IOSChatScrollProductionTests.swift */; };
 		07009971363AD7EBB365BAF8 /* DeviceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6162027FE71CB62BA4255 /* DeviceListView.swift */; };
 		08F85030BFB022147598ABAE /* MacHTMLArtifactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FFF5CE3173503A2C9A577C /* MacHTMLArtifactPanel.swift */; };
 		0904D2B58EE9736437D89A18 /* MessageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02010E839BEA2321FB4E19C7 /* MessageStore.swift */; };
@@ -398,6 +399,7 @@
 		D5BAEA7249F10D6067F0886F /* LiveBubbleTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveBubbleTestView.swift; sourceTree = "<group>"; };
 		D7BD07326375D7E516A8ACD4 /* MessageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProvider.swift; sourceTree = "<group>"; };
 		DC9B1FD19F5052C3B8BD91E4 /* MessageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStoreTests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F708192A3B4C5 /* IOSChatScrollProductionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSChatScrollProductionTests.swift; sourceTree = "<group>"; };
 		DD29591F2C7F6E0D0AFAE855 /* NewSessionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionSheet.swift; sourceTree = "<group>"; };
 		E2E016C4ACE0484D7DB04166 /* MessageDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDatabase.swift; sourceTree = "<group>"; };
 		E355FDA07A62D1D2FA07ECB1 /* PermissionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCardView.swift; sourceTree = "<group>"; };
@@ -814,6 +816,7 @@
 				27B142EE244DC79E4A704032 /* KrakiVoiceInputTests.swift */,
 				1D6472A002F2CB9C07380792 /* MessagesTests.swift */,
 				DC9B1FD19F5052C3B8BD91E4 /* MessageStoreTests.swift */,
+				1A2B3C4D5E6F708192A3B4C5 /* IOSChatScrollProductionTests.swift */,
 				97C99EF2A08DFF67F9951044 /* PendingTailBufferTests.swift */,
 				22F6388085A5234FBAB8906F /* ProtocolTypesTests.swift */,
 				6DF461DDEA102ED1927719DE /* SessionStoreTests.swift */,
@@ -1013,6 +1016,7 @@
 				DCDE31F2BEB3BB9017D46BE8 /* HelpersTests.swift in Sources */,
 				7F8B97ABC14A68350C0D43A6 /* KrakiVoiceInputTests.swift in Sources */,
 				06E56E8528A16D9D6D294135 /* MessageStoreTests.swift in Sources */,
+				0F1D9E8A3B4C5D6E7F8091A2 /* IOSChatScrollProductionTests.swift in Sources */,
 				C0C4528A1D3D1773A0BA9870 /* MessagesTests.swift in Sources */,
 				3E6DC3A38E8C02979FFFA91D /* PendingTailBufferTests.swift in Sources */,
 				5AAAC8892D718A7C7AC7F28D /* ProtocolTypesTests.swift in Sources */,

--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -1993,6 +1993,15 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
         prefetchNewerIfNeeded()
     }
 
+    #if DEBUG
+    /// Focus-free integration probe equivalent of the first real drag packet.
+    /// It changes only the production follow-state latch; pagination, sizing,
+    /// batch updates, and anchor correction still run through their normal paths.
+    func automationMarkUserScrolledAway() {
+        followingBottom = false
+    }
+    #endif
+
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         KLog.chat("📜 [scroll] drag-begin session=\(sessionId.prefix(12)) off=\(Int(scrollView.contentOffset.y)) content=\(Int(scrollView.contentSize.height)) following=\(followingBottom)")
         codeHighlightSettleWork?.cancel()
@@ -2234,6 +2243,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// Top up the newer buffer while approaching the bottom, until it can clear
     /// the band. Mirror of `prefetchOlderIfNeeded`.
     private func prefetchNewerIfNeeded() {
+        guard viewIfLoaded?.window != nil else { return }
         guard !suppressPagingForBottom else { return }
         guard pendingApply == nil else { return }
         guard !atNewest, !fetchingNewer, !measuringNewerPage, !scrollingToTop else { return }
@@ -2388,6 +2398,7 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
 
     /// Top up the buffer while approaching the top, until it can clear the band.
     private func prefetchOlderIfNeeded() {
+        guard viewIfLoaded?.window != nil else { return }
         guard !suppressPagingForBottom else { return }
         guard pendingApply == nil else { return }
         guard !atOldest, !fetchingOlder, !measuringOlderPage,

--- a/packages/arm/ios/KrakiTests/IOSChatScrollProductionTests.swift
+++ b/packages/arm/ios/KrakiTests/IOSChatScrollProductionTests.swift
@@ -1,0 +1,309 @@
+import XCTest
+@testable import Kraki
+
+#if os(iOS)
+@MainActor
+final class IOSChatScrollProductionTests: XCTestCase {
+    private var temporaryRoots: [URL] = []
+    private var windows: [UIWindow] = []
+    private var appStates: [AppState] = []
+
+    override func tearDown() async throws {
+        windows.forEach { $0.isHidden = true; $0.rootViewController = nil }
+        windows.removeAll()
+        appStates.removeAll()
+        temporaryRoots.forEach { try? FileManager.default.removeItem(at: $0) }
+        temporaryRoots.removeAll()
+        try await super.tearDown()
+    }
+
+    func testProductionScrollGate() throws {
+        let fixture = try makeFixture(totalMessages: 240)
+        let viewController = fixture.viewController
+        let collectionView = fixture.collectionView
+
+        drainMainRunLoop(milliseconds: 700)
+        collectionView.layoutIfNeeded()
+
+        let entry = snapshot(collectionView)
+        XCTAssertGreaterThan(entry.itemCount, 0)
+        XCTAssertGreaterThan(entry.contentHeight, entry.viewportHeight)
+        XCTAssertLessThanOrEqual(abs(entry.distanceToBottom), 1.5,
+                                 "iOS Session entry must be pinned to the newest tail")
+        XCTAssertTrue(entry.visibleCellsMaterialized,
+                      "every visible index path must have a production bubble cell")
+
+        let minimumOffset = -collectionView.adjustedContentInset.top
+        collectionView.setContentOffset(
+            CGPoint(x: collectionView.contentOffset.x, y: minimumOffset),
+            animated: false
+        )
+        collectionView.layoutIfNeeded()
+        viewController.automationMarkUserScrolledAway()
+        let topBefore = snapshot(collectionView)
+        let anchorBefore = topBefore.firstVisibleBubble
+        XCTAssertNotNil(anchorBefore, "top viewport must contain a bubble before prepend")
+
+        viewController.scrollViewDidScroll(collectionView)
+        viewController.scrollViewDidEndDragging(collectionView, willDecelerate: false)
+        drainMainRunLoop(milliseconds: 3_500)
+        collectionView.layoutIfNeeded()
+
+        let afterOlder = snapshot(collectionView)
+        let rawTopAfterOlder = fixture.appState.messageStore.windowState(fixture.sessionId)?.topSeq ?? 0
+        XCTAssertLessThan(rawTopAfterOlder, fixture.entryRawTopSeq,
+                          "first upward approach must load older history")
+        XCTAssertGreaterThan(afterOlder.itemCount, entry.itemCount,
+                             "older prepend must reveal additional cells")
+        XCTAssertTrue(afterOlder.visibleCellsMaterialized)
+        XCTAssertGreaterThanOrEqual(afterOlder.contentOffsetY, minimumOffset - 1)
+        XCTAssertLessThanOrEqual(afterOlder.contentOffsetY, afterOlder.maximumOffsetY + 1)
+
+        if let anchorBefore {
+            let anchorAfter = afterOlder.bubble(named: anchorBefore.id)
+            XCTAssertNotNil(anchorAfter, "the pre-pagination anchor must remain present")
+            if let anchorAfter {
+                let drift = abs(anchorAfter.screenY - anchorBefore.screenY)
+                print("IOS_SCROLL_GATE anchor id=\(anchorBefore.id) before=\(anchorBefore.screenY) after=\(anchorAfter.screenY) drift=\(drift) offsetBefore=\(topBefore.contentOffsetY) offsetAfter=\(afterOlder.contentOffsetY) contentBefore=\(topBefore.contentHeight) contentAfter=\(afterOlder.contentHeight)")
+                XCTAssertLessThanOrEqual(drift, 2.0,
+                                         "older prepend moved the visible anchor by \(drift)pt")
+            }
+        }
+
+        // A continuous upward approach must not expose blank cells while the
+        // async DB-first page and the exact-height barrier are settling.
+        let duringFlingOffsets = stride(from: afterOlder.maximumOffsetY,
+                                         through: minimumOffset,
+                                         by: -120).map { CGFloat($0) }
+        for offset in duringFlingOffsets {
+            collectionView.setContentOffset(
+                CGPoint(x: collectionView.contentOffset.x, y: max(minimumOffset, offset)),
+                animated: false
+            )
+            viewController.scrollViewDidScroll(collectionView)
+            viewController.scrollViewDidEndDragging(collectionView, willDecelerate: false)
+            drainMainRunLoop(milliseconds: 40)
+            XCTAssertTrue(snapshot(collectionView).visibleCellsMaterialized)
+        }
+        drainMainRunLoop(milliseconds: 900)
+        XCTAssertFalse(collectionView.isDecelerating)
+
+        // A later distinct approach may continue paging until the true oldest
+        // boundary; it must remain clamped and must not duplicate item ids.
+        for _ in 0..<8 {
+            let state = snapshot(collectionView)
+            guard state.topSeq > 1 else { break }
+            collectionView.setContentOffset(
+                CGPoint(x: collectionView.contentOffset.x, y: minimumOffset),
+                animated: false
+            )
+            viewController.scrollViewDidScroll(collectionView)
+            viewController.scrollViewDidEndDragging(collectionView, willDecelerate: false)
+            drainMainRunLoop(milliseconds: 450)
+        }
+        let final = snapshot(collectionView)
+        XCTAssertGreaterThanOrEqual(final.contentOffsetY, minimumOffset - 1)
+        XCTAssertLessThanOrEqual(final.contentOffsetY, final.maximumOffsetY + 1)
+        XCTAssertEqual(final.itemIDs.count, Set(final.itemIDs).count,
+                       "pagination must not duplicate visible spine identities")
+        XCTAssertTrue(final.visibleCellsMaterialized)
+
+        // The px-managed window can trim the far/newer edge while walking to
+        // the oldest history. A later downward approach must recover that
+        // newer page through the symmetric production path.
+        let bottomBeforeNewer = fixture.appState.messageStore.windowState(fixture.sessionId)?.bottomSeq ?? 0
+        collectionView.setContentOffset(
+            CGPoint(x: collectionView.contentOffset.x, y: final.maximumOffsetY),
+            animated: false
+        )
+        viewController.scrollViewDidScroll(collectionView)
+        viewController.scrollViewDidEndDragging(collectionView, willDecelerate: false)
+        drainMainRunLoop(milliseconds: 3_500)
+        let afterNewer = snapshot(collectionView)
+        let bottomAfterNewer = fixture.appState.messageStore.windowState(fixture.sessionId)?.bottomSeq ?? 0
+        XCTAssertGreaterThan(bottomAfterNewer, bottomBeforeNewer,
+                             "downward approach must recover trimmed newer history")
+        XCTAssertGreaterThanOrEqual(afterNewer.contentOffsetY, minimumOffset - 1)
+        XCTAssertLessThanOrEqual(afterNewer.contentOffsetY, afterNewer.maximumOffsetY + 1)
+        XCTAssertTrue(afterNewer.visibleCellsMaterialized)
+
+        // Reflow/size change while history mode is active must not expose an
+        // invalid offset or an unmaterialized visible cell.
+        fixture.window.frame = CGRect(x: 0, y: 0, width: 430, height: 700)
+        viewController.view.frame = fixture.window.bounds
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+        drainMainRunLoop(milliseconds: 500)
+        let afterResize = snapshot(collectionView)
+        XCTAssertGreaterThanOrEqual(afterResize.contentOffsetY, minimumOffset - 1)
+        XCTAssertLessThanOrEqual(afterResize.contentOffsetY, afterResize.maximumOffsetY + 1)
+        XCTAssertTrue(afterResize.visibleCellsMaterialized)
+    }
+
+    private struct Fixture { 
+        let viewController: ChatPerfListVC
+        let collectionView: UICollectionView
+        let window: UIWindow
+        let appState: AppState
+        let sessionId: String
+        let entryRawTopSeq: Int
+    }
+
+    private struct BubbleFrame {
+        let id: String
+        let screenY: CGFloat
+    }
+
+    private struct ScrollSnapshot {
+        let itemCount: Int
+        let itemIDs: [String]
+        let topSeq: Int
+        let contentHeight: CGFloat
+        let viewportHeight: CGFloat
+        let contentOffsetY: CGFloat
+        let maximumOffsetY: CGFloat
+        let distanceToBottom: CGFloat
+        let visibleCellsMaterialized: Bool
+        let visibleBubbles: [BubbleFrame]
+        let firstVisibleBubble: BubbleFrame?
+
+        func bubble(named id: String) -> BubbleFrame? {
+            visibleBubbles.first { $0.id == id }
+        }
+    }
+
+    private func makeFixture(totalMessages: Int) throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kraki-ios-scroll-gate-\(UUID().uuidString)", isDirectory: true)
+        temporaryRoots.append(root)
+        let database = try MessageDatabase(databaseURL: root.appendingPathComponent("messages.sqlite"))
+        let sessionId = "ios-scroll-gate"
+        let messages = (1...totalMessages).map { seq in
+            let paragraph = String(
+                repeating: "Message \(seq): a realistic wrapped response keeps pagination anchored while the viewport moves. ",
+                count: 4
+            )
+            return ChatMessage(
+                type: seq.isMultiple(of: 2) ? "agent_message" : "user_message",
+                seq: seq,
+                sessionId: sessionId,
+                deviceId: "ios-scroll-device",
+                timestamp: "2026-08-22T00:00:00Z",
+                payload: ["content": AnyCodable(paragraph)]
+            )
+        }
+        try database.insert(sessionId, messages)
+
+        let appState = AppState(testDatabase: database)
+        appStates.append(appState)
+        appState.messageProvider?.setTentacleInfo(
+            sessionId: sessionId,
+            lastSeq: totalMessages,
+            deviceId: "ios-scroll-device"
+        )
+        _ = appState.messageStore.loadInitialWindow(sessionId)
+
+        let viewController = ChatPerfListVC(
+            sessionId: sessionId,
+            appState: appState,
+            agent: "claude",
+            bottomContentInset: 54
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        windows.append(window)
+        viewController.view.frame = window.bounds
+        viewController.loadViewIfNeeded()
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+        viewController.viewDidAppear(false)
+
+        guard let collectionView = findCollectionView(in: viewController.view) else {
+            throw XCTSkip("ChatPerfListVC did not mount its UICollectionView")
+        }
+        let entryRawTopSeq = appState.messageStore.windowState(sessionId)?.topSeq ?? 0
+        return Fixture(
+            viewController: viewController,
+            collectionView: collectionView,
+            window: window,
+            appState: appState,
+            sessionId: sessionId,
+            entryRawTopSeq: entryRawTopSeq
+        )
+    }
+
+    private func findCollectionView(in view: UIView) -> UICollectionView? {
+        if let collectionView = view as? UICollectionView { return collectionView }
+        for child in view.subviews {
+            if let collectionView = findCollectionView(in: child) { return collectionView }
+        }
+        return nil
+    }
+
+    private func snapshot(_ collectionView: UICollectionView) -> ScrollSnapshot {
+        collectionView.layoutIfNeeded()
+        let itemCount = collectionView.numberOfItems(inSection: 0)
+        let itemIDs = collectionView.indexPathsForVisibleItems.compactMap { indexPath in
+            (collectionView.cellForItem(at: indexPath) as? TKBubbleCell)?.contentSnapshot?.message.id
+        }
+        let visibleCellsMaterialized = collectionView.indexPathsForVisibleItems.allSatisfy {
+            collectionView.cellForItem(at: $0) is TKBubbleCell
+        }
+        let visible = collectionView.indexPathsForVisibleItems
+            .sorted()
+            .compactMap { indexPath -> BubbleFrame? in
+                guard let cell = collectionView.cellForItem(at: indexPath) as? TKBubbleCell,
+                      let message = cell.contentSnapshot?.message else { return nil }
+                return BubbleFrame(
+                    id: message.id,
+                    screenY: cell.frame.minY - collectionView.contentOffset.y
+                )
+            }
+            .first
+        let minY = -collectionView.adjustedContentInset.top
+        let maxY = max(
+            minY,
+            collectionView.contentSize.height
+                - collectionView.bounds.height
+                + collectionView.adjustedContentInset.bottom
+        )
+        let distance = collectionView.contentSize.height
+            + collectionView.adjustedContentInset.bottom
+            - collectionView.bounds.height
+            - collectionView.contentOffset.y
+        let topSeq = collectionView.indexPathsForVisibleItems
+            .compactMap { (collectionView.cellForItem(at: $0) as? TKBubbleCell)?.contentSnapshot?.message.seq }
+            .min() ?? 0
+        return ScrollSnapshot(
+            itemCount: itemCount,
+            itemIDs: itemIDs,
+            topSeq: topSeq,
+            contentHeight: collectionView.contentSize.height,
+            viewportHeight: collectionView.bounds.height,
+            contentOffsetY: collectionView.contentOffset.y,
+            maximumOffsetY: maxY,
+            distanceToBottom: distance,
+            visibleCellsMaterialized: visibleCellsMaterialized,
+            visibleBubbles: collectionView.indexPathsForVisibleItems
+                .sorted()
+                .compactMap { indexPath -> BubbleFrame? in
+                    guard let cell = collectionView.cellForItem(at: indexPath) as? TKBubbleCell,
+                          let message = cell.contentSnapshot?.message else { return nil }
+                    return BubbleFrame(
+                        id: message.id,
+                        screenY: cell.frame.minY - collectionView.contentOffset.y
+                    )
+                },
+            firstVisibleBubble: visible
+        )
+    }
+
+    private func drainMainRunLoop(milliseconds: Int) {
+        let deadline = Date().addingTimeInterval(Double(milliseconds) / 1_000)
+        while Date() < deadline {
+            RunLoop.main.run(mode: .default, before: min(deadline, Date().addingTimeInterval(0.01)))
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a real iOS `ChatPerfListVC` scroll production gate using temporary SQLite data and the production TextKit / pagination / measurement paths
- cover Session entry, older prepend anchoring, continuous upward packets, oldest clamp, newer recovery after px-window trimming, and resize/reflow materialization
- prevent older/newer prefetch from starting before `ChatPerfListVC` is mounted in a window, avoiding a pre-attachment measurement deadlock
- keep the focus-free follow-state probe Debug-only

## Validation
- focused iOS scroll gate passed in 3 fresh simulator test processes
- full iOS suite: 308 executed, 2 skipped, 0 failures
- iOS Simulator Release build passed
- no production app, database, Relay, credentials, or Session was touched