### PR TITLE
feat(chat): add latest message start jump control

### DIFF
--- a/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/ChatPerfListView.swift
@@ -573,13 +573,18 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
     /// animation-end / user touch / a safety timeout.
     private var suppressPagingForBottom = false
 
-    /// Floating "jump to latest" button, shown only when the user has scrolled
-    /// away from the live bottom. Tapping re-anchors at the chat's true newest
-    /// end and glides down. A UIKit sibling of the collection view (the SwiftUI
-    /// `ChatPerfListView` wrapper mounts the VC bare), tinted by the agent hue.
+    /// Two floating navigation controls share the same lower-right rail:
+    /// "latest message start" places the newest bubble below the top chrome,
+    /// while "latest" keeps the existing live-tail behavior. They are UIKit
+    /// siblings of the collection view so the SwiftUI wrapper stays simple.
     private let jumpButton = UIButton(type: .system)
+    private let latestMessageStartButton = UIButton(type: .system)
     private var jumpButtonBlur: UIVisualEffectView?
+    private var latestMessageStartButtonBlur: UIVisualEffectView?
     private var jumpButtonBottomConstraint: NSLayoutConstraint?
+    private var jumpButtonVisibilityTargets: [ObjectIdentifier: Bool] = [:]
+    private var jumpButtonVisibilityGenerations: [ObjectIdentifier: Int] = [:]
+    private static let latestMessageTopPadding: CGFloat = 118
 
     /// Flip to `true` for the spinner-free local-seamless experiment.
     /// `false` = the robust, production-style experience: show a loading
@@ -1077,8 +1082,9 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
                             for: .normal)
         jumpButton.tintColor = agentTint()
         jumpButton.addTarget(self, action: #selector(onBottomTapped), for: .touchUpInside)
-        jumpButton.alpha = 0                 // hidden until scrolled up
+        jumpButton.alpha = 0
         jumpButton.isHidden = true
+        jumpButton.accessibilityLabel = "Jump to latest"
 
         view.addSubview(jumpButton)
         jumpButton.addSubview(blur)
@@ -1100,27 +1106,128 @@ final class ChatPerfListVC: UIViewController, UICollectionViewDataSource, UIColl
             blur.topAnchor.constraint(equalTo: jumpButton.topAnchor),
             blur.bottomAnchor.constraint(equalTo: jumpButton.bottomAnchor),
         ])
+
+        let startBlur = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+        startBlur.translatesAutoresizingMaskIntoConstraints = false
+        startBlur.isUserInteractionEnabled = false
+        startBlur.layer.cornerRadius = 15
+        startBlur.layer.masksToBounds = true
+        startBlur.layer.borderWidth = 0.5
+        startBlur.layer.borderColor = agentTint().withAlphaComponent(0.25).cgColor
+
+        latestMessageStartButton.translatesAutoresizingMaskIntoConstraints = false
+        latestMessageStartButton.setImage(
+            UIImage(
+                systemName: "arrow.up.to.line",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
+            ),
+            for: .normal
+        )
+        latestMessageStartButton.tintColor = agentTint()
+        latestMessageStartButton.addTarget(self, action: #selector(onLatestMessageStartTapped), for: .touchUpInside)
+        latestMessageStartButton.alpha = 0
+        latestMessageStartButton.isHidden = true
+        latestMessageStartButton.accessibilityLabel = "Jump to start of latest message"
+
+        view.addSubview(latestMessageStartButton)
+        latestMessageStartButton.addSubview(startBlur)
+        latestMessageStartButton.sendSubviewToBack(startBlur)
+        latestMessageStartButtonBlur = startBlur
+
+        NSLayoutConstraint.activate([
+            latestMessageStartButton.trailingAnchor.constraint(equalTo: jumpButton.trailingAnchor),
+            latestMessageStartButton.bottomAnchor.constraint(equalTo: jumpButton.topAnchor, constant: -8),
+            latestMessageStartButton.widthAnchor.constraint(equalTo: jumpButton.widthAnchor),
+            latestMessageStartButton.heightAnchor.constraint(equalTo: jumpButton.heightAnchor),
+            startBlur.leadingAnchor.constraint(equalTo: latestMessageStartButton.leadingAnchor),
+            startBlur.trailingAnchor.constraint(equalTo: latestMessageStartButton.trailingAnchor),
+            startBlur.topAnchor.constraint(equalTo: latestMessageStartButton.topAnchor),
+            startBlur.bottomAnchor.constraint(equalTo: latestMessageStartButton.bottomAnchor),
+        ])
     }
 
-    /// Show the jump button only when the user has scrolled away from the live
-    /// bottom (or newer history remains unloaded below). Animated fade so it
-    /// doesn't pop during the glide.
+    /// The newest bubble's start gets a stable reading position below the
+    /// navigation glass. Clamp to the scrollable range when the bubble is
+    /// shorter than the viewport or the conversation has little history.
+    private func latestMessageStartOffset() -> CGFloat? {
+        guard collectionView.numberOfSections > 0 else { return nil }
+        let lastItem = collectionView.numberOfItems(inSection: 0) - 1
+        guard lastItem >= 0 else { return nil }
+        let indexPath = IndexPath(item: lastItem, section: 0)
+        guard let frame = collectionView.layoutAttributesForItem(at: indexPath)?.frame else { return nil }
+
+        let minimumY = -collectionView.adjustedContentInset.top
+        let maximumY = max(
+            minimumY,
+            collectionView.contentSize.height
+                - collectionView.bounds.height
+                + collectionView.adjustedContentInset.bottom
+        )
+        let desired = frame.minY - Self.latestMessageTopPadding
+        return min(maximumY, max(minimumY, desired))
+    }
+
+    /// Show each control only when its own target is meaningfully away. This
+    /// keeps "latest" hidden at the tail while the start control remains
+    /// available for a long newest reply.
     private func updateJumpButtonVisibility() {
         guard collectionView != nil else { return }
         let farFromBottom = distanceToBottom() > 1.5 * collectionView.bounds.height
-        let shouldShow = !suppressPagingForBottom && (farFromBottom || !atNewest)
-        let isShown = !jumpButton.isHidden && jumpButton.alpha > 0.5
-        guard shouldShow != isShown else { return }
-        if shouldShow { jumpButton.isHidden = false }
-        UIView.animate(withDuration: 0.2) {
-            self.jumpButton.alpha = shouldShow ? 1 : 0
-        } completion: { _ in
-            if !shouldShow { self.jumpButton.isHidden = true }
+        let shouldShowBottom = !suppressPagingForBottom && (farFromBottom || !atNewest)
+        let shouldShowStart = !suppressPagingForBottom
+            && latestMessageStartOffset().map {
+                abs(collectionView.contentOffset.y - $0) > 24
+            } == true
+        setJumpButtonVisibility(jumpButton, shouldShow: shouldShowBottom)
+        setJumpButtonVisibility(latestMessageStartButton, shouldShow: shouldShowStart)
+    }
+
+    private func setJumpButtonVisibility(_ button: UIButton, shouldShow: Bool) {
+        let key = ObjectIdentifier(button)
+        guard jumpButtonVisibilityTargets[key] != shouldShow else { return }
+        jumpButtonVisibilityTargets[key] = shouldShow
+        let generation = (jumpButtonVisibilityGenerations[key] ?? 0) + 1
+        jumpButtonVisibilityGenerations[key] = generation
+        button.layer.removeAllAnimations()
+        if shouldShow { button.isHidden = false }
+        UIView.animate(withDuration: 0.2) { [weak button] in
+            button?.alpha = shouldShow ? 1 : 0
+        } completion: { [weak self, weak button] finished in
+            guard let self, let button,
+                  finished,
+                  self.jumpButtonVisibilityTargets[key] == shouldShow,
+                  self.jumpButtonVisibilityGenerations[key] == generation else { return }
+            if !shouldShow { button.isHidden = true }
         }
     }
 
     @objc private func onBottomTapped() {
         jumpToLiveBottom(animated: true)
+    }
+
+    @objc private func onLatestMessageStartTapped() {
+        jumpToLatestMessageStart(animated: true)
+    }
+
+    private func jumpToLatestMessageStart(animated: Bool) {
+        suppressPagingForBottom = true
+        if !atNewest {
+            reanchorNewest()
+        }
+        collectionView.layoutIfNeeded()
+        guard let target = latestMessageStartOffset() else {
+            endBottomGlide()
+            return
+        }
+        followingBottom = false
+        collectionView.setContentOffset(
+            CGPoint(x: collectionView.contentOffset.x, y: target),
+            animated: animated
+        )
+        updateJumpButtonVisibility()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+            self?.endBottomGlide()
+        }
     }
 
     /// Re-anchor at the chat's true newest end, then pin the viewport to the

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatScrollView.swift
@@ -513,6 +513,10 @@ final class MacChatDocumentView: NSView {
         return itemFrames[index]
     }
 
+    func latestItemFrame() -> NSRect? {
+        itemFrames.last
+    }
+
     /// Materialize only the viewport plus a small runway. A scrollbar-thumb
     /// drag may jump across the whole document in one event, so it never does
     /// cold Markdown/TextKit work synchronously; idle warming fills those
@@ -1876,6 +1880,7 @@ final class MacChatScrollView: MacSmoothScrollView {
     private var lastPresentationLogSignature = ""
     private var presentationHealthWorkItem: DispatchWorkItem?
     private var geometryAnchorLock: (key: String, delta: CGFloat)?
+    private var latestStartJumpPending = false
     private var bubbleActionMouseMonitor: Any?
     private var pendingBubbleActionClick: (
         target: MacBubbleActionHitTarget?,
@@ -1886,8 +1891,15 @@ final class MacChatScrollView: MacSmoothScrollView {
 
     private let jumpMaterial = NSVisualEffectView()
     private let jumpButton = NSButton()
+    private let latestStartMaterial = NSVisualEffectView()
+    private let latestStartButton = NSButton()
+    private var jumpButtonVisibilityTargets: [ObjectIdentifier: Bool] = [:]
+    private var jumpButtonVisibilityGenerations: [ObjectIdentifier: Int] = [:]
+    private let latestMessageTopPadding: CGFloat = 72
 
     var onJumpToLatest: (() -> Void)?
+    var onRequestLatestTail: (() -> Void)?
+    var hasPendingLatestStartJump: Bool { latestStartJumpPending }
     var onScrolledNearTop: (() -> Void)?
     var onScrolledNearBottom: (() -> Void)?
     var onRenderedHeightsSettled: (() -> Void)?
@@ -1978,15 +1990,17 @@ final class MacChatScrollView: MacSmoothScrollView {
             self?.requestInitialTailTrimIfReady()
         }
 
-        jumpMaterial.material = .popover
-        jumpMaterial.blendingMode = .withinWindow
-        jumpMaterial.state = .active
-        jumpMaterial.wantsLayer = true
-        jumpMaterial.layer?.cornerRadius = 15
-        jumpMaterial.layer?.masksToBounds = true
-        jumpMaterial.layer?.borderWidth = 0.5
-        jumpMaterial.isHidden = true
-        addSubview(jumpMaterial)
+        for material in [jumpMaterial, latestStartMaterial] {
+            material.material = .popover
+            material.blendingMode = .withinWindow
+            material.state = .active
+            material.wantsLayer = true
+            material.layer?.cornerRadius = 15
+            material.layer?.masksToBounds = true
+            material.layer?.borderWidth = 0.5
+            material.isHidden = true
+            addSubview(material)
+        }
 
         jumpButton.image = NSImage(systemSymbolName: "chevron.down", accessibilityDescription: "Jump to latest")
         jumpButton.imagePosition = .imageOnly
@@ -1996,6 +2010,18 @@ final class MacChatScrollView: MacSmoothScrollView {
         jumpButton.isHidden = true
         jumpButton.setAccessibilityLabel("Jump to latest")
         addSubview(jumpButton)
+
+        latestStartButton.image = NSImage(
+            systemSymbolName: "arrow.up.to.line",
+            accessibilityDescription: "Jump to start of latest message"
+        )
+        latestStartButton.imagePosition = .imageOnly
+        latestStartButton.isBordered = false
+        latestStartButton.target = self
+        latestStartButton.action = #selector(latestStartTapped)
+        latestStartButton.isHidden = true
+        latestStartButton.setAccessibilityLabel("Jump to start of latest message")
+        addSubview(latestStartButton)
 
         bubbleActionMouseMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]
@@ -2149,6 +2175,9 @@ final class MacChatScrollView: MacSmoothScrollView {
         thumbViewportGeneration += 1
         thumbViewportUpdateScheduled = false
         pendingBubbleActionClick = nil
+        latestStartJumpPending = false
+        jumpButtonVisibilityTargets.removeAll(keepingCapacity: true)
+        jumpButtonVisibilityGenerations.removeAll(keepingCapacity: true)
         snapshotApplyActive = false
         suppressRunwayForNextReflect = false
         olderEdgeArmed = false
@@ -2372,7 +2401,9 @@ final class MacChatScrollView: MacSmoothScrollView {
             return NSColor(calibratedHue: hsb.0, saturation: hsb.1, brightness: hsb.2, alpha: 1)
         }
         jumpButton.contentTintColor = tint
+        latestStartButton.contentTintColor = tint
         jumpMaterial.layer?.borderColor = tint.withAlphaComponent(0.25).cgColor
+        latestStartMaterial.layer?.borderColor = tint.withAlphaComponent(0.25).cgColor
     }
 
     override func layout() {
@@ -2401,8 +2432,16 @@ final class MacChatScrollView: MacSmoothScrollView {
             width: 52,
             height: 30
         )
+        let latestStartFrame = NSRect(
+            x: jumpFrame.minX,
+            y: jumpFrame.minY - 8 - jumpFrame.height,
+            width: jumpFrame.width,
+            height: jumpFrame.height
+        )
         jumpMaterial.frame = jumpFrame
         jumpButton.frame = jumpFrame
+        latestStartMaterial.frame = latestStartFrame
+        latestStartButton.frame = latestStartFrame
     }
 
     @objc private func jumpTapped() {
@@ -2416,6 +2455,48 @@ final class MacChatScrollView: MacSmoothScrollView {
         onJumpToLatest?()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
             self?.suppressPagingForBottom = false
+        }
+    }
+
+    @objc private func latestStartTapped() {
+        geometryAnchorLock = nil
+        suppressNewerPagingAfterOlder = false
+        latestStartJumpPending = hasUnloadedNewer
+        suppressPagingForBottom = true
+        if hasUnloadedNewer {
+            // The true newest item may not be in the current sliding window.
+            // Ask the owner to re-anchor first; updateNSView completes this jump
+            // after the authoritative tail snapshot lands.
+            onRequestLatestTail?()
+        } else {
+            completeLatestStartJump()
+        }
+    }
+
+    func completeLatestStartJump() {
+        latestStartJumpPending = false
+        guard let frame = chatDocumentView.latestItemFrame() else {
+            suppressPagingForBottom = false
+            updateJumpButtonVisibility(animated: false)
+            return
+        }
+        let minimumY = -topContentInset
+        let maximumY = max(
+            minimumY,
+            chatDocumentView.frame.height - contentView.bounds.height
+        )
+        let target = min(maximumY, max(minimumY, frame.minY - latestMessageTopPadding))
+        followingBottom = false
+        let point = NSPoint(x: contentView.bounds.origin.x, y: target)
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            contentView.animator().bounds.origin = point
+        }
+        updateJumpButtonVisibility(animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+            guard let self else { return }
+            self.suppressPagingForBottom = false
+            self.updateJumpButtonVisibility(animated: false)
         }
     }
 
@@ -2811,22 +2892,66 @@ final class MacChatScrollView: MacSmoothScrollView {
     }
     var isEntryBottomLocked: Bool { entryBottomLocked }
 
+    private func latestMessageStartTarget() -> CGFloat? {
+        guard let frame = chatDocumentView.latestItemFrame() else { return nil }
+        let minimumY = -topContentInset
+        let maximumY = max(
+            minimumY,
+            chatDocumentView.frame.height - contentView.bounds.height
+        )
+        let desired = frame.minY - latestMessageTopPadding
+        return min(maximumY, max(minimumY, desired))
+    }
+
     private func updateJumpButtonVisibility(animated: Bool) {
         let farFromBottom = distanceToBottom > 1.5 * max(contentView.bounds.height, 1)
-        let shouldShow = farFromBottom || hasUnloadedNewer
-        guard shouldShow != !jumpButton.isHidden else { return }
+        let shouldShowBottom = !suppressPagingForBottom && (farFromBottom || hasUnloadedNewer)
+        let shouldShowStart = !suppressPagingForBottom
+            && latestMessageStartTarget().map {
+                abs(contentView.bounds.minY - $0) > 24
+            } == true
+        setJumpButtonVisibility(
+            jumpButton,
+            material: jumpMaterial,
+            shouldShow: shouldShowBottom,
+            animated: animated
+        )
+        setJumpButtonVisibility(
+            latestStartButton,
+            material: latestStartMaterial,
+            shouldShow: shouldShowStart,
+            animated: animated
+        )
+    }
+
+    private func setJumpButtonVisibility(
+        _ button: NSButton,
+        material: NSVisualEffectView,
+        shouldShow: Bool,
+        animated: Bool
+    ) {
+        let key = ObjectIdentifier(button)
+        guard jumpButtonVisibilityTargets[key] != shouldShow else { return }
+        jumpButtonVisibilityTargets[key] = shouldShow
+        let generation = (jumpButtonVisibilityGenerations[key] ?? 0) + 1
+        jumpButtonVisibilityGenerations[key] = generation
+        button.layer?.removeAllAnimations()
+        material.layer?.removeAllAnimations()
         if shouldShow {
-            jumpButton.isHidden = false
-            jumpMaterial.isHidden = false
+            button.isHidden = false
+            material.isHidden = false
         }
         let changes = {
-            self.jumpButton.alphaValue = shouldShow ? 1 : 0
-            self.jumpMaterial.alphaValue = shouldShow ? 1 : 0
+            button.alphaValue = shouldShow ? 1 : 0
+            material.alphaValue = shouldShow ? 1 : 0
         }
-        let completion = {
+        let completion = { [weak self, weak button, weak material] in
+            guard let self, let button, let material,
+                  self.jumpButtonVisibilityTargets[key] == shouldShow,
+                  self.jumpButtonVisibilityGenerations[key] == generation else { return }
             if !shouldShow {
-                self.jumpButton.isHidden = true
-                self.jumpMaterial.isHidden = true
+                button.isHidden = true
+                material.isHidden = true
             }
         }
         if animated {
@@ -2909,6 +3034,7 @@ struct MacChatListRepresentable: NSViewRepresentable {
     let atOldest: Bool
     let atNewest: Bool
     let onJumpToLatest: () -> Void
+    let onRequestLatestTail: () -> Void
     let onLoadOlder: () -> Void
     let onLoadNewer: () -> Void
     let onOpenSteps: (Int, Bool) -> Void
@@ -2931,6 +3057,7 @@ struct MacChatListRepresentable: NSViewRepresentable {
             return documentView?.measuredHeight(forSeq: seq) ?? 0
         }
         MacChatPerf.log("make session=\(sessionId.prefix(12)) pxWindow=4800")
+        scrollView.onRequestLatestTail = onRequestLatestTail
         scrollView.onRenderedHeightsSettled = { [weak scrollView] in
             DispatchQueue.main.async { [weak scrollView] in
                 guard let scrollView,
@@ -2964,6 +3091,7 @@ struct MacChatListRepresentable: NSViewRepresentable {
     static func dismantleNSView(_ scrollView: MacChatScrollView, coordinator: Coordinator) {
         scrollView.chatDocumentView.tearDown()
         scrollView.onJumpToLatest = nil
+        scrollView.onRequestLatestTail = nil
         scrollView.onScrolledNearTop = nil
         scrollView.onScrolledNearBottom = nil
         scrollView.onRenderedHeightsSettled = nil
@@ -2992,6 +3120,7 @@ struct MacChatListRepresentable: NSViewRepresentable {
             guard sid == sessionId else { return 0 }
             return documentView?.measuredHeight(forSeq: seq) ?? 0
         }
+        scrollView.onRequestLatestTail = onRequestLatestTail
         scrollView.onRenderedHeightsSettled = { [weak scrollView] in
             DispatchQueue.main.async { [weak scrollView] in
                 guard let scrollView,
@@ -3092,6 +3221,9 @@ struct MacChatListRepresentable: NSViewRepresentable {
             atOldest: atOldest,
             atNewest: atNewest
         )
+        if scrollView.hasPendingLatestStartJump, atNewest {
+            scrollView.completeLatestStartJump()
+        }
         let totalMs = (CACurrentMediaTime() - totalStarted) * 1_000
         if totalMs >= 16 {
             MacChatPerf.slow(

--- a/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatView.swift
+++ b/packages/arm/ios/Kraki/Features/Chat/Mac/MacChatView.swift
@@ -466,6 +466,9 @@ struct MacChatView: View {
                 onJumpToLatest: {
                     reanchorNewest(viewModel)
                 },
+                onRequestLatestTail: {
+                    reanchorNewest(viewModel)
+                },
                 onLoadOlder: { viewModel.loadOlderIfPossible() },
                 onLoadNewer: {
                     if viewModel.pageNewerRaw() {

--- a/packages/arm/ios/KrakiTests/IOSChatScrollProductionTests.swift
+++ b/packages/arm/ios/KrakiTests/IOSChatScrollProductionTests.swift
@@ -17,6 +17,40 @@ final class IOSChatScrollProductionTests: XCTestCase {
         try await super.tearDown()
     }
 
+    func testLatestMessageJumpControls() throws {
+        let fixture = try makeFixture(totalMessages: 80, lastMessageParagraphs: 60)
+        let viewController = fixture.viewController
+        let collectionView = fixture.collectionView
+
+        drainMainRunLoop(milliseconds: 900)
+        collectionView.layoutIfNeeded()
+        let initial = snapshot(collectionView)
+        XCTAssertLessThanOrEqual(abs(initial.distanceToBottom), 1.5)
+
+        let buttons = findButtons(in: viewController.view)
+        let startButton = try XCTUnwrap(
+            buttons.first { $0.accessibilityLabel == "Jump to start of latest message" }
+        )
+        let bottomButton = try XCTUnwrap(
+            buttons.first { $0.accessibilityLabel == "Jump to latest" }
+        )
+        XCTAssertFalse(startButton.isHidden, "long latest message should expose its start control at the tail")
+        XCTAssertTrue(bottomButton.isHidden, "latest-tail control is unnecessary while already at the tail")
+
+        startButton.sendActions(for: .touchUpInside)
+        drainMainRunLoop(milliseconds: 900)
+        collectionView.layoutIfNeeded()
+
+        let afterStart = snapshot(collectionView)
+        let latest = try XCTUnwrap(afterStart.visibleBubbles.last(where: { $0.id == "ios-scroll-gate:80" }))
+        XCTAssertGreaterThanOrEqual(latest.screenY, 100,
+                                    "latest message start must remain below the top navigation glass")
+        XCTAssertLessThanOrEqual(latest.screenY, 140,
+                                 "latest message start should land near the reading position")
+        XCTAssertGreaterThan(afterStart.distanceToBottom, 100,
+                             "latest-message-start must not pin the viewport to the tail")
+    }
+
     func testProductionScrollGate() throws {
         let fixture = try makeFixture(totalMessages: 240)
         let viewController = fixture.viewController
@@ -172,7 +206,7 @@ final class IOSChatScrollProductionTests: XCTestCase {
         }
     }
 
-    private func makeFixture(totalMessages: Int) throws -> Fixture {
+    private func makeFixture(totalMessages: Int, lastMessageParagraphs: Int = 4) throws -> Fixture {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("kraki-ios-scroll-gate-\(UUID().uuidString)", isDirectory: true)
         temporaryRoots.append(root)
@@ -181,7 +215,7 @@ final class IOSChatScrollProductionTests: XCTestCase {
         let messages = (1...totalMessages).map { seq in
             let paragraph = String(
                 repeating: "Message \(seq): a realistic wrapped response keeps pagination anchored while the viewport moves. ",
-                count: 4
+                count: seq == totalMessages ? lastMessageParagraphs : 4
             )
             return ChatMessage(
                 type: seq.isMultiple(of: 2) ? "agent_message" : "user_message",
@@ -239,6 +273,15 @@ final class IOSChatScrollProductionTests: XCTestCase {
             if let collectionView = findCollectionView(in: child) { return collectionView }
         }
         return nil
+    }
+
+    private func findButtons(in view: UIView) -> [UIButton] {
+        var result: [UIButton] = []
+        if let button = view as? UIButton { result.append(button) }
+        for child in view.subviews {
+            result.append(contentsOf: findButtons(in: child))
+        }
+        return result
     }
 
     private func snapshot(_ collectionView: UICollectionView) -> ScrollSnapshot {


### PR DESCRIPTION
## Summary
- add a second lower-right Chat control for jumping to the start of the latest message
- keep the existing control for jumping to the live tail/latest bottom
- stack both controls vertically with native glass treatment on iOS and macOS
- keep the latest-message-start target below the top navigation glass and preserve pagination/anchor behavior

## Verification
- macOS Debug build passed
- macOS Release build passed
- iOS Debug Simulator build passed
- iOS focused scroll tests passed: 2/2
- iOS full Simulator suite passed: 309 executed, 2 skipped, 0 failures
- `git diff --check`

No production app was installed, replaced, activated, or restarted.
