### PR TITLE
chore(mac): prepare 0.2.25 build 27

### DIFF
--- a/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
+++ b/packages/arm/ios/Kraki.xcodeproj/project.pbxproj
@@ -1485,7 +1485,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1495,7 +1495,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.24;
+				MARKETING_VERSION = 0.2.25;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac.dev;
 				PRODUCT_NAME = "Kraki Dev";
 				SDKROOT = macosx;
@@ -1565,7 +1565,7 @@
 				CODE_SIGN_ENTITLEMENTS = Kraki/KrakiMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				DEVELOPMENT_TEAM = 3A83X5JZ3S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1575,7 +1575,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.24;
+				MARKETING_VERSION = 0.2.25;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.kraki.mac;
 				PRODUCT_NAME = Kraki;
 				SDKROOT = macosx;

--- a/packages/arm/ios/project.yml
+++ b/packages/arm/ios/project.yml
@@ -181,8 +181,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.kraki.mac
         PRODUCT_NAME: Kraki
-        MARKETING_VERSION: "0.2.24"
-        CURRENT_PROJECT_VERSION: 26
+        MARKETING_VERSION: "0.2.25"
+        CURRENT_PROJECT_VERSION: 27
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- bump the macOS GUI marketing version to 0.2.25
- bump the macOS GUI build to 27 for the next green-main release

## Validation
- KrakiMac Release build passed
- `git diff --check` passed
- release will be tagged only after merged-main CI is green